### PR TITLE
Replaces $var with $_GET['var']

### DIFF
--- a/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.en-gb.md
+++ b/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.en-gb.md
@@ -89,7 +89,7 @@ These rules run the testing.php script with the GET variable containing the URL.
 ```
 <?
 print("testing server <br/>\n");
-print("var: $var\n");
+print("var: {$_GET['var']}\n");
 ?>
 ```
 

--- a/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.en-ie.md
+++ b/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.en-ie.md
@@ -89,7 +89,7 @@ These rules run the testing.php script with the GET variable containing the URL.
 ```
 <?
 print("testing server <br/>\n");
-print("var: $var\n");
+print("var: {$_GET['var']}\n");
 ?>
 ```
 

--- a/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.es-es.md
+++ b/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.es-es.md
@@ -91,7 +91,7 @@ Estas reglas lanzan el script testing.php con la variable GET que contiene la UR
 ```
 <?
 print("testing server <br/>\n");
-print("var: $var\n");
+print("var: {$_GET['var']}\n");
 ?>
 ```
 

--- a/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.fr-fr.md
+++ b/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.fr-fr.md
@@ -73,7 +73,7 @@ Ces règles lancent le script  **testing.php**  avec la variable GET contenant l
 ```php
 1. <?
 2. print("testing server <br/>\n");
-3. print("var: $var\n");
+3. print("var: {$_GET['var']}\n");
 4. ?>
 ```
 

--- a/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.lt-lt.md
+++ b/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.lt-lt.md
@@ -90,7 +90,7 @@ Tai kreipsis į failą testing.php ir iškart pateiks URL su GET tipo kintamuoju
 [code]
 <?
 print("testing server <br/>\n");
-print("var: $var\n");
+print("var: {$_GET['var']}\n");
 ?>
 
 

--- a/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.pl-pl.md
+++ b/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.pl-pl.md
@@ -90,7 +90,7 @@ Reguły te uruchamiają skrypt testing.php ze zmienną GET zawierającą URL pod
 ```
 <?
 print("testing server <br/>\n");
-print("var: $var\n");
+print("var: {$_GET['var']}\n");
 ?>
 ```
 

--- a/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.pt-pt.md
+++ b/pages/web/hosting/htaccess_url_rewriting_using_mod_rewrite/guide.pt-pt.md
@@ -89,7 +89,7 @@ Estas regras iniciam o script testing.php com a variável GET a conter o URL atu
 ```
 <?
 print("testing server <br/>\n");
-print("var: $var\n");
+print("var: {$_GET['var']}\n");
 ?>
 ```
 


### PR DESCRIPTION
Assuming GET variables are automatically expanded in the global space, is assuming the `register_globals` config is on. This presents a security risk and has been deprecated since PHP 5.3.0, see http://php.net/manual/en/security.globals.php
This pull request updates all localizations of the document “htaccess url rewriting using mod_rewrite” to reflect PHP’s current best practices.