### PR TITLE
Remove mentions of old LBaaS FQDNs in k8s docs

### DIFF
--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-asia.md
@@ -316,8 +316,8 @@ NAME                                    READY   STATUS    RESTARTS   AGE
 pod/nginx-deployment-54f57cf6bf-2qhbd   1/1     Running   0          4m19s
 pod/nginx-deployment-54f57cf6bf-twrkm   1/1     Running   0          4m19s
 
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)        AGE
-service/my-nginx   LoadBalancer   10.3.19.133   xyzxyz.lb.c1.gra.k8s.ovh.net   80:30942/TCP   4m21s
+NAME               TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)        AGE
+service/my-nginx   LoadBalancer   10.3.19.133   XY.XY.XY.XY   80:30942/TCP   4m21s
 
 NAME                               READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/nginx-deployment   2/2     2            2           4m21s

--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-au.md
@@ -316,8 +316,8 @@ NAME                                    READY   STATUS    RESTARTS   AGE
 pod/nginx-deployment-54f57cf6bf-2qhbd   1/1     Running   0          4m19s
 pod/nginx-deployment-54f57cf6bf-twrkm   1/1     Running   0          4m19s
 
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)        AGE
-service/my-nginx   LoadBalancer   10.3.19.133   xyzxyz.lb.c1.gra.k8s.ovh.net   80:30942/TCP   4m21s
+NAME               TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)        AGE
+service/my-nginx   LoadBalancer   10.3.19.133   XY.XY.XY.XY   80:30942/TCP   4m21s
 
 NAME                               READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/nginx-deployment   2/2     2            2           4m21s

--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-ca.md
@@ -316,8 +316,8 @@ NAME                                    READY   STATUS    RESTARTS   AGE
 pod/nginx-deployment-54f57cf6bf-2qhbd   1/1     Running   0          4m19s
 pod/nginx-deployment-54f57cf6bf-twrkm   1/1     Running   0          4m19s
 
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)        AGE
-service/my-nginx   LoadBalancer   10.3.19.133   xyzxyz.lb.c1.gra.k8s.ovh.net   80:30942/TCP   4m21s
+NAME               TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)        AGE
+service/my-nginx   LoadBalancer   10.3.19.133   XY.XY.XY.XY   80:30942/TCP   4m21s
 
 NAME                               READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/nginx-deployment   2/2     2            2           4m21s

--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-gb.md
@@ -316,8 +316,8 @@ NAME                                    READY   STATUS    RESTARTS   AGE
 pod/nginx-deployment-54f57cf6bf-2qhbd   1/1     Running   0          4m19s
 pod/nginx-deployment-54f57cf6bf-twrkm   1/1     Running   0          4m19s
 
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)        AGE
-service/my-nginx   LoadBalancer   10.3.19.133   xyzxyz.lb.c1.gra.k8s.ovh.net   80:30942/TCP   4m21s
+NAME               TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)        AGE
+service/my-nginx   LoadBalancer   10.3.19.133   XY.XY.XY.XY   80:30942/TCP   4m21s
 
 NAME                               READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/nginx-deployment   2/2     2            2           4m21s

--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-ie.md
@@ -316,8 +316,8 @@ NAME                                    READY   STATUS    RESTARTS   AGE
 pod/nginx-deployment-54f57cf6bf-2qhbd   1/1     Running   0          4m19s
 pod/nginx-deployment-54f57cf6bf-twrkm   1/1     Running   0          4m19s
 
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)        AGE
-service/my-nginx   LoadBalancer   10.3.19.133   xyzxyz.lb.c1.gra.k8s.ovh.net   80:30942/TCP   4m21s
+NAME               TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)        AGE
+service/my-nginx   LoadBalancer   10.3.19.133   XY.XY.XY.XY   80:30942/TCP   4m21s
 
 NAME                               READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/nginx-deployment   2/2     2            2           4m21s

--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-sg.md
@@ -316,8 +316,8 @@ NAME                                    READY   STATUS    RESTARTS   AGE
 pod/nginx-deployment-54f57cf6bf-2qhbd   1/1     Running   0          4m19s
 pod/nginx-deployment-54f57cf6bf-twrkm   1/1     Running   0          4m19s
 
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)        AGE
-service/my-nginx   LoadBalancer   10.3.19.133   xyzxyz.lb.c1.gra.k8s.ovh.net   80:30942/TCP   4m21s
+NAME               TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)        AGE
+service/my-nginx   LoadBalancer   10.3.19.133   XY.XY.XY.XY   80:30942/TCP   4m21s
 
 NAME                               READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/nginx-deployment   2/2     2            2           4m21s

--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-us.md
@@ -316,8 +316,8 @@ NAME                                    READY   STATUS    RESTARTS   AGE
 pod/nginx-deployment-54f57cf6bf-2qhbd   1/1     Running   0          4m19s
 pod/nginx-deployment-54f57cf6bf-twrkm   1/1     Running   0          4m19s
 
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)        AGE
-service/my-nginx   LoadBalancer   10.3.19.133   xyzxyz.lb.c1.gra.k8s.ovh.net   80:30942/TCP   4m21s
+NAME               TYPE           CLUSTER-IP    EXTERNAL-IP   PORT(S)        AGE
+service/my-nginx   LoadBalancer   10.3.19.133   XY.XY.XY.XY   80:30942/TCP   4m21s
 
 NAME                               READY   UP-TO-DATE   AVAILABLE   AGE
 deployment.apps/nginx-deployment   2/2     2            2           4m21s

--- a/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-asia.md
@@ -159,8 +159,6 @@ hello-world   LoadBalancer   10.3.234.211   51.178.69.47   80:31885/TCP   6m54s
 > [!primary]
 > If under `EXTERNAL-IP` you get `<pending>`, don't worry, the provisioning of the LoadBalancer can take a minute or two, please try again in a few moments.
 
-For each service you deploy with LoadBalancer type, you will get a new sub-domain `XXXXXX.lb.c1.gra.k8s.ovh.net` to access the service. In my example that URL to access the service would be `http://6d6regsa9pc.lb.c1.gra.k8s.ovh.net`
-
 ### Step 5 - Test your service
 
 If you point your web browser to the service URL, the `hello-world` service will answer you:

--- a/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-au.md
@@ -159,8 +159,6 @@ hello-world   LoadBalancer   10.3.234.211   51.178.69.47   80:31885/TCP   6m54s
 > [!primary]
 > If under `EXTERNAL-IP` you get `<pending>`, don't worry, the provisioning of the LoadBalancer can take a minute or two, please try again in a few moments.
 
-For each service you deploy with LoadBalancer type, you will get a new sub-domain `XXXXXX.lb.c1.gra.k8s.ovh.net` to access the service. In my example that URL to access the service would be `http://6d6regsa9pc.lb.c1.gra.k8s.ovh.net`
-
 ### Step 5 - Test your service
 
 If you point your web browser to the service URL, the `hello-world` service will answer you:

--- a/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-ca.md
@@ -159,8 +159,6 @@ hello-world   LoadBalancer   10.3.234.211   51.178.69.47   80:31885/TCP   6m54s
 > [!primary]
 > If under `EXTERNAL-IP` you get `<pending>`, don't worry, the provisioning of the LoadBalancer can take a minute or two, please try again in a few moments.
 
-For each service you deploy with LoadBalancer type, you will get a new sub-domain `XXXXXX.lb.c1.gra.k8s.ovh.net` to access the service. In my example that URL to access the service would be `http://6d6regsa9pc.lb.c1.gra.k8s.ovh.net`
-
 ### Step 5 - Test your service
 
 If you point your web browser to the service URL, the `hello-world` service will answer you:

--- a/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-gb.md
@@ -159,8 +159,6 @@ hello-world   LoadBalancer   10.3.234.211   51.178.69.47   80:31885/TCP   6m54s
 > [!primary]
 > If under `EXTERNAL-IP` you get `<pending>`, don't worry, the provisioning of the LoadBalancer can take a minute or two, please try again in a few moments.
 
-For each service you deploy with LoadBalancer type, you will get a new sub-domain `XXXXXX.lb.c1.gra.k8s.ovh.net` to access the service. In my example that URL to access the service would be `http://6d6regsa9pc.lb.c1.gra.k8s.ovh.net`
-
 ### Step 5 - Test your service
 
 If you point your web browser to the service URL, the `hello-world` service will answer you:

--- a/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-ie.md
@@ -159,8 +159,6 @@ hello-world   LoadBalancer   10.3.234.211   51.178.69.47   80:31885/TCP   6m54s
 > [!primary]
 > If under `EXTERNAL-IP` you get `<pending>`, don't worry, the provisioning of the LoadBalancer can take a minute or two, please try again in a few moments.
 
-For each service you deploy with LoadBalancer type, you will get a new sub-domain `XXXXXX.lb.c1.gra.k8s.ovh.net` to access the service. In my example that URL to access the service would be `http://6d6regsa9pc.lb.c1.gra.k8s.ovh.net`
-
 ### Step 5 - Test your service
 
 If you point your web browser to the service URL, the `hello-world` service will answer you:

--- a/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-sg.md
@@ -159,8 +159,6 @@ hello-world   LoadBalancer   10.3.234.211   51.178.69.47   80:31885/TCP   6m54s
 > [!primary]
 > If under `EXTERNAL-IP` you get `<pending>`, don't worry, the provisioning of the LoadBalancer can take a minute or two, please try again in a few moments.
 
-For each service you deploy with LoadBalancer type, you will get a new sub-domain `XXXXXX.lb.c1.gra.k8s.ovh.net` to access the service. In my example that URL to access the service would be `http://6d6regsa9pc.lb.c1.gra.k8s.ovh.net`
-
 ### Step 5 - Test your service
 
 If you point your web browser to the service URL, the `hello-world` service will answer you:

--- a/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/deploying-an-application/guide.en-us.md
@@ -159,8 +159,6 @@ hello-world   LoadBalancer   10.3.234.211   51.178.69.47   80:31885/TCP   6m54s
 > [!primary]
 > If under `EXTERNAL-IP` you get `<pending>`, don't worry, the provisioning of the LoadBalancer can take a minute or two, please try again in a few moments.
 
-For each service you deploy with LoadBalancer type, you will get a new sub-domain `XXXXXX.lb.c1.gra.k8s.ovh.net` to access the service. In my example that URL to access the service would be `http://6d6regsa9pc.lb.c1.gra.k8s.ovh.net`
-
 ### Step 5 - Test your service
 
 If you point your web browser to the service URL, the `hello-world` service will answer you:

--- a/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-asia.md
@@ -207,15 +207,15 @@ In my own deployment (URLs and IP changed), the precedent operations gave:
 
 
 <pre class="console"><code>$ kubectl get svc -n openfaas gateway-external -o wide
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)          AGE     SELECTOR
-gateway-external   LoadBalancer   10.3.xxx.yyy   xxxrt657xx.lb.c1.gra.k8s.ovh.net   8080:30012/TCP   9m10s   app=gateway
+NAME               TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE     SELECTOR
+gateway-external   LoadBalancer   10.3.xxx.yyy   xy.xy.xy.xy   8080:30012/TCP   9m10s   app=gateway
 
-$ export OPENFAAS_URL=xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+$ export OPENFAAS_URL=xy.xy.xy.xy:8080
 
 $ echo -n $PASSWORD | ./faas-cli login -g $OPENFAAS_URL -u admin --password-stdin
 Calling the OpenFaaS server to validate the credentials...
 WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
-credentials saved for admin http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+credentials saved for admin http://xy.xy.xy.xy:8080
  
 $ ./faas-cli version
   ___                   _____           ____
@@ -230,7 +230,7 @@ CLI:
  version: 0.12.4
 
 Gateway
- uri:     http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+ uri:     http://xy.xy.xy.xy:8080
  version: 0.18.17
  sha:     18f6c720b50db7da5f9c410f9fd3369ed7aff379
  commit:  Extract a caching function_query type

--- a/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-au.md
@@ -199,7 +199,7 @@ echo -n $PASSWORD | ./faas-cli login -g $OPENFAAS_URL -u admin --password-stdin
 ```
 
 Now you're connected to the gateway, and you can send commands to the OpenFaaS platform. 
-
+~~~~
 By default, there is no function installed on your OpenFaaS platform, as you can verify with the `faas-cli list` command.
 
 
@@ -207,15 +207,15 @@ In my own deployment (URLs and IP changed), the precedent operations gave:
 
 
 <pre class="console"><code>$ kubectl get svc -n openfaas gateway-external -o wide
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)          AGE     SELECTOR
-gateway-external   LoadBalancer   10.3.xxx.yyy   xxxrt657xx.lb.c1.gra.k8s.ovh.net   8080:30012/TCP   9m10s   app=gateway
-
-$ export OPENFAAS_URL=xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+NAME               TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE     SELECTOR
+gateway-external   LoadBalancer   10.3.xxx.yyy   xy.xy.xy.xy   8080:30012/TCP   9m10s   app=gateway
+~~~~
+$ export OPENFAAS_URL=xy.xy.xy.xy:8080
 
 $ echo -n $PASSWORD | ./faas-cli login -g $OPENFAAS_URL -u admin --password-stdin
 Calling the OpenFaaS server to validate the credentials...
 WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
-credentials saved for admin http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+credentials saved for admin http://xy.xy.xy.xy:8080
  
 $ ./faas-cli version
   ___                   _____           ____
@@ -230,7 +230,7 @@ CLI:
  version: 0.12.4
 
 Gateway
- uri:     http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+ uri:     http://xy.xy.xy.xy:8080
  version: 0.18.17
  sha:     18f6c720b50db7da5f9c410f9fd3369ed7aff379
  commit:  Extract a caching function_query type

--- a/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-ca.md
@@ -207,15 +207,15 @@ In my own deployment (URLs and IP changed), the precedent operations gave:
 
 
 <pre class="console"><code>$ kubectl get svc -n openfaas gateway-external -o wide
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)          AGE     SELECTOR
-gateway-external   LoadBalancer   10.3.xxx.yyy   xxxrt657xx.lb.c1.gra.k8s.ovh.net   8080:30012/TCP   9m10s   app=gateway
+NAME               TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE     SELECTOR
+gateway-external   LoadBalancer   10.3.xxx.yyy   xy.xy.xy.xy   8080:30012/TCP   9m10s   app=gateway
 
-$ export OPENFAAS_URL=xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+$ export OPENFAAS_URL=xy.xy.xy.xy:8080
 
 $ echo -n $PASSWORD | ./faas-cli login -g $OPENFAAS_URL -u admin --password-stdin
 Calling the OpenFaaS server to validate the credentials...
 WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
-credentials saved for admin http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+credentials saved for admin http://xy.xy.xy.xy:8080
  
 $ ./faas-cli version
   ___                   _____           ____
@@ -230,7 +230,7 @@ CLI:
  version: 0.12.4
 
 Gateway
- uri:     http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+ uri:     http://xy.xy.xy.xy:8080
  version: 0.18.17
  sha:     18f6c720b50db7da5f9c410f9fd3369ed7aff379
  commit:  Extract a caching function_query type

--- a/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-gb.md
@@ -207,15 +207,15 @@ In my own deployment (URLs and IP changed), the precedent operations gave:
 
 
 <pre class="console"><code>$ kubectl get svc -n openfaas gateway-external -o wide
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)          AGE     SELECTOR
-gateway-external   LoadBalancer   10.3.xxx.yyy   xxxrt657xx.lb.c1.gra.k8s.ovh.net   8080:30012/TCP   9m10s   app=gateway
+NAME               TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE     SELECTOR
+gateway-external   LoadBalancer   10.3.xxx.yyy   xy.xy.xy.xy   8080:30012/TCP   9m10s   app=gateway
 
-$ export OPENFAAS_URL=xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+$ export OPENFAAS_URL=xy.xy.xy.xy:8080
 
 $ echo -n $PASSWORD | ./faas-cli login -g $OPENFAAS_URL -u admin --password-stdin
 Calling the OpenFaaS server to validate the credentials...
 WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
-credentials saved for admin http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+credentials saved for admin http://xy.xy.xy.xy:8080
  
 $ ./faas-cli version
   ___                   _____           ____
@@ -230,7 +230,7 @@ CLI:
  version: 0.12.4
 
 Gateway
- uri:     http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+ uri:     http://xy.xy.xy.xy:8080
  version: 0.18.17
  sha:     18f6c720b50db7da5f9c410f9fd3369ed7aff379
  commit:  Extract a caching function_query type

--- a/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-ie.md
@@ -207,15 +207,15 @@ In my own deployment (URLs and IP changed), the precedent operations gave:
 
 
 <pre class="console"><code>$ kubectl get svc -n openfaas gateway-external -o wide
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)          AGE     SELECTOR
-gateway-external   LoadBalancer   10.3.xxx.yyy   xxxrt657xx.lb.c1.gra.k8s.ovh.net   8080:30012/TCP   9m10s   app=gateway
+NAME               TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE     SELECTOR
+gateway-external   LoadBalancer   10.3.xxx.yyy   xy.xy.xy.xy   8080:30012/TCP   9m10s   app=gateway
 
-$ export OPENFAAS_URL=xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+$ export OPENFAAS_URL=xy.xy.xy.xy:8080
 
 $ echo -n $PASSWORD | ./faas-cli login -g $OPENFAAS_URL -u admin --password-stdin
 Calling the OpenFaaS server to validate the credentials...
 WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
-credentials saved for admin http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+credentials saved for admin http://xy.xy.xy.xy:8080
  
 $ ./faas-cli version
   ___                   _____           ____
@@ -230,7 +230,7 @@ CLI:
  version: 0.12.4
 
 Gateway
- uri:     http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+ uri:     http://xy.xy.xy.xy:8080
  version: 0.18.17
  sha:     18f6c720b50db7da5f9c410f9fd3369ed7aff379
  commit:  Extract a caching function_query type

--- a/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-sg.md
@@ -207,15 +207,15 @@ In my own deployment (URLs and IP changed), the precedent operations gave:
 
 
 <pre class="console"><code>$ kubectl get svc -n openfaas gateway-external -o wide
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)          AGE     SELECTOR
-gateway-external   LoadBalancer   10.3.xxx.yyy   xxxrt657xx.lb.c1.gra.k8s.ovh.net   8080:30012/TCP   9m10s   app=gateway
+NAME               TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE     SELECTOR
+gateway-external   LoadBalancer   10.3.xxx.yyy   xy.xy.xy.xy   8080:30012/TCP   9m10s   app=gateway
 
-$ export OPENFAAS_URL=xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+$ export OPENFAAS_URL=xy.xy.xy.xy:8080
 
 $ echo -n $PASSWORD | ./faas-cli login -g $OPENFAAS_URL -u admin --password-stdin
 Calling the OpenFaaS server to validate the credentials...
 WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
-credentials saved for admin http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+credentials saved for admin http://xy.xy.xy.xy:8080
  
 $ ./faas-cli version
   ___                   _____           ____
@@ -230,7 +230,7 @@ CLI:
  version: 0.12.4
 
 Gateway
- uri:     http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+ uri:     http://xy.xy.xy.xy:8080
  version: 0.18.17
  sha:     18f6c720b50db7da5f9c410f9fd3369ed7aff379
  commit:  Extract a caching function_query type

--- a/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/installing-openfaas/guide.en-us.md
@@ -207,15 +207,15 @@ In my own deployment (URLs and IP changed), the precedent operations gave:
 
 
 <pre class="console"><code>$ kubectl get svc -n openfaas gateway-external -o wide
-NAME               TYPE           CLUSTER-IP    EXTERNAL-IP                        PORT(S)          AGE     SELECTOR
-gateway-external   LoadBalancer   10.3.xxx.yyy   xxxrt657xx.lb.c1.gra.k8s.ovh.net   8080:30012/TCP   9m10s   app=gateway
+NAME               TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)          AGE     SELECTOR
+gateway-external   LoadBalancer   10.3.xxx.yyy   xy.xy.xy.xy   8080:30012/TCP   9m10s   app=gateway
 
-$ export OPENFAAS_URL=xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+$ export OPENFAAS_URL=xy.xy.xy.xy:8080
 
 $ echo -n $PASSWORD | ./faas-cli login -g $OPENFAAS_URL -u admin --password-stdin
 Calling the OpenFaaS server to validate the credentials...
 WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
-credentials saved for admin http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+credentials saved for admin http://xy.xy.xy.xy:8080
  
 $ ./faas-cli version
   ___                   _____           ____
@@ -230,7 +230,7 @@ CLI:
  version: 0.12.4
 
 Gateway
- uri:     http://xxxrt657xx.lb.c1.gra.k8s.ovh.net:8080
+ uri:     http://xy.xy.xy.xy:8080
  version: 0.18.17
  sha:     18f6c720b50db7da5f9c410f9fd3369ed7aff379
  commit:  Extract a caching function_query type


### PR DESCRIPTION
Some docs are outdated with information about the old LBaaS mechanism (before the switch to IOLB).