### PR TITLE
Typo: Fix VMware case sensitivity.

### DIFF
--- a/pages/cloud/cloud-desktop-infrastructure/activating_2FA/guide.fr-fr.md
+++ b/pages/cloud/cloud-desktop-infrastructure/activating_2FA/guide.fr-fr.md
@@ -8,7 +8,7 @@ section: Tutoriels
 
 ## Objectif
 
-Vmware View vous permet d'accéder à un bureau virtuel à n'importe quel moment de la journée, quel que soit l'endroit où vous vous trouvez. Le challenge est de vous permettre d'y accéder de manière sécurisée grâce aux points d'accès, mais aussi en ajoutant une double authentification.
+VMware View vous permet d'accéder à un bureau virtuel à n'importe quel moment de la journée, quel que soit l'endroit où vous vous trouvez. Le challenge est de vous permettre d'y accéder de manière sécurisée grâce aux points d'accès, mais aussi en ajoutant une double authentification.
 
 **Ce guide va vous expliquer comment l'activer.**
 
@@ -28,7 +28,7 @@ Une fois la mise en place d'un serveur d'authentification de votre côté effect
 Le serveur Radius a été créé dans un réseau privé.
 
 Si vous souhaitez utiliser ce Radius sur un pool public, il est nécessaire d'ajouter le réseau privé, si ce n'est pas déjà fait. Pour cela référez-vous au guide sur l'[ajout d'un réseau privé](https://docs.ovh.com/fr/cloud-desktop-infrastructure/allow-virtual-desktop/).
- 
+
 ### Étape 2 : réaliser le call dans l'APIv6 et dans l'espace client
 
 Une fois le serveur d'authentification mis en place côté client, il est nécessaire de renseigner les points suivants dans le call :

--- a/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-asia.md
+++ b/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-asia.md
@@ -10,7 +10,7 @@ order: 3
 
 ## Objective
 
-If you have followed the previous steps, you will now know how to [log in to the VMWare Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
+If you have followed the previous steps, you will now know how to [log in to the VMware Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
 
 **This guide will explain how to create pools using the VMware Horizon 7.1 platform.**
 
@@ -35,13 +35,13 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > There are three main desktop pool types: *automated*, *manual* and *RDS*.
-> 
+>
 > - *Automated* desktop pools are created using the same template, or using a template snapshot of a virtual machine (VM).
-> 
+>
 > - *Manual* desktop pools are a collection of VMs, physical computers or third-party VMs. In *automated* and *manual* desktop pools, each machine can only be accessed by one remote user at a time.
 >
 > - *RDS* desktop pools are not a collection of machines. Instead, they provide desktop sessions on RDS hosts. On an RDS host, several users can have different desktop sessions running simultaneously.
-> 
+>
 
 
 ![creating a pool](images/1201.png){.thumbnail}
@@ -70,7 +70,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > We recommend using the **Blast** protocol as it provides you with significantly smoother performance (regardless of your bandwidth conditions), higher security, and much longer battery life if you are using a mobile device. For more information on this protocol, please refer to [this VMware documentation page](https://docs.vmware.com/en/VMware-Horizon-7/7.4/horizon-architecture-planning/GUID-F64BAD49-78A0-44FE-97EA-76A56FD022D6.html){.external}.
-> 
+>
 
 ![creating a pool](images/1205.png){.thumbnail}
 
@@ -91,7 +91,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > If the VM does not appear, select `Show all parent VMs`{.action} to find out why.
-> 
+>
 
 ![creating a pool](images/1209.png){.thumbnail}
 

--- a/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-au.md
+++ b/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-au.md
@@ -10,7 +10,7 @@ order: 3
 
 ## Objective
 
-If you have followed the previous steps, you will now know how to [log in to the VMWare Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
+If you have followed the previous steps, you will now know how to [log in to the VMware Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
 
 **This guide will explain how to create pools using the VMware Horizon 7.1 platform.**
 
@@ -35,13 +35,13 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > There are three main desktop pool types: *automated*, *manual* and *RDS*.
-> 
+>
 > - *Automated* desktop pools are created using the same template, or using a template snapshot of a virtual machine (VM).
-> 
+>
 > - *Manual* desktop pools are a collection of VMs, physical computers or third-party VMs. In *automated* and *manual* desktop pools, each machine can only be accessed by one remote user at a time.
 >
 > - *RDS* desktop pools are not a collection of machines. Instead, they provide desktop sessions on RDS hosts. On an RDS host, several users can have different desktop sessions running simultaneously.
-> 
+>
 
 
 ![creating a pool](images/1201.png){.thumbnail}
@@ -70,7 +70,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > We recommend using the **Blast** protocol as it provides you with significantly smoother performance (regardless of your bandwidth conditions), higher security, and much longer battery life if you are using a mobile device. For more information on this protocol, please refer to [this VMware documentation page](https://docs.vmware.com/en/VMware-Horizon-7/7.4/horizon-architecture-planning/GUID-F64BAD49-78A0-44FE-97EA-76A56FD022D6.html){.external}.
-> 
+>
 
 ![creating a pool](images/1205.png){.thumbnail}
 
@@ -91,7 +91,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > If the VM does not appear, select `Show all parent VMs`{.action} to find out why.
-> 
+>
 
 ![creating a pool](images/1209.png){.thumbnail}
 

--- a/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-ca.md
+++ b/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-ca.md
@@ -10,7 +10,7 @@ order: 3
 
 ## Objective
 
-If you have followed the previous steps, you will now know how to [log in to the VMWare Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
+If you have followed the previous steps, you will now know how to [log in to the VMware Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
 
 **This guide will explain how to create pools using the VMware Horizon 7.1 platform.**
 
@@ -35,13 +35,13 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > There are three main desktop pool types: *automated*, *manual* and *RDS*.
-> 
+>
 > - *Automated* desktop pools are created using the same template, or using a template snapshot of a virtual machine (VM).
-> 
+>
 > - *Manual* desktop pools are a collection of VMs, physical computers or third-party VMs. In *automated* and *manual* desktop pools, each machine can only be accessed by one remote user at a time.
 >
 > - *RDS* desktop pools are not a collection of machines. Instead, they provide desktop sessions on RDS hosts. On an RDS host, several users can have different desktop sessions running simultaneously.
-> 
+>
 
 
 ![creating a pool](images/1201.png){.thumbnail}
@@ -70,7 +70,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > We recommend using the **Blast** protocol as it provides you with significantly smoother performance (regardless of your bandwidth conditions), higher security, and much longer battery life if you are using a mobile device. For more information on this protocol, please refer to [this VMware documentation page](https://docs.vmware.com/en/VMware-Horizon-7/7.4/horizon-architecture-planning/GUID-F64BAD49-78A0-44FE-97EA-76A56FD022D6.html){.external}.
-> 
+>
 
 ![creating a pool](images/1205.png){.thumbnail}
 
@@ -91,7 +91,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > If the VM does not appear, select `Show all parent VMs`{.action} to find out why.
-> 
+>
 
 ![creating a pool](images/1209.png){.thumbnail}
 

--- a/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-gb.md
+++ b/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-gb.md
@@ -10,7 +10,7 @@ order: 3
 
 ## Objective
 
-If you have followed the previous steps, you will now know how to [log in to the VMWare Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
+If you have followed the previous steps, you will now know how to [log in to the VMware Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
 
 **This guide will explain how to create pools using the VMware Horizon 7.1 platform.**
 
@@ -35,13 +35,13 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > There are three main desktop pool types: *automated*, *manual* and *RDS*.
-> 
+>
 > - *Automated* desktop pools are created using the same template, or using a template snapshot of a virtual machine (VM).
-> 
+>
 > - *Manual* desktop pools are a collection of VMs, physical computers or third-party VMs. In *automated* and *manual* desktop pools, each machine can only be accessed by one remote user at a time.
 >
 > - *RDS* desktop pools are not a collection of machines. Instead, they provide desktop sessions on RDS hosts. On an RDS host, several users can have different desktop sessions running simultaneously.
-> 
+>
 
 
 ![creating a pool](images/1201.png){.thumbnail}
@@ -70,7 +70,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > We recommend using the **Blast** protocol as it provides you with significantly smoother performance (regardless of your bandwidth conditions), higher security, and much longer battery life if you are using a mobile device. For more information on this protocol, please refer to [this VMware documentation page](https://docs.vmware.com/en/VMware-Horizon-7/7.4/horizon-architecture-planning/GUID-F64BAD49-78A0-44FE-97EA-76A56FD022D6.html){.external}.
-> 
+>
 
 ![creating a pool](images/1205.png){.thumbnail}
 
@@ -91,7 +91,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > If the VM does not appear, select `Show all parent VMs`{.action} to find out why.
-> 
+>
 
 ![creating a pool](images/1209.png){.thumbnail}
 

--- a/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-ie.md
+++ b/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-ie.md
@@ -10,7 +10,7 @@ order: 3
 
 ## Objective
 
-If you have followed the previous steps, you will now know how to [log in to the VMWare Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
+If you have followed the previous steps, you will now know how to [log in to the VMware Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
 
 **This guide will explain how to create pools using the VMware Horizon 7.1 platform.**
 
@@ -35,13 +35,13 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > There are three main desktop pool types: *automated*, *manual* and *RDS*.
-> 
+>
 > - *Automated* desktop pools are created using the same template, or using a template snapshot of a virtual machine (VM).
-> 
+>
 > - *Manual* desktop pools are a collection of VMs, physical computers or third-party VMs. In *automated* and *manual* desktop pools, each machine can only be accessed by one remote user at a time.
 >
 > - *RDS* desktop pools are not a collection of machines. Instead, they provide desktop sessions on RDS hosts. On an RDS host, several users can have different desktop sessions running simultaneously.
-> 
+>
 
 
 ![creating a pool](images/1201.png){.thumbnail}
@@ -70,7 +70,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > We recommend using the **Blast** protocol as it provides you with significantly smoother performance (regardless of your bandwidth conditions), higher security, and much longer battery life if you are using a mobile device. For more information on this protocol, please refer to [this VMware documentation page](https://docs.vmware.com/en/VMware-Horizon-7/7.4/horizon-architecture-planning/GUID-F64BAD49-78A0-44FE-97EA-76A56FD022D6.html){.external}.
-> 
+>
 
 ![creating a pool](images/1205.png){.thumbnail}
 
@@ -91,7 +91,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > If the VM does not appear, select `Show all parent VMs`{.action} to find out why.
-> 
+>
 
 ![creating a pool](images/1209.png){.thumbnail}
 

--- a/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-sg.md
+++ b/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-sg.md
@@ -10,7 +10,7 @@ order: 3
 
 ## Objective
 
-If you have followed the previous steps, you will now know how to [log in to the VMWare Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
+If you have followed the previous steps, you will now know how to [log in to the VMware Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
 
 **This guide will explain how to create pools using the VMware Horizon 7.1 platform.**
 
@@ -35,13 +35,13 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > There are three main desktop pool types: *automated*, *manual* and *RDS*.
-> 
+>
 > - *Automated* desktop pools are created using the same template, or using a template snapshot of a virtual machine (VM).
-> 
+>
 > - *Manual* desktop pools are a collection of VMs, physical computers or third-party VMs. In *automated* and *manual* desktop pools, each machine can only be accessed by one remote user at a time.
 >
 > - *RDS* desktop pools are not a collection of machines. Instead, they provide desktop sessions on RDS hosts. On an RDS host, several users can have different desktop sessions running simultaneously.
-> 
+>
 
 
 ![creating a pool](images/1201.png){.thumbnail}
@@ -70,7 +70,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > We recommend using the **Blast** protocol as it provides you with significantly smoother performance (regardless of your bandwidth conditions), higher security, and much longer battery life if you are using a mobile device. For more information on this protocol, please refer to [this VMware documentation page](https://docs.vmware.com/en/VMware-Horizon-7/7.4/horizon-architecture-planning/GUID-F64BAD49-78A0-44FE-97EA-76A56FD022D6.html){.external}.
-> 
+>
 
 ![creating a pool](images/1205.png){.thumbnail}
 
@@ -91,7 +91,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > If the VM does not appear, select `Show all parent VMs`{.action} to find out why.
-> 
+>
 
 ![creating a pool](images/1209.png){.thumbnail}
 

--- a/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-us.md
+++ b/pages/cloud/cloud-desktop-infrastructure/step_three/guide.en-us.md
@@ -10,7 +10,7 @@ order: 3
 
 ## Objective
 
-If you have followed the previous steps, you will now know how to [log in to the VMWare Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
+If you have followed the previous steps, you will now know how to [log in to the VMware Horizon platform](../horizon-7-platform/), and your [pool template](../create-pool/) will be ready. It is now time to create your first pool.
 
 **This guide will explain how to create pools using the VMware Horizon 7.1 platform.**
 
@@ -35,13 +35,13 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > There are three main desktop pool types: *automated*, *manual* and *RDS*.
-> 
+>
 > - *Automated* desktop pools are created using the same template, or using a template snapshot of a virtual machine (VM).
-> 
+>
 > - *Manual* desktop pools are a collection of VMs, physical computers or third-party VMs. In *automated* and *manual* desktop pools, each machine can only be accessed by one remote user at a time.
 >
 > - *RDS* desktop pools are not a collection of machines. Instead, they provide desktop sessions on RDS hosts. On an RDS host, several users can have different desktop sessions running simultaneously.
-> 
+>
 
 
 ![creating a pool](images/1201.png){.thumbnail}
@@ -70,7 +70,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > We recommend using the **Blast** protocol as it provides you with significantly smoother performance (regardless of your bandwidth conditions), higher security, and much longer battery life if you are using a mobile device. For more information on this protocol, please refer to [this VMware documentation page](https://docs.vmware.com/en/VMware-Horizon-7/7.4/horizon-architecture-planning/GUID-F64BAD49-78A0-44FE-97EA-76A56FD022D6.html){.external}.
-> 
+>
 
 ![creating a pool](images/1205.png){.thumbnail}
 
@@ -91,7 +91,7 @@ Once you have logged in to VMware Horizon, follow the steps below:
 > [!primary]
 >
 > If the VM does not appear, select `Show all parent VMs`{.action} to find out why.
-> 
+>
 
 ![creating a pool](images/1209.png){.thumbnail}
 

--- a/pages/cloud/cloud-desktop-infrastructure/step_three/guide.it-it.md
+++ b/pages/cloud/cloud-desktop-infrastructure/step_three/guide.it-it.md
@@ -10,14 +10,14 @@ order: 3
 
 ## Obiettivo
 
-Dopo aver [eseguito l’accesso all’interfaccia VMWare Horizon](https://docs.ovh.com/it/cloud-desktop-infrastructure/piattaforma-horizon-7/){.external} e aver [creato il template di un <i>pool</i>](https://docs.ovh.com/it/cloud-desktop-infrastructure/creare-template-pool/){.external}, è il momento di creare il tuo primo <i>pool</i>.
+Dopo aver [eseguito l’accesso all’interfaccia VMware Horizon](https://docs.ovh.com/it/cloud-desktop-infrastructure/piattaforma-horizon-7/){.external} e aver [creato il template di un <i>pool</i>](https://docs.ovh.com/it/cloud-desktop-infrastructure/creare-template-pool/){.external}, è il momento di creare il tuo primo <i>pool</i>.
 
 **Questa guida ti mostra come creare un pool utilizzando VMware Horizon 7.1.**
 
 
 ## Prerequisiti
 
-- Essere connesso a VMware Horizon 7.1. 
+- Essere connesso a VMware Horizon 7.1.
 
 
 ## Procedura
@@ -34,13 +34,13 @@ Dopo aver eseguito l’accesso a VMware Horizon, segui i seguenti passaggi:
 > [!primary]
 >
 > Esistono tre principali tipologie di <i>pool </i>di desktop virtuali: automatizzato, manuale e RDS.
-> 
+>
 > - I <i>pool</i> di desktop virtuali <b>automatizzati</b> si creano a partire dallo stesso template o da uno snapshot del template di una macchina virtuale (VM).
-> 
+>
 > - I <i>pool</i> di desktop virtuali <b>manuali</b> sono una raccolta di VM, computer fisici o VM appartenenti a terzi. Nei <i>pool</i> automatizzati e manuali, ogni macchina è accessibile da un'utenza remota alla volta.
 >
 > - I <i>pool</i> di desktop virtuali <b>RDS</b> non consistono in una raccolta di macchine ma forniscono sessioni desktop sugli host RDS. Su un host RDS, più utenti possono avere varie sessioni di lavoro aperte contemporaneamente.
-> 
+>
 
 
 ![création d'un pool](images/1201.png){.thumbnail}
@@ -69,7 +69,7 @@ Dopo aver eseguito l’accesso a VMware Horizon, segui i seguenti passaggi:
 > [!primary]
 >
 > Ti consigliamo di utilizzare il protocollo **Blast**, che ti garantisce in particolare una migliore performance (indipendentemente dalla larghezza di banda della tua connessione), una maggiore sicurezza e, per gli utilizzi da dispositivo mobile, un importante risparmio di batteria. Per maggiori informazioni riguardanti il protocollo, clicca su [questo link](https://docs.vmware.com/fr/VMware-Horizon-7/7.2/com.vmware.horizon-view.installation.doc/GUID-F64BAD49-78A0-44FE-97EA-76A56FD022D6.html){.external}.
-> 
+>
 
 ![création d'un pool](images/1205.png){.thumbnail}
 
@@ -90,7 +90,7 @@ Dopo aver eseguito l’accesso a VMware Horizon, segui i seguenti passaggi:
 > [!primary]
 >
 > Se la VM non appare, seleziona `Show all parent VMs`{.action} per capirne il motivo.
-> 
+>
 
 ![création d'un pool](images/1209.png){.thumbnail}
 

--- a/pages/cloud/cloud-desktop-infrastructure/step_three/guide.pl-pl.md
+++ b/pages/cloud/cloud-desktop-infrastructure/step_three/guide.pl-pl.md
@@ -10,7 +10,7 @@ order: 3
 
 ## Wprowadzenie
 
-Wiesz już, jak [się zalogować do VMWare Horizon](https://docs.ovh.com/pl/cloud-desktop-infrastructure/platforma-horizon-7/){.external}, a Twój [szablon puli](https://docs.ovh.com/pl/cloud-desktop-infrastructure/tworzenie-szablonu-puli/){.external} jest gotowy. Teraz utwórz Twoją pierwszą pulę pulpitów.
+Wiesz już, jak [się zalogować do VMware Horizon](https://docs.ovh.com/pl/cloud-desktop-infrastructure/platforma-horizon-7/){.external}, a Twój [szablon puli](https://docs.ovh.com/pl/cloud-desktop-infrastructure/tworzenie-szablonu-puli/){.external} jest gotowy. Teraz utwórz Twoją pierwszą pulę pulpitów.
 
 **Niniejszy przewodnik wyjaśni Ci, jak to zrobić, korzystając z VMware Horizon 7.1.**
 
@@ -34,13 +34,13 @@ Po zalogowaniu się do VMware Horizon wykonaj następujące kroki:
 > [!primary]
 >
 > Istnieją trzy główne typy pul wirtualnych pulpitów: *zautomatyzowana*, *ręczna* oraz *RDS* (Remote Desktop Services).
-> 
+>
 > - *Zautomatyzowane* pule są tworzone na podstawie tego samego szablonu lub snapshota wirtualnej maszyny (VM).
-> 
+>
 > - *Ręczne* pule stacji roboczych są zbiorem wirtualnych maszyn lub komputerów. W przypadku pul *zautomatyzowanych* i *ręcznych* każda maszyna dostępna jest dla jednego zdalnego użytkownika w danym czasie.
 >
 > - Pule stacji roboczych *RDS* (Remote Desktop Service) nie są zbiorem maszyn. Udostępniają sesje stacji roboczej na hostach RDS. Z sesji stacji roboczej na hoście RDS może korzystać kilku użytkowników jednocześnie.
-> 
+>
 
 
 ![tworzenie puli](images/1201.png){.thumbnail}
@@ -69,7 +69,7 @@ Po zalogowaniu się do VMware Horizon wykonaj następujące kroki:
 > [!primary]
 >
 > Zalecamy użycie protokołu **Blast**. Zapewnia on większą płynność (niezależnie od przepustowości Twojego łącza), wyższy poziom bezpieczeństwa, a w przypadku użytkowników korzystających z usługi na urządzeniu przenośnym - istotnie mniejsze zużycie baterii. Więcej informacji o protokole znajdziesz pod [tym linkiem](https://docs.vmware.com/fr/VMware-Horizon-7/7.2/com.vmware.horizon-view.installation.doc/GUID-F64BAD49-78A0-44FE-97EA-76A56FD022D6.html){.external}.
-> 
+>
 
 ![tworzenie puli](images/1205.png){.thumbnail}
 
@@ -90,7 +90,7 @@ Po zalogowaniu się do VMware Horizon wykonaj następujące kroki:
 > [!primary]
 >
 > Jeśli wirtualna maszyna nie pojawia się, wybierz `Show all parent VMs`{.action}, aby poznać przyczynę.
-> 
+>
 
 ![tworzenie puli](images/1209.png){.thumbnail}
 

--- a/pages/cloud/cloud-desktop-infrastructure/step_three/guide.pt-pt.md
+++ b/pages/cloud/cloud-desktop-infrastructure/step_three/guide.pt-pt.md
@@ -10,7 +10,7 @@ order: 3
 
 ## Sumário
 
-Já sabe como [conectar-se ao VMWare Horizon - EN](https://docs.ovh.com/gb/en/cloud-desktop-infrastructure/horizon-7-platform/){.external} e o seu [modelo de pool - EN](https://docs.ovh.com/gb/en/cloud-desktop-infrastructure/create-pool/){.external} está pronto. Chegou o momento de criar a sua primeira pool.
+Já sabe como [conectar-se ao VMware Horizon - EN](https://docs.ovh.com/gb/en/cloud-desktop-infrastructure/horizon-7-platform/){.external} e o seu [modelo de pool - EN](https://docs.ovh.com/gb/en/cloud-desktop-infrastructure/create-pool/){.external} está pronto. Chegou o momento de criar a sua primeira pool.
 
 **Este guia explica-lhe como efetuar essa criação a partir do VMware Horizon 7.1.**
 
@@ -35,13 +35,13 @@ Depois de se ter autenticado no VMware Horizon, realize os procedimentos seguint
 > [!primary]
 >
 > Existem três tipos principais de pools de ambientes de trabalho: *automatizadas*, *manuais* e *RDS*.
-> 
+>
 > - As pools de ambientes de trabalho *automatizadas* são criadas a partir de um mesmo modelo ou de um snapshot de modelo de máquina virtual (VM).
-> 
+>
 > - As pools de ambientes de trabalho *manuais* são uma coleção de VM, de computadores físicos ou de VM de terceiros. Nas pools *automatizadas* e *manuais*, cada máquina está disponível para um único acesso de utilizador remoto de cada vez.
 >
 > - As pools de ambientes de trabalho *RDS* não são uma coleção de máquinas. Em vez disso, fornecem sessões de ambientes de trabalho em hosts RDS. Vários utilizadores podem ter várias sessões de ambiente de trabalho em simultâneo num host RDS.
-> 
+>
 
 
 ![criação de uma pool](images/1201.png){.thumbnail}
@@ -70,7 +70,7 @@ Depois de se ter autenticado no VMware Horizon, realize os procedimentos seguint
 > [!primary]
 >
 > Aconselhamos que utilize o protocolo **Blast**, pois este garante uma melhor fluidez (independentemente da largura de banda da sua conexão), uma maior proteção e, para as utilizações em dispositivos móveis, uma importante economia da bateria. Para mais informações relativamente a este protocolo, clique [aqui](https://docs.vmware.com/fr/VMware-Horizon-7/7.2/com.vmware.horizon-view.installation.doc/GUID-F64BAD49-78A0-44FE-97EA-76A56FD022D6.html){.external}.
-> 
+>
 
 ![criação de uma pool](images/1205.png){.thumbnail}
 
@@ -91,7 +91,7 @@ Depois de se ter autenticado no VMware Horizon, realize os procedimentos seguint
 > [!primary]
 >
 > Se a VM não surgir, selecione `Show all parent VMs`{.action} para saber a razão.
-> 
+>
 
 ![criação de uma pool](images/1209.png){.thumbnail}
 

--- a/pages/cloud/managed-bare-metal/veeam_backup_as_a_service/guide.fr-fr.md
+++ b/pages/cloud/managed-bare-metal/veeam_backup_as_a_service/guide.fr-fr.md
@@ -62,7 +62,7 @@ Vous verrez apparaître sur votre infrastructure vSphere une machine virtuelle c
 
 Maintenant que le service est en place, il suffit de réaliser les demandes de sauvegarde pour chaque machine virtuelle identifiée comme critique depuis le vSphere Web Client.
 
-Sélectionnez le datacenter Vmware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHCloud du menu.
+Sélectionnez le datacenter VMware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHCloud du menu.
 
 ![Backup Management](images/backupvm_01.png){.thumbnail}
 
@@ -85,7 +85,7 @@ Chaque jour, un e-mail contenant les statuts de l'ensemble des travaux effectué
 
 ### Restaurer une sauvegarde
 
-Sélectionnez le datacenter Vmware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHcloud du menu.
+Sélectionnez le datacenter VMware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHcloud du menu.
 
 Dans la liste, sélectionnez la VM pour laquelle vous souhaitez restaurer une sauvegarde (celle-ci doit avoir un **backup state** à **Enabled**).
 
@@ -118,7 +118,7 @@ Pour effectuer ces actions, vous pouvez sélectionner le datacenter dans votre i
 
 ### Désactiver la sauvegarde d'une machine virtuelle
 
-Sélectionnez le datacenter Vmware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHcloud du menu.
+Sélectionnez le datacenter VMware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHcloud du menu.
 
 Dans la liste sélectionnez la VM pour laquelle vous souhaitez désactiver la sauvegarde.
 
@@ -135,7 +135,7 @@ Confirmez ensuite la désactivation en cliquant sur `OK`{.action}.
 > [!warning]
 >
 > Il est possible de réactiver la sauvegarde à tout moment à partir du moment où la machine virtuelle est présente dans l'infrastructure.
-> 
+>
 > A noter que les sauvegardes effectuées restent disponibles pour la restauration juqu'à l'expiration du délai de retention.
 >
 

--- a/pages/cloud/managed-bare-metal/vmware_storage_vmotion/guide.it-it.md
+++ b/pages/cloud/managed-bare-metal/vmware_storage_vmotion/guide.it-it.md
@@ -1,5 +1,5 @@
 ---
-title: Vmware Storage VMotion
+title: VMware Storage VMotion
 routes:
     canonical: 'https://docs.ovh.com/it/private-cloud/vmware_storage_vmotion/'
 excerpt: Come trasferire a caldo una macchina virtuale su un datastore differente
@@ -28,7 +28,7 @@ Per migrare i file di una macchina virtuale verso un altro datastore, è suffici
 
 Il menu propone diverse opzioni di **vMotion**. Nel nostro esempio, migreremo semplicemente la macchina virtuale su un altro datastore. Per eseguire questa operazione è necessario selezionare “Change storage only”.
 
-L’opzione “Change compute resource only” permette invece di migrare la VM su un altro host.  
+L’opzione “Change compute resource only” permette invece di migrare la VM su un altro host.
 
 Questa operazione, chiamata **vMotion**, è descritta in [questa guida](../vmware-vmotion-new/).
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.de-de.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.de-de.md
@@ -12,7 +12,7 @@ order: 07
 
 ## Objective
 
-VMWare offers the ability to clone a VM to create another one or a template.
+VMware offers the ability to clone a VM to create another one or a template.
 
 **This guide explains how to execute those tasks.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.en-asia.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.en-asia.md
@@ -10,7 +10,7 @@ order: 07
 
 ## Objective
 
-VMWare offers the ability to clone a VM to create another one or a template.
+VMware offers the ability to clone a VM to create another one or a template.
 
 **This guide explains how to execute those tasks.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.en-au.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.en-au.md
@@ -10,7 +10,7 @@ order: 07
 
 ## Objective
 
-VMWare offers the ability to clone a VM to create another one or a template.
+VMware offers the ability to clone a VM to create another one or a template.
 
 **This guide explains how to execute those tasks.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.en-ca.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.en-ca.md
@@ -10,7 +10,7 @@ order: 07
 
 ## Objective
 
-VMWare offers the ability to clone a VM to create another one or a template.
+VMware offers the ability to clone a VM to create another one or a template.
 
 **This guide explains how to execute those tasks.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.en-gb.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.en-gb.md
@@ -10,7 +10,7 @@ order: 07
 
 ## Objective
 
-VMWare offers the ability to clone a VM to create another one or a template.
+VMware offers the ability to clone a VM to create another one or a template.
 
 **This guide explains how to execute those tasks.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.en-ie.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.en-ie.md
@@ -10,7 +10,7 @@ order: 07
 
 ## Objective
 
-VMWare offers the ability to clone a VM to create another one or a template.
+VMware offers the ability to clone a VM to create another one or a template.
 
 **This guide explains how to execute those tasks.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.en-sg.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.en-sg.md
@@ -10,7 +10,7 @@ order: 07
 
 ## Objective
 
-VMWare offers the ability to clone a VM to create another one or a template.
+VMware offers the ability to clone a VM to create another one or a template.
 
 **This guide explains how to execute those tasks.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.en-us.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.en-us.md
@@ -10,7 +10,7 @@ order: 07
 
 ## Objective
 
-VMWare offers the ability to clone a VM to create another one or a template.
+VMware offers the ability to clone a VM to create another one or a template.
 
 **This guide explains how to execute those tasks.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.es-es.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.es-es.md
@@ -12,7 +12,7 @@ order: 07
 
 ## Objective
 
-VMWare offers the ability to clone a VM to create another one or a template.
+VMware offers the ability to clone a VM to create another one or a template.
 
 **This guide explains how to execute those tasks.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.es-us.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.es-us.md
@@ -12,7 +12,7 @@ order: 07
 
 ## Objective
 
-VMWare offers the ability to clone a VM to create another one or a template.
+VMware offers the ability to clone a VM to create another one or a template.
 
 **This guide explains how to execute those tasks.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.fr-ca.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.fr-ca.md
@@ -10,7 +10,7 @@ order: 07
 
 ## Objectif
 
-VMWare offre la possibilité de cloner une VM pour créer une nouvelle VM ou un modèle.
+VMware offre la possibilité de cloner une VM pour créer une nouvelle VM ou un modèle.
 
 **Ce guide explique comment exécuter ces tâches.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.fr-fr.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.fr-fr.md
@@ -10,7 +10,7 @@ order: 07
 
 ## Objectif
 
-VMWare offre la possibilité de cloner une VM pour créer une nouvelle VM ou un modèle.
+VMware offre la possibilité de cloner une VM pour créer une nouvelle VM ou un modèle.
 
 **Ce guide explique comment exécuter ces tâches.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.it-it.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.it-it.md
@@ -12,7 +12,7 @@ order: 07
 
 ## Objective
 
-VMWare offers the ability to clone a VM to create another one or a template.
+VMware offers the ability to clone a VM to create another one or a template.
 
 **This guide explains how to execute those tasks.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.pl-pl.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.pl-pl.md
@@ -12,7 +12,7 @@ order: 07
 
 ## Objective
 
-VMWare offers the ability to clone a VM to create another one or a template.
+VMware offers the ability to clone a VM to create another one or a template.
 
 **This guide explains how to execute those tasks.**
 

--- a/pages/cloud/private-cloud/clone_a_vm/guide.pt-pt.md
+++ b/pages/cloud/private-cloud/clone_a_vm/guide.pt-pt.md
@@ -12,7 +12,7 @@ order: 07
 
 ## Objective
 
-VMWare offers the ability to clone a VM to create another one or a template.
+VMware offers the ability to clone a VM to create another one or a template.
 
 **This guide explains how to execute those tasks.**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.de-de.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.de-de.md
@@ -13,7 +13,7 @@ order: 8
 
 ## Objective
 
-VMWare offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
+VMware offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
 
 **This guide explains how to execute these tasks**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.en-asia.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.en-asia.md
@@ -11,7 +11,7 @@ order: 08
 
 ## Objective
 
-VMWare offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
+VMware offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
 
 **This guide explains how to execute these tasks**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.en-au.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.en-au.md
@@ -11,7 +11,7 @@ order: 08
 
 ## Objective
 
-VMWare offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
+VMware offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
 
 **This guide explains how to execute these tasks**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.en-ca.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.en-ca.md
@@ -11,7 +11,7 @@ order: 08
 
 ## Objective
 
-VMWare offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
+VMware offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
 
 **This guide explains how to execute these tasks**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.en-gb.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.en-gb.md
@@ -11,7 +11,7 @@ order: 08
 
 ## Objective
 
-VMWare offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
+VMware offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
 
 **This guide explains how to execute these tasks**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.en-ie.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.en-ie.md
@@ -11,7 +11,7 @@ order: 08
 
 ## Objective
 
-VMWare offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
+VMware offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
 
 **This guide explains how to execute these tasks**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.en-sg.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.en-sg.md
@@ -11,7 +11,7 @@ order: 08
 
 ## Objective
 
-VMWare offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
+VMware offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
 
 **This guide explains how to execute these tasks**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.en-us.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.en-us.md
@@ -11,7 +11,7 @@ order: 08
 
 ## Objective
 
-VMWare offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
+VMware offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
 
 **This guide explains how to execute these tasks**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.es-es.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.es-es.md
@@ -13,7 +13,7 @@ order: 08
 
 ## Objective
 
-VMWare offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
+VMware offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
 
 **This guide explains how to execute these tasks**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.es-us.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.es-us.md
@@ -12,7 +12,7 @@ order: 08
 
 ## Objective
 
-VMWare offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
+VMware offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
 
 **This guide explains how to execute these tasks**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.fr-ca.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.fr-ca.md
@@ -11,7 +11,7 @@ order: 08
 
 ## Objectif
 
-VMWare offre la possibilité de créer des snapshots pour permettre le retour à un état précedent de votre VM.
+VMware offre la possibilité de créer des snapshots pour permettre le retour à un état précedent de votre VM.
 
 **Ce guide explique comment exécuter cette tâche.**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.fr-fr.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.fr-fr.md
@@ -11,7 +11,7 @@ order: 08
 
 ## Objectif
 
-VMWare offre la possibilité de créer des snapshots pour permettre le retour à un état précedent de votre VM.
+VMware offre la possibilité de créer des snapshots pour permettre le retour à un état précedent de votre VM.
 
 **Ce guide explique comment exécuter cette tâche.**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.it-it.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.it-it.md
@@ -12,7 +12,7 @@ order: 08
 
 ## Objective
 
-VMWare offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
+VMware offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
 
 **This guide explains how to execute these tasks**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.pl-pl.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.pl-pl.md
@@ -13,7 +13,7 @@ order: 08
 
 ## Objective
 
-VMWare offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
+VMware offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
 
 **This guide explains how to execute these tasks**
 

--- a/pages/cloud/private-cloud/creer_un_snapshot/guide.pt-pt.md
+++ b/pages/cloud/private-cloud/creer_un_snapshot/guide.pt-pt.md
@@ -12,7 +12,7 @@ order: 08
 
 ## Objective
 
-VMWare offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
+VMware offers the ability to take snapshots so you can save and possibly go back to a VM's previous state.
 
 **This guide explains how to execute these tasks**
 

--- a/pages/cloud/private-cloud/manager_ovh_private_cloud/guide.fr-fr.md
+++ b/pages/cloud/private-cloud/manager_ovh_private_cloud/guide.fr-fr.md
@@ -29,7 +29,7 @@ Naviguez vers l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotoma
 
 ### Vue Hosted Private Cloud
 
-Dans l'onglet `Hosted Private Cloud`{.action}, sélectionnez votre service dans la liste `VMWare`{.action}. Vous pouvez renommer votre infrastructure en cliquant le bouton `Crayon`{.action} au centre de l'écran.
+Dans l'onglet `Hosted Private Cloud`{.action}, sélectionnez votre service dans la liste `VMware`{.action}. Vous pouvez renommer votre infrastructure en cliquant le bouton `Crayon`{.action} au centre de l'écran.
 
 ![HOSTED](images/en02dashboard.png){.thumbnail}
 
@@ -40,7 +40,7 @@ L'onglet `Informations générales`{.action} donne le résumé de vos options Ho
 - La « Description » est modifiable via le bouton `...`{.action}
 - La « Solution logicielle » vous donne la version vCSA installée
 - La « Localisation » de votre Hosted Private Cloud
-- La « Politique d'accès » de votre infrastructure (`Ouverte` ou `Restreinte`) 
+- La « Politique d'accès » de votre infrastructure (`Ouverte` ou `Restreinte`)
 - Le « Nombre de datacenters » de votre infrastructure
 - Le « Nombre de blocs IP » qui vous sont assignés et l'option d'en ajouter via le bouton `...`{.action}
 - Des liens vers les interfaces de gestion sont disponibles.
@@ -53,7 +53,7 @@ L'onglet `Informations générales`{.action} donne le résumé de vos options Ho
 #### Datacentres
 
 L'onglet Datacentres montre vos datacentres virtuels existants et offre la possibilité d'en ajouter.<br>
-La vue Datacentre (voir plus bas), donne tous les détails et options. 
+La vue Datacentre (voir plus bas), donne tous les détails et options.
 
 ![DATACENTERS](images/en04datacenters.png){.thumbnail}
 
@@ -114,7 +114,7 @@ Vous pouvez paramétrer les options à l'aide des boutons sur la droite de l'éc
 > [!warning]
 >
 > Si vous mettez la politique d'accès en mode restreint et que vous ne renseignez aucune IP, aucun utilisateur ne pourra se connecter au client vSphere. Les machines virtuelles resteront toutefois accessibles.
-> 
+>
 
 En bas de la page, vous pouvez aussi ajouter un Key Management Servers.<br>
 Consultez le guide « [Activation du chiffrement des machines virtuelles](https://docs.ovh.com/fr/private-cloud/vm-encrypt/) » pour plus de details.
@@ -153,7 +153,7 @@ Le nom et la description du datacentre sont modifiables en cliquant sur le bouto
 L'onglet Informations générales donne le résumé de vos options :
 
 - Les champs « Nom » et « Description » sont modifiables via le bouton `...`{.action}
-- La « Gamme » montre les services VMWare souscrits
+- La « Gamme » montre les services VMware souscrits
 - Les champs « Hosts » et « Datastores » vous donnent les quantités d'hôtes et de datastores dans votre Hosted Private Cloud
 - « VM Backupée » vous montre le statut de votre solution de sauvegarde
 - « Plan de reprise d’activité » vous montre le statut de votre solution de PRA

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.de-de.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.de-de.md
@@ -23,7 +23,7 @@ NSX is a Software Defined Network (SDN) solution developed by VMware that is act
 
 ## Instructions
 
-VMWare NSX is only available from the vSphere web client.
+VMware NSX is only available from the vSphere web client.
 
 From the vSphere web client homepage, click on `Networking and Security`{.action} in the left-hand side of your screen.
 You can also click on `Networking and Security`{.action} in the main menu.

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.en-asia.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.en-asia.md
@@ -21,7 +21,7 @@ NSX is a Software Defined Network (SDN) solution developed by VMware that is act
 
 ## Instructions
 
-VMWare NSX is only available from the vSphere web client.
+VMware NSX is only available from the vSphere web client.
 
 From the vSphere web client homepage, click on `Networking and Security`{.action} in the left-hand side of your screen.
 You can also click on `Networking and Security`{.action} in the main menu.

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.en-au.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.en-au.md
@@ -21,7 +21,7 @@ NSX is a Software Defined Network (SDN) solution developed by VMware that is act
 
 ## Instructions
 
-VMWare NSX is only available from the vSphere web client.
+VMware NSX is only available from the vSphere web client.
 
 From the vSphere web client homepage, click on `Networking and Security`{.action} in the left-hand side of your screen.
 You can also click on `Networking and Security`{.action} in the main menu.

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.en-ca.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.en-ca.md
@@ -21,7 +21,7 @@ NSX is a Software Defined Network (SDN) solution developed by VMware that is act
 
 ## Instructions
 
-VMWare NSX is only available from the vSphere web client.
+VMware NSX is only available from the vSphere web client.
 
 From the vSphere web client homepage, click on `Networking and Security`{.action} in the left-hand side of your screen.
 You can also click on `Networking and Security`{.action} in the main menu.

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.en-gb.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.en-gb.md
@@ -21,7 +21,7 @@ NSX is a Software Defined Network (SDN) solution developed by VMware that is act
 
 ## Instructions
 
-VMWare NSX is only available from the vSphere web client.
+VMware NSX is only available from the vSphere web client.
 
 From the vSphere web client homepage, click on `Networking and Security`{.action} in the left-hand side of your screen.
 You can also click on `Networking and Security`{.action} in the main menu.

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.en-ie.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.en-ie.md
@@ -21,7 +21,7 @@ NSX is a Software Defined Network (SDN) solution developed by VMware that is act
 
 ## Instructions
 
-VMWare NSX is only available from the vSphere web client.
+VMware NSX is only available from the vSphere web client.
 
 From the vSphere web client homepage, click on `Networking and Security`{.action} in the left-hand side of your screen.
 You can also click on `Networking and Security`{.action} in the main menu.

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.en-sg.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.en-sg.md
@@ -21,7 +21,7 @@ NSX is a Software Defined Network (SDN) solution developed by VMware that is act
 
 ## Instructions
 
-VMWare NSX is only available from the vSphere web client.
+VMware NSX is only available from the vSphere web client.
 
 From the vSphere web client homepage, click on `Networking and Security`{.action} in the left-hand side of your screen.
 You can also click on `Networking and Security`{.action} in the main menu.

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.en-us.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.en-us.md
@@ -21,7 +21,7 @@ NSX is a Software Defined Network (SDN) solution developed by VMware that is act
 
 ## Instructions
 
-VMWare NSX is only available from the vSphere web client.
+VMware NSX is only available from the vSphere web client.
 
 From the vSphere web client homepage, click on `Networking and Security`{.action} in the left-hand side of your screen.
 You can also click on `Networking and Security`{.action} in the main menu.

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.es-es.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.es-es.md
@@ -23,7 +23,7 @@ NSX is a Software Defined Network (SDN) solution developed by VMware that is act
 
 ## Instructions
 
-VMWare NSX is only available from the vSphere web client.
+VMware NSX is only available from the vSphere web client.
 
 From the vSphere web client homepage, click on `Networking and Security`{.action} in the left-hand side of your screen.
 You can also click on `Networking and Security`{.action} in the main menu.

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.es-us.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.es-us.md
@@ -23,7 +23,7 @@ NSX is a Software Defined Network (SDN) solution developed by VMware that is act
 
 ## Instructions
 
-VMWare NSX is only available from the vSphere web client.
+VMware NSX is only available from the vSphere web client.
 
 From the vSphere web client homepage, click on `Networking and Security`{.action} in the left-hand side of your screen.
 You can also click on `Networking and Security`{.action} in the main menu.

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.fr-ca.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.fr-ca.md
@@ -21,7 +21,7 @@ NSX est une solution de Software Defined Network (SDN) développée par VMware q
 
 ## En pratique
 
-VMWare NSX est disponible depuis le client web vSphere uniquement.
+VMware NSX est disponible depuis le client web vSphere uniquement.
 
 Depuis la page d’accueil du client vSphere, cliquez sur `Mise en réseau et sécurité`{.action} dans la barre d'outil à gauche de votre écran.
 Vous pouvez également cliquer sur `Mise en réseau et sécurité`{.action} dans le Menu déroulant.
@@ -37,14 +37,14 @@ Vous avez alors accès au tableau de bord NSX avec tous les menus associés.
 >
 > Pour accéder à l'API NSX, vous devez utiliser https://nsx.pcc-x-x-x-x.ovh.com/api
 >
-> Exemple pour récupérer votre configuration firewall: 
+> Exemple pour récupérer votre configuration firewall:
 >
 > ```
 > curl -u "admin:xxxx" -XGET "https://nsx.pcc-x-x-x-x.ovh.com/api/4.0/firewall/globalroot-0/defaultconfig"
 > ```
 >
 > Pour des raisons de sécurité, /api/1.0/ n'est pas prise en charge.
-> 
+>
 
 
 ## Aller plus loin

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.fr-fr.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.fr-fr.md
@@ -21,7 +21,7 @@ NSX est une solution de Software Defined Network (SDN) développée par VMware q
 
 ## En pratique
 
-VMWare NSX est disponible depuis le client web vSphere uniquement.
+VMware NSX est disponible depuis le client web vSphere uniquement.
 
 Depuis la page d’accueil du client vSphere, cliquez sur `Mise en réseau et sécurité`{.action} dans la barre d'outil à gauche de votre écran.
 Vous pouvez également cliquer sur `Mise en réseau et sécurité`{.action} dans le Menu déroulant.
@@ -37,14 +37,14 @@ Vous avez alors accès au tableau de bord NSX avec tous les menus associés.
 >
 > Pour accéder à l'API NSX, vous devez utiliser https://nsx.pcc-x-x-x-x.ovh.com/api
 >
-> Exemple pour récupérer votre configuration firewall : 
+> Exemple pour récupérer votre configuration firewall :
 >
 > ```
 > curl -u "admin:xxxx" -XGET "https://nsx.pcc-x-x-x-x.ovh.com/api/4.0/firewall/globalroot-0/defaultconfig"
 > ```
 >
 > Pour des raisons de sécurité, /api/1.0/ n'est pas prise en charge.
-> 
+>
 
 
 ## Aller plus loin

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.it-it.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.it-it.md
@@ -23,7 +23,7 @@ NSX is a Software Defined Network (SDN) solution developed by VMware that is act
 
 ## Instructions
 
-VMWare NSX is only available from the vSphere web client.
+VMware NSX is only available from the vSphere web client.
 
 From the vSphere web client homepage, click on `Networking and Security`{.action} in the left-hand side of your screen.
 You can also click on `Networking and Security`{.action} in the main menu.

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.pl-pl.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.pl-pl.md
@@ -23,7 +23,7 @@ NSX is a Software Defined Network (SDN) solution developed by VMware that is act
 
 ## Instructions
 
-VMWare NSX is only available from the vSphere web client.
+VMware NSX is only available from the vSphere web client.
 
 From the vSphere web client homepage, click on `Networking and Security`{.action} in the left-hand side of your screen.
 You can also click on `Networking and Security`{.action} in the main menu.

--- a/pages/cloud/private-cloud/nsx_access-interface/guide.pt-pt.md
+++ b/pages/cloud/private-cloud/nsx_access-interface/guide.pt-pt.md
@@ -23,7 +23,7 @@ NSX is a Software Defined Network (SDN) solution developed by VMware that is act
 
 ## Instructions
 
-VMWare NSX is only available from the vSphere web client.
+VMware NSX is only available from the vSphere web client.
 
 From the vSphere web client homepage, click on `Networking and Security`{.action} in the left-hand side of your screen.
 You can also click on `Networking and Security`{.action} in the main menu.

--- a/pages/cloud/private-cloud/spectre_meltdown_fixes/guide.en-gb.md
+++ b/pages/cloud/private-cloud/spectre_meltdown_fixes/guide.en-gb.md
@@ -30,7 +30,7 @@ As a reminder:
 > [!primary]
 >
 > Meltdown (CVE-2017-5754) does not affect ESXI because ESXI does not run non-verified user codes.
-> 
+>
 
 
 For **Private Cloud** solutions, there is planned scheduled maintenance to apply a patch for this vulnerability automatically on vulnerable hosts. You can find information about this scheduled maintenance on the [associated task](http://travaux.ovh.com/?do=details&id=29250){.external} (English translation below French text).
@@ -52,7 +52,7 @@ If you have an older version of these *builds*, you will need to update your hos
 
 ### Update your host with the patch associated with the vulnerability
 
-Update your host by switching it to maintenance mode (your host will be rebooted during the procedure), and use the [VMWare Update Manager plugin](https://www.vmware.com/support/pubs/vum_pubs.html){.external}.
+Update your host by switching it to maintenance mode (your host will be rebooted during the procedure), and use the [VMware Update Manager plugin](https://www.vmware.com/support/pubs/vum_pubs.html){.external}.
 
 The patches are as follows:
 
@@ -62,7 +62,7 @@ The patches are as follows:
 > [!warning]
 >
 > This version **5.5** patch is only for **CVE-2017-5715**, not CVE-2017-5753.
-> 
+>
 
 
 ![Configuration](images/spectre2.JPG)

--- a/pages/cloud/private-cloud/veeam_backup_as_a_service/guide.fr-ca.md
+++ b/pages/cloud/private-cloud/veeam_backup_as_a_service/guide.fr-ca.md
@@ -57,7 +57,7 @@ Vous verrez apparaître sur votre infrastructure vSphere une machine virtuelle c
 
 Maintenant que le service est en place, il suffit de réaliser les demandes de sauvegarde pour chaque machine virtuelle identifiée comme critique depuis le vSphere Web Client.
 
-Sélectionnez le datacenter Vmware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHCloud du menu.
+Sélectionnez le datacenter VMware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHCloud du menu.
 
 ![Backup Management](images/backupvm_01.png){.thumbnail}
 
@@ -80,7 +80,7 @@ Chaque jour, un e-mail contenant les statuts de l'ensemble des travaux effectué
 
 ### Restaurer une sauvegarde
 
-Sélectionnez le datacenter Vmware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHcloud du menu.
+Sélectionnez le datacenter VMware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHcloud du menu.
 
 Dans la liste, sélectionnez la VM pour laquelle vous souhaitez restaurer une sauvegarde (celle-ci doit avoir un **backup state** à **Enabled**).
 
@@ -113,7 +113,7 @@ Pour effectuer ces actions, vous pouvez sélectionner le datacenter dans votre i
 
 ### Désactiver la sauvegarde d'une machine virtuelle
 
-Sélectionnez le datacenter Vmware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHcloud du menu.
+Sélectionnez le datacenter VMware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHcloud du menu.
 
 Dans la liste sélectionnez la VM pour laquelle vous souhaitez désactiver la sauvegarde.
 
@@ -130,7 +130,7 @@ Confirmez ensuite la désactivation en cliquant sur `OK`{.action}.
 > [!warning]
 >
 > Il est possible de réactiver la sauvegarde à tout moment à partir du moment où la machine virtuelle est présente dans l'infrastructure.
-> 
+>
 > A noter que les sauvegardes effectuées restent disponibles pour la restauration juqu'à l'expiration du délai de retention.
 >
 

--- a/pages/cloud/private-cloud/veeam_backup_as_a_service/guide.fr-fr.md
+++ b/pages/cloud/private-cloud/veeam_backup_as_a_service/guide.fr-fr.md
@@ -57,7 +57,7 @@ Vous verrez apparaître sur votre infrastructure vSphere une machine virtuelle c
 
 Maintenant que le service est en place, il suffit de réaliser les demandes de sauvegarde pour chaque machine virtuelle identifiée comme critique depuis le vSphere Web Client.
 
-Sélectionnez le datacenter Vmware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHCloud du menu.
+Sélectionnez le datacenter VMware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHCloud du menu.
 
 ![Backup Management](images/backupvm_01.png){.thumbnail}
 
@@ -80,7 +80,7 @@ Chaque jour, un e-mail contenant les statuts de l'ensemble des travaux effectué
 
 ### Restaurer une sauvegarde
 
-Sélectionnez le datacenter Vmware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHcloud du menu.
+Sélectionnez le datacenter VMware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHcloud du menu.
 
 Dans la liste, sélectionnez la VM pour laquelle vous souhaitez restaurer une sauvegarde (celle-ci doit avoir un **backup state** à **Enabled**).
 
@@ -113,7 +113,7 @@ Pour effectuer ces actions, vous pouvez sélectionner le datacenter dans votre i
 
 ### Désactiver la sauvegarde d'une machine virtuelle
 
-Sélectionnez le datacenter Vmware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHcloud du menu.
+Sélectionnez le datacenter VMware, puis l'onglet `Configure`{.action} et choisissez `Backup Management`{.action} dans la section OVHcloud du menu.
 
 Dans la liste sélectionnez la VM pour laquelle vous souhaitez désactiver la sauvegarde.
 
@@ -130,7 +130,7 @@ Confirmez ensuite la désactivation en cliquant sur `OK`{.action}.
 > [!warning]
 >
 > Il est possible de réactiver la sauvegarde à tout moment à partir du moment où la machine virtuelle est présente dans l'infrastructure.
-> 
+>
 > A noter que les sauvegardes effectuées restent disponibles pour la restauration juqu'à l'expiration du délai de retention.
 >
 

--- a/pages/cloud/private-cloud/vmware_storage_vmotion/guide.it-it.md
+++ b/pages/cloud/private-cloud/vmware_storage_vmotion/guide.it-it.md
@@ -1,5 +1,5 @@
 ---
-title: Vmware Storage VMotion
+title: VMware Storage VMotion
 excerpt: Come trasferire a caldo una macchina virtuale su un datastore differente
 slug: vmware_storage_vmotion
 section: Funzionalità VMware vSphere
@@ -26,7 +26,7 @@ Per migrare i file di una macchina virtuale verso un altro datastore, è suffici
 
 Il menu propone diverse opzioni di **vMotion**. Nel nostro esempio, migreremo semplicemente la macchina virtuale su un altro datastore. Per eseguire questa operazione è necessario selezionare “Change storage only”.
 
-L’opzione “Change compute resource only” permette invece di migrare la VM su un altro host.  
+L’opzione “Change compute resource only” permette invece di migrare la VM su un altro host.
 
 Questa operazione, chiamata **vMotion**, è descritta in [questa guida](../vmware-vmotion-new/).
 

--- a/pages/cloud/private-cloud/vmware_vsan_add_host/guide.it-it.md
+++ b/pages/cloud/private-cloud/vmware_vsan_add_host/guide.it-it.md
@@ -4,7 +4,7 @@ slug: vmware-vsan-add-host
 routes:
     canonical: 'https://docs.ovh.com/gb/en/private-cloud/vmware-vsan-add-host/'
 excerpt: 'Find out how to add an ESXi server to an existing vSAN cluster'
-section: 'Funzionalità VMWare vSphere'
+section: 'Funzionalità VMware vSphere'
 ---
 
 **Last updated 22nd December 2021**

--- a/pages/platform/public-cloud/creation_launch_deletion_of_images_in_horizon/guide.fr-ca.md
+++ b/pages/platform/public-cloud/creation_launch_deletion_of_images_in_horizon/guide.fr-ca.md
@@ -48,7 +48,7 @@ L'ajout d'images personnalisées est possible via l'interface OpenStack Horizon.
 |RAW|Image disque brute|
 |VDI|VirtualBox format|
 |VHD|Microsoft format|
-|VMDK|VMWare format|
+|VMDK|VMware format|
 
 - Architecture : x86_64
 - Espace disque minimal (en Go) : si non spécifié, la valeur par défaut sera 0.

--- a/pages/platform/public-cloud/creation_launch_deletion_of_images_in_horizon/guide.fr-fr.md
+++ b/pages/platform/public-cloud/creation_launch_deletion_of_images_in_horizon/guide.fr-fr.md
@@ -51,7 +51,7 @@ L'ajout d'images personnalisées est possible via l'interface OpenStack Horizon.
 |RAW|Image disque brute|
 |VDI|VirtualBox format|
 |VHD|Microsoft format|
-|VMDK|VMWare format|
+|VMDK|VMware format|
 
 - Architecture : x86_64
 - Espace disque minimal (en Go) : si non spécifié, la valeur par défaut sera 0.


### PR DESCRIPTION
According to the official website and documentations of VMware: the right spelling of the VMware brand is the letter V and M in uppercase only.