### PR TITLE
FIX: TLS Options "peer-verify" value

### DIFF
--- a/pages/platform/logs-data-platform/how_to_log_your_linux/guide.fr-fr.md
+++ b/pages/platform/logs-data-platform/how_to_log_your_linux/guide.fr-fr.md
@@ -91,7 +91,10 @@ destination ovhPaaSLogs {
         template(ovhTemplate),
         ts_format("iso"),
         transport("tls"),
-        tls(peer-verify("require-trusted") ca_dir("/etc/ssl/certs/")),
+        tls(
+            peer-verify("required-trusted") 
+            ca_dir("/etc/ssl/certs/")
+        ),
         keep-alive(yes),
         so_keepalive(yes),
     );


### PR DESCRIPTION
As I followed this tutorial, I struggled at starting syslog-ng with this error:

    Oct 14 12:34:39 carbon syslog-ng[19287]: Error parsing afsocket, unknown peer-verify() argument in /etc/syslog-ng/conf.d/ldp.conf:22:43-22:44:
    Oct 14 12:34:39 carbon syslog-ng[19287]: 17              template(ovhTemplate),
    Oct 14 12:34:39 carbon syslog-ng[19287]: 18              ts_format("iso"),
    Oct 14 12:34:39 carbon syslog-ng[19287]: 19              transport("tls"),
    Oct 14 12:34:39 carbon syslog-ng[19287]: 20              tls(
    Oct 14 12:34:39 carbon syslog-ng[19287]: 21                   ca_dir("/etc/ssl/certs/")
    Oct 14 12:34:39 carbon syslog-ng[19287]: 22---->              peer-verify("require-trusted")
    Oct 14 12:34:39 carbon syslog-ng[19287]: 22---->                                           ^
    Oct 14 12:34:39 carbon syslog-ng[19287]: 23              ),
    Oct 14 12:34:39 carbon syslog-ng[19287]: 24              keep-alive(yes),
    Oct 14 12:34:39 carbon syslog-ng[19287]: 25              so_keepalive(yes),
    Oct 14 12:34:39 carbon syslog-ng[19287]: 26          );
    Oct 14 12:34:39 carbon syslog-ng[19287]: 27      };
    Oct 14 12:34:39 carbon syslog-ng[19287]: Included from /etc/syslog-ng/syslog-ng.conf:162:1-162:1:
    Oct 14 12:34:39 carbon systemd[1]: syslog-ng.service: Main process exited, code=exited, status=1/FAILURE

It took me a some time to figure out that "require-trusted" is not a valid option for peer-verify. 
The right value is "required-truste**d**" (with a d ate end of 'required').
Here is the syslog-ng doc I referred to fix: https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.16/administration-guide/56#TOPIC-956599
