### PR TITLE
fix(ldp): udp input is not supported

### DIFF
--- a/pages/platform/logs-data-platform/logstash_input/guide.en-gb.md
+++ b/pages/platform/logs-data-platform/logstash_input/guide.en-gb.md
@@ -5,7 +5,7 @@ order: 1
 section: Features
 ---
 
-**Last updated 21st July, 2020**
+**Last updated 30th July, 2021**
 
 ## Objective
 
@@ -246,7 +246,6 @@ For your information, here is the list of Logstash plugins we support. Of course
  logstash-input-syslog
  logstash-input-tcp
  logstash-input-twitter
- logstash-input-udp
 ```
 
 ##### Input gelf plugin

--- a/pages/platform/logs-data-platform/logstash_input/guide.fr-fr.md
+++ b/pages/platform/logs-data-platform/logstash_input/guide.fr-fr.md
@@ -5,7 +5,7 @@ order: 1
 section: Features
 ---
 
-**Last updated 21st July, 2020**
+**Last updated 30th July, 2021**
 
 ## Objective
 
@@ -246,7 +246,6 @@ For your information, here is the list of Logstash plugins we support. Of course
  logstash-input-syslog
  logstash-input-tcp
  logstash-input-twitter
- logstash-input-udp
 ```
 
 ##### Input gelf plugin


### PR DESCRIPTION
Hello,

As reported by a customer, this PR might explicit a current protocol limitation on hosted Logstash.

As always, thanks for your time on this.

Signed-off-by: Pierre De Paepe <pierre.de-paepe@ovhcloud.com>