### PR TITLE
fix: add missing sudo in migration commands

### DIFF
--- a/pages/platform/public-cloud/upgrading_operating_system/guide.de-de.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.de-de.md
@@ -64,8 +64,8 @@ Aktualisieren Sie nach dem Neustart das Verzeichnis `/etc/apt/sources.list`, um 
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Nachdem Sie die neueste Version als Ziel festgelegt haben, führen Sie das Upgrade durch und initiieren Sie abschließend einen Neustart:

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.en-asia.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.en-asia.md
@@ -59,8 +59,8 @@ After the reboot we will update the /etc/apt/sources.list to target the next rel
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Now that the latest release is set as target, perform the upgrade and finally initate a reboot:

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.en-au.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.en-au.md
@@ -59,8 +59,8 @@ After the reboot we will update the /etc/apt/sources.list to target the next rel
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Now that the latest release is set as target, perform the upgrade and finally initate a reboot:

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.en-ca.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.en-ca.md
@@ -59,8 +59,8 @@ After the reboot we will update the /etc/apt/sources.list to target the next rel
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Now that the latest release is set as target, perform the upgrade and finally initate a reboot:

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.en-gb.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.en-gb.md
@@ -59,8 +59,8 @@ After the reboot we will update the /etc/apt/sources.list to target the next rel
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Now that the latest release is set as target, perform the upgrade and finally initate a reboot:

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.en-ie.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.en-ie.md
@@ -59,8 +59,8 @@ After the reboot we will update the /etc/apt/sources.list to target the next rel
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Now that the latest release is set as target, perform the upgrade and finally initate a reboot:

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.en-sg.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.en-sg.md
@@ -59,8 +59,8 @@ After the reboot we will update the /etc/apt/sources.list to target the next rel
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Now that the latest release is set as target, perform the upgrade and finally initate a reboot:

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.en-us.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.en-us.md
@@ -59,8 +59,8 @@ After the reboot we will update the /etc/apt/sources.list to target the next rel
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Now that the latest release is set as target, perform the upgrade and finally initate a reboot:

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.es-es.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.es-es.md
@@ -62,8 +62,8 @@ Después del reinicio, actualice el directorio /etc/apt/sources.list para dirigi
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Una vez que la próxima versión esté lista, puede actualizarla y reiniciarla definitivamente:

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.es-us.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.es-us.md
@@ -62,8 +62,8 @@ Después del reinicio, actualice el directorio /etc/apt/sources.list para dirigi
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Una vez que la próxima versión esté lista, puede actualizarla y reiniciarla definitivamente:

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.fr-ca.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.fr-ca.md
@@ -59,8 +59,8 @@ Après le redémarrage, mettez à jour le répertoire /etc/apt/sources.list pour
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Maintenant que la prochaine version est ciblée, vous pouvez procéder à la mise à jour ainsi qu'au redémarrage final :

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.fr-fr.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.fr-fr.md
@@ -59,8 +59,8 @@ Après le redémarrage, mettez à jour le répertoire /etc/apt/sources.list pour
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Maintenant que la prochaine version est ciblée, vous pouvez procéder à la mise à jour ainsi qu'au redémarrage final :

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.it-it.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.it-it.md
@@ -62,8 +62,8 @@ Dopo il riavvio, aggiorna la directory /etc/apt/sources.list per indirizzare la 
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Una volta che la versione successiva è stata adattata, puoi procedere all'aggiornamento e al riavvio finale:

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.pl-pl.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.pl-pl.md
@@ -62,8 +62,8 @@ Po ponownym uruchomieniu zaktualizuj katalog /etc/apt/sources.list, aby wybrać 
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Teraz, kiedy kolejna wersja jest skierowana, możesz przejść do aktualizacji i do restartu końcowego:

--- a/pages/platform/public-cloud/upgrading_operating_system/guide.pt-pt.md
+++ b/pages/platform/public-cloud/upgrading_operating_system/guide.pt-pt.md
@@ -63,8 +63,8 @@ Após a reinicialização, atualize o diretório /etc/apt/sources.list para orie
 ```bash
 $ sudo cp -v /etc/apt/sources.list /root/
 $ sudo cp -rv /etc/apt/sources.list.d/ /root/
-$ sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-$ sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+$ sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
 ```
 
 Agora que a próxima versão está orientada, pode proceder à atualização assim como ao reboot final:


### PR DESCRIPTION
You need to be root to modify the files in /etc/apt
Without sudo, the commands are failing