### PR TITLE
EN-GB update How to use cli for AI Training

### DIFF
--- a/pages/platform/ai-training/13_HOWTO_usage_cli/guide.en-gb.md
+++ b/pages/platform/ai-training/13_HOWTO_usage_cli/guide.en-gb.md
@@ -107,7 +107,7 @@ ovhai job get <job-id>
 You can execute commands (like `bash`) while a job is running.
 
 ``` {.console}
-ovhai job exec <id> -- bash
+ovhai job exec -it <id> -- bash
 ```
 
 This way you can interact with a running job.


### PR DESCRIPTION
Update instructions for executing bash in a AI Training Job, as the previous syntax is not supported anymore.