### PR TITLE
EN - Typo - Managed Kubernetes Documentation

### DIFF
--- a/pages/platform/kubernetes-k8s/traffic-management-with-istio/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/traffic-management-with-istio/guide.en-asia.md
@@ -350,5 +350,5 @@ And now the `v2` of `reviews` receives all the traffic, and our Rolling Deployme
 
 ## What's next?
 
-Now you have seem some of the traffic management capabilities of Istio, you can explore other [exaples of Istio traffic management](https://istio.io/docs/tasks/traffic-management/){.external}: [fault injection](https://istio.io/docs/tasks/traffic-management/fault-injection/){.external}, [circuit breaking](https://istio.io/docs/tasks/traffic-management/circuit-breaking/){.external}, [mirroring](https://istio.io/docs/tasks/traffic-management/mirroring/){.external}... 
+Now you have seem some of the traffic management capabilities of Istio, you can explore other [examples of Istio traffic management](https://istio.io/docs/tasks/traffic-management/){.external}: [fault injection](https://istio.io/docs/tasks/traffic-management/fault-injection/){.external}, [circuit breaking](https://istio.io/docs/tasks/traffic-management/circuit-breaking/){.external}, [mirroring](https://istio.io/docs/tasks/traffic-management/mirroring/){.external}... 
 

--- a/pages/platform/kubernetes-k8s/traffic-management-with-istio/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/traffic-management-with-istio/guide.en-au.md
@@ -350,5 +350,5 @@ And now the `v2` of `reviews` receives all the traffic, and our Rolling Deployme
 
 ## What's next?
 
-Now you have seem some of the traffic management capabilities of Istio, you can explore other [exaples of Istio traffic management](https://istio.io/docs/tasks/traffic-management/){.external}: [fault injection](https://istio.io/docs/tasks/traffic-management/fault-injection/){.external}, [circuit breaking](https://istio.io/docs/tasks/traffic-management/circuit-breaking/){.external}, [mirroring](https://istio.io/docs/tasks/traffic-management/mirroring/){.external}... 
+Now you have seem some of the traffic management capabilities of Istio, you can explore other [examples of Istio traffic management](https://istio.io/docs/tasks/traffic-management/){.external}: [fault injection](https://istio.io/docs/tasks/traffic-management/fault-injection/){.external}, [circuit breaking](https://istio.io/docs/tasks/traffic-management/circuit-breaking/){.external}, [mirroring](https://istio.io/docs/tasks/traffic-management/mirroring/){.external}... 
 

--- a/pages/platform/kubernetes-k8s/traffic-management-with-istio/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/traffic-management-with-istio/guide.en-ca.md
@@ -350,5 +350,5 @@ And now the `v2` of `reviews` receives all the traffic, and our Rolling Deployme
 
 ## What's next?
 
-Now you have seem some of the traffic management capabilities of Istio, you can explore other [exaples of Istio traffic management](https://istio.io/docs/tasks/traffic-management/){.external}: [fault injection](https://istio.io/docs/tasks/traffic-management/fault-injection/){.external}, [circuit breaking](https://istio.io/docs/tasks/traffic-management/circuit-breaking/){.external}, [mirroring](https://istio.io/docs/tasks/traffic-management/mirroring/){.external}... 
+Now you have seem some of the traffic management capabilities of Istio, you can explore other [examples of Istio traffic management](https://istio.io/docs/tasks/traffic-management/){.external}: [fault injection](https://istio.io/docs/tasks/traffic-management/fault-injection/){.external}, [circuit breaking](https://istio.io/docs/tasks/traffic-management/circuit-breaking/){.external}, [mirroring](https://istio.io/docs/tasks/traffic-management/mirroring/){.external}... 
 

--- a/pages/platform/kubernetes-k8s/traffic-management-with-istio/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/traffic-management-with-istio/guide.en-gb.md
@@ -350,5 +350,5 @@ And now the `v2` of `reviews` receives all the traffic, and our Rolling Deployme
 
 ## What's next?
 
-Now you have seem some of the traffic management capabilities of Istio, you can explore other [exaples of Istio traffic management](https://istio.io/docs/tasks/traffic-management/){.external}: [fault injection](https://istio.io/docs/tasks/traffic-management/fault-injection/){.external}, [circuit breaking](https://istio.io/docs/tasks/traffic-management/circuit-breaking/){.external}, [mirroring](https://istio.io/docs/tasks/traffic-management/mirroring/){.external}... 
+Now you have seem some of the traffic management capabilities of Istio, you can explore other [examples of Istio traffic management](https://istio.io/docs/tasks/traffic-management/){.external}: [fault injection](https://istio.io/docs/tasks/traffic-management/fault-injection/){.external}, [circuit breaking](https://istio.io/docs/tasks/traffic-management/circuit-breaking/){.external}, [mirroring](https://istio.io/docs/tasks/traffic-management/mirroring/){.external}... 
 

--- a/pages/platform/kubernetes-k8s/traffic-management-with-istio/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/traffic-management-with-istio/guide.en-ie.md
@@ -350,5 +350,5 @@ And now the `v2` of `reviews` receives all the traffic, and our Rolling Deployme
 
 ## What's next?
 
-Now you have seem some of the traffic management capabilities of Istio, you can explore other [exaples of Istio traffic management](https://istio.io/docs/tasks/traffic-management/){.external}: [fault injection](https://istio.io/docs/tasks/traffic-management/fault-injection/){.external}, [circuit breaking](https://istio.io/docs/tasks/traffic-management/circuit-breaking/){.external}, [mirroring](https://istio.io/docs/tasks/traffic-management/mirroring/){.external}... 
+Now you have seem some of the traffic management capabilities of Istio, you can explore other [examples of Istio traffic management](https://istio.io/docs/tasks/traffic-management/){.external}: [fault injection](https://istio.io/docs/tasks/traffic-management/fault-injection/){.external}, [circuit breaking](https://istio.io/docs/tasks/traffic-management/circuit-breaking/){.external}, [mirroring](https://istio.io/docs/tasks/traffic-management/mirroring/){.external}... 
 

--- a/pages/platform/kubernetes-k8s/traffic-management-with-istio/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/traffic-management-with-istio/guide.en-sg.md
@@ -350,5 +350,5 @@ And now the `v2` of `reviews` receives all the traffic, and our Rolling Deployme
 
 ## What's next?
 
-Now you have seem some of the traffic management capabilities of Istio, you can explore other [exaples of Istio traffic management](https://istio.io/docs/tasks/traffic-management/){.external}: [fault injection](https://istio.io/docs/tasks/traffic-management/fault-injection/){.external}, [circuit breaking](https://istio.io/docs/tasks/traffic-management/circuit-breaking/){.external}, [mirroring](https://istio.io/docs/tasks/traffic-management/mirroring/){.external}... 
+Now you have seem some of the traffic management capabilities of Istio, you can explore other [examples of Istio traffic management](https://istio.io/docs/tasks/traffic-management/){.external}: [fault injection](https://istio.io/docs/tasks/traffic-management/fault-injection/){.external}, [circuit breaking](https://istio.io/docs/tasks/traffic-management/circuit-breaking/){.external}, [mirroring](https://istio.io/docs/tasks/traffic-management/mirroring/){.external}... 
 


### PR DESCRIPTION
Added missing m in examples.