### PR TITLE
FR Updating SSH key creation for Dedicated servers

### DIFF
--- a/pages/cloud/dedicated/creating-ssh-keys-dedicated/guide.fr-fr.md
+++ b/pages/cloud/dedicated/creating-ssh-keys-dedicated/guide.fr-fr.md
@@ -42,7 +42,7 @@ Utiliser la commande suivante pour créer une clé RSA de 4096 bits :
 ```sh
 # ssh-keygen -b 4096
 ```
-L'utilisation de l'option « -t » avec la commande ci-dessus vous permet de spécifier une méthode de cryptage différente, par exemple :
+L'utilisation de l'option « -t » avec la commande ci-dessus vous permet de spécifier une méthode de chiffrement différente, par exemple :
 
 ```sh
 # ssh-keygen -t ed25519 -a 256
@@ -150,7 +150,7 @@ Supprimez de votre fichier « authorized_keys » la clé qui correspond à l'u
 
 ### Importer votre clé SSH dans l’espace client OVHcloud
 
-L’espace client OVHcloud vous permet de stocker des clés publiques créées en utilisant l'un des types de cryptage pris en charge (actuellement RSA, ECDSA, ED25519). 
+L’espace client OVHcloud vous permet de stocker des clés publiques créées en utilisant l'un des types de chiffrement pris en charge (actuellement RSA, ECDSA, ED25519). 
 
 Ouvrez la barre de navigation latérale en cliquant sur votre nom dans le coin supérieur droit et utilisez le raccourci `Produits et services`{.action}.
 


### PR DESCRIPTION
cryptage => non sens

l'on parle de chiffrement (symétrique / asymétrique) de déchiffrement pour une donné chiffré que l'on déchiffre avec une clé connu et de décryptage lorsque l'on veut retrouver le message original sans posséder la clé. En revanche la notion de cryptage qui est la traduction littéral de encrypt n'as pas de sens d'un point de vu cryptographique.