### PR TITLE
Update guide.fr-fr.md

### DIFF
--- a/pages/platform/public-cloud/configure-a-failover-ip/guide.fr-fr.md
+++ b/pages/platform/public-cloud/configure-a-failover-ip/guide.fr-fr.md
@@ -114,12 +114,12 @@ iface ens3 inet dhcp
 
 auto ens3:0
 iface ens3:0 inet static
-address your_ip_address 0
+address your_ip_address
 netmask 255.255.255.255
 
 auto ens3:1
 iface ens3:1 inet static
-address your_ip_address 1
+address your_ip_address
 netmask 255.255.255.255
 ```
 


### PR DESCRIPTION
Retirer le 0 et le 1 après avoir entré l'adresse IP pour debian, cela génère une erreur.

Error: either "local" is duplicate, or "0/255.255.255.255" is a garbage.