### PR TITLE
Mk8s fix autoscaling documentations

### DIFF
--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-asia.md
@@ -26,7 +26,7 @@ section: Tutorials
  }
 </style>
 
-**Last updated March 23<sup>rd</sup>, 2021.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the hassle of installing or operating them. 
 
@@ -50,7 +50,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 > 
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 

--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-asia.md
@@ -32,10 +32,6 @@ OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the
 
 During the day-to-day life of your cluster, you may want to dynamically adjust the size of your cluster to accommodate to your workloads. The cluster autoscaler simplifies the task by scaling up or down your OVHcloud Managed Kubernetes cluster to meet the demand of your workloads. 
 
-> [!primary]
->
-> The cluster auto-scaler feature is currently available in beta. We expect it to reach General Availability (including support in OVHcloud Control Panel) by Summer 2021.
-
 ## Before you begin
 
 This tutorial assumes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
@@ -51,6 +47,12 @@ As explained in the [How nodes and node pools work](../managing-nodes/) guide, i
 Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling on a full cluster, you enable it for one or more of your node pools.
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
+
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> 
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) or directly [using the Kubernetes API](../managing-nodes/).
 

--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-au.md
@@ -26,7 +26,7 @@ section: Tutorials
  }
 </style>
 
-**Last updated March 23<sup>rd</sup>, 2021.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the hassle of installing or operating them. 
 
@@ -50,7 +50,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 > 
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 

--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-au.md
@@ -32,10 +32,6 @@ OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the
 
 During the day-to-day life of your cluster, you may want to dynamically adjust the size of your cluster to accommodate to your workloads. The cluster autoscaler simplifies the task by scaling up or down your OVHcloud Managed Kubernetes cluster to meet the demand of your workloads. 
 
-> [!primary]
->
-> The cluster auto-scaler feature is currently available in beta. We expect it to reach General Availability (including support in OVHcloud Control Panel) by Summer 2021.
-
 ## Before you begin
 
 This tutorial assumes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
@@ -51,6 +47,12 @@ As explained in the [How nodes and node pools work](../managing-nodes/) guide, i
 Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling on a full cluster, you enable it for one or more of your node pools.
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
+
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> 
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) or directly [using the Kubernetes API](../managing-nodes/).
 

--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-ca.md
@@ -32,10 +32,6 @@ OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the
 
 During the day-to-day life of your cluster, you may want to dynamically adjust the size of your cluster to accommodate to your workloads. The cluster autoscaler simplifies the task by scaling up or down your OVHcloud Managed Kubernetes cluster to meet the demand of your workloads. 
 
-> [!primary]
->
-> The cluster auto-scaler feature is currently available in beta. We expect it to reach General Availability (including support in OVHcloud Control Panel) by Summer 2021.
-
 ## Before you begin
 
 This tutorial assumes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
@@ -51,6 +47,12 @@ As explained in the [How nodes and node pools work](../managing-nodes/) guide, i
 Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling on a full cluster, you enable it for one or more of your node pools.
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
+
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> 
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) or directly [using the Kubernetes API](../managing-nodes/).
 

--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-ca.md
@@ -26,7 +26,7 @@ section: Tutorials
  }
 </style>
 
-**Last updated March 23<sup>rd</sup>, 2021.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the hassle of installing or operating them. 
 
@@ -50,7 +50,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 > 
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 

--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-gb.md
@@ -32,10 +32,6 @@ OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the
 
 During the day-to-day life of your cluster, you may want to dynamically adjust the size of your cluster to accommodate to your workloads. The cluster autoscaler simplifies the task by scaling up or down your OVHcloud Managed Kubernetes cluster to meet the demand of your workloads. 
 
-> [!primary]
->
-> The cluster auto-scaler feature is currently available in beta. We expect it to reach General Availability (including support in OVHcloud Control Panel) by Summer 2021.
-
 ## Before you begin
 
 This tutorial assumes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
@@ -51,6 +47,12 @@ As explained in the [How nodes and node pools work](../managing-nodes/) guide, i
 Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling on a full cluster, you enable it for one or more of your node pools.
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
+
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> 
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://www.ovh.com/auth?onsuccess=https%3A%2F%2Fwww.ovh.com%2Fmanager%2Fpublic-cloud&ovhSubsidiary=gb) or directly [using the Kubernetes API](../managing-nodes/).
 

--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-gb.md
@@ -26,7 +26,7 @@ section: Tutorials
  }
 </style>
 
-**Last updated March 23<sup>rd</sup>, 2021.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the hassle of installing or operating them. 
 
@@ -50,7 +50,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 > 
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 

--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-ie.md
@@ -26,7 +26,7 @@ section: Tutorials
  }
 </style>
 
-**Last updated March 23<sup>rd</sup>, 2021.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the hassle of installing or operating them. 
 
@@ -50,7 +50,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 > 
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 

--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-ie.md
@@ -32,10 +32,6 @@ OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the
 
 During the day-to-day life of your cluster, you may want to dynamically adjust the size of your cluster to accommodate to your workloads. The cluster autoscaler simplifies the task by scaling up or down your OVHcloud Managed Kubernetes cluster to meet the demand of your workloads. 
 
-> [!primary]
->
-> The cluster auto-scaler feature is currently available in beta. We expect it to reach General Availability (including support in OVHcloud Control Panel) by Summer 2021.
-
 ## Before you begin
 
 This tutorial assumes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
@@ -51,6 +47,12 @@ As explained in the [How nodes and node pools work](../managing-nodes/) guide, i
 Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling on a full cluster, you enable it for one or more of your node pools.
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
+
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> 
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://www.ovh.com/auth?onsuccess=https%3A%2F%2Fwww.ovh.com%2Fmanager%2Fpublic-cloud&ovhSubsidiary=ie) or directly [using the Kubernetes API](../managing-nodes/).
 

--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-sg.md
@@ -26,7 +26,7 @@ section: Tutorials
  }
 </style>
 
-**Last updated March 23<sup>rd</sup>, 2021.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the hassle of installing or operating them. 
 
@@ -50,7 +50,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 > 
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 

--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-sg.md
@@ -32,10 +32,6 @@ OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the
 
 During the day-to-day life of your cluster, you may want to dynamically adjust the size of your cluster to accommodate to your workloads. The cluster autoscaler simplifies the task by scaling up or down your OVHcloud Managed Kubernetes cluster to meet the demand of your workloads. 
 
-> [!primary]
->
-> The cluster auto-scaler feature is currently available in beta. We expect it to reach General Availability (including support in OVHcloud Control Panel) by Summer 2021.
-
 ## Before you begin
 
 This tutorial assumes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
@@ -51,6 +47,12 @@ As explained in the [How nodes and node pools work](../managing-nodes/) guide, i
 Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling on a full cluster, you enable it for one or more of your node pools.
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
+
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> 
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) or directly [using the Kubernetes API](../managing-nodes/).
 

--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-us.md
@@ -26,7 +26,7 @@ section: Tutorials
  }
 </style>
 
-**Last updated March 23<sup>rd</sup>, 2021.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the hassle of installing or operating them. 
 
@@ -50,7 +50,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 > 
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 

--- a/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/cluster-autoscaler-example/guide.en-us.md
@@ -32,10 +32,6 @@ OVHcloud Managed Kubernetes service provides you Kubernetes clusters without the
 
 During the day-to-day life of your cluster, you may want to dynamically adjust the size of your cluster to accommodate to your workloads. The cluster autoscaler simplifies the task by scaling up or down your OVHcloud Managed Kubernetes cluster to meet the demand of your workloads. 
 
-> [!primary]
->
-> The cluster auto-scaler feature is currently available in beta. We expect it to reach General Availability (including support in OVHcloud Control Panel) by Summer 2021.
-
 ## Before you begin
 
 This tutorial assumes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
@@ -51,6 +47,12 @@ As explained in the [How nodes and node pools work](../managing-nodes/) guide, i
 Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling on a full cluster, you enable it for one or more of your node pools.
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
+
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> 
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) or directly [using the Kubernetes API](../managing-nodes/).
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-asia.md
@@ -28,7 +28,7 @@ order: 7
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-asia.md
@@ -73,7 +73,7 @@ Here you have a description of the parameters used in the autoscaler configurati
 
 You can get more information on those parameters on the [Kubernetes autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md).
 
-If you consider we should reevaluate the default value and/or prioritize the possible customization of of one of those parameters, we are looking for your feedback concerning this beta feature in the [Gitter community channel around OVHcloud Managed Kubernetes service](https://gitter.im/ovh/kubernetes).
+If you consider we should reevaluate the default value and/or prioritize the possible customization of one of those parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ### Configuring the autoscaler
 
@@ -109,7 +109,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -130,7 +130,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -142,7 +142,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-au.md
@@ -28,7 +28,7 @@ order: 7
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-au.md
@@ -73,7 +73,7 @@ Here you have a description of the parameters used in the autoscaler configurati
 
 You can get more information on those parameters on the [Kubernetes autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md).
 
-If you consider we should reevaluate the default value and/or prioritize the possible customization of of one of those parameters, we are looking for your feedback concerning this beta feature in the [Gitter community channel around OVHcloud Managed Kubernetes service](https://gitter.im/ovh/kubernetes).
+If you consider we should reevaluate the default value and/or prioritize the possible customization of one of those parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ### Configuring the autoscaler
 
@@ -109,7 +109,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -130,7 +130,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -142,7 +142,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-ca.md
@@ -28,7 +28,7 @@ order: 7
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-ca.md
@@ -73,7 +73,7 @@ Here you have a description of the parameters used in the autoscaler configurati
 
 You can get more information on those parameters on the [Kubernetes autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md).
 
-If you consider we should reevaluate the default value and/or prioritize the possible customization of of one of those parameters, we are looking for your feedback concerning this beta feature in the [Gitter community channel around OVHcloud Managed Kubernetes service](https://gitter.im/ovh/kubernetes).
+If you consider we should reevaluate the default value and/or prioritize the possible customization of one of those parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ### Configuring the autoscaler
 
@@ -109,7 +109,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -130,7 +130,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -142,7 +142,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-gb.md
@@ -28,7 +28,7 @@ order: 7
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-gb.md
@@ -73,7 +73,7 @@ Here you have a description of the parameters used in the autoscaler configurati
 
 You can get more information on those parameters on the [Kubernetes autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md).
 
-If you consider we should reevaluate the default value and/or prioritize the possible customization of of one of those parameters, we are looking for your feedback concerning this beta feature in the [Gitter community channel around OVHcloud Managed Kubernetes service](https://gitter.im/ovh/kubernetes).
+If you consider we should reevaluate the default value and/or prioritize the possible customization of one of those parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ### Configuring the autoscaler
 
@@ -109,7 +109,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -130,7 +130,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -142,7 +142,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-ie.md
@@ -28,7 +28,7 @@ order: 7
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-ie.md
@@ -73,7 +73,7 @@ Here you have a description of the parameters used in the autoscaler configurati
 
 You can get more information on those parameters on the [Kubernetes autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md).
 
-If you consider we should reevaluate the default value and/or prioritize the possible customization of of one of those parameters, we are looking for your feedback concerning this beta feature in the [Gitter community channel around OVHcloud Managed Kubernetes service](https://gitter.im/ovh/kubernetes).
+If you consider we should reevaluate the default value and/or prioritize the possible customization of one of those parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ### Configuring the autoscaler
 
@@ -109,7 +109,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -130,7 +130,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -142,7 +142,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-sg.md
@@ -28,7 +28,7 @@ order: 7
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-sg.md
@@ -73,8 +73,7 @@ Here you have a description of the parameters used in the autoscaler configurati
 
 You can get more information on those parameters on the [Kubernetes autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md).
 
-If you consider we should reevaluate the default value and/or prioritize the possible customization of of one of those parameters, we are looking for your feedback concerning this beta feature in the [Gitter community channel around OVHcloud Managed Kubernetes service](https://gitter.im/ovh/kubernetes).
-
+If you consider we should reevaluate the default value and/or prioritize the possible customization of one of those parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 ### Configuring the autoscaler
 
 The easiest way to enable the autoscaler is using the Kubernetes API, for example using `kubectl`.
@@ -109,7 +108,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -130,7 +129,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -142,7 +141,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-us.md
@@ -28,7 +28,7 @@ order: 7
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 

--- a/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/configuring-cluster-autoscaler/guide.en-us.md
@@ -73,7 +73,7 @@ Here you have a description of the parameters used in the autoscaler configurati
 
 You can get more information on those parameters on the [Kubernetes autoscaler documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md).
 
-If you consider we should reevaluate the default value and/or prioritize the possible customization of of one of those parameters, we are looking for your feedback concerning this beta feature in the [Gitter community channel around OVHcloud Managed Kubernetes service](https://gitter.im/ovh/kubernetes).
+If you consider we should reevaluate the default value and/or prioritize the possible customization of one of those parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ### Configuring the autoscaler
 
@@ -109,7 +109,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -130,7 +130,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -142,7 +142,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-asia.md
@@ -44,7 +44,7 @@ We list here some external resources that can help you to go further with Kubern
 
 ## Community sites
 
-- [Our own OVH Kubernetes Gitter community](https://gitter.im/ovh/kubernetes){.external}
+- [OVHcloud Managed Kubernetes Discord channel](https://discord.com/channels/850031577277792286/955385102945370122){.external} - [Invite link](https://discord.gg/27yHfTpv9z){.external}
 - [StackOverflow Kubernetes section](https://stackoverflow.com/questions/tagged/kubernetes){.external}
 - [Reddit Kubernetes section](https://www.reddit.com/r/kubernetes/){.external}
 - [#kubernetes-users Slack channel](http://slack.k8s.io/){.external}

--- a/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-au.md
@@ -44,7 +44,7 @@ We list here some external resources that can help you to go further with Kubern
 
 ## Community sites
 
-- [Our own OVH Kubernetes Gitter community](https://gitter.im/ovh/kubernetes){.external}
+- [OVHcloud Managed Kubernetes Discord channel](https://discord.com/channels/850031577277792286/955385102945370122){.external} - [Invite link](https://discord.gg/27yHfTpv9z){.external}
 - [StackOverflow Kubernetes section](https://stackoverflow.com/questions/tagged/kubernetes){.external}
 - [Reddit Kubernetes section](https://www.reddit.com/r/kubernetes/){.external}
 - [#kubernetes-users Slack channel](http://slack.k8s.io/){.external}

--- a/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-ca.md
@@ -44,7 +44,7 @@ We list here some external resources that can help you to go further with Kubern
 
 ## Community sites
 
-- [Our own OVH Kubernetes Gitter community](https://gitter.im/ovh/kubernetes){.external}
+- [OVHcloud Managed Kubernetes Discord channel](https://discord.com/channels/850031577277792286/955385102945370122){.external} - [Invite link](https://discord.gg/27yHfTpv9z){.external}
 - [StackOverflow Kubernetes section](https://stackoverflow.com/questions/tagged/kubernetes){.external}
 - [Reddit Kubernetes section](https://www.reddit.com/r/kubernetes/){.external}
 - [#kubernetes-users Slack channel](http://slack.k8s.io/){.external}

--- a/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-gb.md
@@ -1,4 +1,33 @@
+---
+title: Recommended external resources
+excerpt: ''
+slug: recommended-external-resources
+section: Technical resources
+---
 
+**Last updated 1<sup>st</sup> July, 2019.**
+
+<style>
+ pre {
+     font-size: 14px;
+ }
+ pre.console {
+   background-color: #300A24; 
+   color: #ccc;
+   font-family: monospace;
+   padding: 5px;
+   margin-bottom: 5px;
+ }
+ pre.console code {
+   border: solid 0px transparent;
+   font-family: monospace !important;
+   font-size: 0.75em;
+   color: #ccc;
+ }
+ .small {
+     font-size: 0.75em;
+ }
+</style>
 
 # Recommended external resources
 

--- a/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-gb.md
@@ -1,34 +1,3 @@
----
-title: Recommended external resources
-excerpt: ''
-slug: recommended-external-resources
-section: Technical resources
----
-
-
-**Last updated 1<sup>st</sup> July, 2019.**
-
-<style>
- pre {
-     font-size: 14px;
- }
- pre.console {
-   background-color: #300A24; 
-   color: #ccc;
-   font-family: monospace;
-   padding: 5px;
-   margin-bottom: 5px;
- }
- pre.console code {
-   border: solid 0px transparent;
-   font-family: monospace !important;
-   font-size: 0.75em;
-   color: #ccc;
- }
- .small {
-     font-size: 0.75em;
- }
-</style>
 
 
 # Recommended external resources
@@ -44,10 +13,8 @@ We list here some external resources that can help you to go further with Kubern
 
 ## Community sites
 
-- [Our own OVH Kubernetes Gitter community](https://gitter.im/ovh/kubernetes){.external}
+- [OVHcloud Managed Kubernetes Discord channel](https://discord.com/channels/850031577277792286/955385102945370122){.external} - [Invite link](https://discord.gg/27yHfTpv9z){.external}
 - [StackOverflow Kubernetes section](https://stackoverflow.com/questions/tagged/kubernetes){.external}
 - [Reddit Kubernetes section](https://www.reddit.com/r/kubernetes/){.external}
 - [#kubernetes-users Slack channel](http://slack.k8s.io/){.external}
 - [awesome-kubernetes](https://ramitsurana.github.io/awesome-kubernetes/){.external}
-
-

--- a/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-ie.md
@@ -44,7 +44,7 @@ We list here some external resources that can help you to go further with Kubern
 
 ## Community sites
 
-- [Our own OVH Kubernetes Gitter community](https://gitter.im/ovh/kubernetes){.external}
+- [OVHcloud Managed Kubernetes Discord channel](https://discord.com/channels/850031577277792286/955385102945370122){.external} - [Invite link](https://discord.gg/27yHfTpv9z){.external}
 - [StackOverflow Kubernetes section](https://stackoverflow.com/questions/tagged/kubernetes){.external}
 - [Reddit Kubernetes section](https://www.reddit.com/r/kubernetes/){.external}
 - [#kubernetes-users Slack channel](http://slack.k8s.io/){.external}

--- a/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-sg.md
@@ -44,7 +44,7 @@ We list here some external resources that can help you to go further with Kubern
 
 ## Community sites
 
-- [Our own OVH Kubernetes Gitter community](https://gitter.im/ovh/kubernetes){.external}
+- [OVHcloud Managed Kubernetes Discord channel](https://discord.com/channels/850031577277792286/955385102945370122){.external} - [Invite link](https://discord.gg/27yHfTpv9z){.external}
 - [StackOverflow Kubernetes section](https://stackoverflow.com/questions/tagged/kubernetes){.external}
 - [Reddit Kubernetes section](https://www.reddit.com/r/kubernetes/){.external}
 - [#kubernetes-users Slack channel](http://slack.k8s.io/){.external}

--- a/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/recommended-external-resources/guide.en-us.md
@@ -44,7 +44,7 @@ We list here some external resources that can help you to go further with Kubern
 
 ## Community sites
 
-- [Our own OVH Kubernetes Gitter community](https://gitter.im/ovh/kubernetes){.external}
+- [OVHcloud Managed Kubernetes Discord channel](https://discord.com/channels/850031577277792286/955385102945370122){.external} - [Invite link](https://discord.gg/27yHfTpv9z){.external}
 - [StackOverflow Kubernetes section](https://stackoverflow.com/questions/tagged/kubernetes){.external}
 - [Reddit Kubernetes section](https://www.reddit.com/r/kubernetes/){.external}
 - [#kubernetes-users Slack channel](http://slack.k8s.io/){.external}

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-asia.md
@@ -96,6 +96,12 @@ Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling 
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
 
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> 
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
+
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) or directly [using the Kubernetes API](../managing-nodes/). 
 
 To list node pools, you can use:
@@ -167,10 +173,6 @@ NAME            FLAVOR   AUTO SCALED   MONTHLY BILLED   ANTI AFFINITY   DESIRED 
 nodepool-b2-7   b2-7     true          false            false           3         3         3            3           [...]   
 </code></pre>
 
-> [!primary]
->
-> During this beta phase, the configuration options for the cluster autoscaler are immutable, set to sensible by-default values. We plan to progressively allow our users to modify some of these parameters to better tailor them to their specific use cases.
-
 When the autoscaler is enabled on a node pool, is uses a by default configuration. To better understand the by-default configuration and its parameters, see the [Configuring the cluster autoscaler](../configuring-cluster-autoscaler/) guide.
 
 ### Configuring the autoscaler
@@ -199,7 +201,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -220,7 +222,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -232,7 +234,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-asia.md
@@ -28,7 +28,7 @@ order: 6
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 
@@ -98,7 +98,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 > 
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload. 
 

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-au.md
@@ -28,7 +28,7 @@ order: 6
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 
@@ -98,7 +98,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 >
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload.
 

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-au.md
@@ -96,6 +96,12 @@ Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling 
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
 
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+>
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload.
+
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) or directly [using the Kubernetes API](../managing-nodes/).
 
 To list node pools, you can use:
@@ -167,10 +173,6 @@ NAME            FLAVOR   AUTO SCALED   MONTHLY BILLED   ANTI AFFINITY   DESIRED 
 nodepool-b2-7   b2-7     true          false            false           3         3         3            3           [...]   
 </code></pre>
 
-> [!primary]
->
-> During this beta phase, the configuration options for the cluster autoscaler are immutable, set to sensible by-default values. We plan to progressively allow our users to modify some of these parameters to better tailor them to their specific use cases.
-
 When the autoscaler is enabled on a node pool, is uses a by default configuration. To better understand the by-default configuration and its parameters, see the [Configuring the cluster autoscaler](../configuring-cluster-autoscaler/) guide.
 
 ### Configuring the autoscaler
@@ -199,7 +201,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -220,7 +222,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -232,7 +234,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-ca.md
@@ -28,7 +28,7 @@ order: 6
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 
@@ -98,7 +98,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 >
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload.
 

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-ca.md
@@ -96,6 +96,12 @@ Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling 
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
 
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+>
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload.
+
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) or directly [using the Kubernetes API](../managing-nodes/).
 
 To list node pools, you can use:
@@ -167,10 +173,6 @@ NAME            FLAVOR   AUTO SCALED   MONTHLY BILLED   ANTI AFFINITY   DESIRED 
 nodepool-b2-7   b2-7     true          false            false           3         3         3            3           [...]   
 </code></pre>
 
-> [!primary]
->
-> During this beta phase, the configuration options for the cluster autoscaler are immutable, set to sensible by-default values. We plan to progressively allow our users to modify some of these parameters to better tailor them to their specific use cases.
-
 When the autoscaler is enabled on a node pool, is uses a by default configuration. To better understand the by-default configuration and its parameters, see the [Configuring the cluster autoscaler](../configuring-cluster-autoscaler/) guide.
 
 ### Configuring the autoscaler
@@ -199,7 +201,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -220,7 +222,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -232,7 +234,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-gb.md
@@ -28,7 +28,7 @@ order: 6
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 
@@ -98,7 +98,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 >
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload.
 

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-gb.md
@@ -96,6 +96,12 @@ Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling 
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
 
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+>
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload.
+
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) or directly [using the Kubernetes API](../managing-nodes/).
 
 To list node pools, you can use:
@@ -167,10 +173,6 @@ NAME            FLAVOR   AUTO SCALED   MONTHLY BILLED   ANTI AFFINITY   DESIRED 
 nodepool-b2-7   b2-7     true          false            false           3         3         3            3           [...]   
 </code></pre>
 
-> [!primary]
->
-> During this beta phase, the configuration options for the cluster autoscaler are immutable, set to sensible by-default values. We plan to progressively allow our users to modify some of these parameters to better tailor them to their specific use cases.
-
 When the autoscaler is enabled on a node pool, is uses a by default configuration. To better understand the by-default configuration and its parameters, see the [Configuring the cluster autoscaler](../configuring-cluster-autoscaler/) guide.
 
 ### Configuring the autoscaler
@@ -199,7 +201,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -220,7 +222,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -232,7 +234,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-ie.md
@@ -28,7 +28,7 @@ order: 6
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 
@@ -98,7 +98,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 >
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload.
 

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-ie.md
@@ -96,6 +96,12 @@ Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling 
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
 
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+>
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload.
+
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) or directly [using the Kubernetes API](../managing-nodes/).
 
 To list node pools, you can use:
@@ -167,10 +173,6 @@ NAME            FLAVOR   AUTO SCALED   MONTHLY BILLED   ANTI AFFINITY   DESIRED 
 nodepool-b2-7   b2-7     true          false            false           3         3         3            3           [...]   
 </code></pre>
 
-> [!primary]
->
-> During this beta phase, the configuration options for the cluster autoscaler are immutable, set to sensible by-default values. We plan to progressively allow our users to modify some of these parameters to better tailor them to their specific use cases.
-
 When the autoscaler is enabled on a node pool, is uses a by default configuration. To better understand the by-default configuration and its parameters, see the [Configuring the cluster autoscaler](../configuring-cluster-autoscaler/) guide.
 
 ### Configuring the autoscaler
@@ -199,7 +201,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -220,7 +222,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -232,7 +234,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-sg.md
@@ -28,7 +28,7 @@ order: 6
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 
@@ -98,7 +98,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 >
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload.
 

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-sg.md
@@ -96,6 +96,12 @@ Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling 
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
 
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+>
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload.
+
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) or directly [using the Kubernetes API](../managing-nodes/).
 
 To list node pools, you can use:
@@ -167,10 +173,6 @@ NAME            FLAVOR   AUTO SCALED   MONTHLY BILLED   ANTI AFFINITY   DESIRED 
 nodepool-b2-7   b2-7     true          false            false           3         3         3            3           [...]   
 </code></pre>
 
-> [!primary]
->
-> During this beta phase, the configuration options for the cluster autoscaler are immutable, set to sensible by-default values. We plan to progressively allow our users to modify some of these parameters to better tailor them to their specific use cases.
-
 When the autoscaler is enabled on a node pool, is uses a by default configuration. To better understand the by-default configuration and its parameters, see the [Configuring the cluster autoscaler](../configuring-cluster-autoscaler/) guide.
 
 ### Configuring the autoscaler
@@ -199,7 +201,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -220,7 +222,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -232,7 +234,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-us.md
@@ -28,7 +28,7 @@ order: 6
  }
 </style>
 
-**Last updated February 18<sup>th</sup>, 2022.**
+**Last updated May 17<sup>th</sup>, 2022.**
 
 ## Objective
 
@@ -98,7 +98,7 @@ You can activate the autoscaler on several node pools, each of which can have a 
 
 > [!primary]
 >
-> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+> In order to avoid unexpected expenses, you should be careful to not enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
 >
 > A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload.
 

--- a/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/using-cluster-autoscaler/guide.en-us.md
@@ -96,6 +96,12 @@ Autoscale is configured on a node pool basis, i.e. you don't enable autoscaling 
 
 You can activate the autoscaler on several node pools, each of which can have a different type of instance as well as different min and max nodes number limits.
 
+> [!primary]
+>
+> In order to avoid unexpected expenses, you should be careful not to enable autoscaling on monthly-billed node pools. However, you are still allowed to do so if you know what you are doing.
+>
+> A common configuration is to use non-autoscaled, monthly-billed node pools as base for your static workload, and autoscaled, hourly-billed node pools with smaller flavors for your dynamic workload.
+
 When you create your cluster, you can bootstrap a default node pool in it, and you can add others in the Public Cloud section of the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) or directly [using the Kubernetes API](../managing-nodes/).
 
 To list node pools, you can use:
@@ -167,10 +173,6 @@ NAME            FLAVOR   AUTO SCALED   MONTHLY BILLED   ANTI AFFINITY   DESIRED 
 nodepool-b2-7   b2-7     true          false            false           3         3         3            3           [...]   
 </code></pre>
 
-> [!primary]
->
-> During this beta phase, the configuration options for the cluster autoscaler are immutable, set to sensible by-default values. We plan to progressively allow our users to modify some of these parameters to better tailor them to their specific use cases.
-
 When the autoscaler is enabled on a node pool, is uses a by default configuration. To better understand the by-default configuration and its parameters, see the [Configuring the cluster autoscaler](../configuring-cluster-autoscaler/) guide.
 
 ### Configuring the autoscaler
@@ -199,7 +201,7 @@ In my example cluster:
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -220,7 +222,7 @@ nodepool.kube.cloud.ovh.com/nodepool-b2-7 patched
   "flavor": "b2-7",
   "maxNodes": 100,
   "minNodes": 0,
-  "monthlyBilled": true
+  "monthlyBilled": false
 }
 </code></pre>
 
@@ -232,7 +234,7 @@ For the moment, only these following parameters are editable:
 - minNodes
 - maxNodes
 
-You can contact us through [Gitter](https://gitter.im/ovh/kubernetes) if you need to edit other parameters and/or you can check our [public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
+If you consider that we should prioritize the possible customization of other autoscaling parameters, you are welcome to create an issue on our [Public roadmap](https://github.com/ovh/public-cloud-roadmap/projects/1).
 
 ## Go further
 


### PR DESCRIPTION
- Remove mentions of the autoscaler as a beta feature
- Remove monthly billed nodepools in the example
- Remove mentions of the Gitter channel and replace them with the Public Roadmap
- Add warning about monthly billed nodepools
- Replace k8s Gitter channel link with Discord link