### PR TITLE
Remove Redis 3.2 references

### DIFF
--- a/pages/cloud/clouddb/clouddb-eos-eol/guide.en-gb.md
+++ b/pages/cloud/clouddb/clouddb-eos-eol/guide.en-gb.md
@@ -21,5 +21,4 @@ The products covered by those End Of Sale (EOS) and End Of Life (EOL) announceme
 |PostgreSQL 10|2021-08-18|2022-05-11|2022-11-10|
 |PostgreSQL 11|To be defined|To be defined|To be defined|
 |PostgreSQL 12|To be defined|To be defined|To be defined|
-|Redis 3.2|2019-07-29|2019-10-29|2020-01-28|
 |Redis 4.0|To be defined|To be defined|To be defined|

--- a/pages/cloud/clouddb/clouddb-eos-eol/guide.fr-fr.md
+++ b/pages/cloud/clouddb/clouddb-eos-eol/guide.fr-fr.md
@@ -21,5 +21,4 @@ Les produits couverts par ces annonces de fin de vente et de fin de vie sont les
 |PostgreSQL 10|2021-08-18|2022-05-11|2022-11-10|
 |PostgreSQL 11|À définir|À définir|À définir|
 |PostgreSQL 12|À définir|À définir|À définir|
-|Redis 3.2|2019-07-29|2019-10-29|2020-01-28|
 |Redis 4.0|À définir|À définir|À définir|

--- a/pages/cloud/clouddb/privatesql-eos-eol/guide.en-gb.md
+++ b/pages/cloud/clouddb/privatesql-eos-eol/guide.en-gb.md
@@ -24,5 +24,4 @@ The products covered by those End Of Sale (EOS) and End Of Life (EOL) announceme
 |PostgreSQL 10|2021-08-18|2022-05-11|2022-11-10|
 |PostgreSQL 11|To be defined|To be defined|To be defined|
 |PostgreSQL 12|To be defined|To be defined|To be defined|
-|Redis 3.2|2019-07-29|2019-10-29|2020-01-28|
 |Redis 4.0|To be defined|To be defined|To be defined|

--- a/pages/cloud/clouddb/privatesql-eos-eol/guide.fr-fr.md
+++ b/pages/cloud/clouddb/privatesql-eos-eol/guide.fr-fr.md
@@ -24,5 +24,4 @@ Les produits couverts par ces annonces de fin de vente et de fin de vie sont les
 |PostgreSQL 10|2021-08-18|2022-05-11|2022-11-10|
 |PostgreSQL 11|À définir|À définir|À définir|
 |PostgreSQL 12|À définir|À définir|À définir|
-|Redis 3.2|2019-07-29|2019-10-29|2020-01-28|
 |Redis 4.0|À définir|À définir|À définir|


### PR DESCRIPTION
As OVH dropped support for Redis 3.2 it does not need to be in the docs anymore