### PR TITLE
EN/FR [Logs Data Platform] add IP handling information in field namin…

### DIFF
--- a/pages/platform/logs-data-platform/field_naming_conventions/guide.en-gb.md
+++ b/pages/platform/logs-data-platform/field_naming_conventions/guide.en-gb.md
@@ -5,7 +5,7 @@ order: 2
 section: Get Started
 ---
 
-**Last updated 29th July 2019**
+**Last updated 25th October 2021**
 
 ## Objective
 
@@ -86,8 +86,7 @@ Specifying correct numeric suffix type is the only way to generate numeric Widge
 
 ![Numeric widget](images/bytes.png){.thumbnail}
 
-
-Our platform limits the usage of IP adresses as field keys. IP adresses have a high cardinality and thus are not allowed to be use as keys (of course they are supported and enriched as values as you can see above). If you use an IP address as key, it will be changed. For example:
+Our platform limits the usage of IP adresses as field keys. IP addresses have a high cardinality and thus are not allowed to be used as keys (of course they are supported and enriched as values, as you can see above). If you use an IP address as key, it will be changed. For example:
 
 ```json
 {  

--- a/pages/platform/logs-data-platform/field_naming_conventions/guide.en-gb.md
+++ b/pages/platform/logs-data-platform/field_naming_conventions/guide.en-gb.md
@@ -86,6 +86,34 @@ Specifying correct numeric suffix type is the only way to generate numeric Widge
 
 ![Numeric widget](images/bytes.png){.thumbnail}
 
+
+Our platform limits the usage of IP adresses as field keys. IP adresses have a high cardinality and thus are not allowed to be use as keys (of course they are supported and enriched as values as you can see above). If you use an IP address as key, it will be changed. For example:
+
+```json
+{  
+   "version":"1.1",
+   "host":"my_host",
+   "_some_user_id_float":123,
+   "short_message":"A short message that can save your life",
+   "192.168.1.1":"SSL Handshake Failures"
+}
+```
+
+will become:
+
+```json
+{  
+   "version":"1.1",
+   "host":"my_host",
+   "_some_user_id_float":123,
+   "short_message":"A short message that can save your life",
+   "invalid_ip_fields":"192.168.1.1",
+   "invalid_ip_fields_values":"SSL Handshake Failures",
+   "ovh_warn_ip_as_field":"One of your field name is an IP"
+}
+```
+
+
 So this is everything you need to know to send valid messages format and not shoot yourself in the foot. If you have any question you can always reach us [on the community hub](https://community.ovh.com/en/c/Platform/data-platforms){.external}.
 
 Happy Logging

--- a/pages/platform/logs-data-platform/field_naming_conventions/guide.fr-fr.md
+++ b/pages/platform/logs-data-platform/field_naming_conventions/guide.fr-fr.md
@@ -5,7 +5,7 @@ order: 2
 section: Get Started
 ---
 
-**Last updated 29th July 2019**
+**Last updated 25th October 2021**
 
 ## Objective
 
@@ -86,8 +86,7 @@ Specifying correct numeric suffix type is the only way to generate numeric Widge
 
 ![Numeric widget](images/bytes.png){.thumbnail}
 
-
-Our platform limits the usage of IP adresses as field keys. IP adresses have a high cardinality and thus are not allowed to be use as keys (of course they are supported and enriched as values as you can see above). If you use an IP address as key, it will be changed. For example:
+Our platform limits the usage of IP adresses as field keys. IP addresses have a high cardinality and thus are not allowed to be used as keys (of course they are supported and enriched as values, as you can see above). If you use an IP address as key, it will be changed. For example:
 
 ```json
 {  

--- a/pages/platform/logs-data-platform/field_naming_conventions/guide.fr-fr.md
+++ b/pages/platform/logs-data-platform/field_naming_conventions/guide.fr-fr.md
@@ -86,6 +86,34 @@ Specifying correct numeric suffix type is the only way to generate numeric Widge
 
 ![Numeric widget](images/bytes.png){.thumbnail}
 
+
+Our platform limits the usage of IP adresses as field keys. IP adresses have a high cardinality and thus are not allowed to be use as keys (of course they are supported and enriched as values as you can see above). If you use an IP address as key, it will be changed. For example:
+
+```json
+{  
+   "version":"1.1",
+   "host":"my_host",
+   "_some_user_id_float":123,
+   "short_message":"A short message that can save your life",
+   "192.168.1.1":"SSL Handshake Failures"
+}
+```
+
+will become:
+
+```json
+{  
+   "version":"1.1",
+   "host":"my_host",
+   "_some_user_id_float":123,
+   "short_message":"A short message that can save your life",
+   "invalid_ip_fields":"192.168.1.1",
+   "invalid_ip_fields_values":"SSL Handshake Failures",
+   "ovh_warn_ip_as_field":"One of your field name is an IP"
+}
+```
+
+
 So this is everything you need to know to send valid messages format and not shoot yourself in the foot. If you have any question you can always reach us [on the community hub](https://community.ovh.com/c/platform/data-platforms){.external}.
 
 Happy Logging


### PR DESCRIPTION
…g conventions

IP adresses are not allowed to be used as key fields in Logs Data PLatform. The commit add this information in the field Naming Convention documentation. 