### PR TITLE
Update k8s known limits concerning LB limitations

### DIFF
--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
@@ -56,7 +56,8 @@ This limit can be exceptionally raised upon request through our support team.
 There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
 
-A Load Balancer has the following non-configurable timeouts:
+A Public Cloud Load Balancer has the following non-configurable timeouts:
+
 - 20 seconds for the backend connection to be established
 - 180 seconds for the client & server connections
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
@@ -53,8 +53,12 @@ The lifespan of the external Load Balancer (and thus the associated IP address) 
 There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
 This limit can be exceptionally raised upon request through our support team.
 
-There is also a limit of __10 open ports__ on every `LoadBalancer`, and these ports must be in a range between __6 and 65535__.
+There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+
+A Load Balancer has the following non-configurable timeouts:
+- 20 seconds for the backend connection to be established
+- 180 seconds for the client & server connections
 
 ## OpenStack
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
@@ -53,8 +53,12 @@ The lifespan of the external Load Balancer (and thus the associated IP address) 
 There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
 This limit can be exceptionally raised upon request through our support team.
 
-There is also a limit of __10 open ports__ on every `LoadBalancer`, and these ports must be in a range between __6 and 65535__.
+There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+
+A Public Cloud Load Balancer has the following non-configurable timeouts:
+- 20 seconds for the backend connection to be established
+- 180 seconds for the client & server connections
 
 ## OpenStack
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
@@ -57,6 +57,7 @@ There is also a limit of __10 open ports__ on every Load Balancer, and these por
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
 
 A Public Cloud Load Balancer has the following non-configurable timeouts:
+
 - 20 seconds for the backend connection to be established
 - 180 seconds for the client & server connections
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
@@ -53,8 +53,12 @@ The lifespan of the external Load Balancer (and thus the associated IP address) 
 There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
 This limit can be exceptionally raised upon request through our support team.
 
-There is also a limit of __10 open ports__ on every `LoadBalancer`, and these ports must be in a range between __6 and 65535__.
+There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+
+A Public Cloud Load Balancer has the following non-configurable timeouts:
+- 20 seconds for the backend connection to be established
+- 180 seconds for the client & server connections
 
 ## OpenStack
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
@@ -57,6 +57,7 @@ There is also a limit of __10 open ports__ on every Load Balancer, and these por
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
 
 A Public Cloud Load Balancer has the following non-configurable timeouts:
+
 - 20 seconds for the backend connection to be established
 - 180 seconds for the client & server connections
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
@@ -53,8 +53,12 @@ The lifespan of the external Load Balancer (and thus the associated IP address) 
 There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
 This limit can be exceptionally raised upon request through our support team.
 
-There is also a limit of __10 open ports__ on every `LoadBalancer`, and these ports must be in a range between __6 and 65535__.
+There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+
+A Public Cloud Load Balancer has the following non-configurable timeouts:
+- 20 seconds for the backend connection to be established
+- 180 seconds for the client & server connections
 
 ## OpenStack
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
@@ -57,6 +57,7 @@ There is also a limit of __10 open ports__ on every Load Balancer, and these por
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
 
 A Public Cloud Load Balancer has the following non-configurable timeouts:
+
 - 20 seconds for the backend connection to be established
 - 180 seconds for the client & server connections
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
@@ -53,8 +53,12 @@ The lifespan of the external Load Balancer (and thus the associated IP address) 
 There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
 This limit can be exceptionally raised upon request through our support team.
 
-There is also a limit of __10 open ports__ on every `LoadBalancer`, and these ports must be in a range between __6 and 65535__.
+There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+
+A Public Cloud Load Balancer has the following non-configurable timeouts:
+- 20 seconds for the backend connection to be established
+- 180 seconds for the client & server connections
 
 ## OpenStack
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
@@ -57,6 +57,7 @@ There is also a limit of __10 open ports__ on every Load Balancer, and these por
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
 
 A Public Cloud Load Balancer has the following non-configurable timeouts:
+
 - 20 seconds for the backend connection to be established
 - 180 seconds for the client & server connections
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
@@ -53,8 +53,12 @@ The lifespan of the external Load Balancer (and thus the associated IP address) 
 There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
 This limit can be exceptionally raised upon request through our support team.
 
-There is also a limit of __10 open ports__ on every `LoadBalancer`, and these ports must be in a range between __6 and 65535__.
+There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+
+A Public Cloud Load Balancer has the following non-configurable timeouts:
+- 20 seconds for the backend connection to be established
+- 180 seconds for the client & server connections
 
 ## OpenStack
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
@@ -57,6 +57,7 @@ There is also a limit of __10 open ports__ on every Load Balancer, and these por
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
 
 A Public Cloud Load Balancer has the following non-configurable timeouts:
+
 - 20 seconds for the backend connection to be established
 - 180 seconds for the client & server connections
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-us.md
@@ -53,8 +53,12 @@ The lifespan of the external Load Balancer (and thus the associated IP address) 
 There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
 This limit can be exceptionally raised upon request through our support team.
 
-There is also a limit of __10 open ports__ on every `LoadBalancer`, and these ports must be in a range between __6 and 65535__.
+There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+
+A Public Cloud Load Balancer has the following non-configurable timeouts:
+- 20 seconds for the backend connection to be established
+- 180 seconds for the client & server connections
 
 ## OpenStack
 

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-us.md
@@ -57,6 +57,7 @@ There is also a limit of __10 open ports__ on every Load Balancer, and these por
 (Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
 
 A Public Cloud Load Balancer has the following non-configurable timeouts:
+
 - 20 seconds for the backend connection to be established
 - 180 seconds for the client & server connections
 


### PR DESCRIPTION
Some timeout information were missing concerning the Public Cloud Load Balancers