### PR TITLE
Fix broken link

### DIFF
--- a/pages/cloud/storage/pcs_syno/guide.fr-fr.md
+++ b/pages/cloud/storage/pcs_syno/guide.fr-fr.md
@@ -26,7 +26,7 @@ Afin de configurer la synchronisation de votre NAS Synology, vous devez être en
 
 Vous pouvez les récupérer en téléchargeant le fichier OpenRC à l'aide de la première partie du guide suivant :
 
-- [Charger les variables d'environnement OpenStack](https://www.ovh.com/fr/publiccloud/guides/g1852.charger_les_variables_denvironnement_openstack){.external}
+- [Charger les variables d'environnement OpenStack](../../../public-cloud/charger-les-variables-denvironnement-openstack/#recuperation-des-variables_1){.ref}
 
 
 ### Configuration du point de synchronisation avec Cloud Sync


### PR DESCRIPTION
Old URL was used, normaly new link goes to page https://docs.ovh.com/fr/public-cloud/charger-les-variables-denvironnement-openstack/#recuperation-des-variables_1