### PR TITLE
Change fluent-bit docker image in LDP documentation about pushing Kubernetes logs

### DIFF
--- a/pages/platform/logs-data-platform/kubernetes_fluent_bit/guide.en-gb.md
+++ b/pages/platform/logs-data-platform/kubernetes_fluent_bit/guide.en-gb.md
@@ -289,7 +289,7 @@ In this file you must specify the address of your cluster (here **gra2.logs.ovh.
 
 Upload this file with the following command:
 ```shell-session 
-$ kubectl create -f fluent-bit-configmap.yaml
+$ kubectl create -f fluent-bit-ds.yaml
 ```
 
 Verify that the pods are running correctly with the command: 

--- a/pages/platform/logs-data-platform/kubernetes_fluent_bit/guide.en-gb.md
+++ b/pages/platform/logs-data-platform/kubernetes_fluent_bit/guide.en-gb.md
@@ -241,7 +241,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit:1.3
+        image: ovhcom/fluent-bit
         imagePullPolicy: Always
         ports:
           - containerPort: 2020

--- a/pages/platform/logs-data-platform/kubernetes_fluent_bit/guide.fr-fr.md
+++ b/pages/platform/logs-data-platform/kubernetes_fluent_bit/guide.fr-fr.md
@@ -289,7 +289,7 @@ In this file you must specify the address of your cluster (here **gra2.logs.ovh.
 
 Upload this file with the following command:
 ```shell-session 
-$ kubectl create -f fluent-bit-configmap.yaml
+$ kubectl create -f fluent-bit-ds.yaml
 ```
 
 Verify that the pods are running correctly with the command: 

--- a/pages/platform/logs-data-platform/kubernetes_fluent_bit/guide.fr-fr.md
+++ b/pages/platform/logs-data-platform/kubernetes_fluent_bit/guide.fr-fr.md
@@ -241,7 +241,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit:1.3
+        image: ovhcom/fluent-bit
         imagePullPolicy: Always
         ports:
           - containerPort: 2020


### PR DESCRIPTION
Hello,

Some customers warned us that the docker image used in the tutorial doesn't exist.
We decided to push our own docker image because fluent-bit didn't release all fixes we need for now. We'll move back to the official image when the next version will be deployed.

Thomas