### PR TITLE
Fix Enterprise Cloud Databases dead links

### DIFF
--- a/pages/cloud/entreprise-cloud-databases/add-delete-cluster-node/guide.fr-ca.md
+++ b/pages/cloud/entreprise-cloud-databases/add-delete-cluster-node/guide.fr-ca.md
@@ -62,6 +62,6 @@ Vous serez amené à choisir le nombre de réplicas que vous souhaitez supprimer
 
 ## Aller plus loin
 
-Apprenez à gérer votre cluster PostgreSQL en consultant la [documentation technique d'OVHcloud](../enterprise-cloud-databases/){.external} pour davantage d'informations sur le fonctionnement technique de votre offre managée.
+Apprenez à gérer votre cluster PostgreSQL en consultant la [documentation technique d'OVHcloud](../../../../fr/enterprise-cloud-databases/){.external} pour davantage d'informations sur le fonctionnement technique de votre offre managée.
 
 Échangez avec notre communauté d'utilisateurs sur <https://community.ovh.com>

--- a/pages/cloud/entreprise-cloud-databases/architectural_principles/guide.fr-fr.md
+++ b/pages/cloud/entreprise-cloud-databases/architectural_principles/guide.fr-fr.md
@@ -52,7 +52,7 @@ Basés sur une infrastructure redondée de serveurs de stockage OVH, ils conserv
 
 - **Haute disponibilité de vos données**
 
-OVH utilise et contribue à [Patroni](https://github.com/zalando/patroni){.external}, un programme en Python utilisé pour gérer la configuration de PostgreSQL.
+OVHcloud utilise et contribue à [Patroni](https://github.com/zalando/patroni){.external}, un programme en Python utilisé pour gérer la configuration de PostgreSQL.
 Cette couche logicielle prend en charge la réplication et la promotion des nœuds au sein du cluster.
 Le quorum de haute disponibilité du cluster est assuré par une instance ZooKeeper installée sur chaque serveur.
 

--- a/pages/cloud/entreprise-cloud-databases/architectural_principles/guide.fr-fr.md
+++ b/pages/cloud/entreprise-cloud-databases/architectural_principles/guide.fr-fr.md
@@ -52,7 +52,7 @@ Basés sur une infrastructure redondée de serveurs de stockage OVH, ils conserv
 
 - **Haute disponibilité de vos données**
 
-OVH utilise et contribue à [https://github.com/zalando/patroni](Patroni){.external}, un programme en Python utilisé pour gérer la configuration de PostgreSQL.
+OVH utilise et contribue à [Patroni](https://github.com/zalando/patroni){.external}, un programme en Python utilisé pour gérer la configuration de PostgreSQL.
 Cette couche logicielle prend en charge la réplication et la promotion des nœuds au sein du cluster.
 Le quorum de haute disponibilité du cluster est assuré par une instance ZooKeeper installée sur chaque serveur.
 

--- a/pages/cloud/entreprise-cloud-databases/eol-policy/guide.en-gb.md
+++ b/pages/cloud/entreprise-cloud-databases/eol-policy/guide.en-gb.md
@@ -10,7 +10,7 @@ OVH managed databases services are based on several major releases of different 
 
 ## Products coverage
 
-The products covered by this EOL policy are Enterprise Cloud Databases. ([See announcements](../clouddb-eos-eol/guide.en-gb.md)).
+The products covered by this EOL policy are Enterprise Cloud Databases. ([See announcements](../postgresql-eos-eol/)).
 
 
 

--- a/pages/cloud/entreprise-cloud-databases/eol-policy/guide.fr-fr.md
+++ b/pages/cloud/entreprise-cloud-databases/eol-policy/guide.fr-fr.md
@@ -10,7 +10,7 @@ OVH managed databases services are based on several major releases of different 
 
 ## Products coverage
 
-The products covered by this EOL policy are Enterprise Cloud Databases. ([See announcements](../clouddb-eos-eol/guide.en-gb.md)).
+The products covered by this EOL policy are Enterprise Cloud Databases. ([See announcements](../postgresql-eos-eol/)).
 
 
 

--- a/pages/cloud/entreprise-cloud-databases/log-management/guide.en-gb.md
+++ b/pages/cloud/entreprise-cloud-databases/log-management/guide.en-gb.md
@@ -39,7 +39,7 @@ A window will appear, prompting you to enter your OVHcloud Logs username. Enter 
 ### Step 3: Use Graylog.
 
 We offer Graylog software for viewing logs in a simple, interactive interface. You can use Graylog to create a range of different dashboard types, and browse event logs.
-[The official OVHcloud Logs documentation](../../platform/logs-data-platform/){.external} details all the configuration steps you need to follow in order to create the dashboards you need, and much more.
+[The official OVHcloud Logs documentation](../../logs-data-platform/){.external} details all the configuration steps you need to follow in order to create the dashboards you need, and much more.
 
 Dashboard example:
 

--- a/pages/cloud/entreprise-cloud-databases/log-management/guide.fr-ca.md
+++ b/pages/cloud/entreprise-cloud-databases/log-management/guide.fr-ca.md
@@ -40,7 +40,7 @@ Une fenêtre vous demande votre nom d'utilisateur OVHcloud Logs. Renseignez-le e
 ### Étape 3 : utilisation de Graylog
 
 Nous vous proposons le logiciel Graylog pour visualiser vos logs de manière simple et interactive. Graylog vous permet de créer des dashboards de toutes sortes et de naviguer dans vos journaux d'évènements.
-[La documentation officielle de OVHcloud Logs](../../platform/logs-data-platform/){.external} détaille toutes les étapes de configuration qui vous permettront de créer les dashboards nécessaires à votre usage, et plus encore.
+[La documentation officielle de OVHcloud Logs](../../../../fr/logs-data-platform/){.external} détaille toutes les étapes de configuration qui vous permettront de créer les dashboards nécessaires à votre usage, et plus encore.
 
 Exemple de dashboard :
 

--- a/pages/cloud/entreprise-cloud-databases/log-management/guide.fr-fr.md
+++ b/pages/cloud/entreprise-cloud-databases/log-management/guide.fr-fr.md
@@ -40,7 +40,7 @@ Une fenêtre vous demande votre nom d'utilisateur OVHcloud Logs. Renseignez-le e
 ### Étape 3 : utilisation de Graylog
 
 Nous vous proposons le logiciel Graylog pour visualiser vos logs de manière simple et interactive. Graylog vous permet de créer des dashboards de toutes sortes et de naviguer dans vos journaux d'évènements.
-[La documentation officielle de OVHcloud Logs](../../platform/logs-data-platform/){.external} détaille toutes les étapes de configuration qui vous permettront de créer les dashboards nécessaires à votre usage, et plus encore.
+[La documentation officielle de OVHcloud Logs](../../logs-data-platform/){.external} détaille toutes les étapes de configuration qui vous permettront de créer les dashboards nécessaires à votre usage, et plus encore.
 
 Exemple de dashboard :
 

--- a/pages/cloud/entreprise-cloud-databases/starting-postgresql/guide.en-gb.md
+++ b/pages/cloud/entreprise-cloud-databases/starting-postgresql/guide.en-gb.md
@@ -93,6 +93,6 @@ Once you have logged in to your cluster, you can create additional databases and
 
 ## Go further
 
-Learn how to manage your PostgreSQL cluster by reading [OVHcloud’s technical guides](../enterprise-cloud-databases/){.external} for further information on the technical aspects of how your managed solution works.
+Learn how to manage your PostgreSQL cluster by reading [OVHcloud’s technical guides](../){.external} for further information on the technical aspects of how your managed solution works.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/cloud/entreprise-cloud-databases/starting-postgresql/guide.fr-fr.md
+++ b/pages/cloud/entreprise-cloud-databases/starting-postgresql/guide.fr-fr.md
@@ -90,11 +90,11 @@ psql -U postgres -h 5f771a6d99ee4102980c2d.prm.clouddb.ovh.net -p 6713 -W --set=
 ### Étape 5 : créer les bases et les utilisateurs
 
 Une fois connecté sur votre cluster, vous pouvez y créer des bases et des utilisateurs supplémentaires.
-Consultez à cet effet la [https://www.postgresql.org/docs/](documentation PostgreSQL){.external} documentation PostgreSQL officielle pour la création de bases et d'utilisateurs.
+Consultez à cet effet la [documentation PostgreSQL](https://www.postgresql.org/docs/){.external} documentation PostgreSQL officielle pour la création de bases et d'utilisateurs.
 
 
 ## Aller plus loin
 
-Apprenez à gérer votre cluster PostgreSQL en consultant la [documentation technique d'OVHcloud](../enterprise-cloud-databases/){.external} pour davantage d'informations sur le fonctionnement technique de votre offre managée.
+Apprenez à gérer votre cluster PostgreSQL en consultant la [documentation technique d'OVHcloud](../){.external} pour davantage d'informations sur le fonctionnement technique de votre offre managée.
 
 Échangez avec notre communauté d'utilisateurs sur <https://community.ovh.com>


### PR DESCRIPTION
Some links where markdown inverted, some were pointing to a wrong file, some were pointing to inexisting documentation pages.