### PR TITLE
prefer https by default

### DIFF
--- a/pages/web/domains/dns_dynhost/guide.fr-fr.md
+++ b/pages/web/domains/dns_dynhost/guide.fr-fr.md
@@ -75,7 +75,7 @@ Les possibilités étant vastes, sachez que ce client peut être installé sur v
 
 Selon le client utilisé, il se peut qu'une adresse URL de mise à jour soit également requise en plus des éléments de l'utilisateur DynHost et du sous-domaine concerné. Si tel est le cas, utilisez l'adresse URL ci-dessous en prenant soin d'y remplacer les informations génériques :
 
-> http://www.ovh.com/nic/update?system=dyndns&hostname=**$HOSTNAME**&myip=**$IP**
+> https://www.ovh.com/nic/update?system=dyndns&hostname=**$HOSTNAME**&myip=**$IP**
 
 |Informations|À remplacer par|
 |---|---|


### PR DESCRIPTION
As far my understanding there is no HTTP -> HTTPS redirection using documented url:
`http://www.ovh.com/nic/update?system=dyndns&hostname=$HOSTNAME&myip=$IP`

So I suppose that user/password travel in clear text on the network, is that a security issue
(by Man in the middle attacker)?

I supposed that a lot of former application do not support redirection that why this support still present
but I would recommend to make it deprecated anyway and at least use HTTPS by default in this documentation.