### PR TITLE
Misleading grave accent on dashboard proxy URL and versions incompatibilities.

### DIFF
--- a/pages/platform/kubernetes-k8s/installing-kubernetes-dashboard/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/installing-kubernetes-dashboard/guide.en-gb.md
@@ -46,15 +46,29 @@ This tutorial assumes that you already have a working OVHcloud Managed Kubernete
 
 ## Deploy the Dashboard in your cluster
 
-To deploy the Dashboard, execute following command:
+According to which version of Kubernetes you are running, you have to choose the right Dashboard version to deploy in order to avoid incompbatibilities.
+
+### For Kubernetes 1.14, choose version [v2.0.0-beta1](https://github.com/kubernetes/dashboard/releases/tag/v2.0.0-beta1)
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta1/aio/deploy/recommended.yaml
+```
+
+### For Kubernetes 1.15, choose version [v2.0.0-beta4](https://github.com/kubernetes/dashboard/releases/tag/v2.0.0-beta4)
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta4/aio/deploy/recommended.yaml
+```
+
+### For Kubernetes 1.16, choose version [v2.0.0-beta6](https://github.com/kubernetes/dashboard/releases/tag/v2.0.0-beta6)
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0-beta6/aio/deploy/recommended.yaml
 ```
 
 It should display something like this:
 
-<pre class="console"><code>$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/aio/deploy/recommended/kubernetes-dashboard.yaml
+<pre class="console"><code>
 secret/kubernetes-dashboard-certs created
 serviceaccount/kubernetes-dashboard created
 role.rbac.authorization.k8s.io/kubernetes-dashboard-minimal created

--- a/pages/platform/kubernetes-k8s/installing-kubernetes-dashboard/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/installing-kubernetes-dashboard/guide.en-gb.md
@@ -171,7 +171,7 @@ Starting to serve on 127.0.0.1:8001
 Next, access the Dashboard at:
 
 ```
-http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/`
+http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/
 ```
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.

--- a/pages/platform/kubernetes-k8s/installing-kubernetes-dashboard/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/installing-kubernetes-dashboard/guide.en-gb.md
@@ -46,7 +46,7 @@ This tutorial assumes that you already have a working OVHcloud Managed Kubernete
 
 ## Deploy the Dashboard in your cluster
 
-According to which version of Kubernetes you are running, you have to choose the right Dashboard version to deploy in order to avoid incompbatibilities.
+According to which version of Kubernetes you are running, you have to choose the right Dashboard version to deploy in order to avoid incompatibilities.
 
 ### For Kubernetes 1.14, choose version [v2.0.0-beta1](https://github.com/kubernetes/dashboard/releases/tag/v2.0.0-beta1)
 


### PR DESCRIPTION
There is a misleading grave accent (`) at the end of the dashboard local URL that results in a missing page while requestes through copy-paste.