### PR TITLE
aws config profile name for default changed

### DIFF
--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-asia.md
@@ -106,7 +106,7 @@ Complete and write down the configuration for `awscli` into `~/.aws/config`:
 [plugins]
 endpoint = awscli_plugin_endpoint
 
-[profile default]
+[default]
 aws_access_key_id = <access fetched in previous step>
 aws_secret_access_key = <secret fetched in previous step>
 region = <public cloud region in lower case without digit>

--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-au.md
@@ -106,7 +106,7 @@ Complete and write down the configuration for `awscli` into `~/.aws/config`:
 [plugins]
 endpoint = awscli_plugin_endpoint
 
-[profile default]
+[default]
 aws_access_key_id = <access fetched in previous step>
 aws_secret_access_key = <secret fetched in previous step>
 region = <public cloud region in lower case without digit>

--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-ca.md
@@ -106,7 +106,7 @@ Complete and write down the configuration for `awscli` into `~/.aws/config`:
 [plugins]
 endpoint = awscli_plugin_endpoint
 
-[profile default]
+[default]
 aws_access_key_id = <access fetched in previous step>
 aws_secret_access_key = <secret fetched in previous step>
 region = <public cloud region in lower case without digit>

--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-gb.md
@@ -106,7 +106,7 @@ Complete and write down the configuration for `awscli` into `~/.aws/config`:
 [plugins]
 endpoint = awscli_plugin_endpoint
 
-[profile default]
+[default]
 aws_access_key_id = <access fetched in previous step>
 aws_secret_access_key = <secret fetched in previous step>
 region = <public cloud region in lower case without digit>

--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-ie.md
@@ -106,7 +106,7 @@ Complete and write down the configuration for `awscli` into `~/.aws/config`:
 [plugins]
 endpoint = awscli_plugin_endpoint
 
-[profile default]
+[default]
 aws_access_key_id = <access fetched in previous step>
 aws_secret_access_key = <secret fetched in previous step>
 region = <public cloud region in lower case without digit>

--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-sg.md
@@ -106,7 +106,7 @@ Complete and write down the configuration for `awscli` into `~/.aws/config`:
 [plugins]
 endpoint = awscli_plugin_endpoint
 
-[profile default]
+[default]
 aws_access_key_id = <access fetched in previous step>
 aws_secret_access_key = <secret fetched in previous step>
 region = <public cloud region in lower case without digit>

--- a/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/backing-up-cluster-with-velero/guide.en-us.md
@@ -106,7 +106,7 @@ Complete and write down the configuration for `awscli` into `~/.aws/config`:
 [plugins]
 endpoint = awscli_plugin_endpoint
 
-[profile default]
+[default]
 aws_access_key_id = <access fetched in previous step>
 aws_secret_access_key = <secret fetched in previous step>
 region = <public cloud region in lower case without digit>


### PR DESCRIPTION
according to the official doc it should be [default] not [profile default].
https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html

test with:
aws-cli/1.22.37 Python/3.9.7 Darwin/21.1.0 botocore/1.23.37

[profile name] is possible but not [profile default]
aws cli will not detect the config.