### PR TITLE
Migrating to Helm 3

### DIFF
--- a/pages/platform/kubernetes-k8s/installing-helm/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/installing-helm/guide.en-asia.md
@@ -6,7 +6,7 @@ section: Tutorials
 order: 4
 ---
 
-**Last updated 19<sup>th</sup> February, 2020.**
+**Last updated April 14<sup>th</sup>, 2020.**
 
 <style>
  pre {
@@ -41,79 +41,53 @@ This tutorial assumes that you already have a working OVHcloud Managed Kubernete
 
 We are assuming that you have the `KUBECONFIG` environment variable pointing to your KubeCtl configuration file, as described in the Quickstarter. If that's not the case, you can use the `--kubeconfig [LOCATION_OF_CONFIG_FILE]` option in both `kubectl` and `helm` calls. 
 
+## Helm concepts
+
+Helm is built around three big concepts: charts, repositories and releases.
+
+A *chart* is a Helm package. Inside the chart you have all the resource definitions necessary to run an application, tool, or service inside of a Kubernetes cluster. It's the Helm equivalent of a Debian pkg for linux, a Maven file for Java or a `package.json` for Node JS.
+
+Charts are stored in *repositories*, where they can be shared. Repositories are the Helm equivalent of the NPM registry for Node JS or Maven Central for Java.
+
+When a chart is installed in a Kubernetes cluster, the running instance is called a *release*. Multiple releases of a single chart can be installed at the same time in a cluster (think for example several instance of the Wordpress chart for several different blogs instances running in the cluster). 
+
+
 ## Installing Helm
 
-Helm has two parts: the client part, `helm`, and the server part, `tiller`. To use Helm on your OVHcloud Managed Kubernetes cluster, you need to deploy `tiller` in the cluster and to install `helm` on your workstation.  
+> [!warn]
+> This guide supposes you're using Helm 3, the latest major version of Helm.
+> The precedent version, Helm 2, is in *maintenance mode*, and considered deprecated.
+> If you want to use Helm 2, please refer to the [official documentation](https://v2.helm.sh/)
+
+Every release of Helm provides binary releases for a variety of OSes. These binary versions can be manually downloaded and installed. 
 
 The simplest way to install Helm is grabbing the binary release for your platform on the [official release page](https://github.com/helm/helm/releases/latest){.external}. You then just need to unpack the client `helm` binary and add it to your PATH.
 
 > [!primary]
 > To use alternative installation procedures, like package managers (Homebrew, Snap etc.), please refer to the [official installation doc](https://docs.helm.sh/using_helm/#installing-helm){.external}.
->
-
-Once you have `helm` ready, you can use it to install `tiller` on your cluster. `helm` will install `tilller` in the current `kubectl` cluster. We assume that your cluster is already configured. If not, please refer to the relevant OVH documentation, and verify you're pointing to the right target by executing:
-
-```bash
-kubectl cluster-info
-```
-
-Before installing Tiller (the Helm server-side component) on your cluster, you need to create a service account for it, and assigning this account admin roles in your cluster:
-
-```bash
-kubectl create serviceaccount --namespace kube-system tiller
-kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
-```
 
 
-You can then install `tiller` on your Kubernetes cluster in one step:
+
+
+## Initialize a Helm Chart Repository
+
+> [!warn]
+> As with Helm 2, the official Helm `stable` repository is currently deprecated. 
+> The Helm community is currently transitioning to a hub model, with a [Helm Hub](https://hub.helm.sh/), where charts can be searched using `helm search hub <keyword>`
+> As the Helm *stable* repository is still popular, we are using it in the tutorial.
+
+Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the official Helm `stable` repository:
 
 ```bash
-helm init
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 ```
 
-Tiller (the Helm server-side component) has been installed into your Kubernetes Cluster.
+Once the repository added, run `helm repo update`to make sure we get the latest list of charts 
 
-Please note: by default, Tiller is deployed with an insecure 'allow unauthenticated users' policy. To prevent this, run `helm init` with the --tiller-tls-verify flag. For more information on securing your installation, see the [official helm doc](https://docs.helm.sh/using_helm/#securing-your-helm-installation){.external}.
-
-<pre class="console"><code>$ helm init
-Creating /Users/user/.helm
-Creating /Users/user/.helm/repository
-Creating /Users/user/.helm/repository/cache
-Creating /Users/user/.helm/repository/local
-Creating /Users/user/.helm/plugins
-Creating /Users/user/.helm/starters
-Creating /Users/user/.helm/cache/archive
-Creating /Users/user/.helm/repository/repositories.yaml
-Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com
-Adding local repo with URL: http://127.0.0.1:8879/charts
-$HELM_HOME has been configured at /Users/user/.helm.
-</code></pre>
-
-Now you need to patch the install to use the service account we defined before:
-
-```bash
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
-```
-
-### Securing your Helm installation
-
-The default Helm installation doesn't apply any security configuration. If you're using Helm in a production context, or in a shared environment, please read this guide to [Securing your Helm Installation page](https://docs.helm.sh/using_helm/#securing-your-helm-installation){.external}. 
-
-
-## Updating the Helm repository
-
-Before installing any package with `helm`, you need you update its repository, to ensure it is equipped with the most recent versions.
-
-```bash
-helm repo update 
-```
-
-Helm will download the repository:
-
-<pre class="console"><code>$ helm repo update
+<pre class="console"><code>$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+"stable" has been added to your repositories
+$ helm repo update
 Hang tight while we grab the latest from your chart repositories...
-...Skip local chart repository
 ...Successfully got an update from the "stable" chart repository
 Update Complete. ⎈ Happy Helming!⎈
 </code></pre>
@@ -124,83 +98,82 @@ Update Complete. ⎈ Happy Helming!⎈
 Let's validate your Helm installation by installing an example chart, the official Redis one, with no persistence:
 
 ```bash
-helm install --set master.persistence.enabled=false stable/redis
+helm install test-redis stable/redis --set master.persistence.enabled=false
 ```
 
-> [!primary]
-> ### Troubleshooting
+> [!warning]
+> As the Helm *stable* repository is deprecated, you're going to get a  
+> *This chart is deprecated* warning. 
+> The current location of the official Redis chart is `bitnami/redis`, 
+> if you want to install a production-ready Redis, please use it:
 >
->If you get an `Error: no available release name found` when installing the `stable/redis` chart, please try the following steps:
->
-> 
->     kubectl create serviceaccount --namespace kube-system tiller
->     kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
->     kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
->     helm init --skip-refresh --upgrade --service-account-tiller
-> 
+> `helm install test-redis stable/redis --set master.persistence.enabled=false`
 
 This will install the required elements and initialise the services. And at the end, it will give you the connection parameters for your new Redis database:
 
 
-<pre class="console"><code>$ helm install --set master.persistence.enabled=false stable/redis
-NAME:   aged-garfish
-LAST DEPLOYED: Mon Oct 15 15:03:35 2018
+<pre class="console"><code>$ helm install test-redis stable/redis --set master.persistence.enabled=false
+WARNING: This chart is deprecated
+NAME: test-redis
+LAST DEPLOYED: Tue Apr 14 14:23:46 2020
 NAMESPACE: default
-STATUS: DEPLOYED
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+This Helm chart is deprecated
 
-RESOURCES:
-==> v1/Secret
-NAME                AGE
-aged-garfish-redis  1s
+Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Redis Helm chart is no
+w located at bitnami/charts (https://github.com/bitnami/charts/).
 
-==> v1/ConfigMap
-aged-garfish-redis-health  1s
+The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've b
+een keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installatio
+n (`bitnami/<chart>` instead of `stable/<chart>`)
 
-==> v1/Service
-aged-garfish-redis-master  1s
-aged-garfish-redis-slave   1s
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/<chart>           # Helm 3
+$ helm install --name my-release bitnami/<chart>    # Helm 2
+```
 
-==> v1beta1/Deployment
-aged-garfish-redis-slave  1s
+To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
+ ```bash
 
-==> v1beta2/StatefulSet
-aged-garfish-redis-master  0s
+                                                                                    $ helm
+ repo add bitnami https://charts.bitnami.com/bitnami
+  $ helm upgrade my-release bitnami/<chart>
+  ```
 
-==> v1/Pod(related)
+  Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to an
+swer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for d
+iscussion.
 
-NAME                                       READY  STATUS             RESTARTS  AGE
-aged-garfish-redis-slave-6596cb6d6c-56vs6  0/1    ContainerCreating  0         0s
-aged-garfish-redis-master-0                0/1    ContainerCreating  0         0s
-
-
-** Note: Please be patient while the chart is being deployed **
-
+** Please be patient while the chart is being deployed **
 Redis can be accessed via port 6379 on the following DNS names from within your cluster:
 
-aged-garfish-redis-master.default.svc.cluster.local for read/write operations
-aged-garfish-redis-slave.default.svc.cluster.local for read-only operations
+test-redis-master.default.svc.cluster.local for read/write operations
+test-redis-slave.default.svc.cluster.local for read-only operations
 
 
-To get your password, run:
+To get your password run:
 
-    export REDIS_PASSWORD=$(kubectl get secret --namespace default aged-garfish-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
+    export REDIS_PASSWORD=$(kubectl get secret --namespace default test-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
 
 To connect to your Redis server:
 
 1. Run a Redis pod that you can use as a client:
 
-   kubectl run --namespace default aged-garfish-redis-client --rm --tty -i \
+   kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
     --env REDIS_PASSWORD=$REDIS_PASSWORD \
-   --image docker.io/bitnami/redis:4.0.11-debian-9 -- bash
+   --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
 
 2. Connect using the Redis CLI:
-3. 
-   redis-cli -h aged-garfish-redis-master -a $REDIS_PASSWORD
-   redis-cli -h aged-garfish-redis-slave -a $REDIS_PASSWORD
+   redis-cli -h test-redis-master -a $REDIS_PASSWORD
+   redis-cli -h test-redis-slave -a $REDIS_PASSWORD
 
-To connect to your database from outside the cluster, execute the following commands:
+To connect to your database from outside the cluster execute the following commands:
 
-    kubectl port-forward --namespace default svc/aged-garfish-redis 6379:6379 &
+    kubectl port-forward --namespace default svc/test-redis-master 6379:6379 &
     redis-cli -h 127.0.0.1 -p 6379 -a $REDIS_PASSWORD
 </code></pre>
 
@@ -208,10 +181,32 @@ To connect to your database from outside the cluster, execute the following comm
 
 After installing the chart, follow the instructions on your console to test your Redis deployment.
 
+
+<pre class="console"><code>s
+$ export REDIS_PASSWORD=$(kubectl get secret --namespace default test-redis \ >     -o jsonpath="{.data.redis-password}" | base64 --decode)
+$ kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
+>     --env REDIS_PASSWORD=$REDIS_PASSWORD \
+>     --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
+If you don't see a command prompt, try pressing enter.
+I have no name!@test-redis-client:/$  redis-cli -h test-redis-master -a $REDIS_PASSWORD
+Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
+test-redis-master:6379> cluster info
+ERR This instance has cluster support disabled
+test-redis-master:6379> ping
+PONG
+test-redis-master:6379> exit
+I have no name!@test-redis-client:/$ exit
+exit
+pod "test-redis-client" deleted
+</code></pre>
+
 ## Cleaning up
 
 To clean up your cluster, simply delete your Redis installation. You can use `helm list` to get the Redis release, and then `helm delete [REDIS_RELEASE]`.
 
-<pre class="console"><code>$$ helm delete aged-garfish
-release "aged-garfish" deleted
+<pre class="console"><code>$ helm list
+NAME            NAMESPACE       REVISION   UPDATED              STATUS     CHART          APP VERSION
+test-redis      default         1          2020-04-14 14:23:46  deployed   redis-10.5.7   5.0.7
+$ helm delete test-redis
+release "test-redis" uninstalled
 </code></pre>

--- a/pages/platform/kubernetes-k8s/installing-helm/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/installing-helm/guide.en-asia.md
@@ -68,27 +68,26 @@ The simplest way to install Helm is grabbing the binary release for your platfor
 
 
 
-
 ## Initialize a Helm Chart Repository
 
 > [!warn]
 > As with Helm 2, the official Helm `stable` repository is currently deprecated. 
 > The Helm community is currently transitioning to a hub model, with a [Helm Hub](https://hub.helm.sh/), where charts can be searched using `helm search hub <keyword>`
-> As the Helm *stable* repository is still popular, we are using it in the tutorial.
+> As most charts from the Helm *stable* repository have been transferred to the [Bitnami repository](https://github.com/bitnami/charts/) we are using it in the tutorial.
 
-Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the official Helm `stable` repository:
+Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the [Bitnami repository](https://github.com/bitnami/charts/):
 
 ```bash
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add bitnami https://charts.bitnami.com/bitnami
 ```
 
 Once the repository added, run `helm repo update`to make sure we get the latest list of charts 
 
-<pre class="console"><code>$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-"stable" has been added to your repositories
+<pre class="console"><code>$ helm repo add bitnami https://charts.bitnami.com/bitnami
+"bitnami" has been added to your repositories
 $ helm repo update
 Hang tight while we grab the latest from your chart repositories...
-...Successfully got an update from the "stable" chart repository
+...Successfully got an update from the "bitnami" chart repository
 Update Complete. ⎈ Happy Helming!⎈
 </code></pre>
 
@@ -98,56 +97,21 @@ Update Complete. ⎈ Happy Helming!⎈
 Let's validate your Helm installation by installing an example chart, the official Redis one, with no persistence:
 
 ```bash
-helm install test-redis stable/redis --set master.persistence.enabled=false
+helm install test-redis bitnami/redis --set master.persistence.enabled=false
 ```
 
-> [!warning]
-> As the Helm *stable* repository is deprecated, you're going to get a  
-> *This chart is deprecated* warning. 
-> The current location of the official Redis chart is `bitnami/redis`, 
-> if you want to install a production-ready Redis, please use it:
->
-> `helm install test-redis stable/redis --set master.persistence.enabled=false`
 
-This will install the required elements and initialise the services. And at the end, it will give you the connection parameters for your new Redis database:
+This will install the required elements and initialize the services. And at the end, it will give you the connection parameters for your new Redis database:
 
 
-<pre class="console"><code>$ helm install test-redis stable/redis --set master.persistence.enabled=false
-WARNING: This chart is deprecated
+<pre class="console"><code>$ helm install test-redis bitnami/redis --set master.persistence.enabled=false
 NAME: test-redis
-LAST DEPLOYED: Tue Apr 14 14:23:46 2020
+LAST DEPLOYED: Tue Apr 14 15:13:14 2020
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
 TEST SUITE: None
 NOTES:
-This Helm chart is deprecated
-
-Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Redis Helm chart is no
-w located at bitnami/charts (https://github.com/bitnami/charts/).
-
-The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've b
-een keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installatio
-n (`bitnami/<chart>` instead of `stable/<chart>`)
-
-```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/<chart>           # Helm 3
-$ helm install --name my-release bitnami/<chart>    # Helm 2
-```
-
-To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
- ```bash
-
-                                                                                    $ helm
- repo add bitnami https://charts.bitnami.com/bitnami
-  $ helm upgrade my-release bitnami/<chart>
-  ```
-
-  Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to an
-swer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for d
-iscussion.
-
 ** Please be patient while the chart is being deployed **
 Redis can be accessed via port 6379 on the following DNS names from within your cluster:
 
@@ -165,7 +129,7 @@ To connect to your Redis server:
 
    kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
     --env REDIS_PASSWORD=$REDIS_PASSWORD \
-   --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
+   --image docker.io/bitnami/redis:5.0.8-debian-10-r39 -- bash
 
 2. Connect using the Redis CLI:
    redis-cli -h test-redis-master -a $REDIS_PASSWORD

--- a/pages/platform/kubernetes-k8s/installing-helm/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/installing-helm/guide.en-au.md
@@ -6,7 +6,7 @@ section: Tutorials
 order: 4
 ---
 
-**Last updated 19<sup>th</sup> February, 2020.**
+**Last updated April 14<sup>th</sup>, 2020.**
 
 <style>
  pre {
@@ -41,79 +41,53 @@ This tutorial assumes that you already have a working OVHcloud Managed Kubernete
 
 We are assuming that you have the `KUBECONFIG` environment variable pointing to your KubeCtl configuration file, as described in the Quickstarter. If that's not the case, you can use the `--kubeconfig [LOCATION_OF_CONFIG_FILE]` option in both `kubectl` and `helm` calls. 
 
+## Helm concepts
+
+Helm is built around three big concepts: charts, repositories and releases.
+
+A *chart* is a Helm package. Inside the chart you have all the resource definitions necessary to run an application, tool, or service inside of a Kubernetes cluster. It's the Helm equivalent of a Debian pkg for linux, a Maven file for Java or a `package.json` for Node JS.
+
+Charts are stored in *repositories*, where they can be shared. Repositories are the Helm equivalent of the NPM registry for Node JS or Maven Central for Java.
+
+When a chart is installed in a Kubernetes cluster, the running instance is called a *release*. Multiple releases of a single chart can be installed at the same time in a cluster (think for example several instance of the Wordpress chart for several different blogs instances running in the cluster). 
+
+
 ## Installing Helm
 
-Helm has two parts: the client part, `helm`, and the server part, `tiller`. To use Helm on your OVHcloud Managed Kubernetes cluster, you need to deploy `tiller` in the cluster and to install `helm` on your workstation.  
+> [!warn]
+> This guide supposes you're using Helm 3, the latest major version of Helm.
+> The precedent version, Helm 2, is in *maintenance mode*, and considered deprecated.
+> If you want to use Helm 2, please refer to the [official documentation](https://v2.helm.sh/)
+
+Every release of Helm provides binary releases for a variety of OSes. These binary versions can be manually downloaded and installed. 
 
 The simplest way to install Helm is grabbing the binary release for your platform on the [official release page](https://github.com/helm/helm/releases/latest){.external}. You then just need to unpack the client `helm` binary and add it to your PATH.
 
 > [!primary]
 > To use alternative installation procedures, like package managers (Homebrew, Snap etc.), please refer to the [official installation doc](https://docs.helm.sh/using_helm/#installing-helm){.external}.
->
-
-Once you have `helm` ready, you can use it to install `tiller` on your cluster. `helm` will install `tilller` in the current `kubectl` cluster. We assume that your cluster is already configured. If not, please refer to the relevant OVH documentation, and verify you're pointing to the right target by executing:
-
-```bash
-kubectl cluster-info
-```
-
-Before installing Tiller (the Helm server-side component) on your cluster, you need to create a service account for it, and assigning this account admin roles in your cluster:
-
-```bash
-kubectl create serviceaccount --namespace kube-system tiller
-kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
-```
 
 
-You can then install `tiller` on your Kubernetes cluster in one step:
+
+
+## Initialize a Helm Chart Repository
+
+> [!warn]
+> As with Helm 2, the official Helm `stable` repository is currently deprecated. 
+> The Helm community is currently transitioning to a hub model, with a [Helm Hub](https://hub.helm.sh/), where charts can be searched using `helm search hub <keyword>`
+> As the Helm *stable* repository is still popular, we are using it in the tutorial.
+
+Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the official Helm `stable` repository:
 
 ```bash
-helm init
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 ```
 
-Tiller (the Helm server-side component) has been installed into your Kubernetes Cluster.
+Once the repository added, run `helm repo update`to make sure we get the latest list of charts 
 
-Please note: by default, Tiller is deployed with an insecure 'allow unauthenticated users' policy. To prevent this, run `helm init` with the --tiller-tls-verify flag. For more information on securing your installation, see the [official helm doc](https://docs.helm.sh/using_helm/#securing-your-helm-installation){.external}.
-
-<pre class="console"><code>$ helm init
-Creating /Users/user/.helm
-Creating /Users/user/.helm/repository
-Creating /Users/user/.helm/repository/cache
-Creating /Users/user/.helm/repository/local
-Creating /Users/user/.helm/plugins
-Creating /Users/user/.helm/starters
-Creating /Users/user/.helm/cache/archive
-Creating /Users/user/.helm/repository/repositories.yaml
-Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com
-Adding local repo with URL: http://127.0.0.1:8879/charts
-$HELM_HOME has been configured at /Users/user/.helm.
-</code></pre>
-
-Now you need to patch the install to use the service account we defined before:
-
-```bash
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
-```
-
-### Securing your Helm installation
-
-The default Helm installation doesn't apply any security configuration. If you're using Helm in a production context, or in a shared environment, please read this guide to [Securing your Helm Installation page](https://docs.helm.sh/using_helm/#securing-your-helm-installation){.external}. 
-
-
-## Updating the Helm repository
-
-Before installing any package with `helm`, you need you update its repository, to ensure it is equipped with the most recent versions.
-
-```bash
-helm repo update 
-```
-
-Helm will download the repository:
-
-<pre class="console"><code>$ helm repo update
+<pre class="console"><code>$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+"stable" has been added to your repositories
+$ helm repo update
 Hang tight while we grab the latest from your chart repositories...
-...Skip local chart repository
 ...Successfully got an update from the "stable" chart repository
 Update Complete. ⎈ Happy Helming!⎈
 </code></pre>
@@ -124,83 +98,82 @@ Update Complete. ⎈ Happy Helming!⎈
 Let's validate your Helm installation by installing an example chart, the official Redis one, with no persistence:
 
 ```bash
-helm install --set master.persistence.enabled=false stable/redis
+helm install test-redis stable/redis --set master.persistence.enabled=false
 ```
 
-> [!primary]
-> ### Troubleshooting
+> [!warning]
+> As the Helm *stable* repository is deprecated, you're going to get a  
+> *This chart is deprecated* warning. 
+> The current location of the official Redis chart is `bitnami/redis`, 
+> if you want to install a production-ready Redis, please use it:
 >
->If you get an `Error: no available release name found` when installing the `stable/redis` chart, please try the following steps:
->
-> 
->     kubectl create serviceaccount --namespace kube-system tiller
->     kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
->     kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
->     helm init --skip-refresh --upgrade --service-account-tiller
-> 
+> `helm install test-redis stable/redis --set master.persistence.enabled=false`
 
 This will install the required elements and initialise the services. And at the end, it will give you the connection parameters for your new Redis database:
 
 
-<pre class="console"><code>$ helm install --set master.persistence.enabled=false stable/redis
-NAME:   aged-garfish
-LAST DEPLOYED: Mon Oct 15 15:03:35 2018
+<pre class="console"><code>$ helm install test-redis stable/redis --set master.persistence.enabled=false
+WARNING: This chart is deprecated
+NAME: test-redis
+LAST DEPLOYED: Tue Apr 14 14:23:46 2020
 NAMESPACE: default
-STATUS: DEPLOYED
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+This Helm chart is deprecated
 
-RESOURCES:
-==> v1/Secret
-NAME                AGE
-aged-garfish-redis  1s
+Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Redis Helm chart is no
+w located at bitnami/charts (https://github.com/bitnami/charts/).
 
-==> v1/ConfigMap
-aged-garfish-redis-health  1s
+The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've b
+een keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installatio
+n (`bitnami/<chart>` instead of `stable/<chart>`)
 
-==> v1/Service
-aged-garfish-redis-master  1s
-aged-garfish-redis-slave   1s
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/<chart>           # Helm 3
+$ helm install --name my-release bitnami/<chart>    # Helm 2
+```
 
-==> v1beta1/Deployment
-aged-garfish-redis-slave  1s
+To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
+ ```bash
 
-==> v1beta2/StatefulSet
-aged-garfish-redis-master  0s
+                                                                                    $ helm
+ repo add bitnami https://charts.bitnami.com/bitnami
+  $ helm upgrade my-release bitnami/<chart>
+  ```
 
-==> v1/Pod(related)
+  Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to an
+swer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for d
+iscussion.
 
-NAME                                       READY  STATUS             RESTARTS  AGE
-aged-garfish-redis-slave-6596cb6d6c-56vs6  0/1    ContainerCreating  0         0s
-aged-garfish-redis-master-0                0/1    ContainerCreating  0         0s
-
-
-** Note: Please be patient while the chart is being deployed **
-
+** Please be patient while the chart is being deployed **
 Redis can be accessed via port 6379 on the following DNS names from within your cluster:
 
-aged-garfish-redis-master.default.svc.cluster.local for read/write operations
-aged-garfish-redis-slave.default.svc.cluster.local for read-only operations
+test-redis-master.default.svc.cluster.local for read/write operations
+test-redis-slave.default.svc.cluster.local for read-only operations
 
 
-To get your password, run:
+To get your password run:
 
-    export REDIS_PASSWORD=$(kubectl get secret --namespace default aged-garfish-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
+    export REDIS_PASSWORD=$(kubectl get secret --namespace default test-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
 
 To connect to your Redis server:
 
 1. Run a Redis pod that you can use as a client:
 
-   kubectl run --namespace default aged-garfish-redis-client --rm --tty -i \
+   kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
     --env REDIS_PASSWORD=$REDIS_PASSWORD \
-   --image docker.io/bitnami/redis:4.0.11-debian-9 -- bash
+   --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
 
 2. Connect using the Redis CLI:
-3. 
-   redis-cli -h aged-garfish-redis-master -a $REDIS_PASSWORD
-   redis-cli -h aged-garfish-redis-slave -a $REDIS_PASSWORD
+   redis-cli -h test-redis-master -a $REDIS_PASSWORD
+   redis-cli -h test-redis-slave -a $REDIS_PASSWORD
 
-To connect to your database from outside the cluster, execute the following commands:
+To connect to your database from outside the cluster execute the following commands:
 
-    kubectl port-forward --namespace default svc/aged-garfish-redis 6379:6379 &
+    kubectl port-forward --namespace default svc/test-redis-master 6379:6379 &
     redis-cli -h 127.0.0.1 -p 6379 -a $REDIS_PASSWORD
 </code></pre>
 
@@ -208,10 +181,32 @@ To connect to your database from outside the cluster, execute the following comm
 
 After installing the chart, follow the instructions on your console to test your Redis deployment.
 
+
+<pre class="console"><code>s
+$ export REDIS_PASSWORD=$(kubectl get secret --namespace default test-redis \ >     -o jsonpath="{.data.redis-password}" | base64 --decode)
+$ kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
+>     --env REDIS_PASSWORD=$REDIS_PASSWORD \
+>     --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
+If you don't see a command prompt, try pressing enter.
+I have no name!@test-redis-client:/$  redis-cli -h test-redis-master -a $REDIS_PASSWORD
+Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
+test-redis-master:6379> cluster info
+ERR This instance has cluster support disabled
+test-redis-master:6379> ping
+PONG
+test-redis-master:6379> exit
+I have no name!@test-redis-client:/$ exit
+exit
+pod "test-redis-client" deleted
+</code></pre>
+
 ## Cleaning up
 
 To clean up your cluster, simply delete your Redis installation. You can use `helm list` to get the Redis release, and then `helm delete [REDIS_RELEASE]`.
 
-<pre class="console"><code>$$ helm delete aged-garfish
-release "aged-garfish" deleted
+<pre class="console"><code>$ helm list
+NAME            NAMESPACE       REVISION   UPDATED              STATUS     CHART          APP VERSION
+test-redis      default         1          2020-04-14 14:23:46  deployed   redis-10.5.7   5.0.7
+$ helm delete test-redis
+release "test-redis" uninstalled
 </code></pre>

--- a/pages/platform/kubernetes-k8s/installing-helm/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/installing-helm/guide.en-au.md
@@ -68,27 +68,26 @@ The simplest way to install Helm is grabbing the binary release for your platfor
 
 
 
-
 ## Initialize a Helm Chart Repository
 
 > [!warn]
 > As with Helm 2, the official Helm `stable` repository is currently deprecated. 
 > The Helm community is currently transitioning to a hub model, with a [Helm Hub](https://hub.helm.sh/), where charts can be searched using `helm search hub <keyword>`
-> As the Helm *stable* repository is still popular, we are using it in the tutorial.
+> As most charts from the Helm *stable* repository have been transferred to the [Bitnami repository](https://github.com/bitnami/charts/) we are using it in the tutorial.
 
-Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the official Helm `stable` repository:
+Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the [Bitnami repository](https://github.com/bitnami/charts/):
 
 ```bash
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add bitnami https://charts.bitnami.com/bitnami
 ```
 
 Once the repository added, run `helm repo update`to make sure we get the latest list of charts 
 
-<pre class="console"><code>$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-"stable" has been added to your repositories
+<pre class="console"><code>$ helm repo add bitnami https://charts.bitnami.com/bitnami
+"bitnami" has been added to your repositories
 $ helm repo update
 Hang tight while we grab the latest from your chart repositories...
-...Successfully got an update from the "stable" chart repository
+...Successfully got an update from the "bitnami" chart repository
 Update Complete. ⎈ Happy Helming!⎈
 </code></pre>
 
@@ -98,56 +97,21 @@ Update Complete. ⎈ Happy Helming!⎈
 Let's validate your Helm installation by installing an example chart, the official Redis one, with no persistence:
 
 ```bash
-helm install test-redis stable/redis --set master.persistence.enabled=false
+helm install test-redis bitnami/redis --set master.persistence.enabled=false
 ```
 
-> [!warning]
-> As the Helm *stable* repository is deprecated, you're going to get a  
-> *This chart is deprecated* warning. 
-> The current location of the official Redis chart is `bitnami/redis`, 
-> if you want to install a production-ready Redis, please use it:
->
-> `helm install test-redis stable/redis --set master.persistence.enabled=false`
 
-This will install the required elements and initialise the services. And at the end, it will give you the connection parameters for your new Redis database:
+This will install the required elements and initialize the services. And at the end, it will give you the connection parameters for your new Redis database:
 
 
-<pre class="console"><code>$ helm install test-redis stable/redis --set master.persistence.enabled=false
-WARNING: This chart is deprecated
+<pre class="console"><code>$ helm install test-redis bitnami/redis --set master.persistence.enabled=false
 NAME: test-redis
-LAST DEPLOYED: Tue Apr 14 14:23:46 2020
+LAST DEPLOYED: Tue Apr 14 15:13:14 2020
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
 TEST SUITE: None
 NOTES:
-This Helm chart is deprecated
-
-Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Redis Helm chart is no
-w located at bitnami/charts (https://github.com/bitnami/charts/).
-
-The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've b
-een keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installatio
-n (`bitnami/<chart>` instead of `stable/<chart>`)
-
-```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/<chart>           # Helm 3
-$ helm install --name my-release bitnami/<chart>    # Helm 2
-```
-
-To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
- ```bash
-
-                                                                                    $ helm
- repo add bitnami https://charts.bitnami.com/bitnami
-  $ helm upgrade my-release bitnami/<chart>
-  ```
-
-  Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to an
-swer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for d
-iscussion.
-
 ** Please be patient while the chart is being deployed **
 Redis can be accessed via port 6379 on the following DNS names from within your cluster:
 
@@ -165,7 +129,7 @@ To connect to your Redis server:
 
    kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
     --env REDIS_PASSWORD=$REDIS_PASSWORD \
-   --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
+   --image docker.io/bitnami/redis:5.0.8-debian-10-r39 -- bash
 
 2. Connect using the Redis CLI:
    redis-cli -h test-redis-master -a $REDIS_PASSWORD

--- a/pages/platform/kubernetes-k8s/installing-helm/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/installing-helm/guide.en-ca.md
@@ -6,7 +6,7 @@ section: Tutorials
 order: 4
 ---
 
-**Last updated 19<sup>th</sup> February, 2020.**
+**Last updated April 14<sup>th</sup>, 2020.**
 
 <style>
  pre {
@@ -41,79 +41,53 @@ This tutorial assumes that you already have a working OVHcloud Managed Kubernete
 
 We are assuming that you have the `KUBECONFIG` environment variable pointing to your KubeCtl configuration file, as described in the Quickstarter. If that's not the case, you can use the `--kubeconfig [LOCATION_OF_CONFIG_FILE]` option in both `kubectl` and `helm` calls. 
 
+## Helm concepts
+
+Helm is built around three big concepts: charts, repositories and releases.
+
+A *chart* is a Helm package. Inside the chart you have all the resource definitions necessary to run an application, tool, or service inside of a Kubernetes cluster. It's the Helm equivalent of a Debian pkg for linux, a Maven file for Java or a `package.json` for Node JS.
+
+Charts are stored in *repositories*, where they can be shared. Repositories are the Helm equivalent of the NPM registry for Node JS or Maven Central for Java.
+
+When a chart is installed in a Kubernetes cluster, the running instance is called a *release*. Multiple releases of a single chart can be installed at the same time in a cluster (think for example several instance of the Wordpress chart for several different blogs instances running in the cluster). 
+
+
 ## Installing Helm
 
-Helm has two parts: the client part, `helm`, and the server part, `tiller`. To use Helm on your OVHcloud Managed Kubernetes cluster, you need to deploy `tiller` in the cluster and to install `helm` on your workstation.  
+> [!warn]
+> This guide supposes you're using Helm 3, the latest major version of Helm.
+> The precedent version, Helm 2, is in *maintenance mode*, and considered deprecated.
+> If you want to use Helm 2, please refer to the [official documentation](https://v2.helm.sh/)
+
+Every release of Helm provides binary releases for a variety of OSes. These binary versions can be manually downloaded and installed. 
 
 The simplest way to install Helm is grabbing the binary release for your platform on the [official release page](https://github.com/helm/helm/releases/latest){.external}. You then just need to unpack the client `helm` binary and add it to your PATH.
 
 > [!primary]
 > To use alternative installation procedures, like package managers (Homebrew, Snap etc.), please refer to the [official installation doc](https://docs.helm.sh/using_helm/#installing-helm){.external}.
->
-
-Once you have `helm` ready, you can use it to install `tiller` on your cluster. `helm` will install `tilller` in the current `kubectl` cluster. We assume that your cluster is already configured. If not, please refer to the relevant OVH documentation, and verify you're pointing to the right target by executing:
-
-```bash
-kubectl cluster-info
-```
-
-Before installing Tiller (the Helm server-side component) on your cluster, you need to create a service account for it, and assigning this account admin roles in your cluster:
-
-```bash
-kubectl create serviceaccount --namespace kube-system tiller
-kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
-```
 
 
-You can then install `tiller` on your Kubernetes cluster in one step:
+
+
+## Initialize a Helm Chart Repository
+
+> [!warn]
+> As with Helm 2, the official Helm `stable` repository is currently deprecated. 
+> The Helm community is currently transitioning to a hub model, with a [Helm Hub](https://hub.helm.sh/), where charts can be searched using `helm search hub <keyword>`
+> As the Helm *stable* repository is still popular, we are using it in the tutorial.
+
+Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the official Helm `stable` repository:
 
 ```bash
-helm init
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 ```
 
-Tiller (the Helm server-side component) has been installed into your Kubernetes Cluster.
+Once the repository added, run `helm repo update`to make sure we get the latest list of charts 
 
-Please note: by default, Tiller is deployed with an insecure 'allow unauthenticated users' policy. To prevent this, run `helm init` with the --tiller-tls-verify flag. For more information on securing your installation, see the [official helm doc](https://docs.helm.sh/using_helm/#securing-your-helm-installation){.external}.
-
-<pre class="console"><code>$ helm init
-Creating /Users/user/.helm
-Creating /Users/user/.helm/repository
-Creating /Users/user/.helm/repository/cache
-Creating /Users/user/.helm/repository/local
-Creating /Users/user/.helm/plugins
-Creating /Users/user/.helm/starters
-Creating /Users/user/.helm/cache/archive
-Creating /Users/user/.helm/repository/repositories.yaml
-Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com
-Adding local repo with URL: http://127.0.0.1:8879/charts
-$HELM_HOME has been configured at /Users/user/.helm.
-</code></pre>
-
-Now you need to patch the install to use the service account we defined before:
-
-```bash
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
-```
-
-### Securing your Helm installation
-
-The default Helm installation doesn't apply any security configuration. If you're using Helm in a production context, or in a shared environment, please read this guide to [Securing your Helm Installation page](https://docs.helm.sh/using_helm/#securing-your-helm-installation){.external}. 
-
-
-## Updating the Helm repository
-
-Before installing any package with `helm`, you need you update its repository, to ensure it is equipped with the most recent versions.
-
-```bash
-helm repo update 
-```
-
-Helm will download the repository:
-
-<pre class="console"><code>$ helm repo update
+<pre class="console"><code>$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+"stable" has been added to your repositories
+$ helm repo update
 Hang tight while we grab the latest from your chart repositories...
-...Skip local chart repository
 ...Successfully got an update from the "stable" chart repository
 Update Complete. ⎈ Happy Helming!⎈
 </code></pre>
@@ -124,83 +98,82 @@ Update Complete. ⎈ Happy Helming!⎈
 Let's validate your Helm installation by installing an example chart, the official Redis one, with no persistence:
 
 ```bash
-helm install --set master.persistence.enabled=false stable/redis
+helm install test-redis stable/redis --set master.persistence.enabled=false
 ```
 
-> [!primary]
-> ### Troubleshooting
+> [!warning]
+> As the Helm *stable* repository is deprecated, you're going to get a  
+> *This chart is deprecated* warning. 
+> The current location of the official Redis chart is `bitnami/redis`, 
+> if you want to install a production-ready Redis, please use it:
 >
->If you get an `Error: no available release name found` when installing the `stable/redis` chart, please try the following steps:
->
-> 
->     kubectl create serviceaccount --namespace kube-system tiller
->     kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
->     kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
->     helm init --skip-refresh --upgrade --service-account-tiller
-> 
+> `helm install test-redis stable/redis --set master.persistence.enabled=false`
 
 This will install the required elements and initialise the services. And at the end, it will give you the connection parameters for your new Redis database:
 
 
-<pre class="console"><code>$ helm install --set master.persistence.enabled=false stable/redis
-NAME:   aged-garfish
-LAST DEPLOYED: Mon Oct 15 15:03:35 2018
+<pre class="console"><code>$ helm install test-redis stable/redis --set master.persistence.enabled=false
+WARNING: This chart is deprecated
+NAME: test-redis
+LAST DEPLOYED: Tue Apr 14 14:23:46 2020
 NAMESPACE: default
-STATUS: DEPLOYED
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+This Helm chart is deprecated
 
-RESOURCES:
-==> v1/Secret
-NAME                AGE
-aged-garfish-redis  1s
+Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Redis Helm chart is no
+w located at bitnami/charts (https://github.com/bitnami/charts/).
 
-==> v1/ConfigMap
-aged-garfish-redis-health  1s
+The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've b
+een keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installatio
+n (`bitnami/<chart>` instead of `stable/<chart>`)
 
-==> v1/Service
-aged-garfish-redis-master  1s
-aged-garfish-redis-slave   1s
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/<chart>           # Helm 3
+$ helm install --name my-release bitnami/<chart>    # Helm 2
+```
 
-==> v1beta1/Deployment
-aged-garfish-redis-slave  1s
+To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
+ ```bash
 
-==> v1beta2/StatefulSet
-aged-garfish-redis-master  0s
+                                                                                    $ helm
+ repo add bitnami https://charts.bitnami.com/bitnami
+  $ helm upgrade my-release bitnami/<chart>
+  ```
 
-==> v1/Pod(related)
+  Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to an
+swer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for d
+iscussion.
 
-NAME                                       READY  STATUS             RESTARTS  AGE
-aged-garfish-redis-slave-6596cb6d6c-56vs6  0/1    ContainerCreating  0         0s
-aged-garfish-redis-master-0                0/1    ContainerCreating  0         0s
-
-
-** Note: Please be patient while the chart is being deployed **
-
+** Please be patient while the chart is being deployed **
 Redis can be accessed via port 6379 on the following DNS names from within your cluster:
 
-aged-garfish-redis-master.default.svc.cluster.local for read/write operations
-aged-garfish-redis-slave.default.svc.cluster.local for read-only operations
+test-redis-master.default.svc.cluster.local for read/write operations
+test-redis-slave.default.svc.cluster.local for read-only operations
 
 
-To get your password, run:
+To get your password run:
 
-    export REDIS_PASSWORD=$(kubectl get secret --namespace default aged-garfish-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
+    export REDIS_PASSWORD=$(kubectl get secret --namespace default test-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
 
 To connect to your Redis server:
 
 1. Run a Redis pod that you can use as a client:
 
-   kubectl run --namespace default aged-garfish-redis-client --rm --tty -i \
+   kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
     --env REDIS_PASSWORD=$REDIS_PASSWORD \
-   --image docker.io/bitnami/redis:4.0.11-debian-9 -- bash
+   --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
 
 2. Connect using the Redis CLI:
-3. 
-   redis-cli -h aged-garfish-redis-master -a $REDIS_PASSWORD
-   redis-cli -h aged-garfish-redis-slave -a $REDIS_PASSWORD
+   redis-cli -h test-redis-master -a $REDIS_PASSWORD
+   redis-cli -h test-redis-slave -a $REDIS_PASSWORD
 
-To connect to your database from outside the cluster, execute the following commands:
+To connect to your database from outside the cluster execute the following commands:
 
-    kubectl port-forward --namespace default svc/aged-garfish-redis 6379:6379 &
+    kubectl port-forward --namespace default svc/test-redis-master 6379:6379 &
     redis-cli -h 127.0.0.1 -p 6379 -a $REDIS_PASSWORD
 </code></pre>
 
@@ -208,10 +181,32 @@ To connect to your database from outside the cluster, execute the following comm
 
 After installing the chart, follow the instructions on your console to test your Redis deployment.
 
+
+<pre class="console"><code>s
+$ export REDIS_PASSWORD=$(kubectl get secret --namespace default test-redis \ >     -o jsonpath="{.data.redis-password}" | base64 --decode)
+$ kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
+>     --env REDIS_PASSWORD=$REDIS_PASSWORD \
+>     --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
+If you don't see a command prompt, try pressing enter.
+I have no name!@test-redis-client:/$  redis-cli -h test-redis-master -a $REDIS_PASSWORD
+Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
+test-redis-master:6379> cluster info
+ERR This instance has cluster support disabled
+test-redis-master:6379> ping
+PONG
+test-redis-master:6379> exit
+I have no name!@test-redis-client:/$ exit
+exit
+pod "test-redis-client" deleted
+</code></pre>
+
 ## Cleaning up
 
 To clean up your cluster, simply delete your Redis installation. You can use `helm list` to get the Redis release, and then `helm delete [REDIS_RELEASE]`.
 
-<pre class="console"><code>$$ helm delete aged-garfish
-release "aged-garfish" deleted
+<pre class="console"><code>$ helm list
+NAME            NAMESPACE       REVISION   UPDATED              STATUS     CHART          APP VERSION
+test-redis      default         1          2020-04-14 14:23:46  deployed   redis-10.5.7   5.0.7
+$ helm delete test-redis
+release "test-redis" uninstalled
 </code></pre>

--- a/pages/platform/kubernetes-k8s/installing-helm/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/installing-helm/guide.en-ca.md
@@ -68,27 +68,26 @@ The simplest way to install Helm is grabbing the binary release for your platfor
 
 
 
-
 ## Initialize a Helm Chart Repository
 
 > [!warn]
 > As with Helm 2, the official Helm `stable` repository is currently deprecated. 
 > The Helm community is currently transitioning to a hub model, with a [Helm Hub](https://hub.helm.sh/), where charts can be searched using `helm search hub <keyword>`
-> As the Helm *stable* repository is still popular, we are using it in the tutorial.
+> As most charts from the Helm *stable* repository have been transferred to the [Bitnami repository](https://github.com/bitnami/charts/) we are using it in the tutorial.
 
-Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the official Helm `stable` repository:
+Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the [Bitnami repository](https://github.com/bitnami/charts/):
 
 ```bash
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add bitnami https://charts.bitnami.com/bitnami
 ```
 
 Once the repository added, run `helm repo update`to make sure we get the latest list of charts 
 
-<pre class="console"><code>$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-"stable" has been added to your repositories
+<pre class="console"><code>$ helm repo add bitnami https://charts.bitnami.com/bitnami
+"bitnami" has been added to your repositories
 $ helm repo update
 Hang tight while we grab the latest from your chart repositories...
-...Successfully got an update from the "stable" chart repository
+...Successfully got an update from the "bitnami" chart repository
 Update Complete. ⎈ Happy Helming!⎈
 </code></pre>
 
@@ -98,56 +97,21 @@ Update Complete. ⎈ Happy Helming!⎈
 Let's validate your Helm installation by installing an example chart, the official Redis one, with no persistence:
 
 ```bash
-helm install test-redis stable/redis --set master.persistence.enabled=false
+helm install test-redis bitnami/redis --set master.persistence.enabled=false
 ```
 
-> [!warning]
-> As the Helm *stable* repository is deprecated, you're going to get a  
-> *This chart is deprecated* warning. 
-> The current location of the official Redis chart is `bitnami/redis`, 
-> if you want to install a production-ready Redis, please use it:
->
-> `helm install test-redis stable/redis --set master.persistence.enabled=false`
 
-This will install the required elements and initialise the services. And at the end, it will give you the connection parameters for your new Redis database:
+This will install the required elements and initialize the services. And at the end, it will give you the connection parameters for your new Redis database:
 
 
-<pre class="console"><code>$ helm install test-redis stable/redis --set master.persistence.enabled=false
-WARNING: This chart is deprecated
+<pre class="console"><code>$ helm install test-redis bitnami/redis --set master.persistence.enabled=false
 NAME: test-redis
-LAST DEPLOYED: Tue Apr 14 14:23:46 2020
+LAST DEPLOYED: Tue Apr 14 15:13:14 2020
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
 TEST SUITE: None
 NOTES:
-This Helm chart is deprecated
-
-Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Redis Helm chart is no
-w located at bitnami/charts (https://github.com/bitnami/charts/).
-
-The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've b
-een keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installatio
-n (`bitnami/<chart>` instead of `stable/<chart>`)
-
-```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/<chart>           # Helm 3
-$ helm install --name my-release bitnami/<chart>    # Helm 2
-```
-
-To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
- ```bash
-
-                                                                                    $ helm
- repo add bitnami https://charts.bitnami.com/bitnami
-  $ helm upgrade my-release bitnami/<chart>
-  ```
-
-  Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to an
-swer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for d
-iscussion.
-
 ** Please be patient while the chart is being deployed **
 Redis can be accessed via port 6379 on the following DNS names from within your cluster:
 
@@ -165,7 +129,7 @@ To connect to your Redis server:
 
    kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
     --env REDIS_PASSWORD=$REDIS_PASSWORD \
-   --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
+   --image docker.io/bitnami/redis:5.0.8-debian-10-r39 -- bash
 
 2. Connect using the Redis CLI:
    redis-cli -h test-redis-master -a $REDIS_PASSWORD

--- a/pages/platform/kubernetes-k8s/installing-helm/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/installing-helm/guide.en-gb.md
@@ -6,7 +6,7 @@ section: Tutorials
 order: 4
 ---
 
-**Last updated 19<sup>th</sup> February, 2020.**
+**Last updated April 14<sup>th</sup>, 2020.**
 
 <style>
  pre {
@@ -41,79 +41,53 @@ This tutorial assumes that you already have a working OVHcloud Managed Kubernete
 
 We are assuming that you have the `KUBECONFIG` environment variable pointing to your KubeCtl configuration file, as described in the Quickstarter. If that's not the case, you can use the `--kubeconfig [LOCATION_OF_CONFIG_FILE]` option in both `kubectl` and `helm` calls. 
 
+## Helm concepts
+
+Helm is built around three big concepts: charts, repositories and releases.
+
+A *chart* is a Helm package. Inside the chart you have all the resource definitions necessary to run an application, tool, or service inside of a Kubernetes cluster. It's the Helm equivalent of a Debian pkg for linux, a Maven file for Java or a `package.json` for Node JS.
+
+Charts are stored in *repositories*, where they can be shared. Repositories are the Helm equivalent of the NPM registry for Node JS or Maven Central for Java.
+
+When a chart is installed in a Kubernetes cluster, the running instance is called a *release*. Multiple releases of a single chart can be installed at the same time in a cluster (think for example several instance of the Wordpress chart for several different blogs instances running in the cluster). 
+
+
 ## Installing Helm
 
-Helm has two parts: the client part, `helm`, and the server part, `tiller`. To use Helm on your OVHcloud Managed Kubernetes cluster, you need to deploy `tiller` in the cluster and to install `helm` on your workstation.  
+> [!warn]
+> This guide supposes you're using Helm 3, the latest major version of Helm.
+> The precedent version, Helm 2, is in *maintenance mode*, and considered deprecated.
+> If you want to use Helm 2, please refer to the [official documentation](https://v2.helm.sh/)
+
+Every release of Helm provides binary releases for a variety of OSes. These binary versions can be manually downloaded and installed. 
 
 The simplest way to install Helm is grabbing the binary release for your platform on the [official release page](https://github.com/helm/helm/releases/latest){.external}. You then just need to unpack the client `helm` binary and add it to your PATH.
 
 > [!primary]
 > To use alternative installation procedures, like package managers (Homebrew, Snap etc.), please refer to the [official installation doc](https://docs.helm.sh/using_helm/#installing-helm){.external}.
->
-
-Once you have `helm` ready, you can use it to install `tiller` on your cluster. `helm` will install `tilller` in the current `kubectl` cluster. We assume that your cluster is already configured. If not, please refer to the relevant OVH documentation, and verify you're pointing to the right target by executing:
-
-```bash
-kubectl cluster-info
-```
-
-Before installing Tiller (the Helm server-side component) on your cluster, you need to create a service account for it, and assigning this account admin roles in your cluster:
-
-```bash
-kubectl create serviceaccount --namespace kube-system tiller
-kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
-```
 
 
-You can then install `tiller` on your Kubernetes cluster in one step:
+
+
+## Initialize a Helm Chart Repository
+
+> [!warn]
+> As with Helm 2, the official Helm `stable` repository is currently deprecated. 
+> The Helm community is currently transitioning to a hub model, with a [Helm Hub](https://hub.helm.sh/), where charts can be searched using `helm search hub <keyword>`
+> As the Helm *stable* repository is still popular, we are using it in the tutorial.
+
+Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the official Helm `stable` repository:
 
 ```bash
-helm init
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 ```
 
-Tiller (the Helm server-side component) has been installed into your Kubernetes Cluster.
+Once the repository added, run `helm repo update`to make sure we get the latest list of charts 
 
-Please note: by default, Tiller is deployed with an insecure 'allow unauthenticated users' policy. To prevent this, run `helm init` with the --tiller-tls-verify flag. For more information on securing your installation, see the [official helm doc](https://docs.helm.sh/using_helm/#securing-your-helm-installation){.external}.
-
-<pre class="console"><code>$ helm init
-Creating /Users/user/.helm
-Creating /Users/user/.helm/repository
-Creating /Users/user/.helm/repository/cache
-Creating /Users/user/.helm/repository/local
-Creating /Users/user/.helm/plugins
-Creating /Users/user/.helm/starters
-Creating /Users/user/.helm/cache/archive
-Creating /Users/user/.helm/repository/repositories.yaml
-Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com
-Adding local repo with URL: http://127.0.0.1:8879/charts
-$HELM_HOME has been configured at /Users/user/.helm.
-</code></pre>
-
-Now you need to patch the install to use the service account we defined before:
-
-```bash
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
-```
-
-### Securing your Helm installation
-
-The default Helm installation doesn't apply any security configuration. If you're using Helm in a production context, or in a shared environment, please read this guide to [Securing your Helm Installation page](https://docs.helm.sh/using_helm/#securing-your-helm-installation){.external}. 
-
-
-## Updating the Helm repository
-
-Before installing any package with `helm`, you need you update its repository, to ensure it is equipped with the most recent versions.
-
-```bash
-helm repo update 
-```
-
-Helm will download the repository:
-
-<pre class="console"><code>$ helm repo update
+<pre class="console"><code>$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+"stable" has been added to your repositories
+$ helm repo update
 Hang tight while we grab the latest from your chart repositories...
-...Skip local chart repository
 ...Successfully got an update from the "stable" chart repository
 Update Complete. ⎈ Happy Helming!⎈
 </code></pre>
@@ -124,83 +98,82 @@ Update Complete. ⎈ Happy Helming!⎈
 Let's validate your Helm installation by installing an example chart, the official Redis one, with no persistence:
 
 ```bash
-helm install --set master.persistence.enabled=false stable/redis
+helm install test-redis stable/redis --set master.persistence.enabled=false
 ```
 
-> [!primary]
-> ### Troubleshooting
+> [!warning]
+> As the Helm *stable* repository is deprecated, you're going to get a  
+> *This chart is deprecated* warning. 
+> The current location of the official Redis chart is `bitnami/redis`, 
+> if you want to install a production-ready Redis, please use it:
 >
->If you get an `Error: no available release name found` when installing the `stable/redis` chart, please try the following steps:
->
-> 
->     kubectl create serviceaccount --namespace kube-system tiller
->     kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
->     kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
->     helm init --skip-refresh --upgrade --service-account-tiller
-> 
+> `helm install test-redis stable/redis --set master.persistence.enabled=false`
 
 This will install the required elements and initialise the services. And at the end, it will give you the connection parameters for your new Redis database:
 
 
-<pre class="console"><code>$ helm install --set master.persistence.enabled=false stable/redis
-NAME:   aged-garfish
-LAST DEPLOYED: Mon Oct 15 15:03:35 2018
+<pre class="console"><code>$ helm install test-redis stable/redis --set master.persistence.enabled=false
+WARNING: This chart is deprecated
+NAME: test-redis
+LAST DEPLOYED: Tue Apr 14 14:23:46 2020
 NAMESPACE: default
-STATUS: DEPLOYED
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+This Helm chart is deprecated
 
-RESOURCES:
-==> v1/Secret
-NAME                AGE
-aged-garfish-redis  1s
+Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Redis Helm chart is no
+w located at bitnami/charts (https://github.com/bitnami/charts/).
 
-==> v1/ConfigMap
-aged-garfish-redis-health  1s
+The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've b
+een keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installatio
+n (`bitnami/<chart>` instead of `stable/<chart>`)
 
-==> v1/Service
-aged-garfish-redis-master  1s
-aged-garfish-redis-slave   1s
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/<chart>           # Helm 3
+$ helm install --name my-release bitnami/<chart>    # Helm 2
+```
 
-==> v1beta1/Deployment
-aged-garfish-redis-slave  1s
+To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
+ ```bash
 
-==> v1beta2/StatefulSet
-aged-garfish-redis-master  0s
+                                                                                    $ helm
+ repo add bitnami https://charts.bitnami.com/bitnami
+  $ helm upgrade my-release bitnami/<chart>
+  ```
 
-==> v1/Pod(related)
+  Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to an
+swer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for d
+iscussion.
 
-NAME                                       READY  STATUS             RESTARTS  AGE
-aged-garfish-redis-slave-6596cb6d6c-56vs6  0/1    ContainerCreating  0         0s
-aged-garfish-redis-master-0                0/1    ContainerCreating  0         0s
-
-
-** Note: Please be patient while the chart is being deployed **
-
+** Please be patient while the chart is being deployed **
 Redis can be accessed via port 6379 on the following DNS names from within your cluster:
 
-aged-garfish-redis-master.default.svc.cluster.local for read/write operations
-aged-garfish-redis-slave.default.svc.cluster.local for read-only operations
+test-redis-master.default.svc.cluster.local for read/write operations
+test-redis-slave.default.svc.cluster.local for read-only operations
 
 
-To get your password, run:
+To get your password run:
 
-    export REDIS_PASSWORD=$(kubectl get secret --namespace default aged-garfish-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
+    export REDIS_PASSWORD=$(kubectl get secret --namespace default test-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
 
 To connect to your Redis server:
 
 1. Run a Redis pod that you can use as a client:
 
-   kubectl run --namespace default aged-garfish-redis-client --rm --tty -i \
+   kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
     --env REDIS_PASSWORD=$REDIS_PASSWORD \
-   --image docker.io/bitnami/redis:4.0.11-debian-9 -- bash
+   --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
 
 2. Connect using the Redis CLI:
-3. 
-   redis-cli -h aged-garfish-redis-master -a $REDIS_PASSWORD
-   redis-cli -h aged-garfish-redis-slave -a $REDIS_PASSWORD
+   redis-cli -h test-redis-master -a $REDIS_PASSWORD
+   redis-cli -h test-redis-slave -a $REDIS_PASSWORD
 
-To connect to your database from outside the cluster, execute the following commands:
+To connect to your database from outside the cluster execute the following commands:
 
-    kubectl port-forward --namespace default svc/aged-garfish-redis 6379:6379 &
+    kubectl port-forward --namespace default svc/test-redis-master 6379:6379 &
     redis-cli -h 127.0.0.1 -p 6379 -a $REDIS_PASSWORD
 </code></pre>
 
@@ -208,10 +181,32 @@ To connect to your database from outside the cluster, execute the following comm
 
 After installing the chart, follow the instructions on your console to test your Redis deployment.
 
+
+<pre class="console"><code>s
+$ export REDIS_PASSWORD=$(kubectl get secret --namespace default test-redis \ >     -o jsonpath="{.data.redis-password}" | base64 --decode)
+$ kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
+>     --env REDIS_PASSWORD=$REDIS_PASSWORD \
+>     --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
+If you don't see a command prompt, try pressing enter.
+I have no name!@test-redis-client:/$  redis-cli -h test-redis-master -a $REDIS_PASSWORD
+Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
+test-redis-master:6379> cluster info
+ERR This instance has cluster support disabled
+test-redis-master:6379> ping
+PONG
+test-redis-master:6379> exit
+I have no name!@test-redis-client:/$ exit
+exit
+pod "test-redis-client" deleted
+</code></pre>
+
 ## Cleaning up
 
 To clean up your cluster, simply delete your Redis installation. You can use `helm list` to get the Redis release, and then `helm delete [REDIS_RELEASE]`.
 
-<pre class="console"><code>$$ helm delete aged-garfish
-release "aged-garfish" deleted
+<pre class="console"><code>$ helm list
+NAME            NAMESPACE       REVISION   UPDATED              STATUS     CHART          APP VERSION
+test-redis      default         1          2020-04-14 14:23:46  deployed   redis-10.5.7   5.0.7
+$ helm delete test-redis
+release "test-redis" uninstalled
 </code></pre>

--- a/pages/platform/kubernetes-k8s/installing-helm/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/installing-helm/guide.en-gb.md
@@ -68,27 +68,26 @@ The simplest way to install Helm is grabbing the binary release for your platfor
 
 
 
-
 ## Initialize a Helm Chart Repository
 
 > [!warn]
 > As with Helm 2, the official Helm `stable` repository is currently deprecated. 
 > The Helm community is currently transitioning to a hub model, with a [Helm Hub](https://hub.helm.sh/), where charts can be searched using `helm search hub <keyword>`
-> As the Helm *stable* repository is still popular, we are using it in the tutorial.
+> As most charts from the Helm *stable* repository have been transferred to the [Bitnami repository](https://github.com/bitnami/charts/) we are using it in the tutorial.
 
-Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the official Helm `stable` repository:
+Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the [Bitnami repository](https://github.com/bitnami/charts/):
 
 ```bash
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add bitnami https://charts.bitnami.com/bitnami
 ```
 
 Once the repository added, run `helm repo update`to make sure we get the latest list of charts 
 
-<pre class="console"><code>$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-"stable" has been added to your repositories
+<pre class="console"><code>$ helm repo add bitnami https://charts.bitnami.com/bitnami
+"bitnami" has been added to your repositories
 $ helm repo update
 Hang tight while we grab the latest from your chart repositories...
-...Successfully got an update from the "stable" chart repository
+...Successfully got an update from the "bitnami" chart repository
 Update Complete. ⎈ Happy Helming!⎈
 </code></pre>
 
@@ -98,56 +97,21 @@ Update Complete. ⎈ Happy Helming!⎈
 Let's validate your Helm installation by installing an example chart, the official Redis one, with no persistence:
 
 ```bash
-helm install test-redis stable/redis --set master.persistence.enabled=false
+helm install test-redis bitnami/redis --set master.persistence.enabled=false
 ```
 
-> [!warning]
-> As the Helm *stable* repository is deprecated, you're going to get a  
-> *This chart is deprecated* warning. 
-> The current location of the official Redis chart is `bitnami/redis`, 
-> if you want to install a production-ready Redis, please use it:
->
-> `helm install test-redis stable/redis --set master.persistence.enabled=false`
 
-This will install the required elements and initialise the services. And at the end, it will give you the connection parameters for your new Redis database:
+This will install the required elements and initialize the services. And at the end, it will give you the connection parameters for your new Redis database:
 
 
-<pre class="console"><code>$ helm install test-redis stable/redis --set master.persistence.enabled=false
-WARNING: This chart is deprecated
+<pre class="console"><code>$ helm install test-redis bitnami/redis --set master.persistence.enabled=false
 NAME: test-redis
-LAST DEPLOYED: Tue Apr 14 14:23:46 2020
+LAST DEPLOYED: Tue Apr 14 15:13:14 2020
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
 TEST SUITE: None
 NOTES:
-This Helm chart is deprecated
-
-Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Redis Helm chart is no
-w located at bitnami/charts (https://github.com/bitnami/charts/).
-
-The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've b
-een keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installatio
-n (`bitnami/<chart>` instead of `stable/<chart>`)
-
-```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/<chart>           # Helm 3
-$ helm install --name my-release bitnami/<chart>    # Helm 2
-```
-
-To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
- ```bash
-
-                                                                                    $ helm
- repo add bitnami https://charts.bitnami.com/bitnami
-  $ helm upgrade my-release bitnami/<chart>
-  ```
-
-  Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to an
-swer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for d
-iscussion.
-
 ** Please be patient while the chart is being deployed **
 Redis can be accessed via port 6379 on the following DNS names from within your cluster:
 
@@ -165,7 +129,7 @@ To connect to your Redis server:
 
    kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
     --env REDIS_PASSWORD=$REDIS_PASSWORD \
-   --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
+   --image docker.io/bitnami/redis:5.0.8-debian-10-r39 -- bash
 
 2. Connect using the Redis CLI:
    redis-cli -h test-redis-master -a $REDIS_PASSWORD

--- a/pages/platform/kubernetes-k8s/installing-helm/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/installing-helm/guide.en-ie.md
@@ -6,7 +6,7 @@ section: Tutorials
 order: 4
 ---
 
-**Last updated 19<sup>th</sup> February, 2020.**
+**Last updated April 14<sup>th</sup>, 2020.**
 
 <style>
  pre {
@@ -41,79 +41,53 @@ This tutorial assumes that you already have a working OVHcloud Managed Kubernete
 
 We are assuming that you have the `KUBECONFIG` environment variable pointing to your KubeCtl configuration file, as described in the Quickstarter. If that's not the case, you can use the `--kubeconfig [LOCATION_OF_CONFIG_FILE]` option in both `kubectl` and `helm` calls. 
 
+## Helm concepts
+
+Helm is built around three big concepts: charts, repositories and releases.
+
+A *chart* is a Helm package. Inside the chart you have all the resource definitions necessary to run an application, tool, or service inside of a Kubernetes cluster. It's the Helm equivalent of a Debian pkg for linux, a Maven file for Java or a `package.json` for Node JS.
+
+Charts are stored in *repositories*, where they can be shared. Repositories are the Helm equivalent of the NPM registry for Node JS or Maven Central for Java.
+
+When a chart is installed in a Kubernetes cluster, the running instance is called a *release*. Multiple releases of a single chart can be installed at the same time in a cluster (think for example several instance of the Wordpress chart for several different blogs instances running in the cluster). 
+
+
 ## Installing Helm
 
-Helm has two parts: the client part, `helm`, and the server part, `tiller`. To use Helm on your OVHcloud Managed Kubernetes cluster, you need to deploy `tiller` in the cluster and to install `helm` on your workstation.  
+> [!warn]
+> This guide supposes you're using Helm 3, the latest major version of Helm.
+> The precedent version, Helm 2, is in *maintenance mode*, and considered deprecated.
+> If you want to use Helm 2, please refer to the [official documentation](https://v2.helm.sh/)
+
+Every release of Helm provides binary releases for a variety of OSes. These binary versions can be manually downloaded and installed. 
 
 The simplest way to install Helm is grabbing the binary release for your platform on the [official release page](https://github.com/helm/helm/releases/latest){.external}. You then just need to unpack the client `helm` binary and add it to your PATH.
 
 > [!primary]
 > To use alternative installation procedures, like package managers (Homebrew, Snap etc.), please refer to the [official installation doc](https://docs.helm.sh/using_helm/#installing-helm){.external}.
->
-
-Once you have `helm` ready, you can use it to install `tiller` on your cluster. `helm` will install `tilller` in the current `kubectl` cluster. We assume that your cluster is already configured. If not, please refer to the relevant OVH documentation, and verify you're pointing to the right target by executing:
-
-```bash
-kubectl cluster-info
-```
-
-Before installing Tiller (the Helm server-side component) on your cluster, you need to create a service account for it, and assigning this account admin roles in your cluster:
-
-```bash
-kubectl create serviceaccount --namespace kube-system tiller
-kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
-```
 
 
-You can then install `tiller` on your Kubernetes cluster in one step:
+
+
+## Initialize a Helm Chart Repository
+
+> [!warn]
+> As with Helm 2, the official Helm `stable` repository is currently deprecated. 
+> The Helm community is currently transitioning to a hub model, with a [Helm Hub](https://hub.helm.sh/), where charts can be searched using `helm search hub <keyword>`
+> As the Helm *stable* repository is still popular, we are using it in the tutorial.
+
+Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the official Helm `stable` repository:
 
 ```bash
-helm init
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 ```
 
-Tiller (the Helm server-side component) has been installed into your Kubernetes Cluster.
+Once the repository added, run `helm repo update`to make sure we get the latest list of charts 
 
-Please note: by default, Tiller is deployed with an insecure 'allow unauthenticated users' policy. To prevent this, run `helm init` with the --tiller-tls-verify flag. For more information on securing your installation, see the [official helm doc](https://docs.helm.sh/using_helm/#securing-your-helm-installation){.external}.
-
-<pre class="console"><code>$ helm init
-Creating /Users/user/.helm
-Creating /Users/user/.helm/repository
-Creating /Users/user/.helm/repository/cache
-Creating /Users/user/.helm/repository/local
-Creating /Users/user/.helm/plugins
-Creating /Users/user/.helm/starters
-Creating /Users/user/.helm/cache/archive
-Creating /Users/user/.helm/repository/repositories.yaml
-Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com
-Adding local repo with URL: http://127.0.0.1:8879/charts
-$HELM_HOME has been configured at /Users/user/.helm.
-</code></pre>
-
-Now you need to patch the install to use the service account we defined before:
-
-```bash
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
-```
-
-### Securing your Helm installation
-
-The default Helm installation doesn't apply any security configuration. If you're using Helm in a production context, or in a shared environment, please read this guide to [Securing your Helm Installation page](https://docs.helm.sh/using_helm/#securing-your-helm-installation){.external}. 
-
-
-## Updating the Helm repository
-
-Before installing any package with `helm`, you need you update its repository, to ensure it is equipped with the most recent versions.
-
-```bash
-helm repo update 
-```
-
-Helm will download the repository:
-
-<pre class="console"><code>$ helm repo update
+<pre class="console"><code>$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+"stable" has been added to your repositories
+$ helm repo update
 Hang tight while we grab the latest from your chart repositories...
-...Skip local chart repository
 ...Successfully got an update from the "stable" chart repository
 Update Complete. ⎈ Happy Helming!⎈
 </code></pre>
@@ -124,83 +98,82 @@ Update Complete. ⎈ Happy Helming!⎈
 Let's validate your Helm installation by installing an example chart, the official Redis one, with no persistence:
 
 ```bash
-helm install --set master.persistence.enabled=false stable/redis
+helm install test-redis stable/redis --set master.persistence.enabled=false
 ```
 
-> [!primary]
-> ### Troubleshooting
+> [!warning]
+> As the Helm *stable* repository is deprecated, you're going to get a  
+> *This chart is deprecated* warning. 
+> The current location of the official Redis chart is `bitnami/redis`, 
+> if you want to install a production-ready Redis, please use it:
 >
->If you get an `Error: no available release name found` when installing the `stable/redis` chart, please try the following steps:
->
-> 
->     kubectl create serviceaccount --namespace kube-system tiller
->     kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
->     kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
->     helm init --skip-refresh --upgrade --service-account-tiller
-> 
+> `helm install test-redis stable/redis --set master.persistence.enabled=false`
 
 This will install the required elements and initialise the services. And at the end, it will give you the connection parameters for your new Redis database:
 
 
-<pre class="console"><code>$ helm install --set master.persistence.enabled=false stable/redis
-NAME:   aged-garfish
-LAST DEPLOYED: Mon Oct 15 15:03:35 2018
+<pre class="console"><code>$ helm install test-redis stable/redis --set master.persistence.enabled=false
+WARNING: This chart is deprecated
+NAME: test-redis
+LAST DEPLOYED: Tue Apr 14 14:23:46 2020
 NAMESPACE: default
-STATUS: DEPLOYED
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+This Helm chart is deprecated
 
-RESOURCES:
-==> v1/Secret
-NAME                AGE
-aged-garfish-redis  1s
+Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Redis Helm chart is no
+w located at bitnami/charts (https://github.com/bitnami/charts/).
 
-==> v1/ConfigMap
-aged-garfish-redis-health  1s
+The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've b
+een keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installatio
+n (`bitnami/<chart>` instead of `stable/<chart>`)
 
-==> v1/Service
-aged-garfish-redis-master  1s
-aged-garfish-redis-slave   1s
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/<chart>           # Helm 3
+$ helm install --name my-release bitnami/<chart>    # Helm 2
+```
 
-==> v1beta1/Deployment
-aged-garfish-redis-slave  1s
+To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
+ ```bash
 
-==> v1beta2/StatefulSet
-aged-garfish-redis-master  0s
+                                                                                    $ helm
+ repo add bitnami https://charts.bitnami.com/bitnami
+  $ helm upgrade my-release bitnami/<chart>
+  ```
 
-==> v1/Pod(related)
+  Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to an
+swer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for d
+iscussion.
 
-NAME                                       READY  STATUS             RESTARTS  AGE
-aged-garfish-redis-slave-6596cb6d6c-56vs6  0/1    ContainerCreating  0         0s
-aged-garfish-redis-master-0                0/1    ContainerCreating  0         0s
-
-
-** Note: Please be patient while the chart is being deployed **
-
+** Please be patient while the chart is being deployed **
 Redis can be accessed via port 6379 on the following DNS names from within your cluster:
 
-aged-garfish-redis-master.default.svc.cluster.local for read/write operations
-aged-garfish-redis-slave.default.svc.cluster.local for read-only operations
+test-redis-master.default.svc.cluster.local for read/write operations
+test-redis-slave.default.svc.cluster.local for read-only operations
 
 
-To get your password, run:
+To get your password run:
 
-    export REDIS_PASSWORD=$(kubectl get secret --namespace default aged-garfish-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
+    export REDIS_PASSWORD=$(kubectl get secret --namespace default test-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
 
 To connect to your Redis server:
 
 1. Run a Redis pod that you can use as a client:
 
-   kubectl run --namespace default aged-garfish-redis-client --rm --tty -i \
+   kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
     --env REDIS_PASSWORD=$REDIS_PASSWORD \
-   --image docker.io/bitnami/redis:4.0.11-debian-9 -- bash
+   --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
 
 2. Connect using the Redis CLI:
-3. 
-   redis-cli -h aged-garfish-redis-master -a $REDIS_PASSWORD
-   redis-cli -h aged-garfish-redis-slave -a $REDIS_PASSWORD
+   redis-cli -h test-redis-master -a $REDIS_PASSWORD
+   redis-cli -h test-redis-slave -a $REDIS_PASSWORD
 
-To connect to your database from outside the cluster, execute the following commands:
+To connect to your database from outside the cluster execute the following commands:
 
-    kubectl port-forward --namespace default svc/aged-garfish-redis 6379:6379 &
+    kubectl port-forward --namespace default svc/test-redis-master 6379:6379 &
     redis-cli -h 127.0.0.1 -p 6379 -a $REDIS_PASSWORD
 </code></pre>
 
@@ -208,10 +181,32 @@ To connect to your database from outside the cluster, execute the following comm
 
 After installing the chart, follow the instructions on your console to test your Redis deployment.
 
+
+<pre class="console"><code>s
+$ export REDIS_PASSWORD=$(kubectl get secret --namespace default test-redis \ >     -o jsonpath="{.data.redis-password}" | base64 --decode)
+$ kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
+>     --env REDIS_PASSWORD=$REDIS_PASSWORD \
+>     --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
+If you don't see a command prompt, try pressing enter.
+I have no name!@test-redis-client:/$  redis-cli -h test-redis-master -a $REDIS_PASSWORD
+Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
+test-redis-master:6379> cluster info
+ERR This instance has cluster support disabled
+test-redis-master:6379> ping
+PONG
+test-redis-master:6379> exit
+I have no name!@test-redis-client:/$ exit
+exit
+pod "test-redis-client" deleted
+</code></pre>
+
 ## Cleaning up
 
 To clean up your cluster, simply delete your Redis installation. You can use `helm list` to get the Redis release, and then `helm delete [REDIS_RELEASE]`.
 
-<pre class="console"><code>$$ helm delete aged-garfish
-release "aged-garfish" deleted
+<pre class="console"><code>$ helm list
+NAME            NAMESPACE       REVISION   UPDATED              STATUS     CHART          APP VERSION
+test-redis      default         1          2020-04-14 14:23:46  deployed   redis-10.5.7   5.0.7
+$ helm delete test-redis
+release "test-redis" uninstalled
 </code></pre>

--- a/pages/platform/kubernetes-k8s/installing-helm/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/installing-helm/guide.en-ie.md
@@ -68,27 +68,26 @@ The simplest way to install Helm is grabbing the binary release for your platfor
 
 
 
-
 ## Initialize a Helm Chart Repository
 
 > [!warn]
 > As with Helm 2, the official Helm `stable` repository is currently deprecated. 
 > The Helm community is currently transitioning to a hub model, with a [Helm Hub](https://hub.helm.sh/), where charts can be searched using `helm search hub <keyword>`
-> As the Helm *stable* repository is still popular, we are using it in the tutorial.
+> As most charts from the Helm *stable* repository have been transferred to the [Bitnami repository](https://github.com/bitnami/charts/) we are using it in the tutorial.
 
-Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the official Helm `stable` repository:
+Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the [Bitnami repository](https://github.com/bitnami/charts/):
 
 ```bash
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add bitnami https://charts.bitnami.com/bitnami
 ```
 
 Once the repository added, run `helm repo update`to make sure we get the latest list of charts 
 
-<pre class="console"><code>$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-"stable" has been added to your repositories
+<pre class="console"><code>$ helm repo add bitnami https://charts.bitnami.com/bitnami
+"bitnami" has been added to your repositories
 $ helm repo update
 Hang tight while we grab the latest from your chart repositories...
-...Successfully got an update from the "stable" chart repository
+...Successfully got an update from the "bitnami" chart repository
 Update Complete. ⎈ Happy Helming!⎈
 </code></pre>
 
@@ -98,56 +97,21 @@ Update Complete. ⎈ Happy Helming!⎈
 Let's validate your Helm installation by installing an example chart, the official Redis one, with no persistence:
 
 ```bash
-helm install test-redis stable/redis --set master.persistence.enabled=false
+helm install test-redis bitnami/redis --set master.persistence.enabled=false
 ```
 
-> [!warning]
-> As the Helm *stable* repository is deprecated, you're going to get a  
-> *This chart is deprecated* warning. 
-> The current location of the official Redis chart is `bitnami/redis`, 
-> if you want to install a production-ready Redis, please use it:
->
-> `helm install test-redis stable/redis --set master.persistence.enabled=false`
 
-This will install the required elements and initialise the services. And at the end, it will give you the connection parameters for your new Redis database:
+This will install the required elements and initialize the services. And at the end, it will give you the connection parameters for your new Redis database:
 
 
-<pre class="console"><code>$ helm install test-redis stable/redis --set master.persistence.enabled=false
-WARNING: This chart is deprecated
+<pre class="console"><code>$ helm install test-redis bitnami/redis --set master.persistence.enabled=false
 NAME: test-redis
-LAST DEPLOYED: Tue Apr 14 14:23:46 2020
+LAST DEPLOYED: Tue Apr 14 15:13:14 2020
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
 TEST SUITE: None
 NOTES:
-This Helm chart is deprecated
-
-Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Redis Helm chart is no
-w located at bitnami/charts (https://github.com/bitnami/charts/).
-
-The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've b
-een keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installatio
-n (`bitnami/<chart>` instead of `stable/<chart>`)
-
-```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/<chart>           # Helm 3
-$ helm install --name my-release bitnami/<chart>    # Helm 2
-```
-
-To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
- ```bash
-
-                                                                                    $ helm
- repo add bitnami https://charts.bitnami.com/bitnami
-  $ helm upgrade my-release bitnami/<chart>
-  ```
-
-  Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to an
-swer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for d
-iscussion.
-
 ** Please be patient while the chart is being deployed **
 Redis can be accessed via port 6379 on the following DNS names from within your cluster:
 
@@ -165,7 +129,7 @@ To connect to your Redis server:
 
    kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
     --env REDIS_PASSWORD=$REDIS_PASSWORD \
-   --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
+   --image docker.io/bitnami/redis:5.0.8-debian-10-r39 -- bash
 
 2. Connect using the Redis CLI:
    redis-cli -h test-redis-master -a $REDIS_PASSWORD

--- a/pages/platform/kubernetes-k8s/installing-helm/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/installing-helm/guide.en-sg.md
@@ -6,7 +6,7 @@ section: Tutorials
 order: 4
 ---
 
-**Last updated 19<sup>th</sup> February, 2020.**
+**Last updated April 14<sup>th</sup>, 2020.**
 
 <style>
  pre {
@@ -41,79 +41,53 @@ This tutorial assumes that you already have a working OVHcloud Managed Kubernete
 
 We are assuming that you have the `KUBECONFIG` environment variable pointing to your KubeCtl configuration file, as described in the Quickstarter. If that's not the case, you can use the `--kubeconfig [LOCATION_OF_CONFIG_FILE]` option in both `kubectl` and `helm` calls. 
 
+## Helm concepts
+
+Helm is built around three big concepts: charts, repositories and releases.
+
+A *chart* is a Helm package. Inside the chart you have all the resource definitions necessary to run an application, tool, or service inside of a Kubernetes cluster. It's the Helm equivalent of a Debian pkg for linux, a Maven file for Java or a `package.json` for Node JS.
+
+Charts are stored in *repositories*, where they can be shared. Repositories are the Helm equivalent of the NPM registry for Node JS or Maven Central for Java.
+
+When a chart is installed in a Kubernetes cluster, the running instance is called a *release*. Multiple releases of a single chart can be installed at the same time in a cluster (think for example several instance of the Wordpress chart for several different blogs instances running in the cluster). 
+
+
 ## Installing Helm
 
-Helm has two parts: the client part, `helm`, and the server part, `tiller`. To use Helm on your OVHcloud Managed Kubernetes cluster, you need to deploy `tiller` in the cluster and to install `helm` on your workstation.  
+> [!warn]
+> This guide supposes you're using Helm 3, the latest major version of Helm.
+> The precedent version, Helm 2, is in *maintenance mode*, and considered deprecated.
+> If you want to use Helm 2, please refer to the [official documentation](https://v2.helm.sh/)
+
+Every release of Helm provides binary releases for a variety of OSes. These binary versions can be manually downloaded and installed. 
 
 The simplest way to install Helm is grabbing the binary release for your platform on the [official release page](https://github.com/helm/helm/releases/latest){.external}. You then just need to unpack the client `helm` binary and add it to your PATH.
 
 > [!primary]
 > To use alternative installation procedures, like package managers (Homebrew, Snap etc.), please refer to the [official installation doc](https://docs.helm.sh/using_helm/#installing-helm){.external}.
->
-
-Once you have `helm` ready, you can use it to install `tiller` on your cluster. `helm` will install `tilller` in the current `kubectl` cluster. We assume that your cluster is already configured. If not, please refer to the relevant OVH documentation, and verify you're pointing to the right target by executing:
-
-```bash
-kubectl cluster-info
-```
-
-Before installing Tiller (the Helm server-side component) on your cluster, you need to create a service account for it, and assigning this account admin roles in your cluster:
-
-```bash
-kubectl create serviceaccount --namespace kube-system tiller
-kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
-```
 
 
-You can then install `tiller` on your Kubernetes cluster in one step:
+
+
+## Initialize a Helm Chart Repository
+
+> [!warn]
+> As with Helm 2, the official Helm `stable` repository is currently deprecated. 
+> The Helm community is currently transitioning to a hub model, with a [Helm Hub](https://hub.helm.sh/), where charts can be searched using `helm search hub <keyword>`
+> As the Helm *stable* repository is still popular, we are using it in the tutorial.
+
+Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the official Helm `stable` repository:
 
 ```bash
-helm init
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 ```
 
-Tiller (the Helm server-side component) has been installed into your Kubernetes Cluster.
+Once the repository added, run `helm repo update`to make sure we get the latest list of charts 
 
-Please note: by default, Tiller is deployed with an insecure 'allow unauthenticated users' policy. To prevent this, run `helm init` with the --tiller-tls-verify flag. For more information on securing your installation, see the [official helm doc](https://docs.helm.sh/using_helm/#securing-your-helm-installation){.external}.
-
-<pre class="console"><code>$ helm init
-Creating /Users/user/.helm
-Creating /Users/user/.helm/repository
-Creating /Users/user/.helm/repository/cache
-Creating /Users/user/.helm/repository/local
-Creating /Users/user/.helm/plugins
-Creating /Users/user/.helm/starters
-Creating /Users/user/.helm/cache/archive
-Creating /Users/user/.helm/repository/repositories.yaml
-Adding stable repo with URL: https://kubernetes-charts.storage.googleapis.com
-Adding local repo with URL: http://127.0.0.1:8879/charts
-$HELM_HOME has been configured at /Users/user/.helm.
-</code></pre>
-
-Now you need to patch the install to use the service account we defined before:
-
-```bash
-kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
-```
-
-### Securing your Helm installation
-
-The default Helm installation doesn't apply any security configuration. If you're using Helm in a production context, or in a shared environment, please read this guide to [Securing your Helm Installation page](https://docs.helm.sh/using_helm/#securing-your-helm-installation){.external}. 
-
-
-## Updating the Helm repository
-
-Before installing any package with `helm`, you need you update its repository, to ensure it is equipped with the most recent versions.
-
-```bash
-helm repo update 
-```
-
-Helm will download the repository:
-
-<pre class="console"><code>$ helm repo update
+<pre class="console"><code>$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+"stable" has been added to your repositories
+$ helm repo update
 Hang tight while we grab the latest from your chart repositories...
-...Skip local chart repository
 ...Successfully got an update from the "stable" chart repository
 Update Complete. ⎈ Happy Helming!⎈
 </code></pre>
@@ -124,83 +98,82 @@ Update Complete. ⎈ Happy Helming!⎈
 Let's validate your Helm installation by installing an example chart, the official Redis one, with no persistence:
 
 ```bash
-helm install --set master.persistence.enabled=false stable/redis
+helm install test-redis stable/redis --set master.persistence.enabled=false
 ```
 
-> [!primary]
-> ### Troubleshooting
+> [!warning]
+> As the Helm *stable* repository is deprecated, you're going to get a  
+> *This chart is deprecated* warning. 
+> The current location of the official Redis chart is `bitnami/redis`, 
+> if you want to install a production-ready Redis, please use it:
 >
->If you get an `Error: no available release name found` when installing the `stable/redis` chart, please try the following steps:
->
-> 
->     kubectl create serviceaccount --namespace kube-system tiller
->     kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
->     kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
->     helm init --skip-refresh --upgrade --service-account-tiller
-> 
+> `helm install test-redis stable/redis --set master.persistence.enabled=false`
 
 This will install the required elements and initialise the services. And at the end, it will give you the connection parameters for your new Redis database:
 
 
-<pre class="console"><code>$ helm install --set master.persistence.enabled=false stable/redis
-NAME:   aged-garfish
-LAST DEPLOYED: Mon Oct 15 15:03:35 2018
+<pre class="console"><code>$ helm install test-redis stable/redis --set master.persistence.enabled=false
+WARNING: This chart is deprecated
+NAME: test-redis
+LAST DEPLOYED: Tue Apr 14 14:23:46 2020
 NAMESPACE: default
-STATUS: DEPLOYED
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+This Helm chart is deprecated
 
-RESOURCES:
-==> v1/Secret
-NAME                AGE
-aged-garfish-redis  1s
+Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Redis Helm chart is no
+w located at bitnami/charts (https://github.com/bitnami/charts/).
 
-==> v1/ConfigMap
-aged-garfish-redis-health  1s
+The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've b
+een keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installatio
+n (`bitnami/<chart>` instead of `stable/<chart>`)
 
-==> v1/Service
-aged-garfish-redis-master  1s
-aged-garfish-redis-slave   1s
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/<chart>           # Helm 3
+$ helm install --name my-release bitnami/<chart>    # Helm 2
+```
 
-==> v1beta1/Deployment
-aged-garfish-redis-slave  1s
+To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
+ ```bash
 
-==> v1beta2/StatefulSet
-aged-garfish-redis-master  0s
+                                                                                    $ helm
+ repo add bitnami https://charts.bitnami.com/bitnami
+  $ helm upgrade my-release bitnami/<chart>
+  ```
 
-==> v1/Pod(related)
+  Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to an
+swer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for d
+iscussion.
 
-NAME                                       READY  STATUS             RESTARTS  AGE
-aged-garfish-redis-slave-6596cb6d6c-56vs6  0/1    ContainerCreating  0         0s
-aged-garfish-redis-master-0                0/1    ContainerCreating  0         0s
-
-
-** Note: Please be patient while the chart is being deployed **
-
+** Please be patient while the chart is being deployed **
 Redis can be accessed via port 6379 on the following DNS names from within your cluster:
 
-aged-garfish-redis-master.default.svc.cluster.local for read/write operations
-aged-garfish-redis-slave.default.svc.cluster.local for read-only operations
+test-redis-master.default.svc.cluster.local for read/write operations
+test-redis-slave.default.svc.cluster.local for read-only operations
 
 
-To get your password, run:
+To get your password run:
 
-    export REDIS_PASSWORD=$(kubectl get secret --namespace default aged-garfish-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
+    export REDIS_PASSWORD=$(kubectl get secret --namespace default test-redis -o jsonpath="{.data.redis-password}" | base64 --decode)
 
 To connect to your Redis server:
 
 1. Run a Redis pod that you can use as a client:
 
-   kubectl run --namespace default aged-garfish-redis-client --rm --tty -i \
+   kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
     --env REDIS_PASSWORD=$REDIS_PASSWORD \
-   --image docker.io/bitnami/redis:4.0.11-debian-9 -- bash
+   --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
 
 2. Connect using the Redis CLI:
-3. 
-   redis-cli -h aged-garfish-redis-master -a $REDIS_PASSWORD
-   redis-cli -h aged-garfish-redis-slave -a $REDIS_PASSWORD
+   redis-cli -h test-redis-master -a $REDIS_PASSWORD
+   redis-cli -h test-redis-slave -a $REDIS_PASSWORD
 
-To connect to your database from outside the cluster, execute the following commands:
+To connect to your database from outside the cluster execute the following commands:
 
-    kubectl port-forward --namespace default svc/aged-garfish-redis 6379:6379 &
+    kubectl port-forward --namespace default svc/test-redis-master 6379:6379 &
     redis-cli -h 127.0.0.1 -p 6379 -a $REDIS_PASSWORD
 </code></pre>
 
@@ -208,10 +181,32 @@ To connect to your database from outside the cluster, execute the following comm
 
 After installing the chart, follow the instructions on your console to test your Redis deployment.
 
+
+<pre class="console"><code>s
+$ export REDIS_PASSWORD=$(kubectl get secret --namespace default test-redis \ >     -o jsonpath="{.data.redis-password}" | base64 --decode)
+$ kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
+>     --env REDIS_PASSWORD=$REDIS_PASSWORD \
+>     --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
+If you don't see a command prompt, try pressing enter.
+I have no name!@test-redis-client:/$  redis-cli -h test-redis-master -a $REDIS_PASSWORD
+Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe.
+test-redis-master:6379> cluster info
+ERR This instance has cluster support disabled
+test-redis-master:6379> ping
+PONG
+test-redis-master:6379> exit
+I have no name!@test-redis-client:/$ exit
+exit
+pod "test-redis-client" deleted
+</code></pre>
+
 ## Cleaning up
 
 To clean up your cluster, simply delete your Redis installation. You can use `helm list` to get the Redis release, and then `helm delete [REDIS_RELEASE]`.
 
-<pre class="console"><code>$$ helm delete aged-garfish
-release "aged-garfish" deleted
+<pre class="console"><code>$ helm list
+NAME            NAMESPACE       REVISION   UPDATED              STATUS     CHART          APP VERSION
+test-redis      default         1          2020-04-14 14:23:46  deployed   redis-10.5.7   5.0.7
+$ helm delete test-redis
+release "test-redis" uninstalled
 </code></pre>

--- a/pages/platform/kubernetes-k8s/installing-helm/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/installing-helm/guide.en-sg.md
@@ -68,27 +68,26 @@ The simplest way to install Helm is grabbing the binary release for your platfor
 
 
 
-
 ## Initialize a Helm Chart Repository
 
 > [!warn]
 > As with Helm 2, the official Helm `stable` repository is currently deprecated. 
 > The Helm community is currently transitioning to a hub model, with a [Helm Hub](https://hub.helm.sh/), where charts can be searched using `helm search hub <keyword>`
-> As the Helm *stable* repository is still popular, we are using it in the tutorial.
+> As most charts from the Helm *stable* repository have been transferred to the [Bitnami repository](https://github.com/bitnami/charts/) we are using it in the tutorial.
 
-Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the official Helm `stable` repository:
+Once you have Helm ready, you can add a chart repository. The easiest way to begin with Helm is to add the [Bitnami repository](https://github.com/bitnami/charts/):
 
 ```bash
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo add bitnami https://charts.bitnami.com/bitnami
 ```
 
 Once the repository added, run `helm repo update`to make sure we get the latest list of charts 
 
-<pre class="console"><code>$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-"stable" has been added to your repositories
+<pre class="console"><code>$ helm repo add bitnami https://charts.bitnami.com/bitnami
+"bitnami" has been added to your repositories
 $ helm repo update
 Hang tight while we grab the latest from your chart repositories...
-...Successfully got an update from the "stable" chart repository
+...Successfully got an update from the "bitnami" chart repository
 Update Complete. ⎈ Happy Helming!⎈
 </code></pre>
 
@@ -98,56 +97,21 @@ Update Complete. ⎈ Happy Helming!⎈
 Let's validate your Helm installation by installing an example chart, the official Redis one, with no persistence:
 
 ```bash
-helm install test-redis stable/redis --set master.persistence.enabled=false
+helm install test-redis bitnami/redis --set master.persistence.enabled=false
 ```
 
-> [!warning]
-> As the Helm *stable* repository is deprecated, you're going to get a  
-> *This chart is deprecated* warning. 
-> The current location of the official Redis chart is `bitnami/redis`, 
-> if you want to install a production-ready Redis, please use it:
->
-> `helm install test-redis stable/redis --set master.persistence.enabled=false`
 
-This will install the required elements and initialise the services. And at the end, it will give you the connection parameters for your new Redis database:
+This will install the required elements and initialize the services. And at the end, it will give you the connection parameters for your new Redis database:
 
 
-<pre class="console"><code>$ helm install test-redis stable/redis --set master.persistence.enabled=false
-WARNING: This chart is deprecated
+<pre class="console"><code>$ helm install test-redis bitnami/redis --set master.persistence.enabled=false
 NAME: test-redis
-LAST DEPLOYED: Tue Apr 14 14:23:46 2020
+LAST DEPLOYED: Tue Apr 14 15:13:14 2020
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
 TEST SUITE: None
 NOTES:
-This Helm chart is deprecated
-
-Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Redis Helm chart is no
-w located at bitnami/charts (https://github.com/bitnami/charts/).
-
-The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've b
-een keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installatio
-n (`bitnami/<chart>` instead of `stable/<chart>`)
-
-```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/<chart>           # Helm 3
-$ helm install --name my-release bitnami/<chart>    # Helm 2
-```
-
-To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
- ```bash
-
-                                                                                    $ helm
- repo add bitnami https://charts.bitnami.com/bitnami
-  $ helm upgrade my-release bitnami/<chart>
-  ```
-
-  Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to an
-swer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for d
-iscussion.
-
 ** Please be patient while the chart is being deployed **
 Redis can be accessed via port 6379 on the following DNS names from within your cluster:
 
@@ -165,7 +129,7 @@ To connect to your Redis server:
 
    kubectl run --namespace default test-redis-client --rm --tty -i --restart='Never' \
     --env REDIS_PASSWORD=$REDIS_PASSWORD \
-   --image docker.io/bitnami/redis:5.0.7-debian-10-r32 -- bash
+   --image docker.io/bitnami/redis:5.0.8-debian-10-r39 -- bash
 
 2. Connect using the Redis CLI:
    redis-cli -h test-redis-master -a $REDIS_PASSWORD

--- a/pages/platform/kubernetes-k8s/installing-wordpress/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/installing-wordpress/guide.en-asia.md
@@ -6,7 +6,7 @@ section: Tutorials
 order: 5
 ---
 
-**Last updated 3<sup>rd</sup> September, 2019.**
+**Last updated April 14<sup>th</sup>, 2020.**
 
 <style>
  pre {
@@ -41,8 +41,7 @@ You also need to have [Helm](https://docs.helm.sh/) installer on your workstatio
 
 ## Installing the Wordpress Helm chart
 
-For this tutorial we are using the [Wordpress Helm chart](https://github.com/helm/charts/tree/master/stable/wordpress){.external} found on Helm repositories.
-The chart is fully configurable, but here we are using the default configuration, with only the minimal set of customization to make it work well on OVHcloud Managed Kubernetes Service.
+For this tutorial we are using the [Wordpress Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/wordpress){.external} found on [Bitnami repository](https://github.com/bitnami/charts/). The chart is fully configurable, but here we are using the default configuration, with only the minimal set of customization to make it work well on OVHcloud Managed Kubernetes Service.
 
 
 > [!primary]
@@ -53,91 +52,65 @@ The chart is fully configurable, but here we are using the default configuration
 > In order to customize your install, without having to leave the simplicity of using helm and the Wordpress helm chart, you can simply set some of the [configurable parameters of the WordPress chart](https://github.com/helm/charts/tree/master/stable/wordpress#configuration){.external}. Then you can add it to your `helm install` with the `--set` option (`--set param1=value1,param2=value2`)
 >
 
+
 ```
-helm install stable/wordpress --set allowOverrideNone=true -n my-first-k8s-wordpress
+helm install my-first-k8s-wordpress bitnami/wordpress --set allowOverrideNone=true
 ```
 
 This will install the needed elements (a MariaDB pod for the database, a Wordpress pod for the webserver with the Worpdress PHP code),
 allocate the persistent volumes and initialize the services. And at the end, it will give you the connection parameters for your new Wordpress:
 
 
-<pre class="console"><code>$ helm install stable/wordpress --set allowOverrideNone=true -n my-first-k8s-wordpress
-NAME:   my-first-k8s-wordpress
-LAST DEPLOYED: Wed Feb  6 22:36:51 2019
+<pre class="console"><code>$ helm install my-first-k8s-wordpress bitnami/wordpress --set allowOverrideNone=true
+NAME: my-first-k8s-wordpress
+LAST DEPLOYED: Tue Apr 14 15:14:57 2020
 NAMESPACE: default
-STATUS: DEPLOYED
+STATUS: deployed
+REVISION: 1
+NOTES:
+** Please be patient while the chart is being deployed **
 
-RESOURCES:
-==> v1beta1/StatefulSet
-NAME                            DESIRED  CURRENT  AGE
-my-first-k8s-wordpress-mariadb  1        1        2s
+To access your WordPress site from outside the cluster follow the steps below:
 
-==> v1/Pod(related)
-NAME                                               READY  STATUS             RESTARTS  AGE
-my-first-k8s-wordpress-wordpress-54947f46cb-j8mjg  0/1    ContainerCreating  0         1s
-my-first-k8s-wordpress-mariadb-0                   0/1    Pending            0         1s
-
-==> v1/Secret
-NAME                              TYPE    DATA  AGE
-my-first-k8s-wordpress-mariadb    Opaque  2     2s
-my-first-k8s-wordpress-wordpress  Opaque  1     2s
-
-==> v1/ConfigMap
-NAME                                  DATA  AGE
-my-first-k8s-wordpress-mariadb        1     2s
-my-first-k8s-wordpress-mariadb-tests  1     2s
-
-==> v1/PersistentVolumeClaim
-NAME                              STATUS  VOLUME                                    CAPACITY  ACCESS MODES  STORAGECLASS       AGE
-my-first-k8s-wordpress-wordpress  Bound   pvc-50c18704-2a57-11e9-b318-563f8efe6191  10Gi      RWO           cinder-high-speed  2s
-
-==> v1/Service
-NAME                              TYPE          CLUSTER-IP   EXTERNAL-IP  PORT(S)                     AGE
-my-first-k8s-wordpress-mariadb    ClusterIP     10.3.203.13  &lt;none>       3306/TCP                    2s
-my-first-k8s-wordpress-wordpress  LoadBalancer  10.3.1.135   &lt;pending>    80:30268/TCP,443:30267/TCP  2s
-
-==> v1beta1/Deployment
-NAME                              DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
-my-first-k8s-wordpress-wordpress  1        1        1           0          2s
-</code></pre>
-
-Then it will show you basic information of how to connect to your new Wordpress:
-
-<pre class="console"><code>NOTES:
-1. Get the WordPress URL:
+1. Get the WordPress URL by running these commands:
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress'
-  export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
-  echo "WordPress URL: http://$SERVICE_IP/"
-  echo "WordPress Admin URL: http://$SERVICE_IP/admin"
+        Watch the status with: 'kubectl get svc --namespace default -w my-first-k8s-wordpress'
 
-2. Login with the following credentials to see your blog
+   export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress --template "{{ range (index .status.loadBalancer.ingress 0
+) }}{{.}}{{ end }}")
+   echo "WordPress URL: http://$SERVICE_IP/"
+   echo "WordPress Admin URL: http://$SERVICE_IP/admin"
+
+2. Open a browser and access WordPress using the obtained URL.
+
+3. Login with the following credentials below to see your blog:
 
   echo Username: user
-  echo Password: $(kubectl get secret --namespace default my-first-k8s-wordpress-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace default my-first-k8s-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
 </code></pre>
+
 
 As the instructions say, you will need to wait a few moments to get the `LoadBalancer` URL. 
 You can test if the `LoadBalancer` is ready using:
 
 ```
-kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress
+kubectl get svc --namespace default -w my-first-k8s-wordpress
 ```
 
 
 After some minutes, you will the `LoadBalancer` URL:
 
 
-<pre class="console"><code>$ kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress
-NAME                               TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)                      AGE
-my-first-k8s-wordpress-wordpress   LoadBalancer   10.3.1.135   &lt;pending>     80:30268/TCP,443:30267/TCP   2m53s
-my-first-k8s-wordpress-wordpress   LoadBalancer   10.3.1.135   XXXXXXX.lb...   80:30268/TCP,443:30267/TCP   3m31s
+<pre class="console"><code>$ kubectl get svc --namespace default -w my-first-k8s-wordpress
+NAME                     TYPE           CLUSTER-IP    EXTERNAL-IP     PORT(S)                      AGE
+my-first-k8s-wordpress   LoadBalancer   10.3.83.253   &lt;pending>      80:32296/TCP,443:31838/TCP   2m13s
+my-first-k8s-wordpress   LoadBalancer   10.3.83.253   XXXXXXX.lb...   80:32296/TCP,443:31838/TCP   2m13s
 </code></pre>
 
 Then you can follow the instructions to get the Admin URL:
 
-<pre class="console"><code>$ export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
+<pre class="console"><code>$ export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
 $ echo "WordPress URL: http://$SERVICE_IP/"
 WordPress URL: http://XXXXXXX.lb.c1.gra.k8s.ovh.net/
 $ echo "WordPress Admin URL: http://$SERVICE_IP/admin"

--- a/pages/platform/kubernetes-k8s/installing-wordpress/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/installing-wordpress/guide.en-au.md
@@ -6,7 +6,7 @@ section: Tutorials
 order: 5
 ---
 
-**Last updated 3<sup>rd</sup> September, 2019.**
+**Last updated April 14<sup>th</sup>, 2020.**
 
 <style>
  pre {
@@ -41,8 +41,7 @@ You also need to have [Helm](https://docs.helm.sh/) installer on your workstatio
 
 ## Installing the Wordpress Helm chart
 
-For this tutorial we are using the [Wordpress Helm chart](https://github.com/helm/charts/tree/master/stable/wordpress){.external} found on Helm repositories.
-The chart is fully configurable, but here we are using the default configuration, with only the minimal set of customization to make it work well on OVHcloud Managed Kubernetes Service.
+For this tutorial we are using the [Wordpress Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/wordpress){.external} found on [Bitnami repository](https://github.com/bitnami/charts/). The chart is fully configurable, but here we are using the default configuration, with only the minimal set of customization to make it work well on OVHcloud Managed Kubernetes Service.
 
 
 > [!primary]
@@ -53,91 +52,65 @@ The chart is fully configurable, but here we are using the default configuration
 > In order to customize your install, without having to leave the simplicity of using helm and the Wordpress helm chart, you can simply set some of the [configurable parameters of the WordPress chart](https://github.com/helm/charts/tree/master/stable/wordpress#configuration){.external}. Then you can add it to your `helm install` with the `--set` option (`--set param1=value1,param2=value2`)
 >
 
+
 ```
-helm install stable/wordpress --set allowOverrideNone=true -n my-first-k8s-wordpress
+helm install my-first-k8s-wordpress bitnami/wordpress --set allowOverrideNone=true
 ```
 
 This will install the needed elements (a MariaDB pod for the database, a Wordpress pod for the webserver with the Worpdress PHP code),
 allocate the persistent volumes and initialize the services. And at the end, it will give you the connection parameters for your new Wordpress:
 
 
-<pre class="console"><code>$ helm install stable/wordpress --set allowOverrideNone=true -n my-first-k8s-wordpress
-NAME:   my-first-k8s-wordpress
-LAST DEPLOYED: Wed Feb  6 22:36:51 2019
+<pre class="console"><code>$ helm install my-first-k8s-wordpress bitnami/wordpress --set allowOverrideNone=true
+NAME: my-first-k8s-wordpress
+LAST DEPLOYED: Tue Apr 14 15:14:57 2020
 NAMESPACE: default
-STATUS: DEPLOYED
+STATUS: deployed
+REVISION: 1
+NOTES:
+** Please be patient while the chart is being deployed **
 
-RESOURCES:
-==> v1beta1/StatefulSet
-NAME                            DESIRED  CURRENT  AGE
-my-first-k8s-wordpress-mariadb  1        1        2s
+To access your WordPress site from outside the cluster follow the steps below:
 
-==> v1/Pod(related)
-NAME                                               READY  STATUS             RESTARTS  AGE
-my-first-k8s-wordpress-wordpress-54947f46cb-j8mjg  0/1    ContainerCreating  0         1s
-my-first-k8s-wordpress-mariadb-0                   0/1    Pending            0         1s
-
-==> v1/Secret
-NAME                              TYPE    DATA  AGE
-my-first-k8s-wordpress-mariadb    Opaque  2     2s
-my-first-k8s-wordpress-wordpress  Opaque  1     2s
-
-==> v1/ConfigMap
-NAME                                  DATA  AGE
-my-first-k8s-wordpress-mariadb        1     2s
-my-first-k8s-wordpress-mariadb-tests  1     2s
-
-==> v1/PersistentVolumeClaim
-NAME                              STATUS  VOLUME                                    CAPACITY  ACCESS MODES  STORAGECLASS       AGE
-my-first-k8s-wordpress-wordpress  Bound   pvc-50c18704-2a57-11e9-b318-563f8efe6191  10Gi      RWO           cinder-high-speed  2s
-
-==> v1/Service
-NAME                              TYPE          CLUSTER-IP   EXTERNAL-IP  PORT(S)                     AGE
-my-first-k8s-wordpress-mariadb    ClusterIP     10.3.203.13  &lt;none>       3306/TCP                    2s
-my-first-k8s-wordpress-wordpress  LoadBalancer  10.3.1.135   &lt;pending>    80:30268/TCP,443:30267/TCP  2s
-
-==> v1beta1/Deployment
-NAME                              DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
-my-first-k8s-wordpress-wordpress  1        1        1           0          2s
-</code></pre>
-
-Then it will show you basic information of how to connect to your new Wordpress:
-
-<pre class="console"><code>NOTES:
-1. Get the WordPress URL:
+1. Get the WordPress URL by running these commands:
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress'
-  export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
-  echo "WordPress URL: http://$SERVICE_IP/"
-  echo "WordPress Admin URL: http://$SERVICE_IP/admin"
+        Watch the status with: 'kubectl get svc --namespace default -w my-first-k8s-wordpress'
 
-2. Login with the following credentials to see your blog
+   export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress --template "{{ range (index .status.loadBalancer.ingress 0
+) }}{{.}}{{ end }}")
+   echo "WordPress URL: http://$SERVICE_IP/"
+   echo "WordPress Admin URL: http://$SERVICE_IP/admin"
+
+2. Open a browser and access WordPress using the obtained URL.
+
+3. Login with the following credentials below to see your blog:
 
   echo Username: user
-  echo Password: $(kubectl get secret --namespace default my-first-k8s-wordpress-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace default my-first-k8s-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
 </code></pre>
+
 
 As the instructions say, you will need to wait a few moments to get the `LoadBalancer` URL. 
 You can test if the `LoadBalancer` is ready using:
 
 ```
-kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress
+kubectl get svc --namespace default -w my-first-k8s-wordpress
 ```
 
 
 After some minutes, you will the `LoadBalancer` URL:
 
 
-<pre class="console"><code>$ kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress
-NAME                               TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)                      AGE
-my-first-k8s-wordpress-wordpress   LoadBalancer   10.3.1.135   &lt;pending>     80:30268/TCP,443:30267/TCP   2m53s
-my-first-k8s-wordpress-wordpress   LoadBalancer   10.3.1.135   XXXXXXX.lb...   80:30268/TCP,443:30267/TCP   3m31s
+<pre class="console"><code>$ kubectl get svc --namespace default -w my-first-k8s-wordpress
+NAME                     TYPE           CLUSTER-IP    EXTERNAL-IP     PORT(S)                      AGE
+my-first-k8s-wordpress   LoadBalancer   10.3.83.253   &lt;pending>      80:32296/TCP,443:31838/TCP   2m13s
+my-first-k8s-wordpress   LoadBalancer   10.3.83.253   XXXXXXX.lb...   80:32296/TCP,443:31838/TCP   2m13s
 </code></pre>
 
 Then you can follow the instructions to get the Admin URL:
 
-<pre class="console"><code>$ export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
+<pre class="console"><code>$ export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
 $ echo "WordPress URL: http://$SERVICE_IP/"
 WordPress URL: http://XXXXXXX.lb.c1.gra.k8s.ovh.net/
 $ echo "WordPress Admin URL: http://$SERVICE_IP/admin"

--- a/pages/platform/kubernetes-k8s/installing-wordpress/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/installing-wordpress/guide.en-ca.md
@@ -6,7 +6,7 @@ section: Tutorials
 order: 5
 ---
 
-**Last updated 3<sup>rd</sup> September, 2019.**
+**Last updated April 14<sup>th</sup>, 2020.**
 
 <style>
  pre {
@@ -41,8 +41,7 @@ You also need to have [Helm](https://docs.helm.sh/) installer on your workstatio
 
 ## Installing the Wordpress Helm chart
 
-For this tutorial we are using the [Wordpress Helm chart](https://github.com/helm/charts/tree/master/stable/wordpress){.external} found on Helm repositories.
-The chart is fully configurable, but here we are using the default configuration, with only the minimal set of customization to make it work well on OVHcloud Managed Kubernetes Service.
+For this tutorial we are using the [Wordpress Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/wordpress){.external} found on [Bitnami repository](https://github.com/bitnami/charts/). The chart is fully configurable, but here we are using the default configuration, with only the minimal set of customization to make it work well on OVHcloud Managed Kubernetes Service.
 
 
 > [!primary]
@@ -53,91 +52,65 @@ The chart is fully configurable, but here we are using the default configuration
 > In order to customize your install, without having to leave the simplicity of using helm and the Wordpress helm chart, you can simply set some of the [configurable parameters of the WordPress chart](https://github.com/helm/charts/tree/master/stable/wordpress#configuration){.external}. Then you can add it to your `helm install` with the `--set` option (`--set param1=value1,param2=value2`)
 >
 
+
 ```
-helm install stable/wordpress --set allowOverrideNone=true -n my-first-k8s-wordpress
+helm install my-first-k8s-wordpress bitnami/wordpress --set allowOverrideNone=true
 ```
 
 This will install the needed elements (a MariaDB pod for the database, a Wordpress pod for the webserver with the Worpdress PHP code),
 allocate the persistent volumes and initialize the services. And at the end, it will give you the connection parameters for your new Wordpress:
 
 
-<pre class="console"><code>$ helm install stable/wordpress --set allowOverrideNone=true -n my-first-k8s-wordpress
-NAME:   my-first-k8s-wordpress
-LAST DEPLOYED: Wed Feb  6 22:36:51 2019
+<pre class="console"><code>$ helm install my-first-k8s-wordpress bitnami/wordpress --set allowOverrideNone=true
+NAME: my-first-k8s-wordpress
+LAST DEPLOYED: Tue Apr 14 15:14:57 2020
 NAMESPACE: default
-STATUS: DEPLOYED
+STATUS: deployed
+REVISION: 1
+NOTES:
+** Please be patient while the chart is being deployed **
 
-RESOURCES:
-==> v1beta1/StatefulSet
-NAME                            DESIRED  CURRENT  AGE
-my-first-k8s-wordpress-mariadb  1        1        2s
+To access your WordPress site from outside the cluster follow the steps below:
 
-==> v1/Pod(related)
-NAME                                               READY  STATUS             RESTARTS  AGE
-my-first-k8s-wordpress-wordpress-54947f46cb-j8mjg  0/1    ContainerCreating  0         1s
-my-first-k8s-wordpress-mariadb-0                   0/1    Pending            0         1s
-
-==> v1/Secret
-NAME                              TYPE    DATA  AGE
-my-first-k8s-wordpress-mariadb    Opaque  2     2s
-my-first-k8s-wordpress-wordpress  Opaque  1     2s
-
-==> v1/ConfigMap
-NAME                                  DATA  AGE
-my-first-k8s-wordpress-mariadb        1     2s
-my-first-k8s-wordpress-mariadb-tests  1     2s
-
-==> v1/PersistentVolumeClaim
-NAME                              STATUS  VOLUME                                    CAPACITY  ACCESS MODES  STORAGECLASS       AGE
-my-first-k8s-wordpress-wordpress  Bound   pvc-50c18704-2a57-11e9-b318-563f8efe6191  10Gi      RWO           cinder-high-speed  2s
-
-==> v1/Service
-NAME                              TYPE          CLUSTER-IP   EXTERNAL-IP  PORT(S)                     AGE
-my-first-k8s-wordpress-mariadb    ClusterIP     10.3.203.13  &lt;none>       3306/TCP                    2s
-my-first-k8s-wordpress-wordpress  LoadBalancer  10.3.1.135   &lt;pending>    80:30268/TCP,443:30267/TCP  2s
-
-==> v1beta1/Deployment
-NAME                              DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
-my-first-k8s-wordpress-wordpress  1        1        1           0          2s
-</code></pre>
-
-Then it will show you basic information of how to connect to your new Wordpress:
-
-<pre class="console"><code>NOTES:
-1. Get the WordPress URL:
+1. Get the WordPress URL by running these commands:
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress'
-  export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
-  echo "WordPress URL: http://$SERVICE_IP/"
-  echo "WordPress Admin URL: http://$SERVICE_IP/admin"
+        Watch the status with: 'kubectl get svc --namespace default -w my-first-k8s-wordpress'
 
-2. Login with the following credentials to see your blog
+   export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress --template "{{ range (index .status.loadBalancer.ingress 0
+) }}{{.}}{{ end }}")
+   echo "WordPress URL: http://$SERVICE_IP/"
+   echo "WordPress Admin URL: http://$SERVICE_IP/admin"
+
+2. Open a browser and access WordPress using the obtained URL.
+
+3. Login with the following credentials below to see your blog:
 
   echo Username: user
-  echo Password: $(kubectl get secret --namespace default my-first-k8s-wordpress-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace default my-first-k8s-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
 </code></pre>
+
 
 As the instructions say, you will need to wait a few moments to get the `LoadBalancer` URL. 
 You can test if the `LoadBalancer` is ready using:
 
 ```
-kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress
+kubectl get svc --namespace default -w my-first-k8s-wordpress
 ```
 
 
 After some minutes, you will the `LoadBalancer` URL:
 
 
-<pre class="console"><code>$ kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress
-NAME                               TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)                      AGE
-my-first-k8s-wordpress-wordpress   LoadBalancer   10.3.1.135   &lt;pending>     80:30268/TCP,443:30267/TCP   2m53s
-my-first-k8s-wordpress-wordpress   LoadBalancer   10.3.1.135   XXXXXXX.lb...   80:30268/TCP,443:30267/TCP   3m31s
+<pre class="console"><code>$ kubectl get svc --namespace default -w my-first-k8s-wordpress
+NAME                     TYPE           CLUSTER-IP    EXTERNAL-IP     PORT(S)                      AGE
+my-first-k8s-wordpress   LoadBalancer   10.3.83.253   &lt;pending>      80:32296/TCP,443:31838/TCP   2m13s
+my-first-k8s-wordpress   LoadBalancer   10.3.83.253   XXXXXXX.lb...   80:32296/TCP,443:31838/TCP   2m13s
 </code></pre>
 
 Then you can follow the instructions to get the Admin URL:
 
-<pre class="console"><code>$ export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
+<pre class="console"><code>$ export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
 $ echo "WordPress URL: http://$SERVICE_IP/"
 WordPress URL: http://XXXXXXX.lb.c1.gra.k8s.ovh.net/
 $ echo "WordPress Admin URL: http://$SERVICE_IP/admin"

--- a/pages/platform/kubernetes-k8s/installing-wordpress/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/installing-wordpress/guide.en-gb.md
@@ -6,7 +6,7 @@ section: Tutorials
 order: 5
 ---
 
-**Last updated 3<sup>rd</sup> September, 2019.**
+**Last updated April 14<sup>th</sup>, 2020.**
 
 <style>
  pre {
@@ -41,8 +41,7 @@ You also need to have [Helm](https://docs.helm.sh/) installer on your workstatio
 
 ## Installing the Wordpress Helm chart
 
-For this tutorial we are using the [Wordpress Helm chart](https://github.com/helm/charts/tree/master/stable/wordpress){.external} found on Helm repositories.
-The chart is fully configurable, but here we are using the default configuration, with only the minimal set of customization to make it work well on OVHcloud Managed Kubernetes Service.
+For this tutorial we are using the [Wordpress Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/wordpress){.external} found on [Bitnami repository](https://github.com/bitnami/charts/). The chart is fully configurable, but here we are using the default configuration, with only the minimal set of customization to make it work well on OVHcloud Managed Kubernetes Service.
 
 
 > [!primary]
@@ -53,91 +52,65 @@ The chart is fully configurable, but here we are using the default configuration
 > In order to customize your install, without having to leave the simplicity of using helm and the Wordpress helm chart, you can simply set some of the [configurable parameters of the WordPress chart](https://github.com/helm/charts/tree/master/stable/wordpress#configuration){.external}. Then you can add it to your `helm install` with the `--set` option (`--set param1=value1,param2=value2`)
 >
 
+
 ```
-helm install stable/wordpress --set allowOverrideNone=true -n my-first-k8s-wordpress
+helm install my-first-k8s-wordpress bitnami/wordpress --set allowOverrideNone=true
 ```
 
 This will install the needed elements (a MariaDB pod for the database, a Wordpress pod for the webserver with the Worpdress PHP code),
 allocate the persistent volumes and initialize the services. And at the end, it will give you the connection parameters for your new Wordpress:
 
 
-<pre class="console"><code>$ helm install stable/wordpress --set allowOverrideNone=true -n my-first-k8s-wordpress
-NAME:   my-first-k8s-wordpress
-LAST DEPLOYED: Wed Feb  6 22:36:51 2019
+<pre class="console"><code>$ helm install my-first-k8s-wordpress bitnami/wordpress --set allowOverrideNone=true
+NAME: my-first-k8s-wordpress
+LAST DEPLOYED: Tue Apr 14 15:14:57 2020
 NAMESPACE: default
-STATUS: DEPLOYED
+STATUS: deployed
+REVISION: 1
+NOTES:
+** Please be patient while the chart is being deployed **
 
-RESOURCES:
-==> v1beta1/StatefulSet
-NAME                            DESIRED  CURRENT  AGE
-my-first-k8s-wordpress-mariadb  1        1        2s
+To access your WordPress site from outside the cluster follow the steps below:
 
-==> v1/Pod(related)
-NAME                                               READY  STATUS             RESTARTS  AGE
-my-first-k8s-wordpress-wordpress-54947f46cb-j8mjg  0/1    ContainerCreating  0         1s
-my-first-k8s-wordpress-mariadb-0                   0/1    Pending            0         1s
-
-==> v1/Secret
-NAME                              TYPE    DATA  AGE
-my-first-k8s-wordpress-mariadb    Opaque  2     2s
-my-first-k8s-wordpress-wordpress  Opaque  1     2s
-
-==> v1/ConfigMap
-NAME                                  DATA  AGE
-my-first-k8s-wordpress-mariadb        1     2s
-my-first-k8s-wordpress-mariadb-tests  1     2s
-
-==> v1/PersistentVolumeClaim
-NAME                              STATUS  VOLUME                                    CAPACITY  ACCESS MODES  STORAGECLASS       AGE
-my-first-k8s-wordpress-wordpress  Bound   pvc-50c18704-2a57-11e9-b318-563f8efe6191  10Gi      RWO           cinder-high-speed  2s
-
-==> v1/Service
-NAME                              TYPE          CLUSTER-IP   EXTERNAL-IP  PORT(S)                     AGE
-my-first-k8s-wordpress-mariadb    ClusterIP     10.3.203.13  &lt;none>       3306/TCP                    2s
-my-first-k8s-wordpress-wordpress  LoadBalancer  10.3.1.135   &lt;pending>    80:30268/TCP,443:30267/TCP  2s
-
-==> v1beta1/Deployment
-NAME                              DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
-my-first-k8s-wordpress-wordpress  1        1        1           0          2s
-</code></pre>
-
-Then it will show you basic information of how to connect to your new Wordpress:
-
-<pre class="console"><code>NOTES:
-1. Get the WordPress URL:
+1. Get the WordPress URL by running these commands:
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress'
-  export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
-  echo "WordPress URL: http://$SERVICE_IP/"
-  echo "WordPress Admin URL: http://$SERVICE_IP/admin"
+        Watch the status with: 'kubectl get svc --namespace default -w my-first-k8s-wordpress'
 
-2. Login with the following credentials to see your blog
+   export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress --template "{{ range (index .status.loadBalancer.ingress 0
+) }}{{.}}{{ end }}")
+   echo "WordPress URL: http://$SERVICE_IP/"
+   echo "WordPress Admin URL: http://$SERVICE_IP/admin"
+
+2. Open a browser and access WordPress using the obtained URL.
+
+3. Login with the following credentials below to see your blog:
 
   echo Username: user
-  echo Password: $(kubectl get secret --namespace default my-first-k8s-wordpress-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace default my-first-k8s-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
 </code></pre>
+
 
 As the instructions say, you will need to wait a few moments to get the `LoadBalancer` URL. 
 You can test if the `LoadBalancer` is ready using:
 
 ```
-kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress
+kubectl get svc --namespace default -w my-first-k8s-wordpress
 ```
 
 
 After some minutes, you will the `LoadBalancer` URL:
 
 
-<pre class="console"><code>$ kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress
-NAME                               TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)                      AGE
-my-first-k8s-wordpress-wordpress   LoadBalancer   10.3.1.135   &lt;pending>     80:30268/TCP,443:30267/TCP   2m53s
-my-first-k8s-wordpress-wordpress   LoadBalancer   10.3.1.135   XXXXXXX.lb...   80:30268/TCP,443:30267/TCP   3m31s
+<pre class="console"><code>$ kubectl get svc --namespace default -w my-first-k8s-wordpress
+NAME                     TYPE           CLUSTER-IP    EXTERNAL-IP     PORT(S)                      AGE
+my-first-k8s-wordpress   LoadBalancer   10.3.83.253   &lt;pending>      80:32296/TCP,443:31838/TCP   2m13s
+my-first-k8s-wordpress   LoadBalancer   10.3.83.253   XXXXXXX.lb...   80:32296/TCP,443:31838/TCP   2m13s
 </code></pre>
 
 Then you can follow the instructions to get the Admin URL:
 
-<pre class="console"><code>$ export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
+<pre class="console"><code>$ export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
 $ echo "WordPress URL: http://$SERVICE_IP/"
 WordPress URL: http://XXXXXXX.lb.c1.gra.k8s.ovh.net/
 $ echo "WordPress Admin URL: http://$SERVICE_IP/admin"

--- a/pages/platform/kubernetes-k8s/installing-wordpress/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/installing-wordpress/guide.en-ie.md
@@ -6,7 +6,7 @@ section: Tutorials
 order: 5
 ---
 
-**Last updated 3<sup>rd</sup> September, 2019.**
+**Last updated April 14<sup>th</sup>, 2020.**
 
 <style>
  pre {
@@ -41,8 +41,7 @@ You also need to have [Helm](https://docs.helm.sh/) installer on your workstatio
 
 ## Installing the Wordpress Helm chart
 
-For this tutorial we are using the [Wordpress Helm chart](https://github.com/helm/charts/tree/master/stable/wordpress){.external} found on Helm repositories.
-The chart is fully configurable, but here we are using the default configuration, with only the minimal set of customization to make it work well on OVHcloud Managed Kubernetes Service.
+For this tutorial we are using the [Wordpress Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/wordpress){.external} found on [Bitnami repository](https://github.com/bitnami/charts/). The chart is fully configurable, but here we are using the default configuration, with only the minimal set of customization to make it work well on OVHcloud Managed Kubernetes Service.
 
 
 > [!primary]
@@ -53,91 +52,65 @@ The chart is fully configurable, but here we are using the default configuration
 > In order to customize your install, without having to leave the simplicity of using helm and the Wordpress helm chart, you can simply set some of the [configurable parameters of the WordPress chart](https://github.com/helm/charts/tree/master/stable/wordpress#configuration){.external}. Then you can add it to your `helm install` with the `--set` option (`--set param1=value1,param2=value2`)
 >
 
+
 ```
-helm install stable/wordpress --set allowOverrideNone=true -n my-first-k8s-wordpress
+helm install my-first-k8s-wordpress bitnami/wordpress --set allowOverrideNone=true
 ```
 
 This will install the needed elements (a MariaDB pod for the database, a Wordpress pod for the webserver with the Worpdress PHP code),
 allocate the persistent volumes and initialize the services. And at the end, it will give you the connection parameters for your new Wordpress:
 
 
-<pre class="console"><code>$ helm install stable/wordpress --set allowOverrideNone=true -n my-first-k8s-wordpress
-NAME:   my-first-k8s-wordpress
-LAST DEPLOYED: Wed Feb  6 22:36:51 2019
+<pre class="console"><code>$ helm install my-first-k8s-wordpress bitnami/wordpress --set allowOverrideNone=true
+NAME: my-first-k8s-wordpress
+LAST DEPLOYED: Tue Apr 14 15:14:57 2020
 NAMESPACE: default
-STATUS: DEPLOYED
+STATUS: deployed
+REVISION: 1
+NOTES:
+** Please be patient while the chart is being deployed **
 
-RESOURCES:
-==> v1beta1/StatefulSet
-NAME                            DESIRED  CURRENT  AGE
-my-first-k8s-wordpress-mariadb  1        1        2s
+To access your WordPress site from outside the cluster follow the steps below:
 
-==> v1/Pod(related)
-NAME                                               READY  STATUS             RESTARTS  AGE
-my-first-k8s-wordpress-wordpress-54947f46cb-j8mjg  0/1    ContainerCreating  0         1s
-my-first-k8s-wordpress-mariadb-0                   0/1    Pending            0         1s
-
-==> v1/Secret
-NAME                              TYPE    DATA  AGE
-my-first-k8s-wordpress-mariadb    Opaque  2     2s
-my-first-k8s-wordpress-wordpress  Opaque  1     2s
-
-==> v1/ConfigMap
-NAME                                  DATA  AGE
-my-first-k8s-wordpress-mariadb        1     2s
-my-first-k8s-wordpress-mariadb-tests  1     2s
-
-==> v1/PersistentVolumeClaim
-NAME                              STATUS  VOLUME                                    CAPACITY  ACCESS MODES  STORAGECLASS       AGE
-my-first-k8s-wordpress-wordpress  Bound   pvc-50c18704-2a57-11e9-b318-563f8efe6191  10Gi      RWO           cinder-high-speed  2s
-
-==> v1/Service
-NAME                              TYPE          CLUSTER-IP   EXTERNAL-IP  PORT(S)                     AGE
-my-first-k8s-wordpress-mariadb    ClusterIP     10.3.203.13  &lt;none>       3306/TCP                    2s
-my-first-k8s-wordpress-wordpress  LoadBalancer  10.3.1.135   &lt;pending>    80:30268/TCP,443:30267/TCP  2s
-
-==> v1beta1/Deployment
-NAME                              DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
-my-first-k8s-wordpress-wordpress  1        1        1           0          2s
-</code></pre>
-
-Then it will show you basic information of how to connect to your new Wordpress:
-
-<pre class="console"><code>NOTES:
-1. Get the WordPress URL:
+1. Get the WordPress URL by running these commands:
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress'
-  export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
-  echo "WordPress URL: http://$SERVICE_IP/"
-  echo "WordPress Admin URL: http://$SERVICE_IP/admin"
+        Watch the status with: 'kubectl get svc --namespace default -w my-first-k8s-wordpress'
 
-2. Login with the following credentials to see your blog
+   export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress --template "{{ range (index .status.loadBalancer.ingress 0
+) }}{{.}}{{ end }}")
+   echo "WordPress URL: http://$SERVICE_IP/"
+   echo "WordPress Admin URL: http://$SERVICE_IP/admin"
+
+2. Open a browser and access WordPress using the obtained URL.
+
+3. Login with the following credentials below to see your blog:
 
   echo Username: user
-  echo Password: $(kubectl get secret --namespace default my-first-k8s-wordpress-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace default my-first-k8s-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
 </code></pre>
+
 
 As the instructions say, you will need to wait a few moments to get the `LoadBalancer` URL. 
 You can test if the `LoadBalancer` is ready using:
 
 ```
-kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress
+kubectl get svc --namespace default -w my-first-k8s-wordpress
 ```
 
 
 After some minutes, you will the `LoadBalancer` URL:
 
 
-<pre class="console"><code>$ kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress
-NAME                               TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)                      AGE
-my-first-k8s-wordpress-wordpress   LoadBalancer   10.3.1.135   &lt;pending>     80:30268/TCP,443:30267/TCP   2m53s
-my-first-k8s-wordpress-wordpress   LoadBalancer   10.3.1.135   XXXXXXX.lb...   80:30268/TCP,443:30267/TCP   3m31s
+<pre class="console"><code>$ kubectl get svc --namespace default -w my-first-k8s-wordpress
+NAME                     TYPE           CLUSTER-IP    EXTERNAL-IP     PORT(S)                      AGE
+my-first-k8s-wordpress   LoadBalancer   10.3.83.253   &lt;pending>      80:32296/TCP,443:31838/TCP   2m13s
+my-first-k8s-wordpress   LoadBalancer   10.3.83.253   XXXXXXX.lb...   80:32296/TCP,443:31838/TCP   2m13s
 </code></pre>
 
 Then you can follow the instructions to get the Admin URL:
 
-<pre class="console"><code>$ export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
+<pre class="console"><code>$ export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
 $ echo "WordPress URL: http://$SERVICE_IP/"
 WordPress URL: http://XXXXXXX.lb.c1.gra.k8s.ovh.net/
 $ echo "WordPress Admin URL: http://$SERVICE_IP/admin"

--- a/pages/platform/kubernetes-k8s/installing-wordpress/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/installing-wordpress/guide.en-sg.md
@@ -6,7 +6,7 @@ section: Tutorials
 order: 5
 ---
 
-**Last updated 3<sup>rd</sup> September, 2019.**
+**Last updated April 14<sup>th</sup>, 2020.**
 
 <style>
  pre {
@@ -41,8 +41,7 @@ You also need to have [Helm](https://docs.helm.sh/) installer on your workstatio
 
 ## Installing the Wordpress Helm chart
 
-For this tutorial we are using the [Wordpress Helm chart](https://github.com/helm/charts/tree/master/stable/wordpress){.external} found on Helm repositories.
-The chart is fully configurable, but here we are using the default configuration, with only the minimal set of customization to make it work well on OVHcloud Managed Kubernetes Service.
+For this tutorial we are using the [Wordpress Helm chart](https://github.com/bitnami/charts/tree/master/bitnami/wordpress){.external} found on [Bitnami repository](https://github.com/bitnami/charts/). The chart is fully configurable, but here we are using the default configuration, with only the minimal set of customization to make it work well on OVHcloud Managed Kubernetes Service.
 
 
 > [!primary]
@@ -53,91 +52,65 @@ The chart is fully configurable, but here we are using the default configuration
 > In order to customize your install, without having to leave the simplicity of using helm and the Wordpress helm chart, you can simply set some of the [configurable parameters of the WordPress chart](https://github.com/helm/charts/tree/master/stable/wordpress#configuration){.external}. Then you can add it to your `helm install` with the `--set` option (`--set param1=value1,param2=value2`)
 >
 
+
 ```
-helm install stable/wordpress --set allowOverrideNone=true -n my-first-k8s-wordpress
+helm install my-first-k8s-wordpress bitnami/wordpress --set allowOverrideNone=true
 ```
 
 This will install the needed elements (a MariaDB pod for the database, a Wordpress pod for the webserver with the Worpdress PHP code),
 allocate the persistent volumes and initialize the services. And at the end, it will give you the connection parameters for your new Wordpress:
 
 
-<pre class="console"><code>$ helm install stable/wordpress --set allowOverrideNone=true -n my-first-k8s-wordpress
-NAME:   my-first-k8s-wordpress
-LAST DEPLOYED: Wed Feb  6 22:36:51 2019
+<pre class="console"><code>$ helm install my-first-k8s-wordpress bitnami/wordpress --set allowOverrideNone=true
+NAME: my-first-k8s-wordpress
+LAST DEPLOYED: Tue Apr 14 15:14:57 2020
 NAMESPACE: default
-STATUS: DEPLOYED
+STATUS: deployed
+REVISION: 1
+NOTES:
+** Please be patient while the chart is being deployed **
 
-RESOURCES:
-==> v1beta1/StatefulSet
-NAME                            DESIRED  CURRENT  AGE
-my-first-k8s-wordpress-mariadb  1        1        2s
+To access your WordPress site from outside the cluster follow the steps below:
 
-==> v1/Pod(related)
-NAME                                               READY  STATUS             RESTARTS  AGE
-my-first-k8s-wordpress-wordpress-54947f46cb-j8mjg  0/1    ContainerCreating  0         1s
-my-first-k8s-wordpress-mariadb-0                   0/1    Pending            0         1s
-
-==> v1/Secret
-NAME                              TYPE    DATA  AGE
-my-first-k8s-wordpress-mariadb    Opaque  2     2s
-my-first-k8s-wordpress-wordpress  Opaque  1     2s
-
-==> v1/ConfigMap
-NAME                                  DATA  AGE
-my-first-k8s-wordpress-mariadb        1     2s
-my-first-k8s-wordpress-mariadb-tests  1     2s
-
-==> v1/PersistentVolumeClaim
-NAME                              STATUS  VOLUME                                    CAPACITY  ACCESS MODES  STORAGECLASS       AGE
-my-first-k8s-wordpress-wordpress  Bound   pvc-50c18704-2a57-11e9-b318-563f8efe6191  10Gi      RWO           cinder-high-speed  2s
-
-==> v1/Service
-NAME                              TYPE          CLUSTER-IP   EXTERNAL-IP  PORT(S)                     AGE
-my-first-k8s-wordpress-mariadb    ClusterIP     10.3.203.13  &lt;none>       3306/TCP                    2s
-my-first-k8s-wordpress-wordpress  LoadBalancer  10.3.1.135   &lt;pending>    80:30268/TCP,443:30267/TCP  2s
-
-==> v1beta1/Deployment
-NAME                              DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
-my-first-k8s-wordpress-wordpress  1        1        1           0          2s
-</code></pre>
-
-Then it will show you basic information of how to connect to your new Wordpress:
-
-<pre class="console"><code>NOTES:
-1. Get the WordPress URL:
+1. Get the WordPress URL by running these commands:
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress'
-  export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
-  echo "WordPress URL: http://$SERVICE_IP/"
-  echo "WordPress Admin URL: http://$SERVICE_IP/admin"
+        Watch the status with: 'kubectl get svc --namespace default -w my-first-k8s-wordpress'
 
-2. Login with the following credentials to see your blog
+   export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress --template "{{ range (index .status.loadBalancer.ingress 0
+) }}{{.}}{{ end }}")
+   echo "WordPress URL: http://$SERVICE_IP/"
+   echo "WordPress Admin URL: http://$SERVICE_IP/admin"
+
+2. Open a browser and access WordPress using the obtained URL.
+
+3. Login with the following credentials below to see your blog:
 
   echo Username: user
-  echo Password: $(kubectl get secret --namespace default my-first-k8s-wordpress-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace default my-first-k8s-wordpress -o jsonpath="{.data.wordpress-password}" | base64 --decode)
 </code></pre>
+
 
 As the instructions say, you will need to wait a few moments to get the `LoadBalancer` URL. 
 You can test if the `LoadBalancer` is ready using:
 
 ```
-kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress
+kubectl get svc --namespace default -w my-first-k8s-wordpress
 ```
 
 
 After some minutes, you will the `LoadBalancer` URL:
 
 
-<pre class="console"><code>$ kubectl get svc --namespace default -w my-first-k8s-wordpress-wordpress
-NAME                               TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)                      AGE
-my-first-k8s-wordpress-wordpress   LoadBalancer   10.3.1.135   &lt;pending>     80:30268/TCP,443:30267/TCP   2m53s
-my-first-k8s-wordpress-wordpress   LoadBalancer   10.3.1.135   XXXXXXX.lb...   80:30268/TCP,443:30267/TCP   3m31s
+<pre class="console"><code>$ kubectl get svc --namespace default -w my-first-k8s-wordpress
+NAME                     TYPE           CLUSTER-IP    EXTERNAL-IP     PORT(S)                      AGE
+my-first-k8s-wordpress   LoadBalancer   10.3.83.253   &lt;pending>      80:32296/TCP,443:31838/TCP   2m13s
+my-first-k8s-wordpress   LoadBalancer   10.3.83.253   XXXXXXX.lb...   80:32296/TCP,443:31838/TCP   2m13s
 </code></pre>
 
 Then you can follow the instructions to get the Admin URL:
 
-<pre class="console"><code>$ export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
+<pre class="console"><code>$ export SERVICE_IP=$(kubectl get svc --namespace default my-first-k8s-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
 $ echo "WordPress URL: http://$SERVICE_IP/"
 WordPress URL: http://XXXXXXX.lb.c1.gra.k8s.ovh.net/
 $ echo "WordPress Admin URL: http://$SERVICE_IP/admin"


### PR DESCRIPTION
Helm 2 is deprecated since the end 2019. It's time to update our tuto to Helm 3