### PR TITLE
Bump ansible from 2.6.4 to 2.6.18 in /pages/cloud/private-cloud/openshift_mono_server/scripts

### DIFF
--- a/pages/cloud/private-cloud/openshift_mono_server/scripts/requirements.txt
+++ b/pages/cloud/private-cloud/openshift_mono_server/scripts/requirements.txt
@@ -1,3 +1,3 @@
-ansible==2.6.4
+ansible==2.6.18
 pyvmomi==6.7.0.2018.9
 requests==2.20.0


### PR DESCRIPTION
Fixes:
- CVE-2019-10156
- CVE-2019-3828
- CVE-2018-16876

Bumps [ansible](https://github.com/ansible/ansible) from 2.6.4 to 2.6.18.
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/ansible/ansible/commit/a5f3791a914e5e288a519aa9f57657ebb9080fdb"><code>a5f3791</code></a> New release v2.6.18</li>
<li><a href="https://github.com/ansible/ansible/commit/f3ce22b1686c16cbb99212027f1885b83a1cedfe"><code>f3ce22b</code></a> Make nuage_vspk test more reliable</li>
<li><a href="https://github.com/ansible/ansible/commit/d981461a7bfc6686cee46519f3089fb693e5160f"><code>d981461</code></a> [stable-2.6] Fix nuage_vspk integration test:</li>
<li><a href="https://github.com/ansible/ansible/commit/37284b05815722b90fda4aeab0fd3e1ade200420"><code>37284b0</code></a> [stable-2.6] also allow None Type for safe eval (<a href="https://github-redirect.dependabot.com/ansible/ansible/issues/58269">#58269</a>)</li>
<li><a href="https://github.com/ansible/ansible/commit/f71a7b9fbdd0b072e9cfb08fa0d6b1ab0685d3cf"><code>f71a7b9</code></a> [stable-2.6] Add Fedora 30 to test matrix (<a href="https://github-redirect.dependabot.com/ansible/ansible/issues/57713">#57713</a>)</li>
<li><a href="https://github.com/ansible/ansible/commit/8047c3d53dd578218a837188906d4e072e0e6ea6"><code>8047c3d</code></a> [stable-2.6] Add work-around for scp issue in tests.</li>
<li><a href="https://github.com/ansible/ansible/commit/f44d23a6018a30e19f5830a958fd467ef8405cb0"><code>f44d23a</code></a> [stable-2.6] passwordstore lookup - replace expired GPG key (<a href="https://github-redirect.dependabot.com/ansible/ansible/issues/58141">#58141</a>)</li>
<li><a href="https://github.com/ansible/ansible/commit/33a92419a3dabd3203f96ac5b4c35ddc7040c25e"><code>33a9241</code></a> backport 2.6 - add dropdown version changer - 55655 (<a href="https://github-redirect.dependabot.com/ansible/ansible/issues/58098">#58098</a>)</li>
<li><a href="https://github.com/ansible/ansible/commit/2aa20a974033df8e185edb341104ae8ca29163c0"><code>2aa20a9</code></a> [stable-2.6] Change integration tests in order to pass on Fedora 30 (<a href="https://github-redirect.dependabot.com/ansible/ansible/issues/58081">#58081</a>)</li>
<li><a href="https://github.com/ansible/ansible/commit/3ff6505e8ff0e4655bab008886983476ef903375"><code>3ff6505</code></a> safe_eval fix (<a href="https://github-redirect.dependabot.com/ansible/ansible/issues/57188">#57188</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/ansible/ansible/compare/v2.6.4...v2.6.18">compare view</a></li>
</ul>
</details>
<br />