### PR TITLE
fix typo in subinterface declaration eth0:0

### DIFF
--- a/pages/cloud/dedicated/network_ipaliasing/guide.fr-ca.md
+++ b/pages/cloud/dedicated/network_ipaliasing/guide.fr-ca.md
@@ -48,7 +48,7 @@ editor /etc/network/interfaces
 Vous devez ensuite ajouter une interface secondaire :
 
 ```bash
-auto eth0.0
+auto eth0:0
 iface eth0:0 inet static
 address FAILOVER_IP
 netmask 255.255.255.255
@@ -71,7 +71,7 @@ netmask 255.255.255.0
 broadcast xxx.xxx.xxx.255
 gateway xxx.xxx.xxx.254
 
-auto eth0.0
+auto eth0:0
 iface eth0:0 inet static
 address FAILOVER_IP
 netmask 255.255.255.255

--- a/pages/cloud/dedicated/network_ipaliasing/guide.fr-fr.md
+++ b/pages/cloud/dedicated/network_ipaliasing/guide.fr-fr.md
@@ -64,7 +64,7 @@ editor /etc/network/interfaces
 Vous devez ensuite ajouter une interface secondaire :
 
 ```bash
-auto eth0.0
+auto eth0:0
 iface eth0:0 inet static
 address FAILOVER_IP
 netmask 255.255.255.255
@@ -87,7 +87,7 @@ netmask 255.255.255.0
 broadcast xxx.xxx.xxx.255
 gateway xxx.xxx.xxx.254
 
-auto eth0.0
+auto eth0:0
 iface eth0:0 inet static
 address FAILOVER_IP
 netmask 255.255.255.255


### PR DESCRIPTION
Signed-off-by: Romain Labat <romain.labat@smood.ch>
Hello,

This PR is aim to fix a typo in the French version of the doc.
Instead of using `eth0.0` concerning IP aliasing for dedicated server, we need to use `eth0:0` to declare an interface
This is well documented here : https://wiki.debian.org/fr/NetworkConfiguration

Kind regards