### PR TITLE
Update URL for SPF Record Syntax

### DIFF
--- a/pages/cloud/dedicated/mail_sending_optimization/guide.en-asia.md
+++ b/pages/cloud/dedicated/mail_sending_optimization/guide.en-asia.md
@@ -39,7 +39,7 @@ If you are using a dedicated infrastructure (e.g. a dedicated server, VPS, Publi
 > - `?`: neutral
 >
 
-For further information on the SPF record, refer to the following page: <http://www.openspf.org/SPF_Record_Syntax>.
+For further information on the SPF record, refer to the following page: <http://www.open-spf.org/SPF_Record_Syntax>.
 
 You can go even further by configuring the SPF record of a specific domain, or by specifying an IPV6 address. You can find out how to do this in our guide to [adding an SPF record](../../domains/web_hosting_the_spf_record/).
 

--- a/pages/cloud/dedicated/mail_sending_optimization/guide.en-au.md
+++ b/pages/cloud/dedicated/mail_sending_optimization/guide.en-au.md
@@ -39,7 +39,7 @@ If you are using a dedicated infrastructure (e.g. a dedicated server, VPS, Publi
 > - `?`: neutral
 >
 
-For further information on the SPF record, refer to the following page: <http://www.openspf.org/SPF_Record_Syntax>.
+For further information on the SPF record, refer to the following page: <http://www.open-spf.org/SPF_Record_Syntax>.
 
 You can go even further by configuring the SPF record of a specific domain, or by specifying an IPV6 address. You can find out how to do this in our guide to [adding an SPF record](../../domains/web_hosting_the_spf_record/).
 

--- a/pages/cloud/dedicated/mail_sending_optimization/guide.en-ca.md
+++ b/pages/cloud/dedicated/mail_sending_optimization/guide.en-ca.md
@@ -39,7 +39,7 @@ If you are using a dedicated infrastructure (e.g. a dedicated server, VPS, Publi
 > - `?`: neutral
 >
 
-For further information on the SPF record, refer to the following page: <http://www.openspf.org/SPF_Record_Syntax>.
+For further information on the SPF record, refer to the following page: <http://www.open-spf.org/SPF_Record_Syntax>.
 
 You can go even further by configuring the SPF record of a specific domain, or by specifying an IPV6 address. You can find out how to do this in our guide to [adding an SPF record](../../domains/web_hosting_the_spf_record/).
 

--- a/pages/cloud/dedicated/mail_sending_optimization/guide.en-gb.md
+++ b/pages/cloud/dedicated/mail_sending_optimization/guide.en-gb.md
@@ -39,7 +39,7 @@ If you are using a dedicated infrastructure (e.g. a dedicated server, VPS, Publi
 > - `?`: neutral
 >
 
-For further information on the SPF record, refer to the following page: <http://www.openspf.org/SPF_Record_Syntax>.
+For further information on the SPF record, refer to the following page: <http://www.open-spf.org/SPF_Record_Syntax>.
 
 You can go even further by configuring the SPF record of a specific domain, or by specifying an IPV6 address. You can find out how to do this in our guide to [adding an SPF record](https://docs.ovh.com/gb/en/domains/web_hosting_the_spf_record/).
 

--- a/pages/cloud/dedicated/mail_sending_optimization/guide.en-ie.md
+++ b/pages/cloud/dedicated/mail_sending_optimization/guide.en-ie.md
@@ -39,7 +39,7 @@ If you are using a dedicated infrastructure (e.g. a dedicated server, VPS, Publi
 > - `?`: neutral
 >
 
-For further information on the SPF record, refer to the following page: <http://www.openspf.org/SPF_Record_Syntax>.
+For further information on the SPF record, refer to the following page: <http://www.open-spf.org/SPF_Record_Syntax>.
 
 You can go even further by configuring the SPF record of a specific domain, or by specifying an IPV6 address. You can find out how to do this in our guide to [adding an SPF record](https://docs.ovh.com/gb/en/domains/web_hosting_the_spf_record/).
 

--- a/pages/cloud/dedicated/mail_sending_optimization/guide.en-sg.md
+++ b/pages/cloud/dedicated/mail_sending_optimization/guide.en-sg.md
@@ -39,7 +39,7 @@ If you are using a dedicated infrastructure (e.g. a dedicated server, VPS, Publi
 > - `?`: neutral
 >
 
-For further information on the SPF record, refer to the following page: <http://www.openspf.org/SPF_Record_Syntax>.
+For further information on the SPF record, refer to the following page: <http://www.open-spf.org/SPF_Record_Syntax>.
 
 You can go even further by configuring the SPF record of a specific domain, or by specifying an IPV6 address. You can find out how to do this in our guide to [adding an SPF record](../../domains/web_hosting_the_spf_record/).
 

--- a/pages/cloud/dedicated/mail_sending_optimization/guide.en-us.md
+++ b/pages/cloud/dedicated/mail_sending_optimization/guide.en-us.md
@@ -39,7 +39,7 @@ If you are using a dedicated infrastructure (e.g. a dedicated server, VPS, Publi
 > - `?`: neutral
 >
 
-For further information on the SPF record, refer to the following page: <http://www.openspf.org/SPF_Record_Syntax>.
+For further information on the SPF record, refer to the following page: <http://www.open-spf.org/SPF_Record_Syntax>.
 
 You can go even further by configuring the SPF record of a specific domain, or by specifying an IPV6 address. You can find out how to do this in our guide to [adding an SPF record](../../domains/web_hosting_the_spf_record/).
 

--- a/pages/cloud/dedicated/mail_sending_optimization/guide.es-us.md
+++ b/pages/cloud/dedicated/mail_sending_optimization/guide.es-us.md
@@ -38,7 +38,7 @@ Si usted está usando una infraestructura dedicada (ejem. Un servidor dedicado, 
 > - `?`: neutro
 >
 
-Para más información sobre el registro SPF, vaya a la siguiente página: <http://www.openspf.org/SPF_Record_Syntax.>
+Para más información sobre el registro SPF, vaya a la siguiente página: <http://www.open-spf.org/SPF_Record_Syntax.>
 
 Usted puede encontrar más información sobre como configurar el registro SPF para un dominio, o especificando directamente la dirección IPV6. Puede encontrar como hacerlo en la siguiente guía: [Añadir un registro SPF a la configuración del dominio](../../domains/web_hosting_el_registro_spf/)
 

--- a/pages/cloud/dedicated/mail_sending_optimization/guide.fr-ca.md
+++ b/pages/cloud/dedicated/mail_sending_optimization/guide.fr-ca.md
@@ -38,7 +38,7 @@ Dans le cas d'une infrastructure dédiée (serveur dédié, VPS, instance Public
 > `?` : neutre
 >
 
-Pour plus d'informations sur la syntaxe du champ SPF, référez-vous au lien suivant : <http://www.openspf.org/SPF_Record_Syntax>.
+Pour plus d'informations sur la syntaxe du champ SPF, référez-vous au lien suivant : <http://www.open-spf.org/SPF_Record_Syntax>.
 
 Vous pouvez bien entendu aller plus loin, en configurant le champ SPF d'un domaine bien spécifique ou en spécifiant une IPv6.
 

--- a/pages/cloud/dedicated/mail_sending_optimization/guide.fr-fr.md
+++ b/pages/cloud/dedicated/mail_sending_optimization/guide.fr-fr.md
@@ -38,7 +38,7 @@ Dans le cas d'une infrastructure dédiée (serveur dédié, VPS, instance Public
 > `?` : neutre
 >
 
-Pour plus d'informations sur la syntaxe du champ SPF, référez-vous au lien suivant : <http://www.openspf.org/SPF_Record_Syntax>.
+Pour plus d'informations sur la syntaxe du champ SPF, référez-vous au lien suivant : <http://www.open-spf.org/SPF_Record_Syntax>.
 
 Vous pouvez bien entendu aller plus loin, en configurant le champ SPF d'un domaine bien spécifique ou en spécifiant une IPv6.
 


### PR DESCRIPTION
openspf.org seems to have been taken down somewhere in 2019:

https://web.archive.org/web/2019*/openspf.org