### PR TITLE
Update configuring-ip-aliasing/guide.fr-fr.md

### DIFF
--- a/pages/cloud/vps/configuring-ip-aliasing/guide.fr-fr.md
+++ b/pages/cloud/vps/configuring-ip-aliasing/guide.fr-fr.md
@@ -127,7 +127,7 @@ Ouvrez le fichier de configuration réseau pour le modifier à l'aide de la comm
 sudo nano /etc/netplan/50-cloud-init.yaml
 ```
 
-Ne modifiez pas les lignes existantes dans le fichier. Ajoutez votre adresse IP fail-over en suivant l'exemple ci-dessous :
+Ne modifiez pas les lignes existantes dans le fichier de configuration de l'ip publique associé à la vm. Ajoutez votre adresse IP fail-over en ajoutant un deuxième bloc de configuration pour l'interface publique, comme dans l'exemple ci-dessous :
 
 ```yaml
 network:
@@ -137,9 +137,15 @@ network:
             dhcp4: true
             match:
                 macaddress: fa:xx:xx:xx:xx:63
+            set-name: NETWORK_INTERFACE            
+        NETWORK_INTERFACE:
+            dhcp4: true
+            match:
+                macaddress: fa:xx:xx:xx:xx:63
             set-name: NETWORK_INTERFACE
             addresses:
             - IP_FAILOVER/32
+           
 ```
 
 > [!warning]


### PR DESCRIPTION
La version actuelle de la doc, prête à confusion, elle peut provoquer une coupure de service si elle est mal interprété (c'est ce qui m'est arrivé). 

J'ai essayé de préciser les choses dans cette PR, mais vous pouvez aussi vous inspirer de ce qui est fait dans la doc VPS : https://support.us.ovhcloud.com/hc/en-us/articles/360014248820-How-to-Configure-IP-Aliasing-on-a-VPS