### PR TITLE
Update guide.fr-fr.md

### DIFF
--- a/pages/platform/public-cloud/howto_configure_ipv6/guide.fr-fr.md
+++ b/pages/platform/public-cloud/howto_configure_ipv6/guide.fr-fr.md
@@ -101,7 +101,7 @@ Voici un exemple concret :
 
 ```
 IPV6INIT=yes
-IPV6ADDR=2001:41d0:xxx:xxxx::999
+IPV6ADDR=2001:41d0:xxx:xxxx::999/128
 IPV6_DEFAULTGW=2001:41d0:xxx:xxxx::111
 ```
 


### PR DESCRIPTION
Bonsoir,

Je me demande si cette page de documentation est toujours à jours et si il ne faudrait pas la remplacer par la page du documentation pour les VPS car elle m'a l'air plus à jours : 

https://github.com/ovh/docs/blob/develop/pages/cloud/vps/configure-ipv6/guide.fr-fr.md

Au cas où j'ai quand même apporté une petit modification.

Amicalement,
Gaëtan MAISON