### PR TITLE
Remove double "Serial" in how to serial guides

### DIFF
--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.cs-cz.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.cs-cz.md
@@ -33,7 +33,7 @@ Za účelem minimalizace rizika vzniku chyby zapříčiněné lidským faktorem 
 Za účelem získání sériového čísla pevného disku v soft-RAID konfiguraci použijte následující příkaz:
 
 ```sh
-smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+smartctl -a /dev/sdX | grep Serial
 ```
 
 Zařízení je detekováno operačním systémem (např.: /dev/sda, /dev/sdb, etc.).
@@ -141,7 +141,7 @@ ID zařízení a ID adaptéru budou v rámci `smartctl` použita pro rozlišení
 Příkaz by měl vypadat takto:
 
 ```sh
-smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 RAID Device ID bude zobrazeno jako: `/dev/sda` = 1\. RAID, `/dev/sdb` = 2\. RAID apod.
@@ -158,7 +158,7 @@ RAID Device ID bude zobrazeno jako: `/dev/sda` = 1\. RAID, `/dev/sdb` = 2\. RAID
 > V takovém případě je zapotřebí hodnotu `megaraid` nahradit hodnotou `sat+megaraid`:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -171,7 +171,7 @@ Detailní informace o sg mapování naleznete v následující dokumentaci: [Har
 Jakmile identifikujete sg zařízení příslušející k disku, který si přejete analyzovat, použijte následující příkaz:
 
 ```sh
-smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+smartctl -a /dev/sgX | grep Serial
 ```
 
 Jednotlivá sg zařízení budou zobrazena jako `/dev/sg0`, `/dev/sg1` apod.

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.de-de.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.de-de.md
@@ -31,7 +31,7 @@ Um das Fehlerrisiko beim Austausch einer Festplatte zu minimieren, bitten wir un
 Um die Seriennummer Ihrer Festplatte mit Software-RAID-Konfiguration zu ermitteln, können Sie einfach smartctl verwenden:
 
 ```sh
-# smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+# smartctl -a /dev/sdX | grep Serial
 ```
 
 Das Gerät wird über das Betriebssystem erkannt. Zum Beispiel: `/dev/sda`, `/dev/sdb` etc.
@@ -137,7 +137,7 @@ Verwenden Sie die Geräte-ID und die Adapter-ID, um smartctl zu zeigen, welche F
 Der Befehl sieht in etwa wie folgt aus:
 
 ```sh
-# smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+# smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 Die ID des RAID-Geräts wird wie folgt angezeigt: `/dev/sda` = 1\. RAID, `/dev/sdb` = 2\. RAID etc.
@@ -167,7 +167,7 @@ Um zu ermitteln, welche Festplatte zu einem bestimmten „sg“-Gerät gehört, 
 Wenn Sie das Gerät ermittelt haben, das mit der Festplatte, die Sie analysieren möchten, verbunden ist, verwenden Sie folgenden Befehl:
 
 ```sh
-# smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+# smartctl -a /dev/sgX | grep Serial
 ```
 
 Die Nummer des sg-Geräts wird wie folgt angezeigt: `/dev/sg0`, `/dev/sg1` etc.

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-asia.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-asia.md
@@ -31,7 +31,7 @@ To minimise the chance of human error during hard disk replacements, we ask our 
 To retrieve your hard drive's serial number with a software RAID configuration, you can simply use smartctl:
 
 ```sh
-smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+smartctl -a /dev/sdX | grep Serial
 ```
 
 The device is detected by the OS (ex: /dev/sda, /dev/sdb, etc.).
@@ -137,7 +137,7 @@ The Device ID and Adapter ID will be used to tell smartctl which disk to look fo
 The command should look like this:
 
 ```sh
-smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb = 2nd RAID, etc.
@@ -154,7 +154,7 @@ The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb =
 > You must then replace megaraid with sat+megaraid:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -167,7 +167,7 @@ You can refer to [this guide (LSI raid controller)](../raid-hard/){.external} to
 Once you have found the sg device related to the hard disk you want to query, use the following command:
 
 ```sh
-smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+smartctl -a /dev/sgX | grep Serial
 ```
 
 The sg device number will be displayed as follows: /dev/sg0, /dev/sg1) etc.

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-au.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-au.md
@@ -31,7 +31,7 @@ To minimise the chance of human error during hard disk replacements, we ask our 
 To retrieve your hard drive's serial number with a software RAID configuration, you can simply use smartctl:
 
 ```sh
-smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+smartctl -a /dev/sdX | grep Serial
 ```
 
 The device is detected by the OS (ex: /dev/sda, /dev/sdb, etc.).
@@ -137,7 +137,7 @@ The Device ID and Adapter ID will be used to tell smartctl which disk to look fo
 The command should look like this:
 
 ```sh
-smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb = 2nd RAID, etc.
@@ -154,7 +154,7 @@ The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb =
 > You must then replace megaraid with sat+megaraid:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -167,7 +167,7 @@ You can refer to [this guide (LSI raid controller)](../raid-hard/){.external} to
 Once you have found the sg device related to the hard disk you want to query, use the following command:
 
 ```sh
-smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+smartctl -a /dev/sgX | grep Serial
 ```
 
 The sg device number will be displayed as follows: /dev/sg0, /dev/sg1) etc.

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-ca.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-ca.md
@@ -32,7 +32,7 @@ To minimise the chance of human error during hard disk replacements, we ask our 
 To retrieve your hard drive's serial number with a software RAID configuration, you can simply use smartctl:
 
 ```sh
-smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+smartctl -a /dev/sdX | grep Serial
 ```
 
 The device is detected by the OS (ex: /dev/sda, /dev/sdb, etc.).
@@ -138,7 +138,7 @@ The Device ID and Adapter ID will be used to tell smartctl which disk to look fo
 The command should look like this:
 
 ```sh
-smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb = 2nd RAID, etc.
@@ -155,7 +155,7 @@ The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb =
 > You must then replace megaraid with sat+megaraid:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -168,7 +168,7 @@ You can refer to [this guide (LSI raid controller)](../raid-hard/){.external} to
 Once you have found the sg device related to the hard disk you want to query, use the following command:
 
 ```sh
-smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+smartctl -a /dev/sgX | grep Serial
 ```
 
 The sg device number will be displayed as follows: /dev/sg0, /dev/sg1) etc.

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-gb.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-gb.md
@@ -31,7 +31,7 @@ To minimise the chance of human error during hard disk replacements, we ask our 
 To retrieve your hard drive's serial number with a software RAID configuration, you can simply use smartctl:
 
 ```sh
-smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+smartctl -a /dev/sdX | grep Serial
 ```
 
 The device is detected by the OS (ex: /dev/sda, /dev/sdb, etc.).
@@ -137,7 +137,7 @@ The Device ID and Adapter ID will be used to tell smartctl which disk to look fo
 The command should look like this:
 
 ```sh
-smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb = 2nd RAID, etc.
@@ -154,7 +154,7 @@ The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb =
 > You must then replace megaraid with sat+megaraid:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -167,7 +167,7 @@ You can refer to [this guide (LSI raid controller)](https://docs.ovh.com/gb/en/d
 Once you have found the sg device related to the hard disk you want to query, use the following command:
 
 ```sh
-smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+smartctl -a /dev/sgX | grep Serial
 ```
 
 The sg device number will be displayed as follows: /dev/sg0, /dev/sg1) etc.

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-ie.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-ie.md
@@ -31,7 +31,7 @@ To minimise the chance of human error during hard disk replacements, we ask our 
 To retrieve your hard drive's serial number with a software RAID configuration, you can simply use smartctl:
 
 ```sh
-smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+smartctl -a /dev/sdX | grep Serial
 ```
 
 The device is detected by the OS (ex: /dev/sda, /dev/sdb, etc.).
@@ -137,7 +137,7 @@ The Device ID and Adapter ID will be used to tell smartctl which disk to look fo
 The command should look like this:
 
 ```sh
-smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb = 2nd RAID, etc.
@@ -154,7 +154,7 @@ The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb =
 > You must then replace megaraid with sat+megaraid:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -167,7 +167,7 @@ You can refer to [this guide (LSI raid controller)](https://docs.ovh.com/gb/en/d
 Once you have found the sg device related to the hard disk you want to query, use the following command:
 
 ```sh
-smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+smartctl -a /dev/sgX | grep Serial
 ```
 
 The sg device number will be displayed as follows: /dev/sg0, /dev/sg1) etc.

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-sg.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-sg.md
@@ -31,7 +31,7 @@ To minimise the chance of human error during hard disk replacements, we ask our 
 To retrieve your hard drive's serial number with a software RAID configuration, you can simply use smartctl:
 
 ```sh
-smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+smartctl -a /dev/sdX | grep Serial
 ```
 
 The device is detected by the OS (ex: /dev/sda, /dev/sdb, etc.).
@@ -137,7 +137,7 @@ The Device ID and Adapter ID will be used to tell smartctl which disk to look fo
 The command should look like this:
 
 ```sh
-smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb = 2nd RAID, etc.
@@ -154,7 +154,7 @@ The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb =
 > You must then replace megaraid with sat+megaraid:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -167,7 +167,7 @@ You can refer to [this guide (LSI raid controller)](../raid-hard/){.external} to
 Once you have found the sg device related to the hard disk you want to query, use the following command:
 
 ```sh
-smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+smartctl -a /dev/sgX | grep Serial
 ```
 
 The sg device number will be displayed as follows: /dev/sg0, /dev/sg1) etc.

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-us.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.en-us.md
@@ -32,7 +32,7 @@ To minimise the chance of human error during hard disk replacements, we ask our 
 To retrieve your hard drive's serial number with a software RAID configuration, you can simply use smartctl:
 
 ```sh
-smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+smartctl -a /dev/sdX | grep Serial
 ```
 
 The device is detected by the OS (ex: /dev/sda, /dev/sdb, etc.).
@@ -138,7 +138,7 @@ The Device ID and Adapter ID will be used to tell smartctl which disk to look fo
 The command should look like this:
 
 ```sh
-smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb = 2nd RAID, etc.
@@ -155,7 +155,7 @@ The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb =
 > You must then replace megaraid with sat+megaraid:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -168,7 +168,7 @@ You can refer to [this guide (LSI raid controller)](../raid-hard/){.external} to
 Once you have found the sg device related to the hard disk you want to query, use the following command:
 
 ```sh
-smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+smartctl -a /dev/sgX | grep Serial
 ```
 
 The sg device number will be displayed as follows: /dev/sg0, /dev/sg1) etc.

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.es-es.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.es-es.md
@@ -31,7 +31,7 @@ Para minimizar el riesgo de error durante la sustitución de un disco duro, pedi
 Para conocer el número de serie de un disco duro con RAID por software, utilice el comando `smartctl`:
 
 ```sh
-# smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+# smartctl -a /dev/sdX | grep Serial
 ```
 
 En este caso, el periférico (por ejemplo, /dev/sda, /dev/sdb...) es detectado por el sistema operativo.
@@ -137,7 +137,7 @@ Una vez disponga del adaptador y del Device Id, deberá utilizarlos para indicar
 El comando debe tener el siguiente formato:
 
 ```sh
-# smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+# smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 No olvide sustituir en el comando anterior **N** por el Device Id y **sdX** por el volumen en RAID (**/dev/sda** para el primer RAID, **/dev/sdb** para el segundo RAID, y así sucesivamente).
@@ -154,7 +154,7 @@ No olvide sustituir en el comando anterior **N** por el Device Id y **sdX** por 
 > En ese caso, deberá sustituir **megaraid** por **sat+megaraid**:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -167,7 +167,7 @@ Para determinar qué periférico sg corresponde a cada disco duro, consulte nues
 Una vez que sepa qué periférico sg corresponde al disco duro que quiera analizar, utilice el siguiente comando:
 
 ```sh
-# smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+# smartctl -a /dev/sgX | grep Serial
 ```
 
 No olvide sustituir en el comando anterior **sgX** por **/dev/sg0**, **/dev/sg1**...

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.es-us.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.es-us.md
@@ -31,7 +31,7 @@ Para minimizar el riesgo de error durante la sustitución de un disco duro, pedi
 Para conocer el número de serie de un disco duro con RAID por software, utilice el comando `smartctl`:
 
 ```sh
-# smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+# smartctl -a /dev/sdX | grep Serial
 ```
 
 En este caso, el periférico (por ejemplo, /dev/sda, /dev/sdb...) es detectado por el sistema operativo.
@@ -137,7 +137,7 @@ Una vez disponga del adaptador y del Device Id, deberá utilizarlos para indicar
 El comando debe tener el siguiente formato:
 
 ```sh
-# smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+# smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 No olvide sustituir en el comando anterior **N** por el Device Id y **sdX** por el volumen en RAID (**/dev/sda** para el primer RAID, **/dev/sdb** para el segundo RAID, y así sucesivamente).
@@ -154,7 +154,7 @@ No olvide sustituir en el comando anterior **N** por el Device Id y **sdX** por 
 > En ese caso, deberá sustituir **megaraid** por **sat+megaraid**:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -167,7 +167,7 @@ Para determinar qué periférico sg corresponde a cada disco duro, consulte nues
 Una vez que sepa qué periférico sg corresponde al disco duro que quiera analizar, utilice el siguiente comando:
 
 ```sh
-# smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+# smartctl -a /dev/sgX | grep Serial
 ```
 
 No olvide sustituir en el comando anterior **sgX** por **/dev/sg0**, **/dev/sg1**...

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.fi-fi.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.fi-fi.md
@@ -33,7 +33,7 @@ Kovalevyn vaihdossa tapahtuvien virheiden minimoimiseksi pyydämme asiakkaitamme
 Voit hakea sarjanumeron ohjelmistopohjaista RAIDia käyttävälle kovalevylle käyttämällä komentoa `smartctl`:
 
 ```sh
-smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+smartctl -a /dev/sdX | grep Serial
 ```
 
 Käyttöjärjestelmä on havainnut laitteen (esim. /dev/sda, /dev/sdb, jne.).
@@ -141,7 +141,7 @@ Laitteen ja adaptorin ID-tunnuksilla ilmoitetaan `smartctl`-komennolle, mitä le
 Komennon pitäisi siis näyttää tältä:
 
 ```sh
-smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 RAID-laitteen ID tulee näkyviin seuraavasti: `/dev/sda`= 1\. RAID, `/dev/sdb`= 2\. RAID jne.
@@ -158,7 +158,7 @@ RAID-laitteen ID tulee näkyviin seuraavasti: `/dev/sda`= 1\. RAID, `/dev/sdb`= 
 > Korvaa silloin kohta `megaraid` kohdalla `sat+megaraid`:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -171,7 +171,7 @@ Voit katsoa [tätä ohjetta](https://docs.ovh.com/gb/en/dedicated/raid-hard/){.e
 Kun olet löytänyt analysoitavaan kovalevyyn liitetyn sg-laitteen, käytä seuraavaa komentoa:
 
 ```sh
-smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+smartctl -a /dev/sgX | grep Serial
 ```
 
 Sg-laitteen numero näkyy seuraavasti: `/dev/sg0`, `/dev/sg1`...

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.fr-ca.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.fr-ca.md
@@ -31,7 +31,7 @@ Pour minimiser le risque d'erreur pendant le remplacement d’un disque dur, nou
 Pour récupérer le numéro de série de votre disque dur avec une configuration RAID logiciel, vous pouvez simplement utiliser smartctl :
 
 ```sh
-# smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+# smartctl -a /dev/sdX | grep Serial
 ```
 
 Le périphérique est détecté par le système d'exploitation. Par exemple : `/dev/sda`, `/dev/sdb`, etc.
@@ -137,7 +137,7 @@ Les ID du périphérique et de l'adaptateur seront utilisés pour indiquer à sm
 La commande devrait donc ressembler à ceci :
 
 ```sh
-# smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+# smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 L'ID du périphérique RAID sera affiché comme suit: `/dev/sda` = 1er RAID, `/dev/sdb` = 2e RAID, etc.
@@ -154,7 +154,7 @@ L'ID du périphérique RAID sera affiché comme suit: `/dev/sda` = 1er RAID, `/d
 > Vous devez alors remplacer `megaraid` par `sat+megaraid` :
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -167,7 +167,7 @@ Vous pouvez vous référer à [ce guide (contrôleur RAID LSI)](../raid-hard/){.
 Une fois que vous avez trouvé ce périphérique lié au disque dur que vous voulez analyser, utilisez la commande suivante :
 
 ```sh
-# smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+# smartctl -a /dev/sgX | grep Serial
 ```
 
 Le numéro du périphérique sg sera affiché comme suit : `/dev/sg0`, `/dev/sg1`, etc.

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.fr-fr.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.fr-fr.md
@@ -31,7 +31,7 @@ Pour minimiser le risque d'erreur pendant le remplacement d’un disque dur, nou
 Pour récupérer le numéro de série de votre disque dur avec une configuration RAID logiciel, vous pouvez simplement utiliser smartctl :
 
 ```sh
-# smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+# smartctl -a /dev/sdX | grep Serial
 ```
 
 Le périphérique est détecté par le système d'exploitation. Par exemple : `/dev/sda`, `/dev/sdb`, etc.
@@ -137,7 +137,7 @@ Les ID du périphérique et de l'adaptateur seront utilisés pour indiquer à sm
 La commande devrait donc ressembler à ceci :
 
 ```sh
-# smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+# smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 L'ID du périphérique RAID sera affiché comme suit: `/dev/sda` = 1er RAID, `/dev/sdb` = 2e RAID, etc.
@@ -154,7 +154,7 @@ L'ID du périphérique RAID sera affiché comme suit: `/dev/sda` = 1er RAID, `/d
 > Vous devez alors remplacer `megaraid` par `sat+megaraid` :
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -167,7 +167,7 @@ Vous pouvez vous référer à [ce guide (contrôleur RAID LSI)](https://docs.ovh
 Une fois que vous avez trouvé ce périphérique lié au disque dur que vous voulez analyser, utilisez la commande suivante :
 
 ```sh
-# smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+# smartctl -a /dev/sgX | grep Serial
 ```
 
 Le numéro du périphérique sg sera affiché comme suit : `/dev/sg0`, `/dev/sg1`, etc.

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.it-it.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.it-it.md
@@ -33,7 +33,7 @@ Per ridurre al minimo il rischio di errore durante la sostituzione di un hard di
 Per conoscere il numero di serie di un hard disk con configurazione softRAID è sufficiente utilizzare il comando `smartctl`:
 
 ```sh
-smartctl -a /dev/sdX | grep "Serial"
+smartctl -a /dev/sdX | grep Serial
 ```
 
 

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.lt-lt.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.lt-lt.md
@@ -32,7 +32,7 @@ To minimise the chance of human error during hard disk replacements, we ask our 
 To retrieve your hard drive's serial number with a software RAID configuration, you can simply use smartctl:
 
 ```sh
-smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+smartctl -a /dev/sdX | grep Serial
 ```
 
 The device is detected by the OS (ex: /dev/sda, /dev/sdb, etc.).
@@ -138,7 +138,7 @@ The Device ID and Adapter ID will be used to tell smartctl which disk to look fo
 The command should look like this:
 
 ```sh
-smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb = 2nd RAID, etc.
@@ -155,7 +155,7 @@ The RAID Device ID will be displayed as follows: /dev/sda = 1st RAID, /dev/sdb =
 > You must then replace megaraid with sat+megaraid:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -168,7 +168,7 @@ You can refer to [this guide (LSI raid controller)](https://docs.ovh.com/gb/en/d
 Once you have found the sg device related to the hard disk you want to query, use the following command:
 
 ```sh
-smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+smartctl -a /dev/sgX | grep Serial
 ```
 
 The sg device number will be displayed as follows: /dev/sg0, /dev/sg1) etc.

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.pl-pl.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.pl-pl.md
@@ -31,7 +31,7 @@ Aby zminimalizować ryzyko błędu podczas wymiany dysku twardego, prosimy naszy
 Aby ustalić numer seryjny Twojego dysku twardego w przypadku konfiguracji programowej macierzy RAID, możesz użyć smartctl:
 
 ```sh
-smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+smartctl -a /dev/sdX | grep Serial
 ```
 
 Urządzenie jest wykrywane przez system operacyjny, na przykład `/dev/sda`, `/dev/sdb`, etc. 
@@ -137,7 +137,7 @@ Numery ID urządzenia i adaptera używane są do wskazania narzędziu smartctl, 
 Należy użyć polecenia podobnego do poniższego:
 
 ```sh
-# smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+# smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 Numer ID urządzenia RAID będzie się wyświetlał w następujący sposób: `/dev/sda` = 1er RAID, `/dev/sdb` = 2e RAID, etc.
@@ -154,7 +154,7 @@ Numer ID urządzenia RAID będzie się wyświetlał w następujący sposób: `/d
 > Zastąp wówczas `megaraid` wpisem `sat+megaraid`:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -167,7 +167,7 @@ Możesz skorzystać z [tego przewodnika (kontroler RAID LSI)](https://docs.ovh.c
 Po odnalezieniu urządzenia „sg” powiązanego z dyskiem twardym, który chcesz przeanalizować, zastosuj następujące polecenie:
 
 ```sh
-# smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+# smartctl -a /dev/sgX | grep Serial
 ```
 
 Numer urządzenia „sg” będzie się wyświetlał w następujący sposób: `/dev/sg0`, `/dev/sg1`...

--- a/pages/cloud/dedicated/how_to_find_hdd_serial/guide.pt-pt.md
+++ b/pages/cloud/dedicated/how_to_find_hdd_serial/guide.pt-pt.md
@@ -31,7 +31,7 @@ Para minimizar os riscos de erro durante a substituição de um disco rígido, p
 Para obter o número de série de um disco rígido com uma configuração RAID de software, pode simplesmente utilizar o smartctl:
 
 ```sh
-# smartctl -a /dev/sdX | grep Serial Serial Number:    XXXXXXX
+# smartctl -a /dev/sdX | grep Serial
 ```
 
 O periférico é detetado pelo sistema operativo. Por exemplo: `/dev/sda`, `/dev/sdb`, etc.
@@ -137,7 +137,7 @@ O ID do periférico e do adaptador serão utilizados para indicar ao smartctl qu
 Assim, o comando deve ter o seguinte formato:
 
 ```sh
-# smartctl -d megaraid,N -a /dev/sdX | grep Serial Serial Number: 1234567890
+# smartctl -d megaraid,N -a /dev/sdX | grep Serial
 ```
 
 O ID do periférico RAID será apresentado como se segue: `/dev/sda` = 1º RAID, `/dev/sdb` = 2º RAID, etc.
@@ -154,7 +154,7 @@ O ID do periférico RAID será apresentado como se segue: `/dev/sda` = 1º RAID,
 > Nesse caso, deve substituir `megaraid` por `sat+megaraid`:
 >
 > ```
-> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial Serial Number:    1234567890
+> smartctl -d sat+megaraid,N -a /dev/sdX | grep Serial
 > ```
 >
 
@@ -167,7 +167,7 @@ Pode recorrer a [este manual](https://docs.ovh.com/gb/en/dedicated/raid-hard/){.
 Quando tiver encontrado este periférico associado ao disco rígido que pretende analisar, utilize o seguinte comando:
 
 ```sh
-# smartctl -a /dev/sgX | grep Serial Serial Number:    1234567890
+# smartctl -a /dev/sgX | grep Serial
 ```
 
 O número do periférico sg será apresentado como se segue: `/dev/sg0`, `/dev/sg1`, etc.


### PR DESCRIPTION
This commit fixes malformated commands in _Finding the serial number of a hard disk_ guides.