### PR TITLE
Add high availability tips to kubernetes Known Limits

### DIFF
--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
@@ -6,7 +6,7 @@ section: Technical resources
 ---
 
 
-**Last updated February 17, 2021.**
+**Last updated March 12, 2021.**
 
 <style>
  pre {
@@ -37,6 +37,8 @@ While we are fairly sure it can go further, we advise you to keep under those li
 Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple node pools with the same instance flavor if needed of course).
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
+
+To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
@@ -38,7 +38,7 @@ Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
 
-To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
+To ensure high availability for your services, it is recommended to possess the computation power capable of handling your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if Kubernetes budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
@@ -6,7 +6,7 @@ section: Technical resources
 ---
 
 
-**Last updated February 17, 2021.**
+**Last updated March 12, 2021.**
 
 <style>
  pre {
@@ -37,6 +37,8 @@ While we are fairly sure it can go further, we advise you to keep under those li
 Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple node pools with the same instance flavor if needed of course).
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
+
+To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
@@ -38,7 +38,7 @@ Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
 
-To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
+To ensure high availability for your services, it is recommended to possess the computation power capable of handling your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if Kubernetes budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
@@ -6,7 +6,7 @@ section: Technical resources
 ---
 
 
-**Last updated February 17, 2021.**
+**Last updated March 12, 2021.**
 
 <style>
  pre {
@@ -37,6 +37,8 @@ While we are fairly sure it can go further, we advise you to keep under those li
 Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple node pools with the same instance flavor if needed of course).
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
+
+To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
@@ -38,7 +38,7 @@ Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
 
-To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
+To ensure high availability for your services, it is recommended to possess the computation power capable of handling your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if Kubernetes budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
@@ -6,7 +6,7 @@ section: Technical resources
 ---
 
 
-**Last updated February 17, 2021.**
+**Last updated March 12, 2021.**
 
 <style>
  pre {
@@ -37,6 +37,8 @@ While we are fairly sure it can go further, we advise you to keep under those li
 Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple node pools with the same instance flavor if needed of course).
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
+
+To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
@@ -38,7 +38,7 @@ Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
 
-To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
+To ensure high availability for your services, it is recommended to possess the computation power capable of handling your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if Kubernetes budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
@@ -6,7 +6,7 @@ section: Technical resources
 ---
 
 
-**Last updated February 17, 2021.**
+**Last updated March 12, 2021.**
 
 <style>
  pre {
@@ -37,6 +37,8 @@ While we are fairly sure it can go further, we advise you to keep under those li
 Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple node pools with the same instance flavor if needed of course).
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
+
+To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
@@ -38,7 +38,7 @@ Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
 
-To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
+To ensure high availability for your services, it is recommended to possess the computation power capable of handling your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if Kubernetes budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
@@ -6,7 +6,7 @@ section: Technical resources
 ---
 
 
-**Last updated February 17, 2021.**
+**Last updated March 12, 2021.**
 
 <style>
  pre {
@@ -37,6 +37,8 @@ While we are fairly sure it can go further, we advise you to keep under those li
 Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple node pools with the same instance flavor if needed of course).
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
+
+To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
@@ -38,7 +38,7 @@ Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
 
-To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
+To ensure high availability for your services, it is recommended to possess the computation power capable of handling your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if Kubernetes budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-us.md
@@ -6,7 +6,7 @@ section: Technical resources
 ---
 
 
-**Last updated February 17, 2021.**
+**Last updated March 12, 2021.**
 
 <style>
  pre {
@@ -37,6 +37,8 @@ While we are fairly sure it can go further, we advise you to keep under those li
 Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple node pools with the same instance flavor if needed of course).
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
+
+To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-us.md
@@ -38,7 +38,7 @@ Nodepools with anti-affinity are limited to 5 nodes (but you can create multiple
 
 In general, it's better to have several mid-size Kubernetes clusters than one monster-size one.
 
-To ensure high availability for your services, it is recommended to possess the computation power to handle your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if budget restrictions are present.
+To ensure high availability for your services, it is recommended to possess the computation power capable of handling your workload even when one of your nodes becomes unavailable. Note that any operation requested to our services, like node deletions or updates, will be performed even if Kubernetes budget restrictions are present.
 
 Delivering a fully managed service, including OS and other component updates, you will neither need nor be able to SSH as root into your nodes.
 


### PR DESCRIPTION
Kubernetes administration workflows will soon ignore PodDisruptionBudgets, so we are adding this information to our documentation.