### PR TITLE
Add cluster192 to Enterprise Cloud Databases offers

### DIFF
--- a/pages/cloud/entreprise-cloud-databases/offer-description/guide.fr-fr.md
+++ b/pages/cloud/entreprise-cloud-databases/offer-description/guide.fr-fr.md
@@ -12,11 +12,13 @@ Nos clusters PostgreSQL se divisent en différentes tailles détaillées ci-dess
 
 **Caractéristiques techniques de l'offre, par nœud (3 nœuds par défaut):**
 
-|**Cluster16**|**Cluster32**|**Cluster64**|**Cluster128**|**Cluster192**|
-|---|---|---|---|---|
-|16 Go de RAM|32 Go de RAM|64 Go de RAM|128 Go de RAM|192 Go de RAM|
-|4 Cores|4 Cores|6 Cores|8 Cores|16 Cores|
-|960 Go SSD|960 Go SSD|1.92 Tb SSD|3.84 Go SSD|30 Tb SSD|
+|**Cluster** |**RAM (Go)**|**Nombre de cœurs**|**Stockage**          |
+|------------|------------|-------------------|----------------------|
+| Cluster16  |         16 |                 4 | 960 Go SSD RAID 10   |
+| Cluster32  |         32 |                 4 | 960 Go SSD RAID 10   |
+| Cluster64  |         64 |                 6 | 1.92 To SSD RAID 10  |
+| Cluster128 |        128 |                 8 | 3.84 Go SSD RAID 10  |
+| Cluster192 |        192 |                16 | 30 To SSD RAID 10    |
 
 Ces ressources s'expriment par nœud. Elles sont mises en place automatiquement lors de la création d'un cluster.
 

--- a/pages/cloud/entreprise-cloud-databases/offer-description/guide.fr-fr.md
+++ b/pages/cloud/entreprise-cloud-databases/offer-description/guide.fr-fr.md
@@ -12,11 +12,11 @@ Nos clusters PostgreSQL se divisent en différentes tailles détaillées ci-dess
 
 **Caractéristiques techniques de l'offre, par nœud (3 nœuds par défaut):**
 
-|**Cluster16**|**Cluster32**|**Cluster64**|**Cluster128**|
-|---|---|---|----|
-|16 Go de RAM|32 Go de RAM|64 Go de RAM|128 Go de RAM|
-|4 Cores|4 Cores|6 Cores|8 Cores|
-|960 Go SSD|960 Go SSD|1.92 Tb SSD|3.84 Go SSD|
+|**Cluster16**|**Cluster32**|**Cluster64**|**Cluster128**|**Cluster192**|
+|---|---|---|---|---|
+|16 Go de RAM|32 Go de RAM|64 Go de RAM|128 Go de RAM|192 Go de RAM|
+|4 Cores|4 Cores|6 Cores|8 Cores|16 Cores|
+|960 Go SSD|960 Go SSD|1.92 Tb SSD|3.84 Go SSD|30 Tb SSD|
 
 Ces ressources s'expriment par nœud. Elles sont mises en place automatiquement lors de la création d'un cluster.
 


### PR DESCRIPTION
The Enterprise Cloud Databases team has been working this week to add a new PostgreSQL offer named "Cluster192". This page reflect the automated change done to [this page](https://www.ovhcloud.com/fr/enterprise/products/enterprise-cloud-databases/postgresql/).