### PR TITLE
Precision about region name case in the aws config

### DIFF
--- a/pages/platform/public-cloud/starting_with_swift_s3api/guide.en-gb.md
+++ b/pages/platform/public-cloud/starting_with_swift_s3api/guide.en-gb.md
@@ -104,12 +104,12 @@ endpoint = awscli_plugin_endpoint
 [profile default]
 aws_access_key_id = <access fetched in previous step>
 aws_secret_access_key = <secret fetched in previous step>
-region = <public cloud region without digit>
+region = <public cloud region without digit in upper case>
 s3 =
-  endpoint_url = https://storage.<public cloud region without digit>.cloud.ovh.net
+  endpoint_url = https://storage.<public cloud region without digit in lower case>.cloud.ovh.net
   signature_version = s3v4
 s3api =
-  endpoint_url = https://storage.<public cloud region without digit>.cloud.ovh.net
+  endpoint_url = https://storage.<public cloud region without digit in lower case>.cloud.ovh.net
 ```
 
 ## Use aws client


### PR DESCRIPTION
aws cli not work with a region in lower case