### PR TITLE
EN Update Configuring kubectl 

### DIFF
--- a/pages/platform/kubernetes-k8s/configuring-kubectl-on-an-ovh-managed-kubernetes-cluster/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/configuring-kubectl-on-an-ovh-managed-kubernetes-cluster/guide.en-gb.md
@@ -36,7 +36,7 @@ Then, download the `kubectl` configuration file:
 
 ![Configuring default settings for kubectl](images/kubernetes-quickstart-02.png){.thumbnail}
 
-If you want to use this configuration file by default in `kubectl`, you can save it with the filename `kube-config` in the `$HOME/.kube` directory. Alternatively, you can place it in your working directory, with either the `KUBECONFIG` environment variable or the `--kubeconfig` flag. 
+If you want to use this configuration file by default in `kubectl`, you can save it with the filename `config` in the `$HOME/.kube` directory. Alternatively, you can place it in your working directory, with either the `KUBECONFIG` environment variable or the `--kubeconfig` flag. 
 
 In this example, we are using the environment variable method.
 


### PR DESCRIPTION
In the official kubernetes docs at https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
The kubeconfig file is to be named config by default. The proposed name `kube-config` in the previous version of the docs did not work while the name `config` works as intended.