### PR TITLE
Remove postgresql 9.4 references

### DIFF
--- a/pages/cloud/clouddb/privatesql-eos-eol/guide.en-gb.md
+++ b/pages/cloud/clouddb/privatesql-eos-eol/guide.en-gb.md
@@ -18,7 +18,6 @@ The products covered by those End Of Sale (EOS) and End Of Life (EOL) announceme
 |MySQL 5.6|2019-07-29|2020-08-02|2021-02-01|
 |MySQL 5.7|To be defined|To be defined|To be defined|
 |MySQL 8.0|To be defined|To be defined|To be defined|
-|PostgreSQL 9.4|2019-07-29|2019-10-29|2020-02-13|
 |PostgreSQL 9.5|2019-07-29|2020-08-12|2021-02-11|
 |PostgreSQL 9.6|2020-01-21|2021-05-12|2021-11-11|
 |PostgreSQL 10|2021-08-18|2022-05-11|2022-11-10|

--- a/pages/cloud/clouddb/privatesql-eos-eol/guide.fr-fr.md
+++ b/pages/cloud/clouddb/privatesql-eos-eol/guide.fr-fr.md
@@ -18,7 +18,6 @@ Les produits couverts par ces annonces de fin de vente et de fin de vie sont les
 |MySQL 5.6|2019-07-29|2020-08-02|2021-02-01|
 |MySQL 5.7|À définir|À définir|À définir|
 |MySQL 8.0|À définir|À définir|À définir|
-|PostgreSQL 9.4|2019-07-29|2019-10-29|2020-02-13|
 |PostgreSQL 9.5|2019-07-29|2020-08-12|2021-02-11|
 |PostgreSQL 9.6|2020-01-21|2021-05-12|2021-11-11|
 |PostgreSQL 10|2021-08-18|2022-05-11|2022-11-10|


### PR DESCRIPTION
As OVH dropped support for PG 9.4 it does not need to be in the docs anymore