### PR TITLE
Update k8s persistent volumes examples with Cinder csi

### DIFF
--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-asia.md
@@ -27,7 +27,7 @@ section: Tutorials
  }
 </style>
 
-**Last updated 1<sup>st</sup> July, 2019.**
+**Last updated 6<sup>th</sup> January, 2020.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -49,7 +49,7 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).
 
-Let's begin by creating a `mysql-pvc.yaml` to define an initial PVC with 2 GB of allotted space:
+Let's begin by creating a `mysql-pvc.yaml` to define an initial PVC with 2 GB of allocated space:
 
 ```yaml
 apiVersion: v1
@@ -57,7 +57,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: mysql-pv-claim
 spec:
-  storageClassName: cinder-high-speed
   accessModes:
     - ReadWriteOnce
   resources:
@@ -141,24 +140,26 @@ persistentvolumeclaim/mysql-pv-claim created
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
 Capacity:      2Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
+Mounted By:    mysql-c85f7f79c-wz4w7
 Events:
-  Type       Reason                 Age   From                         Message
-  ----       ------                 ----  ----                         -------
-  Normal     ProvisioningSucceeded  13m   persistentvolume-controller  Successfully provisioned volume pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33 using kubernetes.io/cinder
-Mounted By:  mysql-799956477c-kbshn
+  Type    Reason                 Age                From                                                                                         Message
+  ----    ------                 ----               ----                                                                                         -------
+  Normal  ExternalProvisioning   72s (x2 over 72s)  persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal  Provisioning           72s                cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal  ProvisioningSucceeded  70s                cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 
 $ kubectl apply -f mysql/mysql-deployment.yaml 
 service/mysql created
@@ -167,7 +168,7 @@ deployment.apps/mysql created
 $ kubectl describe deployment mysql
 Name:               mysql
 Namespace:          default
-CreationTimestamp:  Wed, 29 May 2019 11:49:06 +0200
+CreationTimestamp:  Mon, 06 Jan 2020 11:45:03 +0100
 Labels:             &lt;none>
 Annotations:        deployment.kubernetes.io/revision: 1
                     kubectl.kubernetes.io/last-applied-configuration:
@@ -198,12 +199,11 @@ Conditions:
   Available      True    MinimumReplicasAvailable
   Progressing    True    NewReplicaSetAvailable
 OldReplicaSets:  &lt;none>
-NewReplicaSet:   mysql-799956477c (1/1 replicas created)
+NewReplicaSet:   mysql-c85f7f79c (1/1 replicas created)
 Events:
-  Type    Reason             Age    From                   Message
-  ----    ------             ----   ----                   -------
-  Normal  ScalingReplicaSet  3m45s  deployment-controller  Scaled up replica set mysql-799956477c to 1
-
+  Type    Reason             Age   From                   Message
+  ----    ------             ----  ----                   -------
+  Normal  ScalingReplicaSet  27s   deployment-controller  Scaled up replica set mysql-c85f7f79c to 1
 </code></pre>
 
 
@@ -282,7 +282,7 @@ We verify that the volume has been expanded:
 kubectl describe pvc mysql-pv-claim
 ```
 
-We will get a message that the PVC is waiting for user to start a pod to finish file system resize of the volume.
+In the "conditions" field shown by the output of the previous command line, we can see that the PVC is waiting for user to start a pod to finish file system resize of the volume.
 Let's put `replicas` back to `1` on `mysql-deployment.yaml`, and deploy it again to start a pod:
 
 ```bash
@@ -308,25 +308,32 @@ persistentvolumeclaim/mysql-pv-claim patched
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
-Capacity:      4Gi
+Capacity:      2Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
+Mounted By:    &lt;none>
 Conditions:
   Type                      Status  LastProbeTime                     LastTransitionTime                Reason  Message
   ----                      ------  -----------------                 ------------------                ------  -------
-  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Wed, 29 May 2019 15:50:37 +0200           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
-Events:                     &lt;none>
-Mounted By:                 &lt;none>
+  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Mon, 06 Jan 2020 11:47:22 +0100           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
+Events:
+  Type     Reason                 Age                    From                                                                                         Message
+  ----     ------                 ----                   ----                                                                                         -------
+  Normal   ExternalProvisioning   2m27s (x2 over 2m27s)  persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal   Provisioning           2m27s                  cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal   ProvisioningSucceeded  2m25s                  cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   Resizing                  9s (x9 over 13s)  external-resizer cinder.csi.openstack.org  External resizer is resizing volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   FileSystemResizeRequired  8s                external-resizer cinder.csi.openstack.org  Require file system resize of volume on node
 
 $ kubectl patch deployment mysql -p '{ "spec": { "replicas": 1 }}'
 deployment.extensions/mysql patched
@@ -342,21 +349,28 @@ mysql   1/1     1            1           4h4m
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
 Capacity:      6Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
-Events:        &lt;none>
-Mounted By:    mysql-799956477c-bj5m5
+Mounted By:    mysql-c85f7f79c-9nn8q
+Events:
+  Type     Reason                 Age                    From                                                                                         Message
+  ----     ------                 ----                   ----                                                                                         -------
+  Normal   ExternalProvisioning   8m8s (x2 over 8m8s)    persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal   Provisioning           8m8s                   cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal   ProvisioningSucceeded  8m6s                   cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   Resizing                  5m50s (x9 over 5m54s)  external-resizer cinder.csi.openstack.org  External resizer is resizing volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   FileSystemResizeRequired  5m49s                  external-resizer cinder.csi.openstack.org  Require file system resize of volume on node
 </code></pre>
 
 

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-au.md
@@ -27,7 +27,7 @@ section: Tutorials
  }
 </style>
 
-**Last updated 1<sup>st</sup> July, 2019.**
+**Last updated 6<sup>th</sup> January, 2020.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -49,7 +49,7 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).
 
-Let's begin by creating a `mysql-pvc.yaml` to define an initial PVC with 2 GB of allotted space:
+Let's begin by creating a `mysql-pvc.yaml` to define an initial PVC with 2 GB of allocated space:
 
 ```yaml
 apiVersion: v1
@@ -57,7 +57,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: mysql-pv-claim
 spec:
-  storageClassName: cinder-high-speed
   accessModes:
     - ReadWriteOnce
   resources:
@@ -141,24 +140,26 @@ persistentvolumeclaim/mysql-pv-claim created
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
 Capacity:      2Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
+Mounted By:    mysql-c85f7f79c-wz4w7
 Events:
-  Type       Reason                 Age   From                         Message
-  ----       ------                 ----  ----                         -------
-  Normal     ProvisioningSucceeded  13m   persistentvolume-controller  Successfully provisioned volume pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33 using kubernetes.io/cinder
-Mounted By:  mysql-799956477c-kbshn
+  Type    Reason                 Age                From                                                                                         Message
+  ----    ------                 ----               ----                                                                                         -------
+  Normal  ExternalProvisioning   72s (x2 over 72s)  persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal  Provisioning           72s                cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal  ProvisioningSucceeded  70s                cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 
 $ kubectl apply -f mysql/mysql-deployment.yaml 
 service/mysql created
@@ -167,7 +168,7 @@ deployment.apps/mysql created
 $ kubectl describe deployment mysql
 Name:               mysql
 Namespace:          default
-CreationTimestamp:  Wed, 29 May 2019 11:49:06 +0200
+CreationTimestamp:  Mon, 06 Jan 2020 11:45:03 +0100
 Labels:             &lt;none>
 Annotations:        deployment.kubernetes.io/revision: 1
                     kubectl.kubernetes.io/last-applied-configuration:
@@ -198,12 +199,11 @@ Conditions:
   Available      True    MinimumReplicasAvailable
   Progressing    True    NewReplicaSetAvailable
 OldReplicaSets:  &lt;none>
-NewReplicaSet:   mysql-799956477c (1/1 replicas created)
+NewReplicaSet:   mysql-c85f7f79c (1/1 replicas created)
 Events:
-  Type    Reason             Age    From                   Message
-  ----    ------             ----   ----                   -------
-  Normal  ScalingReplicaSet  3m45s  deployment-controller  Scaled up replica set mysql-799956477c to 1
-
+  Type    Reason             Age   From                   Message
+  ----    ------             ----  ----                   -------
+  Normal  ScalingReplicaSet  27s   deployment-controller  Scaled up replica set mysql-c85f7f79c to 1
 </code></pre>
 
 
@@ -282,7 +282,7 @@ We verify that the volume has been expanded:
 kubectl describe pvc mysql-pv-claim
 ```
 
-We will get a message that the PVC is waiting for user to start a pod to finish file system resize of the volume.
+In the "conditions" field shown by the output of the previous command line, we can see that the PVC is waiting for user to start a pod to finish file system resize of the volume.
 Let's put `replicas` back to `1` on `mysql-deployment.yaml`, and deploy it again to start a pod:
 
 ```bash
@@ -308,25 +308,32 @@ persistentvolumeclaim/mysql-pv-claim patched
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
-Capacity:      4Gi
+Capacity:      2Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
+Mounted By:    &lt;none>
 Conditions:
   Type                      Status  LastProbeTime                     LastTransitionTime                Reason  Message
   ----                      ------  -----------------                 ------------------                ------  -------
-  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Wed, 29 May 2019 15:50:37 +0200           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
-Events:                     &lt;none>
-Mounted By:                 &lt;none>
+  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Mon, 06 Jan 2020 11:47:22 +0100           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
+Events:
+  Type     Reason                 Age                    From                                                                                         Message
+  ----     ------                 ----                   ----                                                                                         -------
+  Normal   ExternalProvisioning   2m27s (x2 over 2m27s)  persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal   Provisioning           2m27s                  cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal   ProvisioningSucceeded  2m25s                  cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   Resizing                  9s (x9 over 13s)  external-resizer cinder.csi.openstack.org  External resizer is resizing volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   FileSystemResizeRequired  8s                external-resizer cinder.csi.openstack.org  Require file system resize of volume on node
 
 $ kubectl patch deployment mysql -p '{ "spec": { "replicas": 1 }}'
 deployment.extensions/mysql patched
@@ -342,21 +349,28 @@ mysql   1/1     1            1           4h4m
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
 Capacity:      6Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
-Events:        &lt;none>
-Mounted By:    mysql-799956477c-bj5m5
+Mounted By:    mysql-c85f7f79c-9nn8q
+Events:
+  Type     Reason                 Age                    From                                                                                         Message
+  ----     ------                 ----                   ----                                                                                         -------
+  Normal   ExternalProvisioning   8m8s (x2 over 8m8s)    persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal   Provisioning           8m8s                   cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal   ProvisioningSucceeded  8m6s                   cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   Resizing                  5m50s (x9 over 5m54s)  external-resizer cinder.csi.openstack.org  External resizer is resizing volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   FileSystemResizeRequired  5m49s                  external-resizer cinder.csi.openstack.org  Require file system resize of volume on node
 </code></pre>
 
 

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-ca.md
@@ -27,7 +27,7 @@ section: Tutorials
  }
 </style>
 
-**Last updated 1<sup>st</sup> July, 2019.**
+**Last updated 6<sup>th</sup> January, 2020.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -49,7 +49,7 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).
 
-Let's begin by creating a `mysql-pvc.yaml` to define an initial PVC with 2 GB of allotted space:
+Let's begin by creating a `mysql-pvc.yaml` to define an initial PVC with 2 GB of allocated space:
 
 ```yaml
 apiVersion: v1
@@ -57,7 +57,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: mysql-pv-claim
 spec:
-  storageClassName: cinder-high-speed
   accessModes:
     - ReadWriteOnce
   resources:
@@ -141,24 +140,26 @@ persistentvolumeclaim/mysql-pv-claim created
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
 Capacity:      2Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
+Mounted By:    mysql-c85f7f79c-wz4w7
 Events:
-  Type       Reason                 Age   From                         Message
-  ----       ------                 ----  ----                         -------
-  Normal     ProvisioningSucceeded  13m   persistentvolume-controller  Successfully provisioned volume pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33 using kubernetes.io/cinder
-Mounted By:  mysql-799956477c-kbshn
+  Type    Reason                 Age                From                                                                                         Message
+  ----    ------                 ----               ----                                                                                         -------
+  Normal  ExternalProvisioning   72s (x2 over 72s)  persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal  Provisioning           72s                cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal  ProvisioningSucceeded  70s                cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 
 $ kubectl apply -f mysql/mysql-deployment.yaml 
 service/mysql created
@@ -167,7 +168,7 @@ deployment.apps/mysql created
 $ kubectl describe deployment mysql
 Name:               mysql
 Namespace:          default
-CreationTimestamp:  Wed, 29 May 2019 11:49:06 +0200
+CreationTimestamp:  Mon, 06 Jan 2020 11:45:03 +0100
 Labels:             &lt;none>
 Annotations:        deployment.kubernetes.io/revision: 1
                     kubectl.kubernetes.io/last-applied-configuration:
@@ -198,12 +199,11 @@ Conditions:
   Available      True    MinimumReplicasAvailable
   Progressing    True    NewReplicaSetAvailable
 OldReplicaSets:  &lt;none>
-NewReplicaSet:   mysql-799956477c (1/1 replicas created)
+NewReplicaSet:   mysql-c85f7f79c (1/1 replicas created)
 Events:
-  Type    Reason             Age    From                   Message
-  ----    ------             ----   ----                   -------
-  Normal  ScalingReplicaSet  3m45s  deployment-controller  Scaled up replica set mysql-799956477c to 1
-
+  Type    Reason             Age   From                   Message
+  ----    ------             ----  ----                   -------
+  Normal  ScalingReplicaSet  27s   deployment-controller  Scaled up replica set mysql-c85f7f79c to 1
 </code></pre>
 
 
@@ -282,7 +282,7 @@ We verify that the volume has been expanded:
 kubectl describe pvc mysql-pv-claim
 ```
 
-We will get a message that the PVC is waiting for user to start a pod to finish file system resize of the volume.
+In the "conditions" field shown by the output of the previous command line, we can see that the PVC is waiting for user to start a pod to finish file system resize of the volume.
 Let's put `replicas` back to `1` on `mysql-deployment.yaml`, and deploy it again to start a pod:
 
 ```bash
@@ -308,25 +308,32 @@ persistentvolumeclaim/mysql-pv-claim patched
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
-Capacity:      4Gi
+Capacity:      2Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
+Mounted By:    &lt;none>
 Conditions:
   Type                      Status  LastProbeTime                     LastTransitionTime                Reason  Message
   ----                      ------  -----------------                 ------------------                ------  -------
-  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Wed, 29 May 2019 15:50:37 +0200           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
-Events:                     &lt;none>
-Mounted By:                 &lt;none>
+  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Mon, 06 Jan 2020 11:47:22 +0100           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
+Events:
+  Type     Reason                 Age                    From                                                                                         Message
+  ----     ------                 ----                   ----                                                                                         -------
+  Normal   ExternalProvisioning   2m27s (x2 over 2m27s)  persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal   Provisioning           2m27s                  cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal   ProvisioningSucceeded  2m25s                  cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   Resizing                  9s (x9 over 13s)  external-resizer cinder.csi.openstack.org  External resizer is resizing volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   FileSystemResizeRequired  8s                external-resizer cinder.csi.openstack.org  Require file system resize of volume on node
 
 $ kubectl patch deployment mysql -p '{ "spec": { "replicas": 1 }}'
 deployment.extensions/mysql patched
@@ -342,21 +349,28 @@ mysql   1/1     1            1           4h4m
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
 Capacity:      6Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
-Events:        &lt;none>
-Mounted By:    mysql-799956477c-bj5m5
+Mounted By:    mysql-c85f7f79c-9nn8q
+Events:
+  Type     Reason                 Age                    From                                                                                         Message
+  ----     ------                 ----                   ----                                                                                         -------
+  Normal   ExternalProvisioning   8m8s (x2 over 8m8s)    persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal   Provisioning           8m8s                   cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal   ProvisioningSucceeded  8m6s                   cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   Resizing                  5m50s (x9 over 5m54s)  external-resizer cinder.csi.openstack.org  External resizer is resizing volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   FileSystemResizeRequired  5m49s                  external-resizer cinder.csi.openstack.org  Require file system resize of volume on node
 </code></pre>
 
 

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-gb.md
@@ -27,7 +27,7 @@ section: Tutorials
  }
 </style>
 
-**Last updated 1<sup>st</sup> July, 2019.**
+**Last updated 6<sup>th</sup> January, 2020.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -49,7 +49,7 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).
 
-Let's begin by creating a `mysql-pvc.yaml` to define an initial PVC with 2 GB of allotted space:
+Let's begin by creating a `mysql-pvc.yaml` to define an initial PVC with 2 GB of allocated space:
 
 ```yaml
 apiVersion: v1
@@ -57,7 +57,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: mysql-pv-claim
 spec:
-  storageClassName: cinder-high-speed
   accessModes:
     - ReadWriteOnce
   resources:
@@ -141,24 +140,26 @@ persistentvolumeclaim/mysql-pv-claim created
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
 Capacity:      2Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
+Mounted By:    mysql-c85f7f79c-wz4w7
 Events:
-  Type       Reason                 Age   From                         Message
-  ----       ------                 ----  ----                         -------
-  Normal     ProvisioningSucceeded  13m   persistentvolume-controller  Successfully provisioned volume pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33 using kubernetes.io/cinder
-Mounted By:  mysql-799956477c-kbshn
+  Type    Reason                 Age                From                                                                                         Message
+  ----    ------                 ----               ----                                                                                         -------
+  Normal  ExternalProvisioning   72s (x2 over 72s)  persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal  Provisioning           72s                cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal  ProvisioningSucceeded  70s                cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 
 $ kubectl apply -f mysql/mysql-deployment.yaml 
 service/mysql created
@@ -167,7 +168,7 @@ deployment.apps/mysql created
 $ kubectl describe deployment mysql
 Name:               mysql
 Namespace:          default
-CreationTimestamp:  Wed, 29 May 2019 11:49:06 +0200
+CreationTimestamp:  Mon, 06 Jan 2020 11:45:03 +0100
 Labels:             &lt;none>
 Annotations:        deployment.kubernetes.io/revision: 1
                     kubectl.kubernetes.io/last-applied-configuration:
@@ -198,12 +199,11 @@ Conditions:
   Available      True    MinimumReplicasAvailable
   Progressing    True    NewReplicaSetAvailable
 OldReplicaSets:  &lt;none>
-NewReplicaSet:   mysql-799956477c (1/1 replicas created)
+NewReplicaSet:   mysql-c85f7f79c (1/1 replicas created)
 Events:
-  Type    Reason             Age    From                   Message
-  ----    ------             ----   ----                   -------
-  Normal  ScalingReplicaSet  3m45s  deployment-controller  Scaled up replica set mysql-799956477c to 1
-
+  Type    Reason             Age   From                   Message
+  ----    ------             ----  ----                   -------
+  Normal  ScalingReplicaSet  27s   deployment-controller  Scaled up replica set mysql-c85f7f79c to 1
 </code></pre>
 
 
@@ -282,7 +282,7 @@ We verify that the volume has been expanded:
 kubectl describe pvc mysql-pv-claim
 ```
 
-We will get a message that the PVC is waiting for user to start a pod to finish file system resize of the volume.
+In the "conditions" field shown by the output of the previous command line, we can see that the PVC is waiting for user to start a pod to finish file system resize of the volume.
 Let's put `replicas` back to `1` on `mysql-deployment.yaml`, and deploy it again to start a pod:
 
 ```bash
@@ -308,25 +308,32 @@ persistentvolumeclaim/mysql-pv-claim patched
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
-Capacity:      4Gi
+Capacity:      2Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
+Mounted By:    &lt;none>
 Conditions:
   Type                      Status  LastProbeTime                     LastTransitionTime                Reason  Message
   ----                      ------  -----------------                 ------------------                ------  -------
-  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Wed, 29 May 2019 15:50:37 +0200           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
-Events:                     &lt;none>
-Mounted By:                 &lt;none>
+  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Mon, 06 Jan 2020 11:47:22 +0100           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
+Events:
+  Type     Reason                 Age                    From                                                                                         Message
+  ----     ------                 ----                   ----                                                                                         -------
+  Normal   ExternalProvisioning   2m27s (x2 over 2m27s)  persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal   Provisioning           2m27s                  cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal   ProvisioningSucceeded  2m25s                  cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   Resizing                  9s (x9 over 13s)  external-resizer cinder.csi.openstack.org  External resizer is resizing volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   FileSystemResizeRequired  8s                external-resizer cinder.csi.openstack.org  Require file system resize of volume on node
 
 $ kubectl patch deployment mysql -p '{ "spec": { "replicas": 1 }}'
 deployment.extensions/mysql patched
@@ -342,21 +349,28 @@ mysql   1/1     1            1           4h4m
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
 Capacity:      6Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
-Events:        &lt;none>
-Mounted By:    mysql-799956477c-bj5m5
+Mounted By:    mysql-c85f7f79c-9nn8q
+Events:
+  Type     Reason                 Age                    From                                                                                         Message
+  ----     ------                 ----                   ----                                                                                         -------
+  Normal   ExternalProvisioning   8m8s (x2 over 8m8s)    persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal   Provisioning           8m8s                   cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal   ProvisioningSucceeded  8m6s                   cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   Resizing                  5m50s (x9 over 5m54s)  external-resizer cinder.csi.openstack.org  External resizer is resizing volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   FileSystemResizeRequired  5m49s                  external-resizer cinder.csi.openstack.org  Require file system resize of volume on node
 </code></pre>
 
 

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-ie.md
@@ -27,7 +27,7 @@ section: Tutorials
  }
 </style>
 
-**Last updated 1<sup>st</sup> July, 2019.**
+**Last updated 6<sup>th</sup> January, 2020.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -49,7 +49,7 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).
 
-Let's begin by creating a `mysql-pvc.yaml` to define an initial PVC with 2 GB of allotted space:
+Let's begin by creating a `mysql-pvc.yaml` to define an initial PVC with 2 GB of allocated space:
 
 ```yaml
 apiVersion: v1
@@ -57,7 +57,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: mysql-pv-claim
 spec:
-  storageClassName: cinder-high-speed
   accessModes:
     - ReadWriteOnce
   resources:
@@ -141,24 +140,26 @@ persistentvolumeclaim/mysql-pv-claim created
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
 Capacity:      2Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
+Mounted By:    mysql-c85f7f79c-wz4w7
 Events:
-  Type       Reason                 Age   From                         Message
-  ----       ------                 ----  ----                         -------
-  Normal     ProvisioningSucceeded  13m   persistentvolume-controller  Successfully provisioned volume pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33 using kubernetes.io/cinder
-Mounted By:  mysql-799956477c-kbshn
+  Type    Reason                 Age                From                                                                                         Message
+  ----    ------                 ----               ----                                                                                         -------
+  Normal  ExternalProvisioning   72s (x2 over 72s)  persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal  Provisioning           72s                cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal  ProvisioningSucceeded  70s                cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 
 $ kubectl apply -f mysql/mysql-deployment.yaml 
 service/mysql created
@@ -167,7 +168,7 @@ deployment.apps/mysql created
 $ kubectl describe deployment mysql
 Name:               mysql
 Namespace:          default
-CreationTimestamp:  Wed, 29 May 2019 11:49:06 +0200
+CreationTimestamp:  Mon, 06 Jan 2020 11:45:03 +0100
 Labels:             &lt;none>
 Annotations:        deployment.kubernetes.io/revision: 1
                     kubectl.kubernetes.io/last-applied-configuration:
@@ -198,12 +199,11 @@ Conditions:
   Available      True    MinimumReplicasAvailable
   Progressing    True    NewReplicaSetAvailable
 OldReplicaSets:  &lt;none>
-NewReplicaSet:   mysql-799956477c (1/1 replicas created)
+NewReplicaSet:   mysql-c85f7f79c (1/1 replicas created)
 Events:
-  Type    Reason             Age    From                   Message
-  ----    ------             ----   ----                   -------
-  Normal  ScalingReplicaSet  3m45s  deployment-controller  Scaled up replica set mysql-799956477c to 1
-
+  Type    Reason             Age   From                   Message
+  ----    ------             ----  ----                   -------
+  Normal  ScalingReplicaSet  27s   deployment-controller  Scaled up replica set mysql-c85f7f79c to 1
 </code></pre>
 
 
@@ -282,7 +282,7 @@ We verify that the volume has been expanded:
 kubectl describe pvc mysql-pv-claim
 ```
 
-We will get a message that the PVC is waiting for user to start a pod to finish file system resize of the volume.
+In the "conditions" field shown by the output of the previous command line, we can see that the PVC is waiting for user to start a pod to finish file system resize of the volume.
 Let's put `replicas` back to `1` on `mysql-deployment.yaml`, and deploy it again to start a pod:
 
 ```bash
@@ -308,25 +308,32 @@ persistentvolumeclaim/mysql-pv-claim patched
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
-Capacity:      4Gi
+Capacity:      2Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
+Mounted By:    &lt;none>
 Conditions:
   Type                      Status  LastProbeTime                     LastTransitionTime                Reason  Message
   ----                      ------  -----------------                 ------------------                ------  -------
-  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Wed, 29 May 2019 15:50:37 +0200           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
-Events:                     &lt;none>
-Mounted By:                 &lt;none>
+  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Mon, 06 Jan 2020 11:47:22 +0100           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
+Events:
+  Type     Reason                 Age                    From                                                                                         Message
+  ----     ------                 ----                   ----                                                                                         -------
+  Normal   ExternalProvisioning   2m27s (x2 over 2m27s)  persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal   Provisioning           2m27s                  cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal   ProvisioningSucceeded  2m25s                  cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   Resizing                  9s (x9 over 13s)  external-resizer cinder.csi.openstack.org  External resizer is resizing volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   FileSystemResizeRequired  8s                external-resizer cinder.csi.openstack.org  Require file system resize of volume on node
 
 $ kubectl patch deployment mysql -p '{ "spec": { "replicas": 1 }}'
 deployment.extensions/mysql patched
@@ -342,21 +349,28 @@ mysql   1/1     1            1           4h4m
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
 Capacity:      6Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
-Events:        &lt;none>
-Mounted By:    mysql-799956477c-bj5m5
+Mounted By:    mysql-c85f7f79c-9nn8q
+Events:
+  Type     Reason                 Age                    From                                                                                         Message
+  ----     ------                 ----                   ----                                                                                         -------
+  Normal   ExternalProvisioning   8m8s (x2 over 8m8s)    persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal   Provisioning           8m8s                   cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal   ProvisioningSucceeded  8m6s                   cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   Resizing                  5m50s (x9 over 5m54s)  external-resizer cinder.csi.openstack.org  External resizer is resizing volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   FileSystemResizeRequired  5m49s                  external-resizer cinder.csi.openstack.org  Require file system resize of volume on node
 </code></pre>
 
 

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-sg.md
@@ -27,7 +27,7 @@ section: Tutorials
  }
 </style>
 
-**Last updated 1<sup>st</sup> July, 2019.**
+**Last updated 6<sup>th</sup> January, 2020.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -49,7 +49,7 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).
 
-Let's begin by creating a `mysql-pvc.yaml` to define an initial PVC with 2 GB of allotted space:
+Let's begin by creating a `mysql-pvc.yaml` to define an initial PVC with 2 GB of allocated space:
 
 ```yaml
 apiVersion: v1
@@ -57,7 +57,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: mysql-pv-claim
 spec:
-  storageClassName: cinder-high-speed
   accessModes:
     - ReadWriteOnce
   resources:
@@ -141,24 +140,26 @@ persistentvolumeclaim/mysql-pv-claim created
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
 Capacity:      2Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
+Mounted By:    mysql-c85f7f79c-wz4w7
 Events:
-  Type       Reason                 Age   From                         Message
-  ----       ------                 ----  ----                         -------
-  Normal     ProvisioningSucceeded  13m   persistentvolume-controller  Successfully provisioned volume pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33 using kubernetes.io/cinder
-Mounted By:  mysql-799956477c-kbshn
+  Type    Reason                 Age                From                                                                                         Message
+  ----    ------                 ----               ----                                                                                         -------
+  Normal  ExternalProvisioning   72s (x2 over 72s)  persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal  Provisioning           72s                cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal  ProvisioningSucceeded  70s                cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 
 $ kubectl apply -f mysql/mysql-deployment.yaml 
 service/mysql created
@@ -167,7 +168,7 @@ deployment.apps/mysql created
 $ kubectl describe deployment mysql
 Name:               mysql
 Namespace:          default
-CreationTimestamp:  Wed, 29 May 2019 11:49:06 +0200
+CreationTimestamp:  Mon, 06 Jan 2020 11:45:03 +0100
 Labels:             &lt;none>
 Annotations:        deployment.kubernetes.io/revision: 1
                     kubectl.kubernetes.io/last-applied-configuration:
@@ -198,12 +199,11 @@ Conditions:
   Available      True    MinimumReplicasAvailable
   Progressing    True    NewReplicaSetAvailable
 OldReplicaSets:  &lt;none>
-NewReplicaSet:   mysql-799956477c (1/1 replicas created)
+NewReplicaSet:   mysql-c85f7f79c (1/1 replicas created)
 Events:
-  Type    Reason             Age    From                   Message
-  ----    ------             ----   ----                   -------
-  Normal  ScalingReplicaSet  3m45s  deployment-controller  Scaled up replica set mysql-799956477c to 1
-
+  Type    Reason             Age   From                   Message
+  ----    ------             ----  ----                   -------
+  Normal  ScalingReplicaSet  27s   deployment-controller  Scaled up replica set mysql-c85f7f79c to 1
 </code></pre>
 
 
@@ -282,7 +282,7 @@ We verify that the volume has been expanded:
 kubectl describe pvc mysql-pv-claim
 ```
 
-We will get a message that the PVC is waiting for user to start a pod to finish file system resize of the volume.
+In the "conditions" field shown by the output of the previous command line, we can see that the PVC is waiting for user to start a pod to finish file system resize of the volume.
 Let's put `replicas` back to `1` on `mysql-deployment.yaml`, and deploy it again to start a pod:
 
 ```bash
@@ -308,25 +308,32 @@ persistentvolumeclaim/mysql-pv-claim patched
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
-Capacity:      4Gi
+Capacity:      2Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
+Mounted By:    &lt;none>
 Conditions:
   Type                      Status  LastProbeTime                     LastTransitionTime                Reason  Message
   ----                      ------  -----------------                 ------------------                ------  -------
-  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Wed, 29 May 2019 15:50:37 +0200           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
-Events:                     &lt;none>
-Mounted By:                 &lt;none>
+  FileSystemResizePending   True    Mon, 01 Jan 0001 00:00:00 +0000   Mon, 06 Jan 2020 11:47:22 +0100           Waiting for user to (re-)start a pod to finish file system resize of volume on node.
+Events:
+  Type     Reason                 Age                    From                                                                                         Message
+  ----     ------                 ----                   ----                                                                                         -------
+  Normal   ExternalProvisioning   2m27s (x2 over 2m27s)  persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal   Provisioning           2m27s                  cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal   ProvisioningSucceeded  2m25s                  cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   Resizing                  9s (x9 over 13s)  external-resizer cinder.csi.openstack.org  External resizer is resizing volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   FileSystemResizeRequired  8s                external-resizer cinder.csi.openstack.org  Require file system resize of volume on node
 
 $ kubectl patch deployment mysql -p '{ "spec": { "replicas": 1 }}'
 deployment.extensions/mysql patched
@@ -342,21 +349,28 @@ mysql   1/1     1            1           4h4m
 $ kubectl describe pvc mysql-pv-claim
 Name:          mysql-pv-claim
 Namespace:     default
-StorageClass:  cinder-high-speed
+StorageClass:  csi-cinder-high-speed
 Status:        Bound
-Volume:        pvc-0e5b7256-81f6-11e9-92ef-32a9d43e9f33
+Volume:        ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
 Labels:        &lt;none>
 Annotations:   kubectl.kubernetes.io/last-applied-configuration:
                  {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"mysql-pv-claim","namespace":"default"},"spec":{"acc...
                pv.kubernetes.io/bind-completed: yes
                pv.kubernetes.io/bound-by-controller: yes
-               volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/cinder
+               volume.beta.kubernetes.io/storage-provisioner: cinder.csi.openstack.org
 Finalizers:    [kubernetes.io/pvc-protection]
 Capacity:      6Gi
 Access Modes:  RWO
 VolumeMode:    Filesystem
-Events:        &lt;none>
-Mounted By:    mysql-799956477c-bj5m5
+Mounted By:    mysql-c85f7f79c-9nn8q
+Events:
+  Type     Reason                 Age                    From                                                                                         Message
+  ----     ------                 ----                   ----                                                                                         -------
+  Normal   ExternalProvisioning   8m8s (x2 over 8m8s)    persistentvolume-controller                                                                  waiting for a volume to be created, either by external provisioner "cinder.csi.openstack.org" or manually created by system administrator
+  Normal   Provisioning           8m8s                   cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  External provisioner is provisioning volume for claim "default/mysql-pv-claim"
+  Normal   ProvisioningSucceeded  8m6s                   cinder.csi.openstack.org_csi-cinder-controllerplugin-0_4da74c15-1973-486d-9dde-2ccf2f19811b  Successfully provisioned volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   Resizing                  5m50s (x9 over 5m54s)  external-resizer cinder.csi.openstack.org  External resizer is resizing volume ovh-managed-kubernetes-btw8lc-pvc-ab896768-b995-453b-85ab-4bcb378de01d
+  Normal   FileSystemResizeRequired  5m49s                  external-resizer cinder.csi.openstack.org  Require file system resize of volume on node
 </code></pre>
 
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-asia.md
@@ -5,7 +5,7 @@ excerpt: ''
 section: Tutorials
 ---
 
-**Last updated September 6<sup>th,</sup> 2019.**
+**Last updated January 6<sup>th,</sup> 2020.**
 
 <style>
  pre {
@@ -73,8 +73,11 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: cinder-high-speed
-```      
+  storageClassName: csi-cinder-high-speed
+```
+
+> [!warning]
+> For Kubernetes clusters running in versions 1.12.x, 1.13.x and 1.14.x the storageClassName should be: cinder-high-speed.
 
 And apply it to your cluster:
 
@@ -92,12 +95,14 @@ kubectl get pv
 
 <pre class="console"><code>$ kubectl apply -f test-pvc.yaml
 persistentvolumeclaim/test-pvc created
+
 $ kubectl get pvc
-NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
-test-pvc   Bound    pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            cinder-high-speed   16s
+NAME       STATUS   VOLUME                                                                   CAPACITY   ACCESS MODES   STORAGECLASS            AGE
+test-pvc   Bound    ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            csi-cinder-high-speed   5s
+
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            15s
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            15s
 </code></pre>
 
 ## Using the PVC
@@ -138,7 +143,7 @@ Namespace:          default
 Priority:           0
 PriorityClassName:  &lt;none>
 Node:               node-03/51.75.199.0
-Start Time:         Thu, 05 Sep 2019 18:14:42 +0200
+Start Time:         Mon, 06 Jan 2020 11:38:16 +0100
 Labels:             &lt;none>
 [...]
 Volumes:
@@ -151,7 +156,7 @@ Events:
   Type    Reason                  Age   From                     Message
   ----    ------                  ----  ----                     -------
   Normal  Scheduled               70s   default-scheduler        Successfully assigned default/test-pvc-pod to node-03
-  Normal  SuccessfulAttachVolume  68s   attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-8e0c9b3c-7760-41e7-b89b-cc3f8f04a735"
+  Normal  SuccessfulAttachVolume  68s   attachdetach-controller  AttachVolume.Attach succeeded for volume "ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee"
   Normal  Pulling                 60s   kubelet, node-03         Pulling image "nginx"
   Normal  Pulled                  59s   kubelet, node-03         Successfully pulled image "nginx"
   Normal  Created                 59s   kubelet, node-03         Created container myfrontend
@@ -161,7 +166,7 @@ Events:
 
 ## Storage Classes
 
-We currently support two [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) on OVHcloud Managed Kubernetes: `cinder-high-speed` and `cinder-classic`, both based on [Cinder](https://docs.openstack.org/cinder/latest/){.external}, the OpenStack Block Storage service. The difference between them is the associated physical storage device. `cinder-high-speed` uses SSD, while `cinder-classic` uses traditional spinning disks. Both are distributed transparently, on three physical local replicas.
+We currently support two [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) on OVHcloud Managed Kubernetes: `csi-cinder-high-speed` and `csi-cinder-classic`, both based on [Cinder](https://docs.openstack.org/cinder/latest/){.external}, the OpenStack Block Storage service. The difference between them is the associated physical storage device. `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently, on three physical local replicas.
 
 When you create a Persistent Volume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [flexible cloud storage prices](https://www.ovh.com/world/public-cloud/storage/additional-disks/){.external}.
 
@@ -198,8 +203,8 @@ kubectl get pv
 
 <pre class="console"><code>$ kubectl 
 get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            15s
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            15s
 </code></pre>
 
 
@@ -216,8 +221,10 @@ kubectl get pv
 <pre class="console"><code>$ kubectl 
 $ kubectl delete pvc test-pvc
 persistentvolumeclaim "test-pvc" deleted
+
 $ kubectl get pvc
 No resources found.
+
 $ kubectl get pv
 No resources found.
 </code></pre>
@@ -256,14 +263,16 @@ kubectl get pv
 <pre class="console"><code>$ kubectl apply -f test-pvc.yaml
 persistentvolumeclaim/test-pvc created
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            3s
-$ kubectl patch pv pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-e935df1d-7b7f-4839-bed7-43cb3bf0bb72   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            19s
+
 $ kubectl patch pv pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
 persistentvolume/pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf patched
+
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf   10Gi       RWO            Retain           Bound    default/test-pvc   cinder-high-speed            4m
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-e935df1d-7b7f-4839-bed7-43cb3bf0bb72   10Gi       RWO            Retain           Bound    default/test-pvc   csi-cinder-high-speed            19s
+
 </code></pre>
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`. It will not be automatically deleted when a user deletes PVC `default/test-pvc`

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-au.md
@@ -5,7 +5,7 @@ excerpt: ''
 section: Tutorials
 ---
 
-**Last updated September 6<sup>th,</sup> 2019.**
+**Last updated January 6<sup>th,</sup> 2020.**
 
 <style>
  pre {
@@ -73,8 +73,11 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: cinder-high-speed
-```      
+  storageClassName: csi-cinder-high-speed
+```
+
+> [!warning]
+> For Kubernetes clusters running in versions 1.12.x, 1.13.x and 1.14.x the storageClassName should be: cinder-high-speed.
 
 And apply it to your cluster:
 
@@ -92,12 +95,14 @@ kubectl get pv
 
 <pre class="console"><code>$ kubectl apply -f test-pvc.yaml
 persistentvolumeclaim/test-pvc created
+
 $ kubectl get pvc
-NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
-test-pvc   Bound    pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            cinder-high-speed   16s
+NAME       STATUS   VOLUME                                                                   CAPACITY   ACCESS MODES   STORAGECLASS            AGE
+test-pvc   Bound    ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            csi-cinder-high-speed   5s
+
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            15s
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            15s
 </code></pre>
 
 ## Using the PVC
@@ -138,7 +143,7 @@ Namespace:          default
 Priority:           0
 PriorityClassName:  &lt;none>
 Node:               node-03/51.75.199.0
-Start Time:         Thu, 05 Sep 2019 18:14:42 +0200
+Start Time:         Mon, 06 Jan 2020 11:38:16 +0100
 Labels:             &lt;none>
 [...]
 Volumes:
@@ -151,7 +156,7 @@ Events:
   Type    Reason                  Age   From                     Message
   ----    ------                  ----  ----                     -------
   Normal  Scheduled               70s   default-scheduler        Successfully assigned default/test-pvc-pod to node-03
-  Normal  SuccessfulAttachVolume  68s   attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-8e0c9b3c-7760-41e7-b89b-cc3f8f04a735"
+  Normal  SuccessfulAttachVolume  68s   attachdetach-controller  AttachVolume.Attach succeeded for volume "ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee"
   Normal  Pulling                 60s   kubelet, node-03         Pulling image "nginx"
   Normal  Pulled                  59s   kubelet, node-03         Successfully pulled image "nginx"
   Normal  Created                 59s   kubelet, node-03         Created container myfrontend
@@ -161,7 +166,7 @@ Events:
 
 ## Storage Classes
 
-We currently support two [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) on OVHcloud Managed Kubernetes: `cinder-high-speed` and `cinder-classic`, both based on [Cinder](https://docs.openstack.org/cinder/latest/){.external}, the OpenStack Block Storage service. The difference between them is the associated physical storage device. `cinder-high-speed` uses SSD, while `cinder-classic` uses traditional spinning disks. Both are distributed transparently, on three physical local replicas.
+We currently support two [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) on OVHcloud Managed Kubernetes: `csi-cinder-high-speed` and `csi-cinder-classic`, both based on [Cinder](https://docs.openstack.org/cinder/latest/){.external}, the OpenStack Block Storage service. The difference between them is the associated physical storage device. `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently, on three physical local replicas.
 
 When you create a Persistent Volume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [flexible cloud storage prices](https://www.ovh.com/world/public-cloud/storage/additional-disks/){.external}.
 
@@ -198,8 +203,8 @@ kubectl get pv
 
 <pre class="console"><code>$ kubectl 
 get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            15s
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            15s
 </code></pre>
 
 
@@ -216,8 +221,10 @@ kubectl get pv
 <pre class="console"><code>$ kubectl 
 $ kubectl delete pvc test-pvc
 persistentvolumeclaim "test-pvc" deleted
+
 $ kubectl get pvc
 No resources found.
+
 $ kubectl get pv
 No resources found.
 </code></pre>
@@ -256,14 +263,16 @@ kubectl get pv
 <pre class="console"><code>$ kubectl apply -f test-pvc.yaml
 persistentvolumeclaim/test-pvc created
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            3s
-$ kubectl patch pv pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-e935df1d-7b7f-4839-bed7-43cb3bf0bb72   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            19s
+
 $ kubectl patch pv pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
 persistentvolume/pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf patched
+
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf   10Gi       RWO            Retain           Bound    default/test-pvc   cinder-high-speed            4m
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-e935df1d-7b7f-4839-bed7-43cb3bf0bb72   10Gi       RWO            Retain           Bound    default/test-pvc   csi-cinder-high-speed            19s
+
 </code></pre>
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`. It will not be automatically deleted when a user deletes PVC `default/test-pvc`

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-ca.md
@@ -5,7 +5,7 @@ excerpt: ''
 section: Tutorials
 ---
 
-**Last updated September 6<sup>th,</sup> 2019.**
+**Last updated January 6<sup>th,</sup> 2020.**
 
 <style>
  pre {
@@ -73,8 +73,11 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: cinder-high-speed
-```      
+  storageClassName: csi-cinder-high-speed
+```
+
+> [!warning]
+> For Kubernetes clusters running in versions 1.12.x, 1.13.x and 1.14.x the storageClassName should be: cinder-high-speed.
 
 And apply it to your cluster:
 
@@ -92,12 +95,14 @@ kubectl get pv
 
 <pre class="console"><code>$ kubectl apply -f test-pvc.yaml
 persistentvolumeclaim/test-pvc created
+
 $ kubectl get pvc
-NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
-test-pvc   Bound    pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            cinder-high-speed   16s
+NAME       STATUS   VOLUME                                                                   CAPACITY   ACCESS MODES   STORAGECLASS            AGE
+test-pvc   Bound    ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            csi-cinder-high-speed   5s
+
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            15s
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            15s
 </code></pre>
 
 ## Using the PVC
@@ -138,7 +143,7 @@ Namespace:          default
 Priority:           0
 PriorityClassName:  &lt;none>
 Node:               node-03/51.75.199.0
-Start Time:         Thu, 05 Sep 2019 18:14:42 +0200
+Start Time:         Mon, 06 Jan 2020 11:38:16 +0100
 Labels:             &lt;none>
 [...]
 Volumes:
@@ -151,7 +156,7 @@ Events:
   Type    Reason                  Age   From                     Message
   ----    ------                  ----  ----                     -------
   Normal  Scheduled               70s   default-scheduler        Successfully assigned default/test-pvc-pod to node-03
-  Normal  SuccessfulAttachVolume  68s   attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-8e0c9b3c-7760-41e7-b89b-cc3f8f04a735"
+  Normal  SuccessfulAttachVolume  68s   attachdetach-controller  AttachVolume.Attach succeeded for volume "ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee"
   Normal  Pulling                 60s   kubelet, node-03         Pulling image "nginx"
   Normal  Pulled                  59s   kubelet, node-03         Successfully pulled image "nginx"
   Normal  Created                 59s   kubelet, node-03         Created container myfrontend
@@ -161,7 +166,7 @@ Events:
 
 ## Storage Classes
 
-We currently support two [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) on OVHcloud Managed Kubernetes: `cinder-high-speed` and `cinder-classic`, both based on [Cinder](https://docs.openstack.org/cinder/latest/){.external}, the OpenStack Block Storage service. The difference between them is the associated physical storage device. `cinder-high-speed` uses SSD, while `cinder-classic` uses traditional spinning disks. Both are distributed transparently, on three physical local replicas.
+We currently support two [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) on OVHcloud Managed Kubernetes: `csi-cinder-high-speed` and `csi-cinder-classic`, both based on [Cinder](https://docs.openstack.org/cinder/latest/){.external}, the OpenStack Block Storage service. The difference between them is the associated physical storage device. `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently, on three physical local replicas.
 
 When you create a Persistent Volume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [flexible cloud storage prices](https://www.ovh.com/world/public-cloud/storage/additional-disks/){.external}.
 
@@ -198,8 +203,8 @@ kubectl get pv
 
 <pre class="console"><code>$ kubectl 
 get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            15s
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            15s
 </code></pre>
 
 
@@ -216,8 +221,10 @@ kubectl get pv
 <pre class="console"><code>$ kubectl 
 $ kubectl delete pvc test-pvc
 persistentvolumeclaim "test-pvc" deleted
+
 $ kubectl get pvc
 No resources found.
+
 $ kubectl get pv
 No resources found.
 </code></pre>
@@ -256,14 +263,16 @@ kubectl get pv
 <pre class="console"><code>$ kubectl apply -f test-pvc.yaml
 persistentvolumeclaim/test-pvc created
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            3s
-$ kubectl patch pv pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-e935df1d-7b7f-4839-bed7-43cb3bf0bb72   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            19s
+
 $ kubectl patch pv pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
 persistentvolume/pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf patched
+
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf   10Gi       RWO            Retain           Bound    default/test-pvc   cinder-high-speed            4m
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-e935df1d-7b7f-4839-bed7-43cb3bf0bb72   10Gi       RWO            Retain           Bound    default/test-pvc   csi-cinder-high-speed            19s
+
 </code></pre>
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`. It will not be automatically deleted when a user deletes PVC `default/test-pvc`

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-gb.md
@@ -5,7 +5,7 @@ excerpt: ''
 section: Tutorials
 ---
 
-**Last updated September 6<sup>th,</sup> 2019.**
+**Last updated January 6<sup>th,</sup> 2020.**
 
 <style>
  pre {
@@ -73,8 +73,11 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: cinder-high-speed
-```      
+  storageClassName: csi-cinder-high-speed
+```
+
+> [!warning]
+> For Kubernetes clusters running in versions 1.12.x, 1.13.x and 1.14.x the storageClassName should be: cinder-high-speed.
 
 And apply it to your cluster:
 
@@ -92,12 +95,14 @@ kubectl get pv
 
 <pre class="console"><code>$ kubectl apply -f test-pvc.yaml
 persistentvolumeclaim/test-pvc created
+
 $ kubectl get pvc
-NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
-test-pvc   Bound    pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            cinder-high-speed   16s
+NAME       STATUS   VOLUME                                                                   CAPACITY   ACCESS MODES   STORAGECLASS            AGE
+test-pvc   Bound    ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            csi-cinder-high-speed   5s
+
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            15s
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            15s
 </code></pre>
 
 ## Using the PVC
@@ -138,7 +143,7 @@ Namespace:          default
 Priority:           0
 PriorityClassName:  &lt;none>
 Node:               node-03/51.75.199.0
-Start Time:         Thu, 05 Sep 2019 18:14:42 +0200
+Start Time:         Mon, 06 Jan 2020 11:38:16 +0100
 Labels:             &lt;none>
 [...]
 Volumes:
@@ -151,7 +156,7 @@ Events:
   Type    Reason                  Age   From                     Message
   ----    ------                  ----  ----                     -------
   Normal  Scheduled               70s   default-scheduler        Successfully assigned default/test-pvc-pod to node-03
-  Normal  SuccessfulAttachVolume  68s   attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-8e0c9b3c-7760-41e7-b89b-cc3f8f04a735"
+  Normal  SuccessfulAttachVolume  68s   attachdetach-controller  AttachVolume.Attach succeeded for volume "ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee"
   Normal  Pulling                 60s   kubelet, node-03         Pulling image "nginx"
   Normal  Pulled                  59s   kubelet, node-03         Successfully pulled image "nginx"
   Normal  Created                 59s   kubelet, node-03         Created container myfrontend
@@ -161,7 +166,7 @@ Events:
 
 ## Storage Classes
 
-We currently support two [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) on OVHcloud Managed Kubernetes: `cinder-high-speed` and `cinder-classic`, both based on [Cinder](https://docs.openstack.org/cinder/latest/){.external}, the OpenStack Block Storage service. The difference between them is the associated physical storage device. `cinder-high-speed` uses SSD, while `cinder-classic` uses traditional spinning disks. Both are distributed transparently, on three physical local replicas.
+We currently support two [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) on OVHcloud Managed Kubernetes: `csi-cinder-high-speed` and `csi-cinder-classic`, both based on [Cinder](https://docs.openstack.org/cinder/latest/){.external}, the OpenStack Block Storage service. The difference between them is the associated physical storage device. `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently, on three physical local replicas.
 
 When you create a Persistent Volume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [flexible cloud storage prices](https://www.ovh.com/world/public-cloud/storage/additional-disks/){.external}.
 
@@ -198,8 +203,8 @@ kubectl get pv
 
 <pre class="console"><code>$ kubectl 
 get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            15s
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            15s
 </code></pre>
 
 
@@ -216,8 +221,10 @@ kubectl get pv
 <pre class="console"><code>$ kubectl 
 $ kubectl delete pvc test-pvc
 persistentvolumeclaim "test-pvc" deleted
+
 $ kubectl get pvc
 No resources found.
+
 $ kubectl get pv
 No resources found.
 </code></pre>
@@ -256,14 +263,16 @@ kubectl get pv
 <pre class="console"><code>$ kubectl apply -f test-pvc.yaml
 persistentvolumeclaim/test-pvc created
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            3s
-$ kubectl patch pv pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-e935df1d-7b7f-4839-bed7-43cb3bf0bb72   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            19s
+
 $ kubectl patch pv pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
 persistentvolume/pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf patched
+
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf   10Gi       RWO            Retain           Bound    default/test-pvc   cinder-high-speed            4m
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-e935df1d-7b7f-4839-bed7-43cb3bf0bb72   10Gi       RWO            Retain           Bound    default/test-pvc   csi-cinder-high-speed            19s
+
 </code></pre>
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`. It will not be automatically deleted when a user deletes PVC `default/test-pvc`

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-ie.md
@@ -5,7 +5,7 @@ excerpt: ''
 section: Tutorials
 ---
 
-**Last updated September 6<sup>th,</sup> 2019.**
+**Last updated January 6<sup>th,</sup> 2020.**
 
 <style>
  pre {
@@ -73,8 +73,11 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: cinder-high-speed
-```      
+  storageClassName: csi-cinder-high-speed
+```
+
+> [!warning]
+> For Kubernetes clusters running in versions 1.12.x, 1.13.x and 1.14.x the storageClassName should be: cinder-high-speed.
 
 And apply it to your cluster:
 
@@ -92,12 +95,14 @@ kubectl get pv
 
 <pre class="console"><code>$ kubectl apply -f test-pvc.yaml
 persistentvolumeclaim/test-pvc created
+
 $ kubectl get pvc
-NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
-test-pvc   Bound    pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            cinder-high-speed   16s
+NAME       STATUS   VOLUME                                                                   CAPACITY   ACCESS MODES   STORAGECLASS            AGE
+test-pvc   Bound    ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            csi-cinder-high-speed   5s
+
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            15s
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            15s
 </code></pre>
 
 ## Using the PVC
@@ -138,7 +143,7 @@ Namespace:          default
 Priority:           0
 PriorityClassName:  &lt;none>
 Node:               node-03/51.75.199.0
-Start Time:         Thu, 05 Sep 2019 18:14:42 +0200
+Start Time:         Mon, 06 Jan 2020 11:38:16 +0100
 Labels:             &lt;none>
 [...]
 Volumes:
@@ -151,7 +156,7 @@ Events:
   Type    Reason                  Age   From                     Message
   ----    ------                  ----  ----                     -------
   Normal  Scheduled               70s   default-scheduler        Successfully assigned default/test-pvc-pod to node-03
-  Normal  SuccessfulAttachVolume  68s   attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-8e0c9b3c-7760-41e7-b89b-cc3f8f04a735"
+  Normal  SuccessfulAttachVolume  68s   attachdetach-controller  AttachVolume.Attach succeeded for volume "ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee"
   Normal  Pulling                 60s   kubelet, node-03         Pulling image "nginx"
   Normal  Pulled                  59s   kubelet, node-03         Successfully pulled image "nginx"
   Normal  Created                 59s   kubelet, node-03         Created container myfrontend
@@ -161,7 +166,7 @@ Events:
 
 ## Storage Classes
 
-We currently support two [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) on OVHcloud Managed Kubernetes: `cinder-high-speed` and `cinder-classic`, both based on [Cinder](https://docs.openstack.org/cinder/latest/){.external}, the OpenStack Block Storage service. The difference between them is the associated physical storage device. `cinder-high-speed` uses SSD, while `cinder-classic` uses traditional spinning disks. Both are distributed transparently, on three physical local replicas.
+We currently support two [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) on OVHcloud Managed Kubernetes: `csi-cinder-high-speed` and `csi-cinder-classic`, both based on [Cinder](https://docs.openstack.org/cinder/latest/){.external}, the OpenStack Block Storage service. The difference between them is the associated physical storage device. `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently, on three physical local replicas.
 
 When you create a Persistent Volume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [flexible cloud storage prices](https://www.ovh.com/world/public-cloud/storage/additional-disks/){.external}.
 
@@ -198,8 +203,8 @@ kubectl get pv
 
 <pre class="console"><code>$ kubectl 
 get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            15s
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            15s
 </code></pre>
 
 
@@ -216,8 +221,10 @@ kubectl get pv
 <pre class="console"><code>$ kubectl 
 $ kubectl delete pvc test-pvc
 persistentvolumeclaim "test-pvc" deleted
+
 $ kubectl get pvc
 No resources found.
+
 $ kubectl get pv
 No resources found.
 </code></pre>
@@ -256,14 +263,16 @@ kubectl get pv
 <pre class="console"><code>$ kubectl apply -f test-pvc.yaml
 persistentvolumeclaim/test-pvc created
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            3s
-$ kubectl patch pv pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-e935df1d-7b7f-4839-bed7-43cb3bf0bb72   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            19s
+
 $ kubectl patch pv pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
 persistentvolume/pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf patched
+
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf   10Gi       RWO            Retain           Bound    default/test-pvc   cinder-high-speed            4m
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-e935df1d-7b7f-4839-bed7-43cb3bf0bb72   10Gi       RWO            Retain           Bound    default/test-pvc   csi-cinder-high-speed            19s
+
 </code></pre>
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`. It will not be automatically deleted when a user deletes PVC `default/test-pvc`

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-sg.md
@@ -5,7 +5,7 @@ excerpt: ''
 section: Tutorials
 ---
 
-**Last updated September 6<sup>th,</sup> 2019.**
+**Last updated January 6<sup>th,</sup> 2020.**
 
 <style>
  pre {
@@ -73,8 +73,11 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: cinder-high-speed
-```      
+  storageClassName: csi-cinder-high-speed
+```
+
+> [!warning]
+> For Kubernetes clusters running in versions 1.12.x, 1.13.x and 1.14.x the storageClassName should be: cinder-high-speed.
 
 And apply it to your cluster:
 
@@ -92,12 +95,14 @@ kubectl get pv
 
 <pre class="console"><code>$ kubectl apply -f test-pvc.yaml
 persistentvolumeclaim/test-pvc created
+
 $ kubectl get pvc
-NAME       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS        AGE
-test-pvc   Bound    pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            cinder-high-speed   16s
+NAME       STATUS   VOLUME                                                                   CAPACITY   ACCESS MODES   STORAGECLASS            AGE
+test-pvc   Bound    ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            csi-cinder-high-speed   5s
+
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            15s
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            15s
 </code></pre>
 
 ## Using the PVC
@@ -138,7 +143,7 @@ Namespace:          default
 Priority:           0
 PriorityClassName:  &lt;none>
 Node:               node-03/51.75.199.0
-Start Time:         Thu, 05 Sep 2019 18:14:42 +0200
+Start Time:         Mon, 06 Jan 2020 11:38:16 +0100
 Labels:             &lt;none>
 [...]
 Volumes:
@@ -151,7 +156,7 @@ Events:
   Type    Reason                  Age   From                     Message
   ----    ------                  ----  ----                     -------
   Normal  Scheduled               70s   default-scheduler        Successfully assigned default/test-pvc-pod to node-03
-  Normal  SuccessfulAttachVolume  68s   attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-8e0c9b3c-7760-41e7-b89b-cc3f8f04a735"
+  Normal  SuccessfulAttachVolume  68s   attachdetach-controller  AttachVolume.Attach succeeded for volume "ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee"
   Normal  Pulling                 60s   kubelet, node-03         Pulling image "nginx"
   Normal  Pulled                  59s   kubelet, node-03         Successfully pulled image "nginx"
   Normal  Created                 59s   kubelet, node-03         Created container myfrontend
@@ -161,7 +166,7 @@ Events:
 
 ## Storage Classes
 
-We currently support two [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) on OVHcloud Managed Kubernetes: `cinder-high-speed` and `cinder-classic`, both based on [Cinder](https://docs.openstack.org/cinder/latest/){.external}, the OpenStack Block Storage service. The difference between them is the associated physical storage device. `cinder-high-speed` uses SSD, while `cinder-classic` uses traditional spinning disks. Both are distributed transparently, on three physical local replicas.
+We currently support two [Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) on OVHcloud Managed Kubernetes: `csi-cinder-high-speed` and `csi-cinder-classic`, both based on [Cinder](https://docs.openstack.org/cinder/latest/){.external}, the OpenStack Block Storage service. The difference between them is the associated physical storage device. `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently, on three physical local replicas.
 
 When you create a Persistent Volume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [flexible cloud storage prices](https://www.ovh.com/world/public-cloud/storage/additional-disks/){.external}.
 
@@ -198,8 +203,8 @@ kubectl get pv
 
 <pre class="console"><code>$ kubectl 
 get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-8ed251c3-4a1e-478e-82cf-01dd637ca459   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            15s
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                        STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-8a035acf-23e9-4125-a392-119f5763edee   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            15s
 </code></pre>
 
 
@@ -216,8 +221,10 @@ kubectl get pv
 <pre class="console"><code>$ kubectl 
 $ kubectl delete pvc test-pvc
 persistentvolumeclaim "test-pvc" deleted
+
 $ kubectl get pvc
 No resources found.
+
 $ kubectl get pv
 No resources found.
 </code></pre>
@@ -256,14 +263,16 @@ kubectl get pv
 <pre class="console"><code>$ kubectl apply -f test-pvc.yaml
 persistentvolumeclaim/test-pvc created
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf   10Gi       RWO            Delete           Bound    default/test-pvc   cinder-high-speed            3s
-$ kubectl patch pv pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-e935df1d-7b7f-4839-bed7-43cb3bf0bb72   10Gi       RWO            Delete           Bound    default/test-pvc   csi-cinder-high-speed            19s
+
 $ kubectl patch pv pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
 persistentvolume/pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf patched
+
 $ kubectl get pv
-NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS        REASON   AGE
-pvc-e53d180d-51a4-4237-b9b3-f6b32cce54cf   10Gi       RWO            Retain           Bound    default/test-pvc   cinder-high-speed            4m
+NAME                                                                     CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM              STORAGECLASS            REASON   AGE
+ovh-managed-kubernetes-btw8lc-pvc-e935df1d-7b7f-4839-bed7-43cb3bf0bb72   10Gi       RWO            Retain           Bound    default/test-pvc   csi-cinder-high-speed            19s
+
 </code></pre>
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`. It will not be automatically deleted when a user deletes PVC `default/test-pvc`


### PR DESCRIPTION
Hello,

We changed the Cinder plugin used in OVH Managed Kubernetes offer from version 1.15.x.
So let's update the documentation with the new cinder plugin used.

Thomas