### PR TITLE
Add PostgreSQL 12 to Enterprise Cloud Databases

### DIFF
--- a/pages/cloud/entreprise-cloud-databases/postgresql-eos-eol/guide.en-gb.md
+++ b/pages/cloud/entreprise-cloud-databases/postgresql-eos-eol/guide.en-gb.md
@@ -10,6 +10,7 @@ The product covered by those End Of Sale (EOS) and End Of Life (EOL) announcemen
 
 |Version|EOL and End-of-Support|
 |---|---|
+|12|2024-11-14|
 |11|2023-11-9|
 |10|2022-11-10|
 |9.6|2021-11-11|

--- a/pages/cloud/entreprise-cloud-databases/postgresql-eos-eol/guide.fr-fr.md
+++ b/pages/cloud/entreprise-cloud-databases/postgresql-eos-eol/guide.fr-fr.md
@@ -10,6 +10,7 @@ The product covered by those End Of Sale (EOS) and End Of Life (EOL) announcemen
 
 |Version|EOL and End-of-Support|
 |---|---|
+|12|2024-11-14|
 |11|2023-11-9|
 |10|2022-11-10|
 |9.6|2021-11-11|


### PR DESCRIPTION
The Enterprise Cloud Databases team has been working on PostgreSQL version 12 this week. It is now publicly available. This commit add the End-of-Life (EOL) policy for this version, based on the official policy.