### PR TITLE
Ajout d'un pré-requis => support 802.3ad

### DIFF
--- a/pages/cloud/dedicated/ola-enable-manager/guide.de-de.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.de-de.md
@@ -15,7 +15,7 @@ order: 1
 ## Ziel
 
 Die OVHcloud Link Aggregation (OLA) wurde von unseren Teams entwickelt, um die Verfügbarkeit Ihres Servers zu erhöhen und die Effizienz Ihrer Netzwerkverbindungen zu steigern. Mit nur wenigen Klicks können Sie Ihre Netzwerkkarten aggregieren und Ihre Netzwerkverbindungen redundant machen. Wenn also eine Verbindung ausfällt, wird der Datenverkehr automatisch auf eine andere verfügbare Verbindung umgeleitet.<br>
-Die Aggregation basiert auf der IEEE 802.3ad-Technologie Link Aggregation Control Protocol (LACP).
+Die Aggregation basiert auf dem Standard IEEE 802.3ad, Link Aggregation Control Protocol (LACP).
 
 **Diese Anleitung erklärt, wie Sie OLA im OVHcloud Kundencenter einrichten.**
 
@@ -23,7 +23,7 @@ Die Aggregation basiert auf der IEEE 802.3ad-Technologie Link Aggregation Contro
 
 - Sie haben einen [Dedicated Server](https://www.ovhcloud.com/de/bare-metal/) in Ihrem Kunden-Account.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
-- Ein Betriebssystem / Hypervisor, das das Aggregationsprotokoll 802.3ad (LACP) unterstützt.
+- Sie verwenden ein Betriebssystem / einen Hypervisor mit Unterstützung für das Aggregationsprotokoll 802.3ad (LACP).
 
 ## In der praktischen Anwendung
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.de-de.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.de-de.md
@@ -10,11 +10,12 @@ order: 1
 > Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In manchen Fällen können ungenaue Formulierungen verwendet worden sein, z.B. bei der Beschriftung von Schaltflächen oder technischen Details. Bitte ziehen Sie beim geringsten Zweifel die englische oder französische Fassung der Anleitung zu Rate. Möchten Sie mithelfen, diese Übersetzung zu verbessern? Dann nutzen Sie dazu bitte den Button «Mitmachen» auf dieser Seite.
 >
 
-**Letzte Aktualisierung am 26.03.2021**
+**Letzte Aktualisierung am 15.11.2021**
 
 ## Ziel
 
-Die OVHcloud Link Aggregation (OLA) wurde von unseren Teams entwickelt, um die Verfügbarkeit Ihres Servers zu erhöhen und die Effizienz Ihrer Netzwerkverbindungen zu steigern. Mit nur wenigen Klicks können Sie Ihre Netzwerkkarten aggregieren und Ihre Netzwerkverbindungen redundant machen. Wenn also eine Verbindung ausfällt, wird der Datenverkehr automatisch auf eine andere verfügbare Verbindung umgeleitet.
+Die OVHcloud Link Aggregation (OLA) wurde von unseren Teams entwickelt, um die Verfügbarkeit Ihres Servers zu erhöhen und die Effizienz Ihrer Netzwerkverbindungen zu steigern. Mit nur wenigen Klicks können Sie Ihre Netzwerkkarten aggregieren und Ihre Netzwerkverbindungen redundant machen. Wenn also eine Verbindung ausfällt, wird der Datenverkehr automatisch auf eine andere verfügbare Verbindung umgeleitet.<br>
+Die Aggregation basiert auf der IEEE 802.3ad-Technologie Link Aggregation Control Protocol (LACP).
 
 **Diese Anleitung erklärt, wie Sie OLA im OVHcloud Kundencenter einrichten.**
 
@@ -22,6 +23,7 @@ Die OVHcloud Link Aggregation (OLA) wurde von unseren Teams entwickelt, um die V
 
 - Sie haben einen [Dedicated Server](https://www.ovhcloud.com/de/bare-metal/) in Ihrem Kunden-Account.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
+- Ein Betriebssystem / Hypervisor, das das Aggregationsprotokoll 802.3ad (LACP) unterstützt.
 
 ## In der praktischen Anwendung
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.en-asia.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.en-asia.md
@@ -6,11 +6,12 @@ section: 'Advanced use'
 order: 1
 ---
 
-**Last updated 24th March 2021**
+**Last updated 15th November 2021**
 
 ## Objective
 
-OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.
+OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.<br>
+Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) technology.
 
 **This guide explains how to configure OLA in the OVHcloud Control Panel.**
 
@@ -18,6 +19,7 @@ OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase 
 
 - a [dedicated server](https://www.ovhcloud.com/asia/bare-metal/) in your OVHcloud account
 - access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- an Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 
 ## Instructions
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.en-au.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.en-au.md
@@ -6,11 +6,12 @@ section: 'Advanced use'
 order: 1
 ---
 
-**Last updated 24th March 2021**
+**Last updated 15th November 2021**
 
 ## Objective
 
-OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.
+OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.<br>
+Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) technology.
 
 **This guide explains how to configure OLA in the OVHcloud Control Panel.**
 
@@ -18,6 +19,7 @@ OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase 
 
 - a [dedicated server](https://www.ovhcloud.com/en-au/bare-metal/) in your OVHcloud account
 - access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- an Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 
 ## Instructions
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.en-ca.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.en-ca.md
@@ -6,11 +6,12 @@ section: 'Advanced use'
 order: 1
 ---
 
-**Last updated 24th March 2021**
+**Last updated 15th November 2021**
 
 ## Objective
 
-OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.
+OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.<br>
+Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) technology.
 
 **This guide explains how to configure OLA in the OVHcloud Control Panel.**
 
@@ -18,6 +19,7 @@ OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase 
 
 - a [dedicated server](https://www.ovhcloud.com/en-ca/bare-metal/) in your OVHcloud account
 - access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- an Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 
 ## Instructions
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.en-gb.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.en-gb.md
@@ -6,11 +6,12 @@ section: 'Advanced use'
 order: 1
 ---
 
-**Last updated 24th March 2021**
+**Last updated 15th November 2021**
 
 ## Objective
 
-OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.
+OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.<br>
+Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) technology.
 
 **This guide explains how to configure OLA in the OVHcloud Control Panel.**
 
@@ -18,6 +19,7 @@ OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase 
 
 - a [dedicated server](https://www.ovhcloud.com/en-gb/bare-metal/) in your OVHcloud account
 - access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- an Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 
 ## Instructions
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.en-ie.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.en-ie.md
@@ -6,11 +6,12 @@ section: 'Advanced use'
 order: 1
 ---
 
-**Last updated 24th March 2021**
+**Last updated 15th November 2021**
 
 ## Objective
 
-OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.
+OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.<br>
+Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) technology.
 
 **This guide explains how to configure OLA in the OVHcloud Control Panel.**
 
@@ -18,6 +19,7 @@ OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase 
 
 - a [dedicated server](https://www.ovhcloud.com/en-ie/bare-metal/) in your OVHcloud account
 - access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- an Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 
 ## Instructions
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.en-sg.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.en-sg.md
@@ -6,11 +6,12 @@ section: 'Advanced use'
 order: 1
 ---
 
-**Last updated 24th March 2021**
+**Last updated 15th November 2021**
 
 ## Objective
 
-OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.
+OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.<br>
+Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) technology.
 
 **This guide explains how to configure OLA in the OVHcloud Control Panel.**
 
@@ -18,6 +19,7 @@ OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase 
 
 - a [dedicated server](https://www.ovhcloud.com/en-sg/bare-metal/) in your OVHcloud account
 - access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- an Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 
 ## Instructions
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.en-us.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.en-us.md
@@ -6,11 +6,12 @@ section: 'Advanced use'
 order: 1
 ---
 
-**Last updated 24th March 2021**
+**Last updated 15th November 2021**
 
 ## Objective
 
-OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.
+OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase your server’s availability, and boost the efficiency of your network connections. In just a few clicks, you can aggregate your network cards and make your network links redundant. This means that if one link goes down, traffic is automatically redirected to another available link.<br>
+Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) technology.
 
 **This guide explains how to configure OLA in the OVHcloud Control Panel.**
 
@@ -18,6 +19,7 @@ OVHcloud Link Aggregation (OLA) technology is designed by our teams to increase 
 
 - a [dedicated server](https://www.ovhcloud.com/en/bare-metal/) in your OVHcloud account
 - access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- an Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 
 ## Instructions
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.es-es.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.es-es.md
@@ -10,18 +10,20 @@ order: 1
 > Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón «Contribuir» de esta página.
 >
 
-**Última actualización: 26/03/2021**
+**Última actualización: 15/11/2021**
 
 ## Objetivo
 
-La tecnología OVHcloud Link Aggregation (OLA) está diseñada para aumentar la disponibilidad de su servidor y mejorar la eficiencia de sus conexiones de red. En solo unos clics, es posible añadir sus tarjetas de red y hacer que sus enlaces de red sean redundantes. De este modo, si un enlace se cae, el tráfico se redirige automáticamente hacia otro enlace disponible.
+La tecnología OVHcloud Link Aggregation (OLA) está diseñada para aumentar la disponibilidad de su servidor y mejorar la eficiencia de sus conexiones de red. En solo unos clics, es posible añadir sus tarjetas de red y hacer que sus enlaces de red sean redundantes. De este modo, si un enlace se cae, el tráfico se redirige automáticamente hacia otro enlace disponible.<br>
+La agregación se basa en la tecnología IEEE 802.3ad o Link Aggregation Control Protocol (LACP).
 
 **Esta guía explica cómo configurar el servicio OLA en el área de cliente.**
 
 ## Requisitos
 
-- Tener un [servidor dedicado de OVHcloud.](https://www.ovhcloud.com/es-es/bare-metal/)
+- Tener un [servidor dedicado de OVHcloud.](https://www.ovhcloud.com/es-es/bare-metal/).
 - Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es).
+- Tener un sistema operativo/hipervisor que soporta el protocolo de agregación 802.3ad (LACP).
 
 ## Procedimiento
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.es-us.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.es-us.md
@@ -10,11 +10,12 @@ order: 1
 > Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón «Contribuir» de esta página.
 >
 
-**Última actualización: 26/03/2021**
+**Última actualización: 15/11/2021**
 
 ## Objetivo
 
-La tecnología OVHcloud Link Aggregation (OLA) está diseñada para aumentar la disponibilidad de su servidor y mejorar la eficiencia de sus conexiones de red. En solo unos clics, es posible añadir sus tarjetas de red y hacer que sus enlaces de red sean redundantes. De este modo, si un enlace se cae, el tráfico se redirige automáticamente hacia otro enlace disponible.
+La tecnología OVHcloud Link Aggregation (OLA) está diseñada para aumentar la disponibilidad de su servidor y mejorar la eficiencia de sus conexiones de red. En solo unos clics, es posible añadir sus tarjetas de red y hacer que sus enlaces de red sean redundantes. De este modo, si un enlace se cae, el tráfico se redirige automáticamente hacia otro enlace disponible.<br>
+La agregación se basa en la tecnología IEEE 802.3ad o Link Aggregation Control Protocol (LACP).
 
 **Esta guía explica cómo configurar el servicio OLA en el área de cliente.**
 
@@ -22,6 +23,7 @@ La tecnología OVHcloud Link Aggregation (OLA) está diseñada para aumentar la 
 
 - Tener un [servidor dedicado de OVHcloud.](https://www.ovhcloud.com/es/bare-metal/)
 - Haber iniciado sesión en el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+- Tener un sistema operativo/hipervisor que soporta el protocolo de agregación 802.3ad (LACP).
 
 ## Procedimiento
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.fr-ca.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.fr-ca.md
@@ -6,11 +6,12 @@ section: 'Utilisation avancée'
 order: 1
 ---
 
-**Dernière mise à jour le 24/03/2021**
+**Dernière mise à jour le 15/11/2021**
 
 ## Objectif
 
-La technologie OVHcloud Link Aggregation (OLA) est conçue par nos équipes pour augmenter la disponibilité de votre serveur et améliorer l'efficacité de vos connexions réseau. En quelques clics, vous pouvez agréger vos cartes réseau et rendre vos liaisons réseau redondantes. Cela signifie que si une liaison tombe en panne, le trafic est automatiquement redirigé vers une autre liaison disponible.
+La technologie OVHcloud Link Aggregation (OLA) est conçue par nos équipes pour augmenter la disponibilité de votre serveur et améliorer l'efficacité de vos connexions réseau. En quelques clics, vous pouvez agréger vos cartes réseau et rendre vos liaisons réseau redondantes. Cela signifie que si une liaison tombe en panne, le trafic est automatiquement redirigé vers une autre liaison disponible.<br>
+L'aggrégation se base sur la technologie IEEE 802.3ad, ou Link Aggregation Control Protocol (LACP).
 
 **Découvrez comment configurer OLA dans votre espace client.**
 
@@ -18,6 +19,7 @@ La technologie OVHcloud Link Aggregation (OLA) est conçue par nos équipes pour
 
 - Disposer d'un [serveur dédié OVHcloud](https://www.ovhcloud.com/fr-ca/bare-metal/)
 - Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Un système d'exploitation / hyperviseur supportant le protocole d'aggrégation 802.3ad (LACP)
 
 ## En pratique
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.fr-fr.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.fr-fr.md
@@ -6,11 +6,12 @@ section: 'Utilisation avancée'
 order: 1
 ---
 
-**Dernière mise à jour le 24/03/2021**
+**Dernière mise à jour le 15/11/2021**
 
 ## Objectif
 
-La technologie OVHcloud Link Aggregation (OLA) est conçue par nos équipes pour augmenter la disponibilité de votre serveur et améliorer l'efficacité de vos connexions réseau. En quelques clics, vous pouvez agréger vos cartes réseau et rendre vos liaisons réseau redondantes. Cela signifie que si une liaison tombe en panne, le trafic est automatiquement redirigé vers une autre liaison disponible. L'aggrégation se base sur la technologie IEEE 802.3ad, ou Link Aggregation Control Protocol (LACP).
+La technologie OVHcloud Link Aggregation (OLA) est conçue par nos équipes pour augmenter la disponibilité de votre serveur et améliorer l'efficacité de vos connexions réseau. En quelques clics, vous pouvez agréger vos cartes réseau et rendre vos liaisons réseau redondantes. Cela signifie que si une liaison tombe en panne, le trafic est automatiquement redirigé vers une autre liaison disponible.<br>
+L'aggrégation se base sur la technologie IEEE 802.3ad, ou Link Aggregation Control Protocol (LACP).
 
 **Découvrez comment configurer OLA dans votre espace client OVHcloud.**
 
@@ -18,7 +19,7 @@ La technologie OVHcloud Link Aggregation (OLA) est conçue par nos équipes pour
 
 - Disposer d'un [serveur dédié OVHcloud](https://www.ovhcloud.com/fr/bare-metal/)
 - Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
-- Système d'exploitation / Hyperviseur supportant le protocole d'aggrégation 802.3ad (LACP)
+- Un système d'exploitation / hyperviseur supportant le protocole d'aggrégation 802.3ad (LACP)
 
 ## En pratique
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.fr-fr.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.fr-fr.md
@@ -10,7 +10,7 @@ order: 1
 
 ## Objectif
 
-La technologie OVHcloud Link Aggregation (OLA) est conçue par nos équipes pour augmenter la disponibilité de votre serveur et améliorer l'efficacité de vos connexions réseau. En quelques clics, vous pouvez agréger vos cartes réseau et rendre vos liaisons réseau redondantes. Cela signifie que si une liaison tombe en panne, le trafic est automatiquement redirigé vers une autre liaison disponible.
+La technologie OVHcloud Link Aggregation (OLA) est conçue par nos équipes pour augmenter la disponibilité de votre serveur et améliorer l'efficacité de vos connexions réseau. En quelques clics, vous pouvez agréger vos cartes réseau et rendre vos liaisons réseau redondantes. Cela signifie que si une liaison tombe en panne, le trafic est automatiquement redirigé vers une autre liaison disponible. L'aggrégation se base sur la technologie IEEE 802.3ad, ou Link Aggregation Control Protocol (LACP).
 
 **Découvrez comment configurer OLA dans votre espace client OVHcloud.**
 
@@ -18,6 +18,7 @@ La technologie OVHcloud Link Aggregation (OLA) est conçue par nos équipes pour
 
 - Disposer d'un [serveur dédié OVHcloud](https://www.ovhcloud.com/fr/bare-metal/)
 - Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Système d'exploitation / Hyperviseur supportant le protocole d'aggrégation 802.3ad (LACP)
 
 ## En pratique
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.it-it.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.it-it.md
@@ -10,11 +10,12 @@ order: 1
 > Questa traduzione è stata generata automaticamente dal nostro partner SYSTRAN. I contenuti potrebbero presentare imprecisioni, ad esempio la nomenclatura dei pulsanti o alcuni dettagli tecnici. In caso di dubbi consigliamo di fare riferimento alla versione inglese o francese della guida. Per aiutarci a migliorare questa traduzione, utilizza il pulsante "Modifica" di questa pagina.
 >
 
-**Ultimo aggiornamento: 26/03/2021**
+**Ultimo aggiornamento: 15/11/2021**
 
 ## Obiettivo
 
-La tecnologia OVHcloud Link Aggregation (OLA) è stata progettata dai team OVHcloud per aumentare la disponibilità dei server e potenziare le connessioni di rete. L’attivazione dell’opzione permette di aggregare in pochi click le schede di rete e rendere i collegamenti ridondati in modo che, in caso di malfunzionamenti, il traffico venga reindirizzato automaticamente verso il collegamento disponibile.
+La tecnologia OVHcloud Link Aggregation (OLA) è stata progettata dai team OVHcloud per aumentare la disponibilità dei server e potenziare le connessioni di rete. L’attivazione dell’opzione permette di aggregare in pochi click le schede di rete e rendere i collegamenti ridondati in modo che, in caso di malfunzionamenti, il traffico venga reindirizzato automaticamente verso il collegamento disponibile.<br>
+L'aggregazione si basa sulla tecnologia IEEE 802.3ad o Link Aggregation Control Protocol (LACP).
 
 **Questa guida ti mostra come configurare il servizio OLA nello Spazio Cliente di OVHcloud.**
 
@@ -22,6 +23,7 @@ La tecnologia OVHcloud Link Aggregation (OLA) è stata progettata dai team OVHcl
 
 - Disporre di un [server dedicato OVHcloud](https://www.ovhcloud.com/it/bare-metal/)
 - Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Disporre di un sistema operativo / Hypervisor che supporta il protocollo di aggregazione 802.3ad (LACP)
 
 ## Procedura
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.pl-pl.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.pl-pl.md
@@ -10,11 +10,12 @@ order: 1
 > Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera SYSTRAN. W niektórych przypadkach mogą wystąpić nieprecyzyjne sformułowania, na przykład w tłumaczeniu nazw przycisków lub szczegółów technicznych. W przypadku jakichkolwiek wątpliwości zalecamy zapoznanie się z angielską/francuską wersją przewodnika. Jeśli chcesz przyczynić się do ulepszenia tłumaczenia, kliknij przycisk „Zaproponuj zmianę” na tej stronie.
 > 
 
-**Ostatnia aktualizacja z dnia 26-03-2021**
+**Ostatnia aktualizacja z dnia 15-11-2021**
 
 ## Wprowadzenie
 
-Technologia OVHcloud Link Aggregation (OLA) została zaprojektowana przez nasze zespoły w celu zwiększenia dostępności serwera i wydajności połączeń sieciowych. Za pomocą kilku kliknięć możesz łączyć karty sieciowe i redundantować połączenia sieciowe. Oznacza to, że w przypadku awarii połączenia ruch jest automatycznie przekierowywany do innego dostępnego połączenia.
+Technologia OVHcloud Link Aggregation (OLA) została zaprojektowana przez nasze zespoły w celu zwiększenia dostępności serwera i wydajności połączeń sieciowych. Za pomocą kilku kliknięć możesz łączyć karty sieciowe i redundantować połączenia sieciowe. Oznacza to, że w przypadku awarii połączenia ruch jest automatycznie przekierowywany do innego dostępnego połączenia.<br>
+Aggregacja oparta jest na technologii IEEE 802.3ad lub Link Aggregation Control Protocol (LACP).
 
 **Dowiedz się, jak skonfigurować OLA w Panelu klienta OVHcloud.**
 
@@ -22,6 +23,7 @@ Technologia OVHcloud Link Aggregation (OLA) została zaprojektowana przez nasze 
 
 - Posiadanie [serwera dedykowanego OVHcloud](https://www.ovhcloud.com/pl/bare-metal/)
 - Zalogowanie do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- System operacyjny / Hypervisor obsługujący protokół 802.3ad (LACP)
 
 ## W praktyce
 

--- a/pages/cloud/dedicated/ola-enable-manager/guide.pt-pt.md
+++ b/pages/cloud/dedicated/ola-enable-manager/guide.pt-pt.md
@@ -10,18 +10,20 @@ order: 1
 > Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certos casos, poderão ocorrer formulações imprecisas, como por exemplo nomes de botões ou detalhes técnicos. Recomendamos que consulte a versão inglesa ou francesa do manual, caso tenha alguma dúvida. Se nos quiser ajudar a melhorar esta tradução, clique em "Contribuir" nesta página.
 >
 
-**Última atualização: 26/03/2021**
+**Última atualização: 15/11/2021**
 
 ## Objetivo
 
-A tecnologia OVHcloud Link Aggregation (OLA) foi criada pelas nossas equipas para aumentar a disponibilidade do seu servidor e aumentar a eficiência das suas ligações de rede. Em apenas alguns cliques, pode agregar as suas placas de rede e tornar as suas ligações de rede redundantes. Isto significa que se uma ligação for interrompida, o tráfego é automaticamente redirecionado para outra ligação disponível.
+A tecnologia OVHcloud Link Aggregation (OLA) foi criada pelas nossas equipas para aumentar a disponibilidade do seu servidor e aumentar a eficiência das suas ligações de rede. Em apenas alguns cliques, pode agregar as suas placas de rede e tornar as suas ligações de rede redundantes. Isto significa que se uma ligação for interrompida, o tráfego é automaticamente redirecionado para outra ligação disponível.<br>
+A agregação baseia-se na tecnologia IEEE 802.3ad, ou Link Aggregation Control Protocol (LACP).
 
 **Neste manual, discutiremos como criar o OLA na Área de Cliente OVHcloud.**
 
 ## Requisitos
 
-- Dispor de um [servidor dedicado OVHcloud](https://www.ovhcloud.com/pt/bare-metal/)
+- Dispor de um [servidor dedicado OVHcloud](https://www.ovhcloud.com/pt/bare-metal/).
 - Estar ligado à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt).
+- Um sistema operativo / Hypervisor que suporta o protocolo de agregação 802.3ad (LACP).
 
 ## Instruções
 


### PR DESCRIPTION
Ajout d'un pré-requis pour la mise en place de OLA => Le protocole 802.3ad (LACP) doit être supporté par l'OS / Hyperviseur installé