### PR TITLE
Fix PV example

### DIFF
--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-gb.md
@@ -117,7 +117,7 @@ spec:
   - name: myfrontend
     image: nginx
     volumeMounts:
-    - mountPath: "/var/www/html"
+    - mountPath: "/usr/share/nginx/html"
       name: test-volume
   volumes:
   - name: test-volume


### PR DESCRIPTION
The mount path is not correct, as documented here : 
https://hub.docker.com/_/nginx

This makes the example not runnable (or at least no as expected)