### PR TITLE
Fix region name in aws config file

### DIFF
--- a/pages/platform/public-cloud/starting_with_swift_s3api/guide.en-gb.md
+++ b/pages/platform/public-cloud/starting_with_swift_s3api/guide.en-gb.md
@@ -75,7 +75,7 @@ user@host:~$ curl -s -D headers -H "Content-Type: application/json" -d '
 user@host:~$ OS_TOKEN=$(egrep "^X-Subject-Token:" headers | awk '{print $2}')
 user@host:~$ OS_USER_ID=$(cat token_info  | jq -r '.["token"]["user"]["id"]')
 user@host:~$ OS_PROJECT_ID=$(cat token_info  | jq -r '.["token"]["project"]["id"]')
-user@host:~$ curl -s -X POST -H "Content-Type: application/json" -H "X-Auth-Token: $OS_TOKEN" -d '{"tenant_id": $OS_PROJECT_ID}' "${OS_AUTH_URL}/v3/users/${OS_USER_ID}/credentials/OS-EC2" | jq .
+user@host:~$ curl -s -X POST -H "Content-Type: application/json" -H "X-Auth-Token: $OS_TOKEN" -d '{"tenant_id": "$OS_PROJECT_ID"}' "${OS_AUTH_URL}/v3/users/${OS_USER_ID}/credentials/OS-EC2" | jq .
 {
   "credential": {
     "user_id": "d74d05ff121b44bea9216495e7f0df61",
@@ -104,12 +104,12 @@ endpoint = awscli_plugin_endpoint
 [profile default]
 aws_access_key_id = <access fetched in previous step>
 aws_secret_access_key = <secret fetched in previous step>
-region = <public cloud region without digit in UPPER CASE>
+region = <public cloud region in lower case>
 s3 =
-  endpoint_url = https://storage.<public cloud region without digit in lower case>.cloud.ovh.net
+  endpoint_url = https://storage.<public cloud region>.cloud.ovh.net
   signature_version = s3v4
 s3api =
-  endpoint_url = https://storage.<public cloud region without digit in lower case>.cloud.ovh.net
+  endpoint_url = https://storage.<public cloud region>.cloud.ovh.net
 ```
 
 ## Use aws client


### PR DESCRIPTION
- Fixed an missing quote in curl POST payload
- Public Cloud region name can now be set in lower or upper case.

Signed-off-by: Julien Lutran <julien.lutran@corp.ovh.com>