### PR TITLE
[K8s: Using Load Balancer] Fix typo in file name

### DIFF
--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-gb.md
@@ -108,7 +108,7 @@ In our OVHcloud Managed Kubernetes we propose a load balancing service enabling 
 
 ## Deploying a Hello World LoadBalancer service
 
-Create a `hello.yaml` file for our `ovhplatform/hello` Docker image, defining the service type as `LoadBalancer`:
+Create a `hello.yml` file for our `ovhplatform/hello` Docker image, defining the service type as `LoadBalancer`:
 
 ```yaml
 apiVersion: v1


### PR DESCRIPTION
Same as #1339 .

The `hello.yml` file is referenced everywhere in this page using the `.yml` extension, except for the first occurence, which was `.yaml`.

This PR simply fixes that (use `.yml` exetension everywhere)