### PR TITLE
Adds missing html end tags in guide.en-gb.md

### DIFF
--- a/pages/platform/kubernetes-k8s/installing-nginx-ingress/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/installing-nginx-ingress/guide.en-gb.md
@@ -64,6 +64,7 @@ STATUS: deployed
 REVISION: 1
 TEST SUITE: None
 NOTES:
+</code></pre>
 
 At the end of the install, as usual with most helm charts, you get the configuration information and some tips to
 test your `nginx-ingress` but the YAML provided is based on old API version ()extensions/v1beta1), the newest version is :


### PR DESCRIPTION
Hello,
it seems that a previous commit as erased html end tags in this page, resulting in a poor display of contents on this page https://docs.ovh.com/gb/en/kubernetes/installing-nginx-ingress/
![image](https://user-images.githubusercontent.com/9193295/117372099-48ebbb00-aec9-11eb-92a5-79c06c2dc062.png)
