### PR TITLE
Update Enterprise Cloud Databases supported extensions

### DIFF
--- a/pages/cloud/entreprise-cloud-databases/limitations/guide.fr-fr.md
+++ b/pages/cloud/entreprise-cloud-databases/limitations/guide.fr-fr.md
@@ -8,10 +8,10 @@ order: 4
 
 ## Limitations réseau
 
-|**Composant**|**Description**|
-|---|---| 
-|Bande passante maximale|1 Gb/s|
-|Réseau privé|Non disponible|
+|**Composant**          |**Description**|
+|-----------------------|---------------|
+|Bande passante maximale|1 Gb/s         |
+|Réseau privé           |Non disponible |
 
 ## Limitations logicielles
 
@@ -19,12 +19,12 @@ Nous supportons les mises à jour mineures du système d'exploitation ainsi que 
 
 ## Limitations d'usage
 
-|**Composant**|**Description**|
-|---|---|
-|SGBD proposés|PostgreSQL 9.6, 10, 11|
-|Maximum de connexions actives|900|
-|Espace disque|L'espace disque est fixe, il ne peut pas être étendu|
-|Type de réplication|Asynchrone. Il est possible qu'il y ai un court délai d'application des changements entre le serveur primaire et le ou les réplicas.|
+|**Composant**                |**Description**                                                                                                                     |
+|-----------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+|SGBD proposés                |PostgreSQL 9.6, 10, 11, 12                                                                                                          |
+|Maximum de connexions actives|900                                                                                                                                 |
+|Espace disque                |L'espace disque est fixe, il ne peut pas être étendu                                                                                |
+|Type de réplication          |Asynchrone. Il est possible qu'il y ai un court délai d'application des changements entre le serveur primaire et le ou les réplicas.|
 
 ## Extensions compatibles
 
@@ -34,77 +34,309 @@ Vous pouvez à tout moment trouver la liste des extensions disponibles sur votre
 
     SELECT * FROM pg_available_extensions ORDER BY name;
 
-Voici un exemple de sortie à partir d'un PostgreSQL 11 datant du 8 Novembre 2019 :
+L'extension "wal2json" n'est pas incluse dans la liste précédente car elle ne peut pas être créée avec la commande `CREATE EXTENSION`. Elle est utilisable lors de la création d'un [slot de réplication logique](https://docs.postgresql.fr/current/functions-admin.html#functions-replication).
 
-                  name               | default_version | installed_version |                                                       comment
-    ----------------------------------+-----------------+-------------------+---------------------------------------------------------------------------------------------------------------------
-    address_standardizer             | 2.5.3           |                   | Used to parse an address into constituent elements. Generally used to support geocoding address normalization step.
-    address_standardizer-2.5         | 2.5.3           |                   | Used to parse an address into constituent elements. Generally used to support geocoding address normalization step.
-    address_standardizer_data_us     | 2.5.3           |                   | Address Standardizer US dataset example
-    address_standardizer_data_us-2.5 | 2.5.3           |                   | Address Standardizer US dataset example
-    adminpack                        | 2.0             |                   | administrative functions for PostgreSQL
-    amcheck                          | 1.1             |                   | functions for verifying relation integrity
-    autoinc                          | 1.0             |                   | functions for autoincrementing fields
-    bloom                            | 1.0             |                   | bloom access method - signature file based index
-    btree_gin                        | 1.3             |                   | support for indexing common datatypes in GIN
-    btree_gist                       | 1.5             |                   | support for indexing common datatypes in GiST
-    citext                           | 1.5             |                   | data type for case-insensitive character strings
-    cube                             | 1.4             |                   | data type for multidimensional cubes
-    dblink                           | 1.2             |                   | connect to other PostgreSQL databases from within a database
-    dict_int                         | 1.0             |                   | text search dictionary template for integers
-    dict_xsyn                        | 1.0             |                   | text search dictionary template for extended synonym processing
-    earthdistance                    | 1.1             |                   | calculate great-circle distances on the surface of the Earth
-    file_fdw                         | 1.0             |                   | foreign-data wrapper for flat file access
-    fuzzystrmatch                    | 1.1             |                   | determine similarities and distance between strings
-    hstore                           | 1.5             |                   | data type for storing sets of (key, value) pairs
-    hstore_plpython2u                | 1.0             |                   | transform between hstore and plpython2u
-    hstore_plpythonu                 | 1.0             |                   | transform between hstore and plpythonu
-    insert_username                  | 1.0             |                   | functions for tracking who changed a table
-    intagg                           | 1.1             |                   | integer aggregator and enumerator (obsolete)
-    intarray                         | 1.2             |                   | functions, operators, and index support for 1-D arrays of integers
-    ip4r                             | 2.4             |                   |
-    isn                              | 1.2             |                   | data types for international product numbering standards
-    jsonb_plpython2u                 | 1.0             |                   | transform between jsonb and plpython2u
-    jsonb_plpythonu                  | 1.0             |                   | transform between jsonb and plpythonu
-    lo                               | 1.1             |                   | Large Object maintenance
-    ltree                            | 1.1             |                   | data type for hierarchical tree-like structures
-    ltree_plpython2u                 | 1.0             |                   | transform between ltree and plpython2u
-    ltree_plpythonu                  | 1.0             |                   | transform between ltree and plpythonu
-    moddatetime                      | 1.0             |                   | functions for tracking last modification time
-    pageinspect                      | 1.7             |                   | inspect the contents of database pages at a low level
-    pg_buffercache                   | 1.3             |                   | examine the shared buffer cache
-    pg_freespacemap                  | 1.2             |                   | examine the free space map (FSM)
-    pg_prewarm                       | 1.2             |                   | prewarm relation data
-    pg_stat_statements               | 1.6             |                   | track execution statistics of all SQL statements executed
-    pg_trgm                          | 1.4             |                   | text similarity measurement and index searching based on trigrams
-    pg_visibility                    | 1.2             |                   | examine the visibility map (VM) and page-level visibility info
-    pgcrypto                         | 1.3             |                   | cryptographic functions
-    pglogical                        | 2.2.2           |                   | PostgreSQL Logical Replication
-    pglogical_origin                 | 1.0.0           |                   | Dummy extension for compatibility when upgrading from Postgres 9.4
-    pgrouting                        | 2.6.2           |                   | pgRouting Extension
-    pgrowlocks                       | 1.2             |                   | show row-level locking information
-    pgstattuple                      | 1.5             |                   | show tuple-level statistics
-    plpgsql                          | 1.0             | 1.0               | PL/pgSQL procedural language
-    plpython2u                       | 1.0             |                   | PL/Python2U untrusted procedural language
-    plpythonu                        | 1.0             |                   | PL/PythonU untrusted procedural language
-    postgis                          | 2.5.3           |                   | PostGIS geometry, geography, and raster spatial types and functions
-    postgis-2.5                      | 2.5.3           |                   | PostGIS geometry, geography, and raster spatial types and functions
-    postgis_sfcgal                   | 2.5.3           |                   | PostGIS SFCGAL functions
-    postgis_sfcgal-2.5               | 2.5.3           |                   | PostGIS SFCGAL functions
-    postgis_tiger_geocoder           | 2.5.3           |                   | PostGIS tiger geocoder and reverse geocoder
-    postgis_tiger_geocoder-2.5       | 2.5.3           |                   | PostGIS tiger geocoder and reverse geocoder
-    postgis_topology                 | 2.5.3           |                   | PostGIS topology spatial types and functions
-    postgis_topology-2.5             | 2.5.3           |                   | PostGIS topology spatial types and functions
-    postgres_fdw                     | 1.0             |                   | foreign-data wrapper for remote PostgreSQL servers
-    refint                           | 1.0             |                   | functions for implementing referential integrity (obsolete)
-    seg                              | 1.3             |                   | data type for representing line segments or floating-point intervals
-    sslinfo                          | 1.2             |                   | information about SSL certificates
-    tablefunc                        | 1.0             |                   | functions that manipulate whole tables, including crosstab
-    tcn                              | 1.0             |                   | Triggered change notifications
-    timetravel                       | 1.0             |                   | functions for implementing time travel
-    tsm_system_rows                  | 1.0             |                   | TABLESAMPLE method which accepts number of rows as a limit
-    tsm_system_time                  | 1.0             |                   | TABLESAMPLE method which accepts time in milliseconds as a limit
-    unaccent                         | 1.1             |                   | text search dictionary that removes accents
-    uuid-ossp                        | 1.1             |                   | generate universally unique identifiers (UUIDs)
-    xml2                             | 1.1             |                   | XPath querying and XSLT
-    (69 rows)
+### PostgreSQL 12
+
+Liste des extensions supportées au 7 Avril 2020 :
+
+|          **Extension**           | **Version** |
+|----------------------------------|-------------|
+| address_standardizer             | 3.0.1       |
+| address_standardizer-2.5         | 2.5.4       |
+| address_standardizer-3           | 3.0.1       |
+| address_standardizer_data_us     | 3.0.1       |
+| address_standardizer_data_us-2.5 | 2.5.4       |
+| address_standardizer_data_us-3   | 3.0.1       |
+| adminpack                        | 2.0         |
+| amcheck                          | 1.2         |
+| autoinc                          | 1.0         |
+| bloom                            | 1.0         |
+| btree_gin                        | 1.3         |
+| btree_gist                       | 1.5         |
+| citext                           | 1.6         |
+| cube                             | 1.4         |
+| dblink                           | 1.2         |
+| dict_int                         | 1.0         |
+| dict_xsyn                        | 1.0         |
+| earthdistance                    | 1.1         |
+| file_fdw                         | 1.0         |
+| fuzzystrmatch                    | 1.1         |
+| hstore                           | 1.6         |
+| hstore_plpython3u                | 1.0         |
+| insert_username                  | 1.0         |
+| intagg                           | 1.1         |
+| intarray                         | 1.2         |
+| ip4r                             | 2.4         |
+| isn                              | 1.2         |
+| jsonb_plpython3u                 | 1.0         |
+| lo                               | 1.1         |
+| ltree                            | 1.1         |
+| ltree_plpython3u                 | 1.0         |
+| moddatetime                      | 1.0         |
+| pageinspect                      | 1.7         |
+| pg_buffercache                   | 1.3         |
+| pg_freespacemap                  | 1.2         |
+| pg_prewarm                       | 1.2         |
+| pg_stat_statements               | 1.7         |
+| pg_trgm                          | 1.4         |
+| pg_visibility                    | 1.2         |
+| pgcrypto                         | 1.3         |
+| pglogical                        | 2.3.0       |
+| pglogical_origin                 | 1.0.0       |
+| pgrouting                        | 3.0.0       |
+| pgrowlocks                       | 1.2         |
+| pgstattuple                      | 1.5         |
+| plpgsql                          | 1.0         |
+| plpython3u                       | 1.0         |
+| postgis                          | 3.0.1       |
+| postgis-2.5                      | 2.5.4       |
+| postgis-3                        | 3.0.1       |
+| postgis_raster                   | 3.0.1       |
+| postgis_raster-3                 | 3.0.1       |
+| postgis_sfcgal                   | 3.0.1       |
+| postgis_sfcgal-2.5               | 2.5.4       |
+| postgis_sfcgal-3                 | 3.0.1       |
+| postgis_tiger_geocoder           | 3.0.1       |
+| postgis_tiger_geocoder-2.5       | 2.5.4       |
+| postgis_tiger_geocoder-3         | 3.0.1       |
+| postgis_topology                 | 3.0.1       |
+| postgis_topology-2.5             | 2.5.4       |
+| postgis_topology-3               | 3.0.1       |
+| postgres_fdw                     | 1.0         |
+| refint                           | 1.0         |
+| seg                              | 1.3         |
+| sslinfo                          | 1.2         |
+| tablefunc                        | 1.0         |
+| tcn                              | 1.0         |
+| tsm_system_rows                  | 1.0         |
+| tsm_system_time                  | 1.0         |
+| unaccent                         | 1.1         |
+| uuid-ossp                        | 1.1         |
+| wal2json                         | 2.2         |
+| xml2                             | 1.1         |
+
+### PostgreSQL 11
+
+Liste des extensions supportées au 7 Avril 2020 :
+
+|         **Extension**          | **Version** |
+|--------------------------------|-------------|
+| address_standardizer           | 3.0.1       |
+| address_standardizer-3         | 3.0.1       |
+| address_standardizer_data_us   | 3.0.1       |
+| address_standardizer_data_us-3 | 3.0.1       |
+| adminpack                      | 2.0         |
+| amcheck                        | 1.1         |
+| autoinc                        | 1.0         |
+| bloom                          | 1.0         |
+| btree_gin                      | 1.3         |
+| btree_gist                     | 1.5         |
+| citext                         | 1.5         |
+| cube                           | 1.4         |
+| dblink                         | 1.2         |
+| dict_int                       | 1.0         |
+| dict_xsyn                      | 1.0         |
+| earthdistance                  | 1.1         |
+| file_fdw                       | 1.0         |
+| fuzzystrmatch                  | 1.1         |
+| hstore                         | 1.5         |
+| hstore_plpython3u              | 1.0         |
+| insert_username                | 1.0         |
+| intagg                         | 1.1         |
+| intarray                       | 1.2         |
+| ip4r                           | 2.4         |
+| isn                            | 1.2         |
+| jsonb_plpython3u               | 1.0         |
+| lo                             | 1.1         |
+| ltree                          | 1.1         |
+| ltree_plpython3u               | 1.0         |
+| moddatetime                    | 1.0         |
+| pageinspect                    | 1.7         |
+| pg_buffercache                 | 1.3         |
+| pg_freespacemap                | 1.2         |
+| pg_prewarm                     | 1.2         |
+| pg_stat_statements             | 1.6         |
+| pg_trgm                        | 1.4         |
+| pg_visibility                  | 1.2         |
+| pgcrypto                       | 1.3         |
+| pglogical                      | 2.3.0       |
+| pglogical_origin               | 1.0.0       |
+| pgrouting                      | 3.0.0       |
+| pgrowlocks                     | 1.2         |
+| pgstattuple                    | 1.5         |
+| plpgsql                        | 1.0         |
+| plpython3u                     | 1.0         |
+| postgis                        | 3.0.1       |
+| postgis-3                      | 3.0.1       |
+| postgis_raster                 | 3.0.1       |
+| postgis_raster-3               | 3.0.1       |
+| postgis_sfcgal                 | 3.0.1       |
+| postgis_sfcgal-3               | 3.0.1       |
+| postgis_tiger_geocoder         | 3.0.1       |
+| postgis_tiger_geocoder-3       | 3.0.1       |
+| postgis_topology               | 3.0.1       |
+| postgis_topology-3             | 3.0.1       |
+| postgres_fdw                   | 1.0         |
+| refint                         | 1.0         |
+| seg                            | 1.3         |
+| sslinfo                        | 1.2         |
+| tablefunc                      | 1.0         |
+| tcn                            | 1.0         |
+| timetravel                     | 1.0         |
+| tsm_system_rows                | 1.0         |
+| tsm_system_time                | 1.0         |
+| unaccent                       | 1.1         |
+| uuid-ossp                      | 1.1         |
+| wal2json                       | 2.2         |
+| xml2                           | 1.1         |
+
+### PostgreSQL 10
+
+Liste des extensions supportées au 7 Avril 2020 :
+
+|         **Extension**          | **Version** |
+|--------------------------------|-------------|
+| address_standardizer           | 3.0.1       |
+| address_standardizer-3         | 3.0.1       |
+| address_standardizer_data_us   | 3.0.1       |
+| address_standardizer_data_us-3 | 3.0.1       |
+| adminpack                      | 1.1         |
+| amcheck                        | 1.0         |
+| autoinc                        | 1.0         |
+| bloom                          | 1.0         |
+| btree_gin                      | 1.2         |
+| btree_gist                     | 1.5         |
+| chkpass                        | 1.0         |
+| citext                         | 1.4         |
+| cube                           | 1.2         |
+| dblink                         | 1.2         |
+| dict_int                       | 1.0         |
+| dict_xsyn                      | 1.0         |
+| earthdistance                  | 1.1         |
+| file_fdw                       | 1.0         |
+| fuzzystrmatch                  | 1.1         |
+| hstore                         | 1.4         |
+| hstore_plpython3u              | 1.0         |
+| insert_username                | 1.0         |
+| intagg                         | 1.1         |
+| intarray                       | 1.2         |
+| ip4r                           | 2.4         |
+| isn                            | 1.1         |
+| lo                             | 1.1         |
+| ltree                          | 1.1         |
+| ltree_plpython3u               | 1.0         |
+| moddatetime                    | 1.0         |
+| pageinspect                    | 1.6         |
+| pg_buffercache                 | 1.3         |
+| pg_freespacemap                | 1.2         |
+| pg_prewarm                     | 1.1         |
+| pg_stat_statements             | 1.6         |
+| pg_trgm                        | 1.3         |
+| pg_visibility                  | 1.2         |
+| pgcrypto                       | 1.3         |
+| pglogical                      | 2.3.0       |
+| pglogical_origin               | 1.0.0       |
+| pgrouting                      | 3.0.0       |
+| pgrowlocks                     | 1.2         |
+| pgstattuple                    | 1.5         |
+| plpgsql                        | 1.0         |
+| plpython3u                     | 1.0         |
+| postgis                        | 3.0.1       |
+| postgis-3                      | 3.0.1       |
+| postgis_raster                 | 3.0.1       |
+| postgis_raster-3               | 3.0.1       |
+| postgis_sfcgal                 | 3.0.1       |
+| postgis_sfcgal-3               | 3.0.1       |
+| postgis_tiger_geocoder         | 3.0.1       |
+| postgis_tiger_geocoder-3       | 3.0.1       |
+| postgis_topology               | 3.0.1       |
+| postgis_topology-3             | 3.0.1       |
+| postgres_fdw                   | 1.0         |
+| refint                         | 1.0         |
+| seg                            | 1.1         |
+| sslinfo                        | 1.2         |
+| tablefunc                      | 1.0         |
+| tcn                            | 1.0         |
+| timetravel                     | 1.0         |
+| tsm_system_rows                | 1.0         |
+| tsm_system_time                | 1.0         |
+| unaccent                       | 1.1         |
+| uuid-ossp                      | 1.1         |
+| wal2json                       | 2.2         |
+| xml2                           | 1.1         |
+
+### PostgreSQL 9.6
+
+Liste des extensions supportées au 7 Avril 2020 :
+
+|         **Extension**          | **Version** |
+|--------------------------------|-------------|
+| address_standardizer           | 3.0.1       |
+| address_standardizer-3         | 3.0.1       |
+| address_standardizer_data_us   | 3.0.1       |
+| address_standardizer_data_us-3 | 3.0.1       |
+| adminpack                      | 1.1         |
+| autoinc                        | 1.0         |
+| bloom                          | 1.0         |
+| btree_gin                      | 1.0         |
+| btree_gist                     | 1.2         |
+| chkpass                        | 1.0         |
+| citext                         | 1.3         |
+| cube                           | 1.2         |
+| dblink                         | 1.2         |
+| dict_int                       | 1.0         |
+| dict_xsyn                      | 1.0         |
+| earthdistance                  | 1.1         |
+| file_fdw                       | 1.0         |
+| fuzzystrmatch                  | 1.1         |
+| hstore                         | 1.4         |
+| hstore_plpython3u              | 1.0         |
+| insert_username                | 1.0         |
+| intagg                         | 1.1         |
+| intarray                       | 1.2         |
+| ip4r                           | 2.4         |
+| isn                            | 1.1         |
+| lo                             | 1.1         |
+| ltree                          | 1.1         |
+| ltree_plpython3u               | 1.0         |
+| moddatetime                    | 1.0         |
+| pageinspect                    | 1.5         |
+| pg_buffercache                 | 1.2         |
+| pg_freespacemap                | 1.1         |
+| pg_prewarm                     | 1.1         |
+| pg_stat_statements             | 1.4         |
+| pg_trgm                        | 1.3         |
+| pg_visibility                  | 1.1         |
+| pgcrypto                       | 1.3         |
+| pglogical                      | 2.3.0       |
+| pglogical_origin               | 1.0.0       |
+| pgrouting                      | 3.0.0       |
+| pgrowlocks                     | 1.2         |
+| pgstattuple                    | 1.4         |
+| plpgsql                        | 1.0         |
+| plpython3u                     | 1.0         |
+| postgis                        | 3.0.1       |
+| postgis-3                      | 3.0.1       |
+| postgis_raster                 | 3.0.1       |
+| postgis_raster-3               | 3.0.1       |
+| postgis_sfcgal                 | 3.0.1       |
+| postgis_sfcgal-3               | 3.0.1       |
+| postgis_tiger_geocoder         | 3.0.1       |
+| postgis_tiger_geocoder-3       | 3.0.1       |
+| postgis_topology               | 3.0.1       |
+| postgis_topology-3             | 3.0.1       |
+| postgres_fdw                   | 1.0         |
+| refint                         | 1.0         |
+| seg                            | 1.1         |
+| sslinfo                        | 1.2         |
+| tablefunc                      | 1.0         |
+| tcn                            | 1.0         |
+| timetravel                     | 1.0         |
+| tsearch2                       | 1.0         |
+| tsm_system_rows                | 1.0         |
+| tsm_system_time                | 1.0         |
+| unaccent                       | 1.1         |
+| uuid-ossp                      | 1.1         |
+| wal2json                       | 2.2         |
+| xml2                           | 1.1         |


### PR DESCRIPTION
- Use better markdown formatting
- Update PostgreSQL 11 extensions list
- Add PostgreSQL 9.6, 10 and 12 extensions