### PR TITLE
EN fixing deadlink in two guides.

### DIFF
--- a/pages/platform/public-cloud/how_to_use_terraform/guide.en-gb.md
+++ b/pages/platform/public-cloud/how_to_use_terraform/guide.en-gb.md
@@ -15,7 +15,7 @@ OpenStack is a cloud operating system open source for creating public and privat
 ### Prerequisites
 - An OpenStack user
 - OpenStack environment variables
-- [Your OVH API identifiers and OVH authorisation key](https://eu.api.ovh.com/g934.first_step_with_api){.external}
+- [Your OVH API identifiers and OVH authorisation key](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api/){.external}
 - [An SSH key](../guide.en-gb.md){.ref}
 - [Terraform executable](https://www.terraform.io/intro/getting-started/install.html){.external}
 - [OpenStack executables](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux_OpenStack_Platform/4/html/End_User_Guide/install_clients.html){.external}

--- a/pages/platform/public-cloud/how_to_use_terraform/guide.fr-fr.md
+++ b/pages/platform/public-cloud/how_to_use_terraform/guide.fr-fr.md
@@ -15,7 +15,7 @@ OpenStack est un système d'exploitation de cloud open source pour créer des in
 ### Prérequis
 - [Un utilisateur OpenStack](https://docs.ovh.com/fr/public-cloud/creation-et-suppression-dun-utilisateur-openstack/){.external}
 - [Les variables d'environnement OpenStack](https://docs.ovh.com/fr/public-cloud/charger-les-variables-denvironnement-openstack/){.external}
-- [Vos identifiants API et clés d'autorisations OVH](https://eu.api.ovh.com/g934.first_step_with_api){.external}
+- [Vos identifiants API et clés d'autorisations OVH](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api/){.external}
 - [Une clé SSH](https://docs.ovh.com/fr/public-cloud/creation-des-cles-ssh/){.external}
 - [L'exécutable Terraform](https://www.terraform.io/intro/getting-started/install.html){.external}
 - [Les clients OpenStack (nova, glance)](https://github.com/openstack/python-openstackclient){.external}

--- a/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.en-asia.md
+++ b/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.en-asia.md
@@ -20,7 +20,7 @@ Beyond converting images, the purpose of this guide is to show how FPGA cards wo
 
 - an OpenStack user account
 - set up the [OpenStack environment variables](https://docs.ovh.com/asia/en/public-cloud/deploy-infrastructure-with-variables-and-formatted-outputs-openstack-heat/){.external}
-- [API credentials and your OVH authorisation keys](https://eu.api.ovh.com/g934.first_step_with_api){.external}
+- [API credentials and your OVH authorisation keys](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api){.external}
 - [an SSH key](https://docs.ovh.com/au/en/public-cloud/create-ssh-keys/){.external}
 - [the OpenStack client installed](https://github.com/openstack/python-openstackclient){.external}
 - [FPGA beta in Public Cloud](https://labs.ovh.com/fpga-accelerators-on-public-cloud){.external} registration

--- a/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.en-au.md
+++ b/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.en-au.md
@@ -20,7 +20,7 @@ Beyond converting images, the purpose of this guide is to show how FPGA cards wo
 
 - an OpenStack user account
 - set up the [OpenStack environment variables](https://docs.ovh.com/au/en/public-cloud/deploy-infrastructure-with-variables-and-formatted-outputs-openstack-heat/){.external}
-- [API credentials and your OVH authorisation keys](https://eu.api.ovh.com/g934.first_step_with_api){.external}
+- [API credentials and your OVH authorisation keys](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api){.external}
 - [an SSH key](https://docs.ovh.com/au/en/public-cloud/create-ssh-keys/){.external}
 - [the OpenStack client installed](https://github.com/openstack/python-openstackclient){.external}
 - [FPGA beta in Public Cloud](https://labs.ovh.com/fpga-accelerators-on-public-cloud){.external} registration

--- a/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.en-ca.md
+++ b/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.en-ca.md
@@ -20,7 +20,7 @@ Beyond converting images, the purpose of this guide is to show how FPGA cards wo
 
 - an OpenStack user account
 - set up the [OpenStack environment variables](https://docs.ovh.com/ca/en/public-cloud/deploy-infrastructure-with-variables-and-formatted-outputs-openstack-heat/){.external}
-- [API credentials and your OVH authorisation keys](https://eu.api.ovh.com/g934.first_step_with_api){.external}
+- [API credentials and your OVH authorisation keys](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api){.external}
 - [an SSH key](https://docs.ovh.com/gb/en/public-cloud/create-ssh-keys/){.external}
 - [the OpenStack client installed](https://github.com/openstack/python-openstackclient){.external}
 - [FPGA beta in Public Cloud](https://labs.ovh.com/fpga-accelerators-on-public-cloud){.external} registration

--- a/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.en-gb.md
+++ b/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.en-gb.md
@@ -20,7 +20,7 @@ Beyond converting images, the purpose of this guide is to show how FPGA cards wo
 
 - an OpenStack user account
 - set up the [OpenStack environment variables](https://docs.ovh.com/gb/en/public-cloud/deploy-infrastructure-with-variables-and-formatted-outputs-openstack-heat/){.external}
-- [API credentials and your OVH authorisation keys](https://eu.api.ovh.com/g934.first_step_with_api){.external}
+- [API credentials and your OVH authorisation keys](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api){.external}
 - [an SSH key](https://docs.ovh.com/gb/en/public-cloud/create-ssh-keys/){.external}
 - [the OpenStack client installed](https://github.com/openstack/python-openstackclient){.external}
 - [FPGA beta in Public Cloud](https://labs.ovh.com/fpga-accelerators-on-public-cloud){.external} registration

--- a/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.en-ie.md
+++ b/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.en-ie.md
@@ -20,7 +20,7 @@ Beyond converting images, the purpose of this guide is to show how FPGA cards wo
 
 - an OpenStack user account
 - set up the [OpenStack environment variables](https://docs.ovh.com/ie/en/public-cloud/deploy-infrastructure-with-variables-and-formatted-outputs-openstack-heat/){.external}
-- [API credentials and your OVH authorisation keys](https://eu.api.ovh.com/g934.first_step_with_api){.external}
+- [API credentials and your OVH authorisation keys](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api){.external}
 - [an SSH key](https://docs.ovh.com/gb/en/public-cloud/create-ssh-keys/){.external}
 - [the OpenStack client installed](https://github.com/openstack/python-openstackclient){.external}
 - [FPGA beta in Public Cloud](https://labs.ovh.com/fpga-accelerators-on-public-cloud){.external} registration

--- a/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.en-sg.md
+++ b/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.en-sg.md
@@ -20,7 +20,7 @@ Beyond converting images, the purpose of this guide is to show how FPGA cards wo
 
 - an OpenStack user account
 - set up the [OpenStack environment variables](https://docs.ovh.com/sg/en/public-cloud/deploy-infrastructure-with-variables-and-formatted-outputs-openstack-heat/){.external}
-- [API credentials and your OVH authorisation keys](https://eu.api.ovh.com/g934.first_step_with_api){.external}
+- [API credentials and your OVH authorisation keys](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api){.external}
 - [an SSH key](https://docs.ovh.com/au/en/public-cloud/create-ssh-keys/){.external}
 - [the OpenStack client installed](https://github.com/openstack/python-openstackclient){.external}
 - [FPGA beta in Public Cloud](https://labs.ovh.com/fpga-accelerators-on-public-cloud){.external} registration

--- a/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.fr-ca.md
+++ b/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.fr-ca.md
@@ -20,7 +20,7 @@ Au-delà de la conversion d'images, l'intérêt de ce guide est de montrer le fo
 
 - Avoir créé [un utilisateur OpenStack](https://docs.ovh.com/fr/public-cloud/creation-et-suppression-dun-utilisateur-openstack/){.external}.
 - Avoir mis en place [les variables d'environnement OpenStack](https://docs.ovh.com/fr/public-cloud/charger-les-variables-denvironnement-openstack/){.external}.
-- Avoir généré [vos identifiants API et les clés d'autorisation OVH](https://eu.api.ovh.com/g934.first_step_with_api){.external}.
+- Avoir généré [vos identifiants API et les clés d'autorisation OVH](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api){.external}.
 - [Posséder une clé SSH](https://docs.ovh.com/fr/public-cloud/creation-des-cles-ssh/){.external}.
 - [Avoir installé le client OpenStack](https://github.com/openstack/python-openstackclient){.external}.
 - Être inscrit à la [bêta FPGA sur Public Cloud](https://labs.ovh.com/fpga-accelerators-on-public-cloud){.external}.

--- a/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.fr-fr.md
+++ b/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.fr-fr.md
@@ -20,7 +20,7 @@ Au-delà de la conversion d'images, l'intérêt de ce guide est de montrer le fo
 
 - Avoir créé [un utilisateur OpenStack](https://docs.ovh.com/fr/public-cloud/creation-et-suppression-dun-utilisateur-openstack/){.external}.
 - Avoir mis en place [les variables d'environnement OpenStack](https://docs.ovh.com/fr/public-cloud/charger-les-variables-denvironnement-openstack/){.external}.
-- Avoir généré [vos identifiants API et les clés d'autorisation OVH](https://eu.api.ovh.com/g934.first_step_with_api){.external}.
+- Avoir généré [vos identifiants API et les clés d'autorisation OVH](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api){.external}.
 - [Posséder une clé SSH](https://docs.ovh.com/fr/public-cloud/creation-des-cles-ssh/){.external}.
 - [Avoir installé le client OpenStack](https://github.com/openstack/python-openstackclient){.external}.
 - Être inscrit à la [bêta FPGA sur Public Cloud](https://labs.ovh.com/fpga-accelerators-on-public-cloud){.external}.

--- a/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.lt-lt.md
+++ b/pages/platform/public-cloud/use-fpga-conversion-bmp-jpg/guide.lt-lt.md
@@ -20,7 +20,7 @@ Beyond converting images, the purpose of this guide is to show how FPGA cards wo
 
 - an OpenStack user account
 - set up the [OpenStack environment variables](https://docs.ovh.com/lt/public-cloud/deploy-infrastructure-with-variables-and-formatted-outputs-openstack-heat/){.external}
-- [API credentials and your OVH authorisation keys](https://eu.api.ovh.com/g934.first_step_with_api){.external}
+- [API credentials and your OVH authorisation keys](https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api){.external}
 - [an SSH key](https://docs.ovh.com/gb/en/public-cloud/create-ssh-keys/){.external}
 - [the OpenStack client installed](https://github.com/openstack/python-openstackclient){.external}
 - [FPGA beta in Public Cloud](https://labs.ovh.com/fpga-accelerators-on-public-cloud){.external} registration


### PR DESCRIPTION
Replacing this:
https://eu.api.ovh.com/g934.first_step_with_api

By this:
https://docs.ovh.com/gb/en/customer/first-steps-with-ovh-api

New link exists only in english for now.