### PR TITLE
Update guide.fr-fr.md

### DIFF
--- a/pages/labs/web-power/nodejs-install-strapi/guide.en-gb.md
+++ b/pages/labs/web-power/nodejs-install-strapi/guide.en-gb.md
@@ -75,6 +75,13 @@ const strapi = require('strapi');
 strapi(/* {...} */).start();
 ```
 
+Build admin UI site : 
+
+```sh
+cd www
+yarn build
+```
+
 Create also an `.htaccess` file to manage HTTPS redirection:
 
 ```sh

--- a/pages/labs/web-power/nodejs-install-strapi/guide.en-ie.md
+++ b/pages/labs/web-power/nodejs-install-strapi/guide.en-ie.md
@@ -73,6 +73,14 @@ Now let's go into the `www` folder and create the entrypoint `index.js`:
 const strapi = require('strapi');
  
 strapi(/* {...} */).start();
+
+```
+
+Build admin UI site : 
+
+```sh
+cd www
+yarn build
 ```
 
 Create also an `.htaccess` file to manage HTTPS redirection:

--- a/pages/labs/web-power/nodejs-install-strapi/guide.fr-fr.md
+++ b/pages/labs/web-power/nodejs-install-strapi/guide.fr-fr.md
@@ -71,6 +71,12 @@ const strapi = require('strapi');
 strapi(/* {...} */).start();
 ```
 
+Construire le site admin UI : 
+```sh
+cd www
+npm run build
+```
+
 Créez un fichier `.htaccess` pour gérer la redirection HTTPS :
 
 ```sh

--- a/pages/labs/web-power/nodejs-install-strapi/guide.fr-fr.md
+++ b/pages/labs/web-power/nodejs-install-strapi/guide.fr-fr.md
@@ -74,7 +74,7 @@ strapi(/* {...} */).start();
 Construire le site admin UI : 
 ```sh
 cd www
-npm run build
+yarn build
 ```
 
 Créez un fichier `.htaccess` pour gérer la redirection HTTPS :


### PR DESCRIPTION
La doc strapi n'est pas complète. 
Le site d'administration du CMS n'est pas construit, Ce qui amène à une page 404 Not found lorsqu'on clique sur le bouton "Create the first administrator".
Il faut le builder explicitement par la commande npm run build