### PR TITLE
FR/EN/PL fix - Add missing configuration for Cloud Web

### DIFF
--- a/pages/web/cloud-web/install-ghost/guide.en-asia.md
+++ b/pages/web/cloud-web/install-ghost/guide.en-asia.md
@@ -118,6 +118,7 @@ Enter the information requested in the pop-up window, adapting the information s
 
 |Name|Variable type|Value| 
 |---|---|---|
+|database__connection__host|string|The MySQL server address|
 |database__connection__user|string|The MySQL username entered during creation|
 |database__connection__database|string|The name of the MySQL database|
 |database__connection__password|password|The MySQL password entered during creation|

--- a/pages/web/cloud-web/install-ghost/guide.en-au.md
+++ b/pages/web/cloud-web/install-ghost/guide.en-au.md
@@ -118,6 +118,7 @@ Enter the information requested in the pop-up window, adapting the information s
 
 |Name|Variable type|Value| 
 |---|---|---|
+|database__connection__host|string|The MySQL server address|
 |database__connection__user|string|The MySQL username entered during creation|
 |database__connection__database|string|The name of the MySQL database|
 |database__connection__password|password|The MySQL password entered during creation|

--- a/pages/web/cloud-web/install-ghost/guide.en-ca.md
+++ b/pages/web/cloud-web/install-ghost/guide.en-ca.md
@@ -118,6 +118,7 @@ Enter the information requested in the pop-up window, adapting the information s
 
 |Name|Variable type|Value| 
 |---|---|---|
+|database__connection__host|string|The MySQL server address|
 |database__connection__user|string|The MySQL username entered during creation|
 |database__connection__database|string|The name of the MySQL database|
 |database__connection__password|password|The MySQL password entered during creation|

--- a/pages/web/cloud-web/install-ghost/guide.en-gb.md
+++ b/pages/web/cloud-web/install-ghost/guide.en-gb.md
@@ -118,6 +118,7 @@ Enter the information requested in the pop-up window, adapting the information s
 
 |Name|Variable type|Value| 
 |---|---|---|
+|database__connection__host|string|The MySQL server address|
 |database__connection__user|string|The MySQL username entered during creation|
 |database__connection__database|string|The name of the MySQL database|
 |database__connection__password|password|The MySQL password entered during creation|

--- a/pages/web/cloud-web/install-ghost/guide.en-ie.md
+++ b/pages/web/cloud-web/install-ghost/guide.en-ie.md
@@ -118,6 +118,7 @@ Enter the information requested in the pop-up window, adapting the information s
 
 |Name|Variable type|Value| 
 |---|---|---|
+|database__connection__host|string|The MySQL server address|
 |database__connection__user|string|The MySQL username entered during creation|
 |database__connection__database|string|The name of the MySQL database|
 |database__connection__password|password|The MySQL password entered during creation|

--- a/pages/web/cloud-web/install-ghost/guide.en-sg.md
+++ b/pages/web/cloud-web/install-ghost/guide.en-sg.md
@@ -118,6 +118,7 @@ Enter the information requested in the pop-up window, adapting the information s
 
 |Name|Variable type|Value| 
 |---|---|---|
+|database__connection__host|string|The MySQL server address|
 |database__connection__user|string|The MySQL username entered during creation|
 |database__connection__database|string|The name of the MySQL database|
 |database__connection__password|password|The MySQL password entered during creation|

--- a/pages/web/cloud-web/install-ghost/guide.en-us.md
+++ b/pages/web/cloud-web/install-ghost/guide.en-us.md
@@ -118,6 +118,7 @@ Enter the information requested in the pop-up window, adapting the information s
 
 |Name|Variable type|Value| 
 |---|---|---|
+|database__connection__host|string|The MySQL server address|
 |database__connection__user|string|The MySQL username entered during creation|
 |database__connection__database|string|The name of the MySQL database|
 |database__connection__password|password|The MySQL password entered during creation|

--- a/pages/web/cloud-web/install-ghost/guide.fr-fr.md
+++ b/pages/web/cloud-web/install-ghost/guide.fr-fr.md
@@ -118,6 +118,7 @@ Dans la fenêtre qui s'affiche, complétez les informations demandées selon vot
 
 |Nom|Type de variable|Valeur| 
 |---|---|---|
+|database\__connection__host|string|L'adresse du serveur MySQL|
 |database\__connection__user|string|Le nom d'utilisateur MySQL choisi à sa création|
 |database\__connection__database|string|Le nom de la base MySQL|
 |database\__connection__password|password|Le mot de passe MySQL choisi à sa création|

--- a/pages/web/cloud-web/install-ghost/guide.pl-pl.md
+++ b/pages/web/cloud-web/install-ghost/guide.pl-pl.md
@@ -118,6 +118,7 @@ W oknie, które się wyświetla, wprowadź wymagane informacje, po czym kliknij 
 
 |Nazwa|Typ zmiennej|Wartość| 
 |---|---|---|
+|database__connection__host|string|Adres serwera MySQL|
 |database__connection__user|string|Nazwa użytkownika MySQL wybrana w momencie jego tworzenia|
 |database__connection__database|string|Nazwa bazy danych MySQL|
 |database__connection__password|hasło|Hasło MySQL wybrane w momencie jego tworzenia|


### PR DESCRIPTION
Add missing configuration in this tutorial (Webhosting -> Cloud Web -> Install Ghost).
Without this configuration the tutorial can't work.

I'm not sure the polish translation is good