### PR TITLE
EN FR Remove Mysql 5.5 EOL

### DIFF
--- a/pages/cloud/clouddb/privatesql-eos-eol/guide.en-gb.md
+++ b/pages/cloud/clouddb/privatesql-eos-eol/guide.en-gb.md
@@ -15,7 +15,6 @@ The products covered by those End Of Sale (EOS) and End Of Life (EOL) announceme
 |MariaDB 10.4|To be defined|To be defined|To be defined|
 |MariaDB 10.5|To be defined|To be defined|To be defined|
 |MongoDB 4|2019-07-29|2019-02-25|To be defined|
-|MySQL 5.5|2019-07-29|2018-08-02|2020-01-28|
 |MySQL 5.6|2019-07-29|2020-08-02|2021-02-01|
 |MySQL 5.7|To be defined|To be defined|To be defined|
 |MySQL 8.0|To be defined|To be defined|To be defined|

--- a/pages/cloud/clouddb/privatesql-eos-eol/guide.fr-fr.md
+++ b/pages/cloud/clouddb/privatesql-eos-eol/guide.fr-fr.md
@@ -15,7 +15,6 @@ Les produits couverts par ces annonces de fin de vente et de fin de vie sont les
 |MariaDB 10.4|À définir|À définir|À définir|
 |MariaDB 10.5|À définir|À définir|À définir|
 |MongoDB 4|2019-07-29|2019-02-25|À définir|
-|MySQL 5.5|2019-07-29|2018-08-02|2020-01-28|
 |MySQL 5.6|2019-07-29|2020-08-02|2021-02-01|
 |MySQL 5.7|À définir|À définir|À définir|
 |MySQL 8.0|À définir|À définir|À définir|


### PR DESCRIPTION
As OVH dropped support for MySQL 5.5 it does not need to be in the docs anymore