### PR TITLE
Updates of platform/kubernetes-k8s documentations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ All docs appear on <https://docs.ovh.com>.
 
 ### Pull requests and commit form
 
-The contributions should be done using GitHub Pull Requests on **develop** branch only. We use a standard form for all commits : <Language - Type of change (Add / Update) - Directory name>. For example : FR Update Change email password. Product shortcut can be added if relevant.
-
+The contributions should be done using GitHub Pull Requests on **develop** branch only. We use a standard form for all commits : `<Language - Type of change (Add / Update) - Directory name>`.  
+For example : FR Update Change email password. Product shortcut can be added if relevant.
 
 ### Pull Request Reviews
 
@@ -21,7 +21,6 @@ All pull requests are reviewed by our Technical Copywriter team to ensure that o
 Once validated by our reviewers, the request will be merged and the updated doc will be online. If online version doesn't suit to what you wanted when you applied, feel free to tell us.
 
 Our team will do his best to answer and deal with your request as fast as possible but don't forget that all requests are reviewed and it takes time.
-
 
 ### License appliance
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
@@ -6,7 +6,7 @@ section: Technical resources
 ---
 
 
-**Last updated 29<sup>th</sup> July, 2019.**
+**Last updated November 19<sup>th</sup>, 2019.**
 
 <style>
  pre {
@@ -49,6 +49,10 @@ There is also a limit of 10 open ports on every `LoadBalancer`, and these ports 
 ## OpenStack
 
 Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVH Public Cloud. As such, you can see them in the *Servers* section of [OVH Cloud Manager](https://www.ovh.com/manager/cloud/). It doesn't mean that you can deal directly with these nodes and persistent volumes as other cloud instances. The *managed* part of OVHcloud Managed Kubernetes means that we have configured those nodes and volumes to be part of our Managed Kubernetes. Please refrain from manipulating them from the *OVH Cloud Manager* (modifying ports left opened, renaming, resizing volumes...), as you could break them.
+
+### Node naming
+
+Due to known limitations currently present in the `Kubelet` service, be carefull to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
 
 ## Ports
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
@@ -52,7 +52,7 @@ Our Managed Kubernetes service is based on OpenStack, and your nodes and persist
 
 ### Node naming
 
-Due to known limitations currently present in the `Kubelet` service, be carefull to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
+Due to known limitations currently present in the `Kubelet` service, be careful to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
 
 ## Ports
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
@@ -58,13 +58,17 @@ Due to known limitations currently present in the `Kubelet` service, be careful 
 
 In any case, there are some ports that you shouldn't block on your instances if you want to keep your OVHcloud Managed Kubernetes service running:
 
-### Ports to open from public network
+### Ports to open from public network (INPUT)
 
 - TCP Port 22 (*ssh*): needed for nodes management by OVH
 - TCP Port 10250 (*kubelet*): needed for [communication from apiserver to worker nodes](https://kubernetes.io/docs/concepts/architecture/master-node-communication/#apiserver-to-kubelet)
 - TCP Ports from 30000 to 32767 (*NodePort* services port range): needed for [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) and [LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) services
 
-### Ports to open from others worker nodes
+### Ports to open from instances to public network (OUTPUT)
+
+- TCP Port 8090 (*internal service*): needed for nodes management by OVH
+
+### Ports to open from others worker nodes (INPUT/OUPUT)
 
 - UDP Port 8472 (*flannel*): needed for communication between pods
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
@@ -6,7 +6,7 @@ section: Technical resources
 ---
 
 
-**Last updated 29<sup>th</sup> July, 2019.**
+**Last updated November 19<sup>th</sup>, 2019.**
 
 <style>
  pre {
@@ -49,6 +49,10 @@ There is also a limit of 10 open ports on every `LoadBalancer`, and these ports 
 ## OpenStack
 
 Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVH Public Cloud. As such, you can see them in the *Servers* section of [OVH Cloud Manager](https://www.ovh.com/manager/cloud/). It doesn't mean that you can deal directly with these nodes and persistent volumes as other cloud instances. The *managed* part of OVHcloud Managed Kubernetes means that we have configured those nodes and volumes to be part of our Managed Kubernetes. Please refrain from manipulating them from the *OVH Cloud Manager* (modifying ports left opened, renaming, resizing volumes...), as you could break them.
+
+### Node naming
+
+Due to known limitations currently present in the `Kubelet` service, be carefull to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
 
 ## Ports
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
@@ -52,7 +52,7 @@ Our Managed Kubernetes service is based on OpenStack, and your nodes and persist
 
 ### Node naming
 
-Due to known limitations currently present in the `Kubelet` service, be carefull to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
+Due to known limitations currently present in the `Kubelet` service, be careful to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
 
 ## Ports
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
@@ -58,13 +58,17 @@ Due to known limitations currently present in the `Kubelet` service, be careful 
 
 In any case, there are some ports that you shouldn't block on your instances if you want to keep your OVHcloud Managed Kubernetes service running:
 
-### Ports to open from public network
+### Ports to open from public network (INPUT)
 
 - TCP Port 22 (*ssh*): needed for nodes management by OVH
 - TCP Port 10250 (*kubelet*): needed for [communication from apiserver to worker nodes](https://kubernetes.io/docs/concepts/architecture/master-node-communication/#apiserver-to-kubelet)
 - TCP Ports from 30000 to 32767 (*NodePort* services port range): needed for [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) and [LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) services
 
-### Ports to open from others worker nodes
+### Ports to open from instances to public network (OUTPUT)
+
+- TCP Port 8090 (*internal service*): needed for nodes management by OVH
+
+### Ports to open from others worker nodes (INPUT/OUPUT)
 
 - UDP Port 8472 (*flannel*): needed for communication between pods
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
@@ -6,7 +6,7 @@ section: Technical resources
 ---
 
 
-**Last updated 29<sup>th</sup> July, 2019.**
+**Last updated November 19<sup>th</sup>, 2019.**
 
 <style>
  pre {
@@ -49,6 +49,10 @@ There is also a limit of 10 open ports on every `LoadBalancer`, and these ports 
 ## OpenStack
 
 Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVH Public Cloud. As such, you can see them in the *Servers* section of [OVH Cloud Manager](https://www.ovh.com/manager/cloud/). It doesn't mean that you can deal directly with these nodes and persistent volumes as other cloud instances. The *managed* part of OVHcloud Managed Kubernetes means that we have configured those nodes and volumes to be part of our Managed Kubernetes. Please refrain from manipulating them from the *OVH Cloud Manager* (modifying ports left opened, renaming, resizing volumes...), as you could break them.
+
+### Node naming
+
+Due to known limitations currently present in the `Kubelet` service, be carefull to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
 
 ## Ports
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
@@ -52,7 +52,7 @@ Our Managed Kubernetes service is based on OpenStack, and your nodes and persist
 
 ### Node naming
 
-Due to known limitations currently present in the `Kubelet` service, be carefull to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
+Due to known limitations currently present in the `Kubelet` service, be careful to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
 
 ## Ports
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
@@ -58,13 +58,17 @@ Due to known limitations currently present in the `Kubelet` service, be careful 
 
 In any case, there are some ports that you shouldn't block on your instances if you want to keep your OVHcloud Managed Kubernetes service running:
 
-### Ports to open from public network
+### Ports to open from public network (INPUT)
 
 - TCP Port 22 (*ssh*): needed for nodes management by OVH
 - TCP Port 10250 (*kubelet*): needed for [communication from apiserver to worker nodes](https://kubernetes.io/docs/concepts/architecture/master-node-communication/#apiserver-to-kubelet)
 - TCP Ports from 30000 to 32767 (*NodePort* services port range): needed for [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) and [LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) services
 
-### Ports to open from others worker nodes
+### Ports to open from instances to public network (OUTPUT)
+
+- TCP Port 8090 (*internal service*): needed for nodes management by OVH
+
+### Ports to open from others worker nodes (INPUT/OUPUT)
 
 - UDP Port 8472 (*flannel*): needed for communication between pods
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
@@ -6,7 +6,7 @@ section: Technical resources
 ---
 
 
-**Last updated 29<sup>th</sup> July, 2019.**
+**Last updated November 19<sup>th</sup>, 2019.**
 
 <style>
  pre {
@@ -49,6 +49,10 @@ There is also a limit of 10 open ports on every `LoadBalancer`, and these ports 
 ## OpenStack
 
 Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVH Public Cloud. As such, you can see them in the *Servers* section of [OVH Cloud Manager](https://www.ovh.com/manager/cloud/). It doesn't mean that you can deal directly with these nodes and persistent volumes as other cloud instances. The *managed* part of OVHcloud Managed Kubernetes means that we have configured those nodes and volumes to be part of our Managed Kubernetes. Please refrain from manipulating them from the *OVH Cloud Manager* (modifying ports left opened, renaming, resizing volumes...), as you could break them.
+
+### Node naming
+
+Due to known limitations currently present in the `Kubelet` service, be carefull to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
 
 ## Ports
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
@@ -52,7 +52,7 @@ Our Managed Kubernetes service is based on OpenStack, and your nodes and persist
 
 ### Node naming
 
-Due to known limitations currently present in the `Kubelet` service, be carefull to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
+Due to known limitations currently present in the `Kubelet` service, be careful to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
 
 ## Ports
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
@@ -58,13 +58,17 @@ Due to known limitations currently present in the `Kubelet` service, be careful 
 
 In any case, there are some ports that you shouldn't block on your instances if you want to keep your OVHcloud Managed Kubernetes service running:
 
-### Ports to open from public network
+### Ports to open from public network (INPUT)
 
 - TCP Port 22 (*ssh*): needed for nodes management by OVH
 - TCP Port 10250 (*kubelet*): needed for [communication from apiserver to worker nodes](https://kubernetes.io/docs/concepts/architecture/master-node-communication/#apiserver-to-kubelet)
 - TCP Ports from 30000 to 32767 (*NodePort* services port range): needed for [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) and [LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) services
 
-### Ports to open from others worker nodes
+### Ports to open from instances to public network (OUTPUT)
+
+- TCP Port 8090 (*internal service*): needed for nodes management by OVH
+
+### Ports to open from others worker nodes (INPUT/OUPUT)
 
 - UDP Port 8472 (*flannel*): needed for communication between pods
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
@@ -6,7 +6,7 @@ section: Technical resources
 ---
 
 
-**Last updated 29<sup>th</sup> July, 2019.**
+**Last updated November 19<sup>th</sup>, 2019.**
 
 <style>
  pre {
@@ -49,6 +49,10 @@ There is also a limit of 10 open ports on every `LoadBalancer`, and these ports 
 ## OpenStack
 
 Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVH Public Cloud. As such, you can see them in the *Servers* section of [OVH Cloud Manager](https://www.ovh.com/manager/cloud/). It doesn't mean that you can deal directly with these nodes and persistent volumes as other cloud instances. The *managed* part of OVHcloud Managed Kubernetes means that we have configured those nodes and volumes to be part of our Managed Kubernetes. Please refrain from manipulating them from the *OVH Cloud Manager* (modifying ports left opened, renaming, resizing volumes...), as you could break them.
+
+### Node naming
+
+Due to known limitations currently present in the `Kubelet` service, be carefull to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
 
 ## Ports
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
@@ -52,7 +52,7 @@ Our Managed Kubernetes service is based on OpenStack, and your nodes and persist
 
 ### Node naming
 
-Due to known limitations currently present in the `Kubelet` service, be carefull to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
+Due to known limitations currently present in the `Kubelet` service, be careful to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
 
 ## Ports
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
@@ -58,13 +58,17 @@ Due to known limitations currently present in the `Kubelet` service, be careful 
 
 In any case, there are some ports that you shouldn't block on your instances if you want to keep your OVHcloud Managed Kubernetes service running:
 
-### Ports to open from public network
+### Ports to open from public network (INPUT)
 
 - TCP Port 22 (*ssh*): needed for nodes management by OVH
 - TCP Port 10250 (*kubelet*): needed for [communication from apiserver to worker nodes](https://kubernetes.io/docs/concepts/architecture/master-node-communication/#apiserver-to-kubelet)
 - TCP Ports from 30000 to 32767 (*NodePort* services port range): needed for [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) and [LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) services
 
-### Ports to open from others worker nodes
+### Ports to open from instances to public network (OUTPUT)
+
+- TCP Port 8090 (*internal service*): needed for nodes management by OVH
+
+### Ports to open from others worker nodes (INPUT/OUPUT)
 
 - UDP Port 8472 (*flannel*): needed for communication between pods
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
@@ -6,7 +6,7 @@ section: Technical resources
 ---
 
 
-**Last updated 29<sup>th</sup> July, 2019.**
+**Last updated November 19<sup>th</sup>, 2019.**
 
 <style>
  pre {
@@ -49,6 +49,10 @@ There is also a limit of 10 open ports on every `LoadBalancer`, and these ports 
 ## OpenStack
 
 Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVH Public Cloud. As such, you can see them in the *Servers* section of [OVH Cloud Manager](https://www.ovh.com/manager/cloud/). It doesn't mean that you can deal directly with these nodes and persistent volumes as other cloud instances. The *managed* part of OVHcloud Managed Kubernetes means that we have configured those nodes and volumes to be part of our Managed Kubernetes. Please refrain from manipulating them from the *OVH Cloud Manager* (modifying ports left opened, renaming, resizing volumes...), as you could break them.
+
+### Node naming
+
+Due to known limitations currently present in the `Kubelet` service, be carefull to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
 
 ## Ports
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
@@ -52,7 +52,7 @@ Our Managed Kubernetes service is based on OpenStack, and your nodes and persist
 
 ### Node naming
 
-Due to known limitations currently present in the `Kubelet` service, be carefull to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
+Due to known limitations currently present in the `Kubelet` service, be careful to set a unique name to all your Openstack instances running in your tenant __including__ your "Managed Kubernetes Service" nodes and the instances that your start directly on Openstack through manager or API.  
 
 ## Ports
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
@@ -58,13 +58,17 @@ Due to known limitations currently present in the `Kubelet` service, be careful 
 
 In any case, there are some ports that you shouldn't block on your instances if you want to keep your OVHcloud Managed Kubernetes service running:
 
-### Ports to open from public network
+### Ports to open from public network (INPUT)
 
 - TCP Port 22 (*ssh*): needed for nodes management by OVH
 - TCP Port 10250 (*kubelet*): needed for [communication from apiserver to worker nodes](https://kubernetes.io/docs/concepts/architecture/master-node-communication/#apiserver-to-kubelet)
 - TCP Ports from 30000 to 32767 (*NodePort* services port range): needed for [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) and [LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) services
 
-### Ports to open from others worker nodes
+### Ports to open from instances to public network (OUTPUT)
+
+- TCP Port 8090 (*internal service*): needed for nodes management by OVH
+
+### Ports to open from others worker nodes (INPUT/OUPUT)
 
 - UDP Port 8472 (*flannel*): needed for communication between pods
 

--- a/readme.md
+++ b/readme.md
@@ -2,27 +2,27 @@
 
 [![Build Status](https://travis-ci.org/ovh/docs.svg?branch=develop)](https://travis-ci.org/ovh/docs)
 
-Here is all public documentation available about OVH products, in all languages. A good way to find answer to some "how to" questions about OVH products. 
+Here is all public documentation available about OVH products, in all languages. A good way to find answer to some "how to" questions about OVH products.
 
  A web version also exist [here](https://docs.ovh.com) ; the website and this repo are sync.
 
 This project is under active development, and new guides are added or updated on a daily basis.
 
-
 ## Built With
 
-* [Grav CMS](https://getgrav.org/) - The editor used internally to produce and manage guides 
+* [Grav CMS](https://getgrav.org/) - The editor used internally to produce and manage guides
 * [Algolia](https://www.algolia.com/) - The search engine used in docs.ovh.com
 
 ## Test it
+
 * [docs-developer-env](https://github.com/ovh/docs-developer-env) - Our developer environment over docker, to live test your guides with our theme.
-* [docs-rendering-engine](https://github.com/ovh/docs-rendering) - Our HTML templating engine based on Pelican. ISO-rendering of docs.ovh.com 
+* [docs-rendering-engine](https://github.com/ovh/docs-rendering) - Our HTML templating engine based on Pelican. ISO-rendering of docs.ovh.com
 
 ## Contributing
 
-We will be happy to take a look to your contributions. You can contribute to this project by update some existing guides, complete them or creating new one. 
+We will be happy to take a look to your contributions. You can contribute to this project by update some existing guides, complete them or creating new one.
 
-Please : 
+Please:
 
 * Verify and test every actions you describe: do not write about things you cannot test by yourself.
 * Prefer to use the English version of the Control Panel to take screenshots.


### PR DESCRIPTION
* Add information into the `Known limits` pages about node renaming in OpenStack
* Rework broken formatting in `Backing up cluster with Velero` pages
* Minor updates on `readme.md` and `CONTRIBUTING.md` files