### PR TITLE
constant PROTOCOL_TLSv1 deprecated

### DIFF
--- a/pages/cloud/private-cloud/vmware_installation_api/guide.de-de.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.de-de.md
@@ -71,7 +71,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -104,7 +104,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.en-asia.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.en-asia.md
@@ -73,7 +73,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -106,7 +106,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.en-au.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.en-au.md
@@ -73,7 +73,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -106,7 +106,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.en-ca.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.en-ca.md
@@ -73,7 +73,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -106,7 +106,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.en-gb.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.en-gb.md
@@ -73,7 +73,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -106,7 +106,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.en-ie.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.en-ie.md
@@ -73,7 +73,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -106,7 +106,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.en-sg.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.en-sg.md
@@ -73,7 +73,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -106,7 +106,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.en-us.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.en-us.md
@@ -73,7 +73,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -106,7 +106,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.es-es.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.es-es.md
@@ -72,7 +72,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -105,7 +105,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.es-us.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.es-us.md
@@ -72,7 +72,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -105,7 +105,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.fr-ca.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.fr-ca.md
@@ -71,7 +71,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -104,7 +104,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.fr-fr.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.fr-fr.md
@@ -71,7 +71,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -104,7 +104,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.it-it.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.it-it.md
@@ -71,7 +71,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -104,7 +104,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.pl-pl.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.pl-pl.md
@@ -71,7 +71,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -104,7 +104,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",

--- a/pages/cloud/private-cloud/vmware_installation_api/guide.pt-pt.md
+++ b/pages/cloud/private-cloud/vmware_installation_api/guide.pt-pt.md
@@ -73,7 +73,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",
@@ -106,7 +106,7 @@ from pyVmomi import vim
  
  
 def vconnect():
-    s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    s = ssl.SSLContext(ssl.PROTOCOL_TLS)
     s.verify_mode = ssl.CERT_NONE
  
     service_instance = connect.SmartConnect(host="pcc-149-202-xxx-xxx.ovh.com",


### PR DESCRIPTION
This constant is deprecated since python 2.7.13 (December 2016) and the examples doesn't work. Replaced by PROTOCOL_TLS and the examples will be functional in python2 and python3.
https://docs.python.org/2/library/ssl.html#ssl.PROTOCOL_TLSv1