### PR TITLE
EN FR Add Mysql 8.0 EOL

### DIFF
--- a/pages/cloud/clouddb/clouddb-eos-eol/guide.en-gb.md
+++ b/pages/cloud/clouddb/clouddb-eos-eol/guide.en-gb.md
@@ -16,6 +16,7 @@ The products covered by those End Of Sale (EOS) and End Of Life (EOL) announceme
 |MariaDB 10.5|To be defined|To be defined|To be defined|
 |MongoDB 4|2019-07-29|2019-02-25|To be defined|
 |MySQL 5.7|To be defined|To be defined|To be defined|
+|MySQL 8.0|To be defined|To be defined|To be defined|
 |PostgreSQL 9.6|2020-01-21|2021-05-12|2021-11-11|
 |PostgreSQL 10|To be defined|To be defined|To be defined|
 |PostgreSQL 11|To be defined|To be defined|To be defined|

--- a/pages/cloud/clouddb/clouddb-eos-eol/guide.fr-fr.md
+++ b/pages/cloud/clouddb/clouddb-eos-eol/guide.fr-fr.md
@@ -16,6 +16,7 @@ Les produits couverts par ces annonces de fin de vente et de fin de vie sont les
 |MariaDB 10.5|À définir|À définir|À définir|
 |MongoDB 4|2019-07-29|2019-02-25|À définir|
 |MySQL 5.7|À définir|À définir|À définir|
+|MySQL 8.0|À définir|À définir|À définir|
 |PostgreSQL 9.6|2020-01-21|2021-05-12|2021-11-11|
 |PostgreSQL 10|À définir|À définir|À définir|
 |PostgreSQL 11|À définir|À définir|À définir|

--- a/pages/cloud/clouddb/privatesql-eos-eol/guide.en-gb.md
+++ b/pages/cloud/clouddb/privatesql-eos-eol/guide.en-gb.md
@@ -18,6 +18,7 @@ The products covered by those End Of Sale (EOS) and End Of Life (EOL) announceme
 |MySQL 5.5|2019-07-29|2018-08-02|2020-01-28|
 |MySQL 5.6|2019-07-29|2020-08-02|2021-02-01|
 |MySQL 5.7|To be defined|To be defined|To be defined|
+|MySQL 8.0|To be defined|To be defined|To be defined|
 |PostgreSQL 9.4|2019-07-29|2019-10-29|2020-02-13|
 |PostgreSQL 9.5|2019-07-29|2020-08-12|2021-02-11|
 |PostgreSQL 9.6|2020-01-21|2021-05-12|2021-11-11|

--- a/pages/cloud/clouddb/privatesql-eos-eol/guide.fr-fr.md
+++ b/pages/cloud/clouddb/privatesql-eos-eol/guide.fr-fr.md
@@ -18,6 +18,7 @@ Les produits couverts par ces annonces de fin de vente et de fin de vie sont les
 |MySQL 5.5|2019-07-29|2018-08-02|2020-01-28|
 |MySQL 5.6|2019-07-29|2020-08-02|2021-02-01|
 |MySQL 5.7|À définir|À définir|À définir|
+|MySQL 8.0|À définir|À définir|À définir|
 |PostgreSQL 9.4|2019-07-29|2019-10-29|2020-02-13|
 |PostgreSQL 9.5|2019-07-29|2020-08-12|2021-02-11|
 |PostgreSQL 9.6|2020-01-21|2021-05-12|2021-11-11|


### PR DESCRIPTION
Mysql 8.0 is available to our customers. As the EOL date is not yet known, I set it to  "To be defined".