### PR TITLE
Update s3ql documentations

### DIFF
--- a/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.de-de.md
+++ b/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.de-de.md
@@ -30,15 +30,6 @@ Die Verwendung eines Object Containers als Dateisystem kann die Performance Ihre
 
 ## Erstellung des Dateisystems
 
-- Installation von S3QL:
-
-```
-admin@serveur1:~$ sudo apt-get install s3ql
-```
-
-
-
-Die neueste Version finden Sie im Debian 8 Repository
 
 - Erstellen Sie eine Datei mit den Verbindungsdaten:
 
@@ -73,7 +64,7 @@ admin@serveur1:~$ sudo chmod 600 s3qlcredentials.txt
 - Object Container formatieren:
 
 ```
-admin@serveur1:~$ sudo mkfs.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL
+admin@serveur1:~$ sudo mkfs.s3ql --backend-options domain=default --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL
 ```
 
 
@@ -95,7 +86,7 @@ admin@serveur1:~$ sudo mkdir /mnt/container
 - Mounten des Object Containers
 
 ```
-admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL /mnt/container/
+admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL /mnt/container/
 ```
 
 
@@ -111,7 +102,7 @@ tmpfs 393M 5.2M 388M 2% /run
 tmpfs 982M 0 982M 0% /dev/shm
 tmpfs 5.0M 0 5.0M 0% /run/lock
 tmpfs 982M 0 982M 0% /sys/fs/cgroup
-swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
+swiftks://auth.cloud.ovh.net/GRA:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
 ```
 
 

--- a/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.en-gb.md
+++ b/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.en-gb.md
@@ -29,16 +29,6 @@ Using an object container as a file system can impact the performance of your op
 
 ## Create your file system
 
-- Install S3QL:
-
-```
-admin@serveur1:~$ sudo apt-get install s3ql
-```
-
-
-
-The latest version should be available in the Debian 8 repository
-
 - Create a file containing the login information:
 
 ```
@@ -72,7 +62,7 @@ admin@serveur1:~$ sudo chmod 600 s3qlcredentials.txt
 - Object container formating:
 
 ```
-admin@serveur1:~$ sudo mkfs.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL
+admin@serveur1:~$ sudo mkfs.s3ql --backend-options domain=default --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL
 ```
 
 
@@ -93,7 +83,7 @@ admin@serveur1:~$ sudo mkdir /mnt/container
 - Mount the object container
 
 ```
-admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL /mnt/container/
+admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL /mnt/container/
 ```
 
 
@@ -109,7 +99,7 @@ tmpfs 393M 5.2M 388M 2% /run
 tmpfs 982M 0 982M 0% /dev/shm
 tmpfs 5.0M 0 5.0M 0% /run/lock
 tmpfs 982M 0 982M 0% /sys/fs/cgroup
-swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
+swiftks://auth.cloud.ovh.net/GRA:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
 ```
 
 

--- a/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.en-ie.md
+++ b/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.en-ie.md
@@ -29,16 +29,6 @@ Using an object container as a file system can impact the performance of your op
 
 ## Create your file system
 
-- Install S3QL:
-
-```
-admin@serveur1:~$ sudo apt-get install s3ql
-```
-
-
-
-The latest version should be available in the Debian 8 repository
-
 - Create a file containing the login information:
 
 ```
@@ -72,7 +62,7 @@ admin@serveur1:~$ sudo chmod 600 s3qlcredentials.txt
 - Object container formating:
 
 ```
-admin@serveur1:~$ sudo mkfs.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL
+admin@serveur1:~$ sudo mkfs.s3ql --backend-options domain=default --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL
 ```
 
 
@@ -93,7 +83,7 @@ admin@serveur1:~$ sudo mkdir /mnt/container
 - Mount the object container
 
 ```
-admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL /mnt/container/
+admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL /mnt/container/
 ```
 
 
@@ -109,7 +99,7 @@ tmpfs 393M 5.2M 388M 2% /run
 tmpfs 982M 0 982M 0% /dev/shm
 tmpfs 5.0M 0 5.0M 0% /run/lock
 tmpfs 982M 0 982M 0% /sys/fs/cgroup
-swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
+swiftks://auth.cloud.ovh.net/GRA:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
 ```
 
 

--- a/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.es-es.md
+++ b/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.es-es.md
@@ -31,15 +31,7 @@ Utilizar un contenedor de objetos como sistema de archivos puede reducir el rend
 
 
 ## Creación del sistema de archivos
-Instale S3QL:
 
-
-```
-admin@servidor1:~$ sudo apt-get install s3ql
-```
-
-
-La última versión suele estar disponible en los repositorios de Debian 8.
 Crear un archivo que contenga los datos de conexión:
 
 
@@ -70,7 +62,7 @@ Formatee el contenedor de objetos:
 
 
 ```
-admin@servidor1:~$ sudo mkfs.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL
+admin@servidor1:~$ sudo mkfs.s3ql --backend-options domain=default --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL
 ```
 
 
@@ -92,7 +84,7 @@ Monte el contenedor de objetos:
 
 
 ```
-admin@servidor1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL /mnt/container/
+admin@servidor1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL /mnt/container/
 ```
 
 
@@ -109,7 +101,7 @@ tmpfs 393M 5.2M 388M 2% /run
 tmpfs 982M 0 982M 0% /dev/shm
 tmpfs 5.0M 0 5.0M 0% /run/lock
 tmpfs 982M 0 982M 0% /sys/fs/cgroup
-swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
+swiftks://auth.cloud.ovh.net/GRA:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
 ```
 
 

--- a/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.it-it.md
+++ b/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.it-it.md
@@ -29,15 +29,6 @@ Utilizzare un container di oggetti come file system può causare un calo delle p
 
 ## Crea il tuo file system
 
-- Installa S3QL:
-
-```
-admin@serveur1:~$ sudo apt-get install s3ql
-```
-
-
-
-Nel repository di Debian 8 in genere è disponibile l'ultima versione
 
 - Crea un file che contenga le informazioni di connessione:
 
@@ -72,7 +63,7 @@ admin@serveur1:~$ sudo chmod 600 s3qlcredentials.txt
 - Formatta il container di oggetti:
 
 ```
-admin@serveur1:~$ sudo mkfs.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL
+admin@serveur1:~$ sudo mkfs.s3ql --backend-options domain=default --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL
 ```
 
 
@@ -93,7 +84,7 @@ admin@serveur1:~$ sudo mkdir /mnt/container
 - Configura il container di oggetti
 
 ```
-admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL /mnt/container/
+admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL /mnt/container/
 ```
 
 
@@ -109,7 +100,7 @@ tmpfs 393M 5.2M 388M 2% /run
 tmpfs 982M 0 982M 0% /dev/shm
 tmpfs 5.0M 0 5.0M 0% /run/lock
 tmpfs 982M 0 982M 0% /sys/fs/cgroup
-swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
+swiftks://auth.cloud.ovh.net/GRA:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
 ```
 
 

--- a/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.lt-lt.md
+++ b/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.lt-lt.md
@@ -29,16 +29,6 @@ Naudokite objektų saugyklą, nes failų sistema gali sumažinti operacijų spar
 
 ## Failų sistemos kūrimas
 
-- S3QL diegimas:
-
-```
-admin@serveur1:~$ sudo apt-get install s3ql
-```
-
-
-
-Naujausia versija yra Debian 8 programų bibliotekoje
-
 - Sukurkite failą su prisijungimo informacija: 
 
 
@@ -73,7 +63,7 @@ admin@serveur1:~$ sudo chmod 600 s3qlcredentials.txt
 - Objektų konteinerio formatavimas:
 
 ```
-admin@serveur1:~$ sudo mkfs.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL
+admin@serveur1:~$ sudo mkfs.s3ql --backend-options domain=default --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL
 ```
 
 
@@ -95,7 +85,7 @@ admin@serveur1:~$ sudo mkdir /mnt/container
 
 
 ```
-admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL /mnt/container/
+admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL /mnt/container/
 ```
 
 
@@ -112,7 +102,7 @@ tmpfs 393M 5.2M 388M 2% /run
 tmpfs 982M 0 982M 0% /dev/shm
 tmpfs 5.0M 0 5.0M 0% /run/lock
 tmpfs 982M 0 982M 0% /sys/fs/cgroup
-swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
+swiftks://auth.cloud.ovh.net/GRA:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
 ```
 
 

--- a/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.pl-pl.md
+++ b/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.pl-pl.md
@@ -29,16 +29,6 @@ Wykorzystywanie kontenera obiektów jako systemu plików może zmniejszyć wydaj
 
 ## Tworzenie systemu plików
 
-- Zainstaluj S3QL:
-
-```
-admin@serveur1:~$ sudo apt-get install s3ql
-```
-
-
-
-Najnowsza wersja jest dostępna w repozytoriach systemu Debian 8.
-
 - Utwórz plik zawierający informacje dotyczące logowania:
 
 ```
@@ -72,7 +62,7 @@ admin@serveur1:~$ sudo chmod 600 s3qlcredentials.txt
 - Formatowanie kontenera obiektów:
 
 ```
-admin@serveur1:~$ sudo mkfs.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL
+admin@serveur1:~$ sudo mkfs.s3ql --backend-options domain=default --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL
 ```
 
 
@@ -94,7 +84,7 @@ admin@serveur1:~$ sudo mkdir /mnt/container
 - Montowanie kontenera obiektów
 
 ```
-admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL /mnt/container/
+admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL /mnt/container/
 ```
 
 
@@ -110,7 +100,7 @@ tmpfs 393M 5.2M 388M 2% /run
 tmpfs 982M 0 982M 0% /dev/shm
 tmpfs 5.0M 0 5.0M 0% /run/lock
 tmpfs 982M 0 982M 0% /sys/fs/cgroup
-swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
+swiftks://auth.cloud.ovh.net/GRA:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
 ```
 
 

--- a/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.pt-pt.md
+++ b/pages/cloud/storage/pcs_use_s3ql_to_mount_containers/guide.pt-pt.md
@@ -29,15 +29,6 @@ Utilizar um container de object como um sistema de ficheiros poderá reduzir as 
 
 ## Criação do sistema de ficheiros
 
-- Instalar o S3QL:
-
-```
-admin@serveur1:~$ sudo apt-get install s3ql
-```
-
-
-
-A última versão é geralmente disponibilizada pelos repositórios do Debian 8
 
 - Crie um ficheiro que contenha as informações de ligação:
 
@@ -72,7 +63,7 @@ admin@serveur1:~$ sudo chmod 600 s3qlcredentials.txt
 - Formate o container do objeto:
 
 ```
-admin@serveur1:~$ sudo mkfs.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL
+admin@serveur1:~$ sudo mkfs.s3ql --backend-options domain=default --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL
 ```
 
 
@@ -93,7 +84,7 @@ admin@serveur1:~$ sudo mkdir /mnt/container
 - Montagem do container do objeto
 
 ```
-admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL /mnt/container/
+admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL /mnt/container/
 ```
 
 
@@ -109,7 +100,7 @@ tmpfs 393M 5.2M 388M 2% /run
 tmpfs 982M 0 982M 0% /dev/shm
 tmpfs 5.0M 0 5.0M 0% /run/lock
 tmpfs 982M 0 982M 0% /sys/fs/cgroup
-swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
+swiftks://auth.cloud.ovh.net/GRA:CT_S3QL 1.0T 0 1.0T 0% /mnt/container
 ```
 
 

--- a/pages/platform/public-cloud/mounting_s3ql_with_object_container/guide.fr-fr.md
+++ b/pages/platform/public-cloud/mounting_s3ql_with_object_container/guide.fr-fr.md
@@ -30,18 +30,11 @@ Ce guide vous explique comment monter un conteneur d'objet en tant que système 
 ## Configuration et montage
 
 ### Creation du systeme de fichier
-- Installer S3QL :
-
-```bash
-admin@serveur1:~$ sudo apt-get install s3ql
-```
-
-
 
 
 > [!success]
 >
-> La dernière version est en général disponible sur les dépôts de Debian 8
+> La version requise minimum de s3ql est 3.3.2
 > 
 
 - Créer un fichier contenant les informations de connexion :
@@ -72,7 +65,7 @@ admin@serveur1:~$ sudo chmod 600 s3qlcredentials.txt
 - Formatage du conteneur d'objet :
 
 ```bash
-admin@serveur1:~$ sudo mkfs.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL
+admin@serveur1:~$ sudo mkfs.s3ql --backend-options domain=default --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL
 ```
 
 
@@ -89,7 +82,7 @@ admin@serveur1:~$ sudo mkdir /mnt/container
 - Montage du conteneur d'objet
 
 ```bash
-admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL /mnt/container/
+admin@serveur1:~$ sudo mount.s3ql --authfile s3qlcredentials.txt swiftks://auth.cloud.ovh.net/GRA:CT_S3QL /mnt/container/
 ```
 
 - Vérification du montage :
@@ -104,7 +97,7 @@ tmpfs                                      393M  5.2M  388M   2% /run
 tmpfs                                      982M     0  982M   0% /dev/shm
 tmpfs                                      5.0M     0  5.0M   0% /run/lock
 tmpfs                                      982M     0  982M   0% /sys/fs/cgroup
-swiftks://auth.cloud.ovh.net/GRA1:CT_S3QL  1.0T     0  1.0T   0% /mnt/container
+swiftks://auth.cloud.ovh.net/GRA:CT_S3QL  1.0T     0  1.0T   0% /mnt/container
 ```
 
 


### PR DESCRIPTION
Current documentation is using keystone version 2 instead of keystone version 3. But keystone version 2 is going to be shut down in 10 days.