### PR TITLE
Translating API guides

### DIFF
--- a/pages/account/api/first-steps/guide.de-de.md
+++ b/pages/account/api/first-steps/guide.de-de.md
@@ -9,7 +9,7 @@ section: 'Erste Schritte'
 > Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In manchen Fällen können ungenaue Formulierungen verwendet worden sein, z.B. bei der Beschriftung von Schaltflächen oder technischen Details. Bitte ziehen Sie beim geringsten Zweifel die englische oder französische Fassung der Anleitung zu Rate. Möchten Sie mithelfen, diese Übersetzung zu verbessern? Dann nutzen Sie dazu bitte den Button “Mitmachen“ auf dieser Seite.
 >
 
-**Letzte Aktualisierung am 04.06.2020**
+**Letzte Aktualisierung am 30.05.2022**
 
 ## Ziel
 

--- a/pages/account/api/first-steps/guide.de-de.md
+++ b/pages/account/api/first-steps/guide.de-de.md
@@ -1,0 +1,213 @@
+---
+title: Erste Schritte mit den OVHcloud APIs
+slug: first-steps-with-ovh-api
+excerpt: 'So verwenden Sie die OVHcloud APIs'
+section: 'Erste Schritte'
+---
+
+> [!primary]
+> Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In manchen Fällen können ungenaue Formulierungen verwendet worden sein, z.B. bei der Beschriftung von Schaltflächen oder technischen Details. Bitte ziehen Sie beim geringsten Zweifel die englische oder französische Fassung der Anleitung zu Rate. Möchten Sie mithelfen, diese Übersetzung zu verbessern? Dann nutzen Sie dazu bitte den Button “Mitmachen“ auf dieser Seite.
+>
+
+**Stand 04.06.2020**
+
+## Ziel
+
+Die auf verfügbaren APIs [https://api.ovh.com/](https://api.ovh.com/){.external} erlauben es Ihnen, OVHcloud Produkte zu kaufen, zu verwalten, zu aktualisieren und zu konfigurieren, ohne ein grafisches Interface wie das Kundencenter zu verwenden.
+
+**Hier erfahren Sie, wie Sie die OVHcloud APIs verwenden und mit Ihren Anwendungen verbinden.**
+
+## Voraussetzungen
+
+- Sie verfügen über einen aktiven OVHcloud Account und kennen dessen Zugangsdaten.
+- Sie sind auf der Webseite der [OVHcloud APIs](https://api.ovh.com/){.external}.
+
+## In der praktischen Anwendung
+
+> [!warning]
+>
+> OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
+> 
+> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen spezialisierten Dienstleister und/oder den Herausgeber des Dienstes zu kontaktieren. Für externe Dienstleistungen bietet OVHcloud leider keine Unterstützung. Genauere Informationen finden Sie im Teil „Weiterführende Informationen" dieser Anleitung.
+> 
+
+
+### Einfache Verwendung
+
+#### Mit den OVHcloud APIs verbinden
+
+Klicken Sie auf der Seite der [OVHcloud](https://api.ovh.com/) APIs auf `Explore the OVH APIs`{.action}, um die Liste der APIs anzuzeigen. 
+
+Um die APIs für Ihre Produkte zu verwenden, loggen Sie sich über Ihre OVHcloud-Zugangsdaten auf dieser Seite ein.
+
+- Klicken Sie auf `Login`{.action} oben rechts. 
+- Geben Sie Ihre OVHcloud Zugangsdaten ein. 
+- Legen Sie eine Dauer unter der Bezeichnung **Validity** fest, während der Sie Aktionen über die OVHcloud APIs erlauben.
+
+![API](images/login.png){.thumbnail} 
+
+> [!primary]
+>
+> Wenn Ihr OVHcloud Account durch [Zwei-Faktor-Authentifizierung geschützt](https://docs.ovh.com/de/customer/Account-mit-2FA-absichern/) ist, müssen Sie auch den per SMS oder OTP-Anwendung oder U2F-Schlüssel generierten Code eingeben.
+>
+
+#### Die auf den APIs verfügbaren Produkte analysieren
+
+Wenn Sie eingeloggt sind, finden Sie die Liste der OVHcloud Produkte, die über APIs verfügen. Diese Liste ist alphabetisch geordnet.
+
+![API](images/api-list.png){.thumbnail} 
+
+Um zum Beispiel die zu Domainnamen gehörenden APIs anzuzeigen, klicken Sie auf **/domain** in der Liste.
+
+Nachdem Sie auf das Produkt geklickt haben, wird unten die Liste der APIs angezeigt. 
+
+![API](images/api-displayed.png){.thumbnail} 
+
+#### Eine API ausführen
+
+Es gibt 4 verfügbare APIs, die so genannte HTTP-Methoden verwenden: 
+
+**GET** 
+
+Die GET-Methode dient dem Abruf von Daten aus einer Ressource.
+
+Um zum Beispiel die Liste Ihrer Domainnamen abzurufen, verwenden Sie folgende API:
+ 
+> [!api]
+>
+> @api {GET} /domain
+>
+
+**POST**
+
+Die POST-Methode wird verwendet, um zusätzliche Daten an die Ressource zu senden. 
+
+Um zum Beispiel einen Eintrag zu Ihrer DNS Zone hinzuzufügen, verwenden Sie folgende API:
+
+> [!api]
+>
+> @api {POST} /domain/zone/{zoneName}/record
+>
+
+**PUT**
+
+Die PUT-Methode dient dazu, die aktuellen Ressourcen-Daten durch die Daten der Abfrage zu ersetzen.
+
+Wenn Sie zum Beispiel bei einem Eintrag in Ihrer DNS Zone den Fehler gemacht haben, verwenden Sie folgende API:
+
+> [!api]
+>
+> @api {PUT} /domain/zone/{zoneName}/record/{id}
+>
+
+**DELETE**
+
+Die DELETE-Methode wird verwendet, um die so genannte Ressource zu löschen.
+
+Wenn Sie zum Beispiel den DNS-Eintrag, den Sie zu Ihrer DNS-Zone hinzugefügt haben, nicht mehr aufbewahren möchten, verwenden Sie folgende API:
+
+> [!api]
+>
+> @api {DELETE} /domain/zone/{zoneName}/record/{id}
+>
+
+##### API Einstellungen
+
+Nachdem Sie auf die API Ihrer Wahl geklickt haben, können Sie im Bereich **Parameters** die Variablen zu seiner Anwendung zuweisen.
+ 
+Um zum Beispiel einen TXT Eintrag in Ihrer DNS Zone hinzuzufügen, optimieren Sie die folgenden Einstellungen:
+ 	
+![API](images/parameters.png){.thumbnail} 
+ 
+Wenn Sie die Einstellungen festgelegt haben, können Sie die API starten, indem Sie auf `Execute`{.action} klicken. 
+
+Der angezeigte `Result`-Tab gibt Ihnen den Bericht zur Durchführung der API.
+
+![API](images/result.png){.thumbnail} 
+
+Die Tabs `PHP` und `Python` enthalten die Elemente, die je nach Sprache in Ihrem Skript hinzugefügt werden müssen.
+
+### Fortgeschrittene Nutzung: OVHcloud APIs mit einer Anwendung verbinden
+
+#### Schlüssel Ihrer Anwendung erstellen
+
+Jede Anwendung, die mit der OVHcloud API kommunizieren möchte, muss im Voraus angemeldet werden.
+
+Klicken Sie hierzu auf folgenden Link: [https://eu.api.ovh.com/createToken/](https://eu.api.ovh.com/createToken/){.external}.
+
+Geben Sie Ihre Kundenkennung, Ihr Passwort und den Namen Ihrer Anwendung ein. Der Name wird später nützlich sein, wenn Sie anderen Personen erlauben möchten, ihn zu verwenden.
+
+Sie können auch eine Beschreibung der Anwendung und eine Zeitangabe hinzufügen. 
+
+Der `Rights` Eintrag erlaubt es Ihnen, die Verwendung der Anwendung auf bestimmte APIs zu beschränken.<br>
+Um allen OVHcloud APIs für eine HTTP-Methode zu erlauben, geben Sie im Feld einen Stern `*` ein, wie im folgenden Beispiel, wo GET für alle APIs erlaubt ist:
+
+![API keys](images/api-keys.png){.thumbnail} 
+
+Wenn Sie auf `Create Keys`{.action} geklickt haben, erhalten Sie drei Schlüssel:
+
+- den so genannten **AK**. Zum Beispiel:
+
+```sh
+7kbG7Bk7S9Nt7ZSV
+```
+
+- Ihr geheimer, nicht zu veröffentlichender Anwendungsschlüssel, **AS**. Zum Beispiel:
+
+```sh
+EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
+```
+
+- ein geheimer "**Consumer Key**", nicht bekannt gegeben, **CK**. Zum Beispiel:
+
+```sh
+MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
+```
+
+Im vorliegenden Fall ist der **CK**-Schlüssel an Ihren Account gebunden.
+
+Das Token **CK** kann für die Übertragung von Rechten verwendet werden. Weitere Informationen finden Sie in folgender Anleitung: [So verwalten Sie den Account eines OVHcloud Kunden über die APIs](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (englische Anleitung).
+
+#### Erste Verwendung der API
+
+Sobald Ihre drei Schlüssel (**AK**, **AS**, **CK**) verfügbar sind, können Sie die API Anfragen unterschreiben. Die Signatur wird wie folgt berechnet:
+
+```sh
+"$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
+```
+
+Um die Entwicklung Ihrer Anwendungen zu vereinfachen, liefert Ihnen OVHcloud API-Wrapper in mehreren Sprachen.
+Wenn Sie diese verwenden, können Sie sich nicht um die Berechnung der Signatur kümmern und sich ganz auf die Entwicklung Ihrer Anwendung konzentrieren.
+
+- *Perl* : <https://eu.api.ovh.com/wrappers/OvhApi-perl-1.1.zip>
+- *Python* : <https://github.com/ovh/python-ovh>
+- *PHP* : <https://github.com/ovh/php-ovh>
+- *Node.js* : <https://github.com/ovh/node-ovh>
+- *Swift* : <https://github.com/ovh/swift-ovh>
+- *C#* : <https://github.com/ovh/csharp-ovh>
+
+Hier ein Beispiel für die Nutzung der Rubrik `/me` zur Verwaltung Ihres OVHcloud Accounts:
+
+```python
+import ovh
+
+# Instantiate. Visit https://api.ovh.com/createToken/?GET=/me
+# to get your credentials
+client = ovh.Client(
+    endpoint='ovh-eu',
+    application_key='<application key>',
+    application_secret='<application secret>',
+    consumer_key='<consumer key>',
+)
+
+# Print nice welcome message
+print("Welcome", client.get('/me')['firstname'])
+```
+
+## Weiterführende Informationen
+
+[Ihre Domainnamen über die API verwalten](https://docs.ovh.com/gb/en/api/ovh-api-domains/) (englische Dokumentation)
+
+[So verwalten Sie den Account eines OVHcloud Kunden über die APIs](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (englische Anleitung)
+
+Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com).

--- a/pages/account/api/first-steps/guide.de-de.md
+++ b/pages/account/api/first-steps/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
-title: Erste Schritte mit den OVHcloud APIs
+title: Erste Schritte mit der OVHcloud API
 slug: first-steps-with-ovh-api
-excerpt: 'So verwenden Sie die OVHcloud APIs'
+excerpt: Erfahren Sie hier, wie Sie die OVHcloud API verwenden
 section: 'Erste Schritte'
 ---
 
@@ -9,69 +9,68 @@ section: 'Erste Schritte'
 > Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In manchen Fällen können ungenaue Formulierungen verwendet worden sein, z.B. bei der Beschriftung von Schaltflächen oder technischen Details. Bitte ziehen Sie beim geringsten Zweifel die englische oder französische Fassung der Anleitung zu Rate. Möchten Sie mithelfen, diese Übersetzung zu verbessern? Dann nutzen Sie dazu bitte den Button “Mitmachen“ auf dieser Seite.
 >
 
-**Stand 04.06.2020**
+**Letzte Aktualisierung am 04.06.2020**
 
 ## Ziel
 
-Die auf verfügbaren APIs [https://api.ovh.com/](https://api.ovh.com/){.external} erlauben es Ihnen, OVHcloud Produkte zu kaufen, zu verwalten, zu aktualisieren und zu konfigurieren, ohne ein grafisches Interface wie das Kundencenter zu verwenden.
+Die unter [https://api.ovh.com/](https://api.ovh.com/){.external} verfügbare API erlauben es Ihnen, OVHcloud Produkte zu bestellen, zu verwalten, zu aktualisieren und zu konfigurieren, ohne ein grafisches Interface wie das Kundencenter zu verwenden.
 
 **Hier erfahren Sie, wie Sie die OVHcloud APIs verwenden und mit Ihren Anwendungen verbinden.**
 
 ## Voraussetzungen
 
-- Sie verfügen über einen aktiven OVHcloud Account und kennen dessen Zugangsdaten.
+- Sie verfügen über einen aktiven OVHcloud Kunden-Account und kennen dessen Zugangsdaten.
 - Sie sind auf der Webseite der [OVHcloud APIs](https://api.ovh.com/){.external}.
 
 ## In der praktischen Anwendung
 
 > [!warning]
->
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 > 
-> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen spezialisierten Dienstleister und/oder den Herausgeber des Dienstes zu kontaktieren. Für externe Dienstleistungen bietet OVHcloud leider keine Unterstützung. Genauere Informationen finden Sie im Teil „Weiterführende Informationen" dieser Anleitung.
-> 
+> Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen spezialisierten Dienstleister zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#gofurther).
+>
 
 
-### Einfache Verwendung
+### Grundlegende Funktionen
 
-#### Mit den OVHcloud APIs verbinden
+#### Verbindung mit der OVHcloud API
 
-Klicken Sie auf der Seite der [OVHcloud](https://api.ovh.com/) APIs auf `Explore the OVH APIs`{.action}, um die Liste der APIs anzuzeigen. 
+Klicken Sie auf der [OVHcloud API Seite](https://api.ovh.com/) auf `Explore the OVH API`{.action}, um die Liste der API-Funktionen anzuzeigen. 
 
-Um die APIs für Ihre Produkte zu verwenden, loggen Sie sich über Ihre OVHcloud-Zugangsdaten auf dieser Seite ein.
+Um die API für Ihre Dienste zu verwenden, loggen Sie sich mit Ihren OVHcloud Zugangsdaten ein:
 
-- Klicken Sie auf `Login`{.action} oben rechts. 
+- Klicken Sie auf oben rechts `Login`{.action}. 
 - Geben Sie Ihre OVHcloud Zugangsdaten ein. 
-- Legen Sie eine Dauer unter der Bezeichnung **Validity** fest, während der Sie Aktionen über die OVHcloud APIs erlauben.
+- Legen Sie unter der Bezeichnung **Validity** einen Zeitraum fest, währenddessen Aktionen über die OVHcloud API erlaubt sein sollen.
 
 ![API](images/login.png){.thumbnail} 
 
 > [!primary]
 >
-> Wenn Ihr OVHcloud Account durch [Zwei-Faktor-Authentifizierung geschützt](https://docs.ovh.com/de/customer/Account-mit-2FA-absichern/) ist, müssen Sie auch den per SMS oder OTP-Anwendung oder U2F-Schlüssel generierten Code eingeben.
+> Wenn Ihr OVHcloud Account durch [Zwei-Faktor-Authentifizierung](https://docs.ovh.com/de/customer/Account-mit-2FA-absichern/) geschützt ist, müssen Sie auch den per SMS, OTP-Anwendung oder U2F-Schlüssel generierten Code eingeben.
 >
 
-#### Die auf den APIs verfügbaren Produkte analysieren
+#### Die mit API verfügbaren Dienste analysieren
 
-Wenn Sie eingeloggt sind, finden Sie die Liste der OVHcloud Produkte, die über APIs verfügen. Diese Liste ist alphabetisch geordnet.
+Wenn Sie eingeloggt sind, werden alle OVHcloud Dienste, die über API-Zugang verfügen, angezeigt. Diese Liste ist alphabetisch geordnet.
 
 ![API](images/api-list.png){.thumbnail} 
 
-Um zum Beispiel die zu Domainnamen gehörenden APIs anzuzeigen, klicken Sie auf **/domain** in der Liste.
+Um zum Beispiel die zu Domainnamen gehörenden API-Aufrufe anzuzeigen, klicken Sie auf **/domain** in der Liste.
 
-Nachdem Sie auf das Produkt geklickt haben, wird unten die Liste der APIs angezeigt. 
+Nachdem Sie auf die Dienstbezeichnung geklickt haben, wird die Liste der verfügbaren API-Funktionen angezeigt. 
 
 ![API](images/api-displayed.png){.thumbnail} 
 
-#### Eine API ausführen
+#### API-Aufrufe ausführen
 
-Es gibt 4 verfügbare APIs, die so genannte HTTP-Methoden verwenden: 
+Es sind 4 HTTP-Methoden für die API verfügbar: 
 
 **GET** 
 
 Die GET-Methode dient dem Abruf von Daten aus einer Ressource.
 
-Um zum Beispiel die Liste Ihrer Domainnamen abzurufen, verwenden Sie folgende API:
+Um zum Beispiel die Liste Ihrer Domainnamen abzurufen, verwenden Sie folgenden Aufruf:
  
 > [!api]
 >
@@ -82,7 +81,7 @@ Um zum Beispiel die Liste Ihrer Domainnamen abzurufen, verwenden Sie folgende AP
 
 Die POST-Methode wird verwendet, um zusätzliche Daten an die Ressource zu senden. 
 
-Um zum Beispiel einen Eintrag zu Ihrer DNS Zone hinzuzufügen, verwenden Sie folgende API:
+Um zum Beispiel einen Eintrag zu Ihrer DNS Zone hinzuzufügen, verwenden Sie folgenden Aufruf:
 
 > [!api]
 >
@@ -93,7 +92,7 @@ Um zum Beispiel einen Eintrag zu Ihrer DNS Zone hinzuzufügen, verwenden Sie fol
 
 Die PUT-Methode dient dazu, die aktuellen Ressourcen-Daten durch die Daten der Abfrage zu ersetzen.
 
-Wenn Sie zum Beispiel bei einem Eintrag in Ihrer DNS Zone den Fehler gemacht haben, verwenden Sie folgende API:
+Um beispielsweise einen Eintrag in Ihrer DNS Zone zu korrigieren, verwenden Sie folgenden Aufruf:
 
 > [!api]
 >
@@ -102,91 +101,91 @@ Wenn Sie zum Beispiel bei einem Eintrag in Ihrer DNS Zone den Fehler gemacht hab
 
 **DELETE**
 
-Die DELETE-Methode wird verwendet, um die so genannte Ressource zu löschen.
+Die DELETE-Methode wird verwendet, um die Ressource zu löschen.
 
-Wenn Sie zum Beispiel den DNS-Eintrag, den Sie zu Ihrer DNS-Zone hinzugefügt haben, nicht mehr aufbewahren möchten, verwenden Sie folgende API:
+Um beispielsweise einen Eintrag in Ihrer DNS Zone zu löschen, verwenden Sie folgenden Aufruf:
 
 > [!api]
 >
 > @api {DELETE} /domain/zone/{zoneName}/record/{id}
 >
 
-##### API Einstellungen
+##### Parameter der API
 
-Nachdem Sie auf die API Ihrer Wahl geklickt haben, können Sie im Bereich **Parameters** die Variablen zu seiner Anwendung zuweisen.
+Nachdem Sie auf den Endpunkt Ihrer Wahl geklickt haben, können Sie im Bereich **Parameters** Ausführungsvariablen eingeben.
  
-Um zum Beispiel einen TXT Eintrag in Ihrer DNS Zone hinzuzufügen, optimieren Sie die folgenden Einstellungen:
+Um zum Beispiel einen TXT Eintrag in Ihrer DNS Zone hinzuzufügen, editieren Sie die folgenden Einstellungen:
  	
 ![API](images/parameters.png){.thumbnail} 
  
-Wenn Sie die Einstellungen festgelegt haben, können Sie die API starten, indem Sie auf `Execute`{.action} klicken. 
+Wenn Sie die Parameter festgelegt haben, können Sie die Ausführung des Aufrufs starten, indem Sie auf `Execute`{.action} klicken. 
 
-Der angezeigte `Result`-Tab gibt Ihnen den Bericht zur Durchführung der API.
+Der Tab `Result` zeigt den Bericht zur Durchführung des API-Aufrufs.
 
 ![API](images/result.png){.thumbnail} 
 
-Die Tabs `PHP` und `Python` enthalten die Elemente, die je nach Sprache in Ihrem Skript hinzugefügt werden müssen.
+Die Tabs `PHP` und `Python` enthalten die Elemente, die entsprechend der Anwendungssprache in Ihrem Skript hinzugefügt werden müssen.
 
-### Fortgeschrittene Nutzung: OVHcloud APIs mit einer Anwendung verbinden
+### Fortgeschrittene Nutzung: OVHcloud API mit einer Anwendung verbinden
 
-#### Schlüssel Ihrer Anwendung erstellen
+#### Schlüssel für Ihre Anwendung erstellen
 
-Jede Anwendung, die mit der OVHcloud API kommunizieren möchte, muss im Voraus angemeldet werden.
+Jede Anwendung, die mit der OVHcloud API kommunizieren möchte, muss zuerst freigegeben werden.
 
 Klicken Sie hierzu auf folgenden Link: [https://eu.api.ovh.com/createToken/](https://eu.api.ovh.com/createToken/){.external}.
 
-Geben Sie Ihre Kundenkennung, Ihr Passwort und den Namen Ihrer Anwendung ein. Der Name wird später nützlich sein, wenn Sie anderen Personen erlauben möchten, ihn zu verwenden.
+Geben Sie Ihre Kundenkennung, Ihr Passwort und den Namen Ihrer Anwendung ein. Der Name kann nützlich sein, um anderen Personen Zugriff zu gewähren.
 
 Sie können auch eine Beschreibung der Anwendung und eine Zeitangabe hinzufügen. 
 
-Der `Rights` Eintrag erlaubt es Ihnen, die Verwendung der Anwendung auf bestimmte APIs zu beschränken.<br>
-Um allen OVHcloud APIs für eine HTTP-Methode zu erlauben, geben Sie im Feld einen Stern `*` ein, wie im folgenden Beispiel, wo GET für alle APIs erlaubt ist:
+Der Eintrag `Rights` erlaubt es, die Verwendung der Anwendung auf bestimmte Funktionen zu beschränken.<br>
+Um eine HTTP-Methode für alle Endpunkte zu erlauben, geben Sie im Feld einen Stern (`*`) ein. Im folgenden Beispiel werden alle GET-Abfragen erlaubt:
 
 ![API keys](images/api-keys.png){.thumbnail} 
 
-Wenn Sie auf `Create Keys`{.action} geklickt haben, erhalten Sie drei Schlüssel:
+Wenn Sie auf `Create Keys`{.action} klicken, erhalten Sie drei Schlüssel:
 
-- den so genannten **AK**. Zum Beispiel:
+- Den Anwendungsschlüssel **AK**. Zum Beispiel:
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
-- Ihr geheimer, nicht zu veröffentlichender Anwendungsschlüssel, **AS**. Zum Beispiel:
+- Den geheimen, nicht zur Veröffentlichung bestimmten Anwendungsschlüssel **AS**. Zum Beispiel:
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
-- ein geheimer "**Consumer Key**", nicht bekannt gegeben, **CK**. Zum Beispiel:
+- Den geheimen, nicht zur Veröffentlichung bestimmten "**Consumer Key**" oder **CK**. Zum Beispiel:
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
-Im vorliegenden Fall ist der **CK**-Schlüssel an Ihren Account gebunden.
+In diesem Fall ist der Schlüssel vom Typ **CK** an Ihren Account gebunden.
 
-Das Token **CK** kann für die Übertragung von Rechten verwendet werden. Weitere Informationen finden Sie in folgender Anleitung: [So verwalten Sie den Account eines OVHcloud Kunden über die APIs](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (englische Anleitung).
+Der **CK**-Token kann für die Übertragung von Rechten verwendet werden. Weitere Informationen finden Sie in dieser Anleitung: [How to manage a customer’s account via OVHcloud API](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (EN).
 
 #### Erste Verwendung der API
 
-Sobald Ihre drei Schlüssel (**AK**, **AS**, **CK**) verfügbar sind, können Sie die API Anfragen unterschreiben. Die Signatur wird wie folgt berechnet:
+Sobald Ihre drei Schlüssel (**AK**, **AS**, **CK**) verfügbar sind, können Sie die API Anfragen signieren. Die Signatur wird wie folgt berechnet:
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
-Um die Entwicklung Ihrer Anwendungen zu vereinfachen, liefert Ihnen OVHcloud API-Wrapper in mehreren Sprachen.
-Wenn Sie diese verwenden, können Sie sich nicht um die Berechnung der Signatur kümmern und sich ganz auf die Entwicklung Ihrer Anwendung konzentrieren.
+Um die Entwicklung Ihrer Anwendungen zu vereinfachen, stellt OVHcloud API-Wrapper in mehreren Sprachen bereit.
+Wenn Sie diese verwenden, müssen Sie sich nicht um die Berechnung der Signatur kümmern und können sich auf die Programmierung Ihrer Anwendung konzentrieren.
 
-- *Perl* : <https://eu.api.ovh.com/wrappers/OvhApi-perl-1.1.zip>
-- *Python* : <https://github.com/ovh/python-ovh>
-- *PHP* : <https://github.com/ovh/php-ovh>
-- *Node.js* : <https://github.com/ovh/node-ovh>
-- *Swift* : <https://github.com/ovh/swift-ovh>
-- *C#* : <https://github.com/ovh/csharp-ovh>
+- *Perl*: <https://eu.api.ovh.com/wrappers/OvhApi-perl-1.1.zip>
+- *Python*: <https://github.com/ovh/python-ovh>
+- *PHP*: <https://github.com/ovh/php-ovh>
+- *Node.js*: <https://github.com/ovh/node-ovh>
+- *Swift*: <https://github.com/ovh/swift-ovh>
+- *C#*: <https://github.com/ovh/csharp-ovh>
 
-Hier ein Beispiel für die Nutzung der Rubrik `/me` zur Verwaltung Ihres OVHcloud Accounts:
+Hier ein Beispiel für die Nutzung der Rubrik `/me` zur Verwaltung Ihres OVHcloud Kunden-Accounts:
 
 ```python
 import ovh
@@ -204,10 +203,10 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Weiterführende Informationen
+## Weiterführende Informationen <a name="gofurther"></a>
 
-[Ihre Domainnamen über die API verwalten](https://docs.ovh.com/gb/en/api/ovh-api-domains/) (englische Dokumentation)
+[Domainnamen über die API verwalten](https://docs.ovh.com/gb/en/api/ovh-api-domains/) (EN)
 
-[So verwalten Sie den Account eines OVHcloud Kunden über die APIs](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (englische Anleitung)
+[OVHcloud Kunden-Account über die API verwalten](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (EN)
 
-Für den Austausch mit unserer User Community gehen Sie auf [https://community.ovh.com/en/](https://community.ovh.com).
+Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/account/api/first-steps/guide.en-asia.md
+++ b/pages/account/api/first-steps/guide.en-asia.md
@@ -5,7 +5,7 @@ excerpt: 'Learn how to use OVHcloud APIs'
 section: 'Getting started'
 ---
 
-**Last updated 5th June 2020**
+**Last updated 30th May 2022**
 
 ## Objective
 
@@ -25,7 +25,7 @@ The APIs available on [https://ca.api.ovh.com/](https://ca.api.ovh.com/){.extern
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the “Go further” section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [“Go further”](#gofurther) section of this guide.
 >
 
 
@@ -146,19 +146,19 @@ After you click `Create keys`{.action}, you will be issued three keys:
 
 - the application key, called **AK**. For example:
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - your secret application key, not to be disclosed, called **AS**. For example:
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - a secret "**consumer key**", not to be disclosed, called **CK**. For example:
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -170,7 +170,7 @@ The **CK** token can be used for rights delegation. See the following guide for 
 
 Once you have obtained your three keys (**AK**, **AS**, **CK**), you can sign API requests. The signature is calculated as follows:
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
@@ -204,7 +204,9 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Go further
+## Go further <a name="gofurther"></a>
+
+[Managing a Domain Name with the OVHcloud API](https://docs.ovh.com/asia/en/domains/api/)
 
 [How to manage a customer’s account via OVHcloud API](../api-rights-delegation/)
 

--- a/pages/account/api/first-steps/guide.en-au.md
+++ b/pages/account/api/first-steps/guide.en-au.md
@@ -5,7 +5,7 @@ excerpt: 'Learn how to use OVHcloud APIs'
 section: 'Getting started'
 ---
 
-**Last updated 5th June 2020**
+**Last updated 30th May 2022**
 
 ## Objective
 
@@ -25,7 +25,7 @@ The APIs available on [https://ca.api.ovh.com/](https://ca.api.ovh.com/){.extern
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the “Go further” section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [“Go further”](#gofurther) section of this guide.
 >
 
 
@@ -146,19 +146,19 @@ After you click `Create keys`{.action}, you will be issued three keys:
 
 - the application key, called **AK**. For example:
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - your secret application key, not to be disclosed, called **AS**. For example:
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - a secret "**consumer key**", not to be disclosed, called **CK**. For example:
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -170,7 +170,7 @@ The **CK** token can be used for rights delegation. See the following guide for 
 
 Once you have obtained your three keys (**AK**, **AS**, **CK**), you can sign API requests. The signature is calculated as follows:
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
@@ -204,7 +204,9 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Go further
+## Go further <a name="gofurther"></a>
+
+[Managing a Domain Name with the OVHcloud API](https://docs.ovh.com/au/en/domains/api/)
 
 [How to manage a customer’s account via OVHcloud API](../api-rights-delegation/)
 

--- a/pages/account/api/first-steps/guide.en-ca.md
+++ b/pages/account/api/first-steps/guide.en-ca.md
@@ -5,7 +5,7 @@ excerpt: 'Learn how to use OVHcloud APIs'
 section: 'Getting started'
 ---
 
-**Last updated 5th June 2020**
+**Last updated 30th May 2022**
 
 ## Objective
 
@@ -25,7 +25,7 @@ The APIs available on [https://ca.api.ovh.com/](https://ca.api.ovh.com/){.extern
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the “Go further” section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [“Go further”](#gofurther) section of this guide.
 >
 
 
@@ -146,19 +146,19 @@ After you click `Create keys`{.action}, you will be issued three keys:
 
 - the application key, called **AK**. For example:
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - your secret application key, not to be disclosed, called **AS**. For example:
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - a secret "**consumer key**", not to be disclosed, called **CK**. For example:
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -170,7 +170,7 @@ The **CK** token can be used for rights delegation. See the following guide for 
 
 Once you have obtained your three keys (**AK**, **AS**, **CK**), you can sign API requests. The signature is calculated as follows:
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
@@ -204,7 +204,9 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Go further
+## Go further <a name="gofurther"></a>
+
+[Managing a Domain Name with the OVHcloud API](https://docs.ovh.com/ca/en/domains/api/)
 
 [How to manage a customer’s account via OVHcloud API](../api-rights-delegation/)
 

--- a/pages/account/api/first-steps/guide.en-gb.md
+++ b/pages/account/api/first-steps/guide.en-gb.md
@@ -5,7 +5,7 @@ excerpt: 'Learn how to use OVHcloud APIs'
 section: 'Getting started'
 ---
 
-**Last updated 5th June 2020**
+**Last updated 30th May 2022**
 
 ## Objective
 
@@ -23,7 +23,7 @@ The APIs available on [https://api.ovh.com/](https://api.ovh.com/){.external} al
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the “Go further” section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [“Go further”](#gofurther) section of this guide.
 >
 
 
@@ -143,19 +143,19 @@ After you click `Create keys`{.action}, you will be issued three keys:
 
 - the application key, called **AK**. For example:
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - your secret application key, not to be disclosed, called **AS**. For example:
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - a secret "**consumer key**", not to be disclosed, called **CK**. For example:
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -167,7 +167,7 @@ The **CK** token can be used for rights delegation. See the following guide for 
 
 Once you have obtained your three keys (**AK**, **AS**, **CK**), you can sign API requests. The signature is calculated as follows:
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
@@ -199,7 +199,9 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Go further
+## Go further <a name="gofurther"></a>
+
+[Managing a Domain Name with the OVHcloud API](https://docs.ovh.com/gb/en/domains/api/)
 
 [How to manage a customer’s account via OVHcloud API](https://docs.ovh.com/gb/en/api/api-rights-delegation/)
 

--- a/pages/account/api/first-steps/guide.en-ie.md
+++ b/pages/account/api/first-steps/guide.en-ie.md
@@ -5,7 +5,7 @@ excerpt: 'Learn how to use OVHcloud APIs'
 section: 'Getting started'
 ---
 
-**Last updated 5th June 2020**
+**Last updated 30th May 2022**
 
 ## Objective
 
@@ -23,7 +23,7 @@ The APIs available on [https://api.ovh.com/](https://api.ovh.com/){.external} al
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the “Go further” section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [“Go further”](#gofurther) section of this guide.
 >
 
 ### Simple Use
@@ -142,19 +142,19 @@ After you click `Create keys`{.action}, you will be issued three keys:
 
 - the application key, called **AK**. For example:
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - your secret application key, not to be disclosed, called **AS**. For example:
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - a secret "**consumer key**", not to be disclosed, called **CK**. For example:
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -166,7 +166,7 @@ The **CK** token can be used for rights delegation. See the following guide for 
 
 Once you have obtained your three keys (**AK**, **AS**, **CK**), you can sign API requests. The signature is calculated as follows:
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
@@ -198,7 +198,9 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Go further
+## Go further <a name="gofurther"></a>
+
+[Managing a Domain Name with the OVHcloud API](https://docs.ovh.com/ie/en/domains/api/)
 
 [How to manage a customer’s account via OVHcloud API](../api-rights-delegation/)
 

--- a/pages/account/api/first-steps/guide.en-sg.md
+++ b/pages/account/api/first-steps/guide.en-sg.md
@@ -5,7 +5,7 @@ excerpt: 'Learn how to use OVHcloud APIs'
 section: 'Getting started'
 ---
 
-**Last updated 5th June 2020**
+**Last updated 30th May 2022**
 
 ## Objective
 
@@ -25,7 +25,7 @@ The APIs available on [https://ca.api.ovh.com/](https://ca.api.ovh.com/){.extern
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the “Go further” section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [“Go further”](#gofurther) section of this guide.
 >
 
 
@@ -146,19 +146,19 @@ After you click `Create keys`{.action}, you will be issued three keys:
 
 - the application key, called **AK**. For example:
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - your secret application key, not to be disclosed, called **AS**. For example:
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - a secret "**consumer key**", not to be disclosed, called **CK**. For example:
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -170,7 +170,7 @@ The **CK** token can be used for rights delegation. See the following guide for 
 
 Once you have obtained your three keys (**AK**, **AS**, **CK**), you can sign API requests. The signature is calculated as follows:
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
@@ -204,7 +204,9 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Go further
+## Go further <a name="gofurther"></a>
+
+[Managing a Domain Name with the OVHcloud API](https://docs.ovh.com/sg/en/domains/api/)
 
 [How to manage a customer’s account via OVHcloud API](../api-rights-delegation/)
 

--- a/pages/account/api/first-steps/guide.en-us.md
+++ b/pages/account/api/first-steps/guide.en-us.md
@@ -5,7 +5,7 @@ excerpt: 'Learn how to use OVHcloud APIs'
 section: 'Getting started'
 ---
 
-**Last updated 5th June 2020**
+**Last updated 30th May 2022**
 
 ## Objective
 
@@ -25,7 +25,7 @@ The APIs available on [https://ca.api.ovh.com/](https://ca.api.ovh.com/){.extern
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the “Go further” section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a specialised provider and/or the software publisher for the service if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [“Go further”](#gofurther) section of this guide.
 >
 
 
@@ -146,19 +146,19 @@ After you click `Create keys`{.action}, you will be issued three keys:
 
 - the application key, called **AK**. For example:
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - your secret application key, not to be disclosed, called **AS**. For example:
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - a secret "**consumer key**", not to be disclosed, called **CK**. For example:
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -170,7 +170,7 @@ The **CK** token can be used for rights delegation. See the following guide for 
 
 Once you have obtained your three keys (**AK**, **AS**, **CK**), you can sign API requests. The signature is calculated as follows:
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
@@ -204,7 +204,9 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Go further
+## Go further <a name="gofurther"></a>
+
+[Managing a Domain Name with the OVHcloud API](https://docs.ovh.com/us/en/domains/api/)
 
 [How to manage a customer’s account via OVHcloud API](../api-rights-delegation/)
 

--- a/pages/account/api/first-steps/guide.es-es.md
+++ b/pages/account/api/first-steps/guide.es-es.md
@@ -1,0 +1,212 @@
+---
+title: 'Primeros pasos con las API de OVHcloud'
+slug: first-steps-with-ovh-api
+excerpt: 'Cómo utilizar las API de OVHcloud'
+section: 'Primeros pasos'
+---
+
+> [!primary]
+> Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón "Contribuir" de esta página.
+>
+
+**Última actualización: 04/06/2020**
+
+## Objetivo
+
+Las API disponibles en [https://api.ovh.com/](https://api.ovh.com/){.external} le permiten adquirir, gestionar, actualizar y configurar productos de OVHcloud sin utilizar una interfaz gráfica como el área de cliente.
+
+**Cómo utilizar las API de OVHcloud y cómo asociarlas a sus aplicaciones**
+
+## Requisitos
+
+- Disponer de una cuenta de OVHcloud activa y conocer sus claves de acceso.
+- Estar en la página web de las [API de OVHcloud](https://api.ovh.com/){.external}.
+
+## Procedimiento
+
+> [!warning]
+>
+> La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
+> 
+> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado «Más información» de esta guía.
+>
+
+### Uso sencillo
+
+#### Conectarse a la API de OVHcloud
+
+En la página de las [API de OVHcloud](https://api.ovh.com/), haga clic en `Explore the OVH API`{.action} para ver la lista de API. 
+
+Para utilizar las API en sus productos, debe conectarse a este sitio web con sus claves de OVHcloud.
+
+- Haga clic en `Login`{.action} en la parte superior derecha. 
+- Introduzca sus claves de OVHcloud. 
+- Establezca una temporalidad bajo el botón **Validity**, durante la cual podrá autorizar las acciones a través de la API de OVHcloud.
+
+![API](images/login.png){.thumbnail} 
+
+> [!primary]
+>
+> Si su cuenta de OVHcloud está protegida por una [doble autenticación](https://docs.ovh.com/es/customer/proteger-su-cuenta-con-una-2FA/), también deberá introducir el código generado por SMS o aplicación OTP o llave U2F.
+>
+
+#### Explorar los productos disponibles en las API
+
+Una vez que se haya conectado, podrá consultar la lista de productos de OVHcloud que disponen de las API. Esta lista se ordena por orden alfabético.
+
+![API](images/api-list.png){.thumbnail} 
+
+Para ver, por ejemplo, las API asociadas a los dominios, haga clic en **/domain** en la lista.
+
+Haga clic en el producto para ver la lista de las API del mismo. 
+
+![API](images/api-displayed.png){.thumbnail} 
+
+#### Ejecutar una API
+
+Existen 4 tipos de API disponibles que utilizan los denominados métodos HTTP: 
+
+**GET** 
+
+El objetivo de la solución GET es recuperar los datos de un recurso.
+
+Por ejemplo, para consultar la lista de dominios, utilice la siguiente API:
+ 
+> [!api]
+>
+> @api {GET} /domain
+>
+
+**POST**
+
+El método POST se utiliza para enviar datos adicionales al recurso. 
+
+Por ejemplo, para añadir un registro a su zona DNS, utilice la siguiente API:
+
+> [!api]
+>
+> @api {POST} /domain/zone/{zoneName}/record
+>
+
+**PUT**
+
+El método PUT se utiliza para sustituir los datos actuales del recurso por los datos de la consulta.
+
+Por ejemplo, si se ha equivocado al guardar la zona DNS, utilice la siguiente API:
+
+> [!api]
+>
+> @api {PUT} /domain/zone/{zoneName}/record/{id}
+>
+
+**DELETE**
+
+El método DELETE se utiliza para eliminar el recurso llamado.
+
+Por ejemplo, si no desea conservar el registro DNS que ha añadido a su zona DNS, utilice la siguiente API:
+
+> [!api]
+>
+> @api {DELETE} /domain/zone/{zoneName}/record/{id}
+>
+
+##### Parámetros de la API
+
+Haga clic en la API que desee y seleccione **Parameters** para asignar las variables relativas a su aplicación.
+
+Por ejemplo, para añadir un registro TXT a su zona DNS, podrá elegir los siguientes parámetros:
+
+![API](images/parameters.png){.thumbnail} 
+
+Una vez configurados los parámetros, puede ejecutar la API haciendo clic en `Execute`{.action}. 
+
+La pestaña `Result` mostrará el informe de ejecución de la API.
+
+![API](images/result.png){.thumbnail} 
+
+Las pestañas `PHP` y `Python` contienen los elementos que se añadirán al script en función del idioma utilizado.
+
+### Uso avanzado: combinar las API de OVHcloud con una aplicación
+
+#### Crear las claves de su aplicación
+
+Todas las aplicaciones que quieran comunicarse con la API de OVHcloud deben notificarse con antelación.
+
+Para ello, haga clic en el siguiente enlace: [https://eu.api.ovh.com/createToken/](https://eu.api.ovh.com/createToken/){.external}.
+
+Introduzca su identificador de cliente, su contraseña y el nombre de su aplicación. El nombre será útil más adelante si desea permitir que otras personas lo usen.
+
+También puede añadir una descripción de la aplicación y una temporalidad. 
+
+El campo `Rights` le permite restringir el uso de la aplicación a determinadas API.<br>
+Para autorizar todas las API de OVHcloud para un método HTTP, introduzca una estrella `*` en el campo, como en el siguiente ejemplo, en el que está autorizado el método GET para todas las API:
+
+![API keys](images/api-keys.png){.thumbnail} 
+
+Al hacer clic en `Create keys`{.action}, obtendrá tres llaves:
+
+- la clave de aplicación, llamada **AK**. Por ejemplo:
+
+```sh
+7kbG7Bk7S9Nt7ZSV
+```
+
+- su clave secreta, a no divulgar, llamada **AS**. Por ejemplo:
+
+```sh
+EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
+```
+
+- una clave "**consumer key**" secreta, a no divulgar, llamada **CK**. Por ejemplo:
+
+```sh
+MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
+```
+
+En este caso, la clave **CK** está asociada a su cuenta.
+
+El token **CK** puede utilizarse para delegar permisos. Para más información, consulte la siguiente guía: [Cómo gestionar la cuenta de un cliente de OVHcloud a través de las API](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (guía en inglés).
+
+#### Uso inicial de la API
+
+Una vez que haya obtenido las tres claves (**AK**, **AS**, **CK**), puede firmar las solicitudes de API. La firma se calcula de la siguiente manera:
+
+```sh
+"$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
+```
+
+Para simplificar el desarrollo de sus aplicaciones, OVHcloud le proporciona wrappers API en varios lenguajes.
+Utilizarlas le permitirá no preocuparse por el cálculo de la firma y centrarse en el desarrollo de su aplicación.
+
+- *Perl* : <https://eu.api.ovh.com/wrappers/OvhApi-perl-1.1.zip>
+- *Python* : <https://github.com/ovh/python-ovh>
+- *PHP* : <https://github.com/ovh/php-ovh>
+- *Node.js* : <https://github.com/ovh/node-ovh>
+- *Swift* : <https://github.com/ovh/swift-ovh>
+- *C#* : <https://github.com/ovh/csharp-ovh>
+
+Este es un ejemplo de uso de la sección `/me`, que permite gestionar su cuenta de OVHcloud:
+
+```python
+import ovh
+
+# Instantiate. Visit https://api.ovh.com/createToken/?GET=/me
+# to get your credentials
+client = ovh.Client(
+    endpoint='ovh-eu',
+    application_key='<application key>',
+    application_secret='<application secret>',
+    consumer_key='<consumer key>',
+)
+
+# Print nice welcome message
+print("Welcome", client.get('/me')['firstname'])
+```
+
+## Más información
+
+[Gestionar los dominios a través de la API](https://docs.ovh.com/es/domains/api/) (documentación en inglés)
+
+[Cómo gestionar la cuenta de un cliente de OVHcloud a través de las API](https://docs.ovh.com/us/en/api/api-rights-delegation/) (guía en inglés)
+
+Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/account/api/first-steps/guide.es-es.md
+++ b/pages/account/api/first-steps/guide.es-es.md
@@ -9,7 +9,7 @@ section: 'Primeros pasos'
 > Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón "Contribuir" de esta página.
 >
 
-**Última actualización: 04/06/2020**
+**Última actualización: 30/05/2022**
 
 ## Objetivo
 
@@ -28,7 +28,7 @@ Las API disponibles en [https://api.ovh.com/](https://api.ovh.com/){.external} l
 >
 > La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
 > 
-> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado «Más información» de esta guía.
+> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado [«Más información»](#gofurther) de esta guía.
 >
 
 ### Uso sencillo
@@ -147,19 +147,19 @@ Al hacer clic en `Create keys`{.action}, obtendrá tres llaves:
 
 - la clave de aplicación, llamada **AK**. Por ejemplo:
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - su clave secreta, a no divulgar, llamada **AS**. Por ejemplo:
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - una clave "**consumer key**" secreta, a no divulgar, llamada **CK**. Por ejemplo:
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -171,7 +171,7 @@ El token **CK** puede utilizarse para delegar permisos. Para más información, 
 
 Una vez que haya obtenido las tres claves (**AK**, **AS**, **CK**), puede firmar las solicitudes de API. La firma se calcula de la siguiente manera:
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
@@ -203,7 +203,7 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Más información
+## Más información <a name="gofurther"></a>
 
 [Gestionar los dominios a través de la API](https://docs.ovh.com/es/domains/api/) (documentación en inglés)
 

--- a/pages/account/api/first-steps/guide.es-us.md
+++ b/pages/account/api/first-steps/guide.es-us.md
@@ -1,0 +1,212 @@
+---
+title: 'Primeros pasos con las API de OVHcloud'
+slug: first-steps-with-ovh-api
+excerpt: 'Cómo utilizar las API de OVHcloud'
+section: 'Primeros pasos'
+---
+
+> [!primary]
+> Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón "Contribuir" de esta página.
+>
+
+**Última actualización: 04/06/2020**
+
+## Objetivo
+
+Las API disponibles en [https://ca.api.ovh.com/](https://ca.api.ovh.com/){.external} le permiten adquirir, gestionar, actualizar y configurar productos de OVHcloud sin utilizar una interfaz gráfica como el área de cliente.
+
+**Cómo utilizar las API de OVHcloud y cómo asociarlas a sus aplicaciones**
+
+## Requisitos
+
+- Disponer de una cuenta de OVHcloud activa y conocer sus claves de acceso.
+- Estar en la página web de las [API de OVHcloud](https://ca.api.ovh.com/){.external}.
+
+## Procedimiento
+
+> [!warning]
+>
+> La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
+> 
+> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado «Más información» de esta guía.
+>
+
+### Uso sencillo
+
+#### Conectarse a la API de OVHcloud
+
+En la página de las [API de OVHcloud](https://ca.api.ovh.com/), haga clic en `Explore the OVH API`{.action} para ver la lista de API. 
+
+Para utilizar las API en sus productos, debe conectarse a este sitio web con sus claves de OVHcloud.
+
+- Haga clic en `Login`{.action} en la parte superior derecha. 
+- Introduzca sus claves de OVHcloud. 
+- Establezca una temporalidad bajo el botón **Validity**, durante la cual podrá autorizar las acciones a través de la API de OVHcloud.
+
+![API](images/login.png){.thumbnail} 
+
+> [!primary]
+>
+> Si su cuenta de OVHcloud está protegida por una [doble autenticación](https://docs.ovh.com/us/es/customer/proteger-su-cuenta-con-una-2FA/), también deberá introducir el código generado por SMS o aplicación OTP o llave U2F.
+>
+
+#### Explorar los productos disponibles en las API
+
+Una vez que se haya conectado, podrá consultar la lista de productos de OVHcloud que disponen de las API. Esta lista se ordena por orden alfabético.
+
+![API](images/api-list.png){.thumbnail} 
+
+Para ver, por ejemplo, las API asociadas a los dominios, haga clic en **/domain** en la lista.
+
+Haga clic en el producto para ver la lista de las API del mismo. 
+
+![API](images/api-displayed.png){.thumbnail} 
+
+#### Ejecutar una API
+
+Existen 4 tipos de API disponibles que utilizan los denominados métodos HTTP: 
+
+**GET** 
+
+El objetivo de la solución GET es recuperar los datos de un recurso.
+
+Por ejemplo, para consultar la lista de dominios, utilice la siguiente API:
+ 
+> [!api]
+>
+> @api {GET} /domain
+>
+
+**POST**
+
+El método POST se utiliza para enviar datos adicionales al recurso. 
+
+Por ejemplo, para añadir un registro a su zona DNS, utilice la siguiente API:
+
+> [!api]
+>
+> @api {POST} /domain/zone/{zoneName}/record
+>
+
+**PUT**
+
+El método PUT se utiliza para sustituir los datos actuales del recurso por los datos de la consulta.
+
+Por ejemplo, si se ha equivocado al guardar la zona DNS, utilice la siguiente API:
+
+> [!api]
+>
+> @api {PUT} /domain/zone/{zoneName}/record/{id}
+>
+
+**DELETE**
+
+El método DELETE se utiliza para eliminar el recurso llamado.
+
+Por ejemplo, si no desea conservar el registro DNS que ha añadido a su zona DNS, utilice la siguiente API:
+
+> [!api]
+>
+> @api {DELETE} /domain/zone/{zoneName}/record/{id}
+>
+
+##### Parámetros de la API
+
+Haga clic en la API que desee y seleccione **Parameters** para asignar las variables relativas a su aplicación.
+
+Por ejemplo, para añadir un registro TXT a su zona DNS, podrá elegir los siguientes parámetros:
+
+![API](images/parameters.png){.thumbnail} 
+
+Una vez configurados los parámetros, puede ejecutar la API haciendo clic en `Execute`{.action}. 
+
+La pestaña `Result` mostrará el informe de ejecución de la API.
+
+![API](images/result.png){.thumbnail} 
+
+Las pestañas `PHP` y `Python` contienen los elementos que se añadirán al script en función del idioma utilizado.
+
+### Uso avanzado: combinar las API de OVHcloud con una aplicación
+
+#### Crear las claves de su aplicación
+
+Todas las aplicaciones que quieran comunicarse con la API de OVHcloud deben notificarse con antelación.
+
+Para ello, haga clic en el siguiente enlace: [https://ca.api.ovh.com/createToken/](https://ca.api.ovh.com/createToken/){.external}.
+
+Introduzca su identificador de cliente, su contraseña y el nombre de su aplicación. El nombre será útil más adelante si desea permitir que otras personas lo usen.
+
+También puede añadir una descripción de la aplicación y una temporalidad. 
+
+El campo `Rights` le permite restringir el uso de la aplicación a determinadas API.<br>
+Para autorizar todas las API de OVHcloud para un método HTTP, introduzca una estrella `*` en el campo, como en el siguiente ejemplo, en el que está autorizado el método GET para todas las API:
+
+![API keys](images/api-keys.png){.thumbnail} 
+
+Al hacer clic en `Create keys`{.action}, obtendrá tres llaves:
+
+- la clave de aplicación, llamada **AK**. Por ejemplo:
+
+```sh
+7kbG7Bk7S9Nt7ZSV
+```
+
+- su clave secreta, a no divulgar, llamada **AS**. Por ejemplo:
+
+```sh
+EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
+```
+
+- una clave "**consumer key**" secreta, a no divulgar, llamada **CK**. Por ejemplo:
+
+```sh
+MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
+```
+
+En este caso, la clave **CK** está asociada a su cuenta.
+
+El token **CK** puede utilizarse para delegar permisos. Para más información, consulte la siguiente guía: [Cómo gestionar la cuenta de un cliente de OVHcloud a través de las API](https://docs.ovh.com/us/en/api/api-rights-delegation/) (guía en inglés).
+
+#### Uso inicial de la API
+
+Una vez que haya obtenido las tres claves (**AK**, **AS**, **CK**), puede firmar las solicitudes de API. La firma se calcula de la siguiente manera:
+
+```sh
+"$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
+```
+
+Para simplificar el desarrollo de sus aplicaciones, OVHcloud le proporciona wrappers API en varios lenguajes.
+Utilizarlas le permitirá no preocuparse por el cálculo de la firma y centrarse en el desarrollo de su aplicación.
+
+- *Perl* : <https://ca.api.ovh.com/wrappers/OvhApi-perl-1.1.zip>
+- *Python* : <https://github.com/ovh/python-ovh>
+- *PHP* : <https://github.com/ovh/php-ovh>
+- *Node.js* : <https://github.com/ovh/node-ovh>
+- *Swift* : <https://github.com/ovh/swift-ovh>
+- *C#* : <https://github.com/ovh/csharp-ovh>
+
+Este es un ejemplo de uso de la sección `/me`, que permite gestionar su cuenta de OVHcloud:
+
+```python
+import ovh
+
+# Instantiate. Visit https://ca.api.ovh.com/createToken/?GET=/me
+# to get your credentials
+client = ovh.Client(
+    endpoint='ovh-eu',
+    application_key='<application key>',
+    application_secret='<application secret>',
+    consumer_key='<consumer key>',
+)
+
+# Print nice welcome message
+print("Welcome", client.get('/me')['firstname'])
+```
+
+## Más información
+
+[Gestionar los dominios a través de la API](https://docs.ovh.com/us/es/domains/api/) (documentación en inglés)
+
+[Cómo gestionar la cuenta de un cliente de OVHcloud a través de las API](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (guía en inglés)
+
+Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/account/api/first-steps/guide.es-us.md
+++ b/pages/account/api/first-steps/guide.es-us.md
@@ -9,7 +9,7 @@ section: 'Primeros pasos'
 > Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón "Contribuir" de esta página.
 >
 
-**Última actualización: 04/06/2020**
+**Última actualización: 30/05/2022**
 
 ## Objetivo
 
@@ -28,7 +28,7 @@ Las API disponibles en [https://ca.api.ovh.com/](https://ca.api.ovh.com/){.exter
 >
 > La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionen correctamente.
 > 
-> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado «Más información» de esta guía.
+> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado [«Más información»](#gofurther) de esta guía.
 >
 
 ### Uso sencillo
@@ -147,19 +147,19 @@ Al hacer clic en `Create keys`{.action}, obtendrá tres llaves:
 
 - la clave de aplicación, llamada **AK**. Por ejemplo:
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - su clave secreta, a no divulgar, llamada **AS**. Por ejemplo:
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - una clave "**consumer key**" secreta, a no divulgar, llamada **CK**. Por ejemplo:
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -171,7 +171,7 @@ El token **CK** puede utilizarse para delegar permisos. Para más información, 
 
 Una vez que haya obtenido las tres claves (**AK**, **AS**, **CK**), puede firmar las solicitudes de API. La firma se calcula de la siguiente manera:
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
@@ -203,7 +203,7 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Más información
+## Más información <a name="gofurther"></a>
 
 [Gestionar los dominios a través de la API](https://docs.ovh.com/us/es/domains/api/) (documentación en inglés)
 

--- a/pages/account/api/first-steps/guide.fr-ca.md
+++ b/pages/account/api/first-steps/guide.fr-ca.md
@@ -5,7 +5,7 @@ excerpt: 'Découvrez comment utiliser les API OVHcloud'
 section: 'Premiers pas'
 ---
 
-**Dernière mise à jour le 04/06/2020**
+**Dernière mise à jour le 30/05/2022**
 
 ## Objectif
 
@@ -24,9 +24,8 @@ Les API disponibles sur [https://ca.api.ovh.com/](https://ca.api.ovh.com/){.exte
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 > 
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un prestataire spécialisé et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un prestataire spécialisé et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « [Aller plus loin ](#gofurther) » de ce guide.
 > 
-
 
 ### Utilisation simple
 
@@ -144,19 +143,19 @@ Après avoir cliqué sur `Create keys`{.action}, Vous obtiendrez trois clés :
 
 - la clé d'application, appelée **AK**. Par exemple :
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - votre clé d'application secrète, à ne pas divulguer, appelée **AS**. Par exemple :
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - une « **consumer key** » secrète, à ne pas divulguer, appelée **CK**. Par exemple :
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -169,7 +168,7 @@ Le token **CK** peut être utilisé pour de la délégation de droits. Consultez
 
 Une fois vos trois clés obtenues (**AK**, **AS**, **CK**), vous pouvez signer les demandes d'API. La signature est calculée ainsi :
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
@@ -201,9 +200,9 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Aller plus loin
+## Aller plus loin <a name="gofurther"></a>
 
- 
+[Gestion d'un nom de domaine via les API OVHcloud](https://docs.ovh.com/ca/fr/domains/api/)
 
 [Comment gérer le compte d'un client OVHcloud via les API](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (guide en anglais)
 

--- a/pages/account/api/first-steps/guide.fr-ca.md
+++ b/pages/account/api/first-steps/guide.fr-ca.md
@@ -1,6 +1,6 @@
 ---
 title: 'Premiers pas avec les API OVHcloud'
-slug: api-premiers-pas
+slug: first-steps-with-ovh-api
 excerpt: 'Découvrez comment utiliser les API OVHcloud'
 section: 'Premiers pas'
 ---

--- a/pages/account/api/first-steps/guide.fr-fr.md
+++ b/pages/account/api/first-steps/guide.fr-fr.md
@@ -1,6 +1,6 @@
 ---
 title: 'Premiers pas avec les API OVHcloud'
-slug: api-premiers-pas
+slug: first-steps-with-ovh-api
 excerpt: 'Découvrez comment utiliser les API OVHcloud'
 section: 'Premiers pas'
 ---

--- a/pages/account/api/first-steps/guide.fr-fr.md
+++ b/pages/account/api/first-steps/guide.fr-fr.md
@@ -5,7 +5,7 @@ excerpt: 'Découvrez comment utiliser les API OVHcloud'
 section: 'Premiers pas'
 ---
 
-**Dernière mise à jour le 04/06/2020**
+**Dernière mise à jour le 30/05/2022**
 
 ## Objectif
 
@@ -24,7 +24,7 @@ Les API disponibles sur [https://api.ovh.com/](https://api.ovh.com/){.external} 
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 > 
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un prestataire spécialisé et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un prestataire spécialisé et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « [Aller plus loin ](#gofurther) » de ce guide.
 > 
 
 
@@ -144,19 +144,19 @@ Après avoir cliqué sur `Create keys`{.action}, Vous obtiendrez trois clés :
 
 - la clé d'application, appelée **AK**. Par exemple :
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - votre clé d'application secrète, à ne pas divulguer, appelée **AS**. Par exemple :
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - une « **consumer key** » secrète, à ne pas divulguer, appelée **CK**. Par exemple :
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -169,7 +169,7 @@ Le token **CK** peut être utilisé pour de la délégation de droits. Consultez
 
 Une fois vos trois clés obtenues (**AK**, **AS**, **CK**), vous pouvez signer les demandes d'API. La signature est calculée ainsi :
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
@@ -201,9 +201,9 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Aller plus loin
+## Aller plus loin <a name="gofurther"></a>
 
-[Utilisation des API sur Private Cloud](../../private-cloud/connexion-a-l-api-ovh/)
+[Gestion d'un nom de domaine via les API OVHcloud](https://docs.ovh.com/fr/domains/api/)
 
 [Comment gérer le compte d'un client OVHcloud via les API](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (guide en anglais)
 

--- a/pages/account/api/first-steps/guide.it-it.md
+++ b/pages/account/api/first-steps/guide.it-it.md
@@ -9,7 +9,7 @@ section: 'Per iniziare'
 > Questa traduzione è stata generata automaticamente dal nostro partner SYSTRAN. I contenuti potrebbero presentare imprecisioni, ad esempio la nomenclatura dei pulsanti o alcuni dettagli tecnici. In caso di dubbi consigliamo di fare riferimento alla versione inglese o francese della guida. Per aiutarci a migliorare questa traduzione, utilizza il pulsante "Modifica" di questa pagina.
 >
 
-**Ultimo aggiornamento: 04/06/2020**
+**Ultimo aggiornamento: 30/05/2022**
 
 ## Obiettivo
 
@@ -28,7 +28,7 @@ Le API disponibili su [https://api.ovh.com/](https://api.ovh.com/){.external} ti
 >
 > OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente.
 > 
-> Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato o l’amministratore del servizio. OVH non può fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione “Per saperne di più”.
+> Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato o l’amministratore del servizio. OVH non può fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione “[Per saperne di più](#gofurther)”.
 > 
 
 
@@ -148,19 +148,19 @@ Dopo aver cliccato su `Create keys`{.action}, ottieni tre chiavi:
 
 - la chiave di applicazione, chiamata **AK**. Ad esempio:
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - la chiave segreta da non divulgare, chiamata **AS**. Ad esempio:
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - una segreta "**consumer key**" da non divulgare, chiamata **CK**. Ad esempio:
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -173,7 +173,7 @@ Il token **CK** può essere utilizzato per la delega dei diritti. Per saperne di
 
 Una volta ottenute le tre chiavi (**AK**, **AS**, **CK**), puoi firmare le richieste di API. La firma è calcolata come segue:
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+" + CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP
 ```
 
@@ -205,7 +205,7 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Per saperne di più
+## Per saperne di più <a name="gofurther"></a>
 
 [Gestire un dominio tramite le API OVHcloud](https://docs.ovh.com/it/domains/api/) (guida in inglese)
 

--- a/pages/account/api/first-steps/guide.it-it.md
+++ b/pages/account/api/first-steps/guide.it-it.md
@@ -1,0 +1,214 @@
+---
+title: Iniziare a utilizzare le API OVHcloud
+slug: first-steps-with-ovh-api
+excerpt: Come utilizzare le API OVHcloud
+section: 'Per iniziare'
+---
+
+> [!primary]
+> Questa traduzione è stata generata automaticamente dal nostro partner SYSTRAN. I contenuti potrebbero presentare imprecisioni, ad esempio la nomenclatura dei pulsanti o alcuni dettagli tecnici. In caso di dubbi consigliamo di fare riferimento alla versione inglese o francese della guida. Per aiutarci a migliorare questa traduzione, utilizza il pulsante "Modifica" di questa pagina.
+>
+
+**Ultimo aggiornamento: 04/06/2020**
+
+## Obiettivo
+
+Le API disponibili su [https://api.ovh.com/](https://api.ovh.com/){.external} ti permettono di acquistare, gestire, aggiornare e configurare prodotti OVHcloud senza utilizzare un'interfaccia grafica come lo Spazio Cliente.
+
+**Scopri come utilizzare le API OVHcloud e come associarle alle tue applicazioni**
+
+## Prerequisiti
+
+- Disporre di un account OVHcloud attivo e conoscere le proprie credenziali
+- Essere sulla pagina Web delle [API OVHcloud](https://api.ovh.com/){.external}.
+
+## Procedura
+
+> [!warning]
+>
+> OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente.
+> 
+> Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato o l’amministratore del servizio. OVH non può fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione “Per saperne di più”.
+> 
+
+
+### Utilizzo semplice
+
+#### Accedi alle API OVHcloud
+
+Nella pagina delle [API OVHcloud](https://api.ovh.com/) clicca su `Explore the OVH API`{.action} per visualizzare la lista delle API. 
+
+Per utilizzare le API sui tuoi prodotti, accedi al sito utilizzando le credenziali OVHcloud.
+
+- Clicca su `Login`{.action} in alto a destra. 
+- Inserisci le credenziali OVHcloud 
+- Definisci una data, sotto la voce **Validity**, durante la quale autorizzi le azioni tramite le API OVHcloud.
+
+![API](images/login.png){.thumbnail} 
+
+> [!primary]
+>
+> Se il tuo account OVHcloud è protetto da una [doppia autenticazione](https://docs.ovh.com/it/customer/proteggi_il_tuo_account_con_2FA/), inserisci anche il codice generato tramite SMS o applicazione OTP o chiave U2F.
+>
+
+#### Esplora i prodotti disponibili sulle API
+
+Una volta connesso, visualizzi la lista dei prodotti OVHcloud che dispongono delle API. Tale elenco è classificato in ordine alfabetico.
+
+![API](images/api-list.png){.thumbnail} 
+
+Per visualizzare, ad esempio, le API associate ai domini, clicca su **/domain** nella lista.
+
+Dopo aver cliccato sul prodotto, visualizzi la lista delle API del prodotto. 
+
+![API](images/api-displayed.png){.thumbnail} 
+
+#### Esegui un'API
+
+Esistono 4 tipi di API disponibili che utilizzano i cosiddetti metodi HTTP: 
+
+**GET** 
+
+La modalità GET ha lo scopo di recuperare i dati di una risorsa.
+
+Ad esempio, per recuperare la lista dei tuoi domini, utilizza questa API:
+ 
+> [!api]
+>
+> @api {GET} /domain
+>
+
+**POST**
+
+Il metodo POST è utilizzato per inviare dati aggiuntivi alla risorsa. 
+
+Ad esempio, per aggiungere un record alla tua zona DNS, utilizza questa API:
+
+> [!api]
+>
+> @api {POST} /domain/zone/{zoneName}/record
+>
+
+**PUT**
+
+Il metodo PUT serve a sostituire i dati attuali della risorsa con i dati della richiesta.
+
+Ad esempio, in caso di errore nel record della tua zona DNS, utilizza questa API:
+
+> [!api]
+>
+> @api {PUT} /domain/zone/{zoneName}/record/{id}
+>
+
+**DELETE**
+
+Il metodo DELETE è utilizzato per eliminare la risorsa chiamata.
+
+Ad esempio, se non vuoi conservare il record DNS che hai aggiunto alla tua zona DNS, utilizza questa API:
+
+> [!api]
+>
+> @api {DELETE} /domain/zone/{zoneName}/record/{id}
+>
+
+##### Impostazioni dell'API
+
+Dopo aver cliccato sull'API di tua scelta, la sezione **Parameters** permette di attribuire le variabili relative alla sua applicazione.
+ 
+Ad esempio, per aggiungere un record TXT nella tua zona DNS, ottieni questi parametri:
+
+![API](images/parameters.png){.thumbnail} 
+
+Una volta definiti i parametri, puoi avviare l'API cliccando su `Execute`{.action}. 
+
+La scheda `Result` mostrata fornirà il report di esecuzione dell'API.
+
+![API](images/result.png){.thumbnail} 
+
+Le schede `PHP` e `Python` contengono gli elementi da aggiungere al tuo script in base al linguaggio utilizzato.
+
+### Utilizzo avanzato: associare le API OVHcloud con un'applicazione
+
+#### Crea le chiavi della tua applicazione
+
+Qualsiasi applicazione che desideri comunicare con l'API OVHcloud deve essere dichiarata in anticipo.
+
+Clicca su questo link: [https://eu.api.ovh.com/createToken/](https://eu.api.ovh.com/createToken/){.external}.
+
+Inserisci il tuo identificativo cliente, la password e il nome della tua applicazione. Il nome sarà utile più tardi se volete autorizzare altre persone a usarlo.
+
+È inoltre possibile aggiungere una descrizione dell'applicazione e una temporalità. 
+
+Il campo `Rights` ti permette di limitare l'utilizzo dell'applicazione a certe API.<br>
+Per autorizzare tutte le API OVHcloud per un metodo HTTP, inserisci una stella `*` nel campo, come nell'esempio qui sotto, dove il metodo GET è autorizzato per tutte le API:
+
+![API keys](images/api-keys.png){.thumbnail} 
+
+Dopo aver cliccato su `Create keys`{.action}, ottieni tre chiavi:
+
+- la chiave di applicazione, chiamata **AK**. Ad esempio:
+
+```sh
+7kbG7Bk7S9Nt7ZSV
+```
+
+- la chiave segreta da non divulgare, chiamata **AS**. Ad esempio:
+
+```sh
+EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
+```
+
+- una segreta "**consumer key**" da non divulgare, chiamata **CK**. Ad esempio:
+
+```sh
+MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
+```
+
+In questo caso, la chiave **CK** è associata al tuo account.
+
+Il token **CK** può essere utilizzato per la delega dei diritti. Per saperne di più, consulta questa guida: [Come gestire l'account di un cliente OVHcloud tramite le API](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (guida in inglese).
+
+
+#### Primo utilizzo dell'API
+
+Una volta ottenute le tre chiavi (**AK**, **AS**, **CK**), puoi firmare le richieste di API. La firma è calcolata come segue:
+
+```sh
+"$1$" + SHA1_HEX(AS+"+" + CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP
+```
+
+Per semplificare lo sviluppo delle tue applicazioni, OVHcloud mette a disposizione wrappers API in diversi linguaggi.
+Utilizzarli ti permette di non preoccuparti del calcolo della firma e di concentrarti sullo sviluppo della tua applicazione.
+
+- *Perl* : <https://eu.api.ovh.com/wrappers/OvhApi-perl-1.1.zip>
+- *Python* : <https://github.com/ovh/python-ovh>
+- *PHP* : <https://github.com/ovh/php-ovh>
+- *Node.js* : <https://github.com/ovh/node-ovh>
+- *Swift* : <https://github.com/ovh/swift-ovh>
+- *C#* : <https://github.com/ovh/csharp-ovh>
+
+Ecco un esempio di utilizzo della sezione `/me` che permette di gestire il tuo account OVHcloud:
+
+```python
+import ovh
+
+# Instantiate. Visit https://api.ovh.com/createToken/?GET=/me
+# to get your credentials
+client = ovh.Client(
+    endpoint='ovh-eu',
+    application_key='<application key>',
+    application_secret='<application secret>',
+    consumer_key='<consumer key>',
+)
+
+# Print nice welcome message
+print("Welcome", client.get('/me')['firstname'])
+```
+
+## Per saperne di più
+
+[Gestire un dominio tramite le API OVHcloud](https://docs.ovh.com/it/domains/api/) (guida in inglese)
+
+[Come gestire l'account di un cliente OVHcloud tramite le API](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (guida in inglese)
+
+Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en](https://community.ovh.com/en/)

--- a/pages/account/api/first-steps/guide.pl-pl.md
+++ b/pages/account/api/first-steps/guide.pl-pl.md
@@ -9,7 +9,7 @@ section: 'Pierwsze kroki'
 > Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera SYSTRAN. W niektórych przypadkach mogą wystąpić nieprecyzyjne sformułowania, na przykład w tłumaczeniu nazw przycisków lub szczegółów technicznych. W przypadku jakichkolwiek wątpliwości zalecamy zapoznanie się z angielską/francuską wersją przewodnika. Jeśli chcesz przyczynić się do ulepszenia tłumaczenia, kliknij przycisk „Zaproponuj zmianę” na tej stronie.
 >
 
-**Ostatnia aktualizacja z dnia 04-06-2020**
+**Ostatnia aktualizacja z dnia 30-05-2022**
 
 ## Wprowadzenie
 
@@ -28,7 +28,7 @@ API dostępne na stronie [https://api.ovh.com/](https://api.ovh.com/){.external}
 >
 > OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
 > 
-> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVH nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji „Sprawdź również”.
+> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVH nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji „[Sprawdź również](#gofurther)”.
 > 
 
 ### Proste użytkowanie
@@ -147,19 +147,19 @@ Po kliknięciu `Create keys`{.action} otrzymasz trzy klucze:
 
 - Klucz aplikacji zwany **AK**. Przykład:
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - klucza aplikacji, który nie zostanie ujawniony, o nazwie **AS**. Przykład:
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - tajnej "**consumer key**", której nie ujawnia się, zwanej **CK**. Przykład:
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -171,7 +171,7 @@ Token **CK** może być wykorzystywany do przekazywania uprawnień. Więcej info
 
 Po uzyskaniu trzech kluczy (**AK**, **AS**, **CK**) możesz podpisać zlecenia API. Podpis oblicza się w następujący sposób:
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
@@ -203,7 +203,7 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Sprawdź również
+## Sprawdź również <a name="gofurther"></a>
 
 [Zarządzanie domeną poprzez API OVHcloud](https://docs.ovh.com/it/domains/api/) (przewodnik po angielsku)
 

--- a/pages/account/api/first-steps/guide.pl-pl.md
+++ b/pages/account/api/first-steps/guide.pl-pl.md
@@ -1,0 +1,212 @@
+---
+title: 'Pierwsze kroki z API OVHcloud'
+slug: first-steps-with-ovh-api
+excerpt: 'Dowiedz się, jak korzystać z API OVHcloud'
+section: 'Pierwsze kroki'
+---
+
+> [!primary]
+> Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera SYSTRAN. W niektórych przypadkach mogą wystąpić nieprecyzyjne sformułowania, na przykład w tłumaczeniu nazw przycisków lub szczegółów technicznych. W przypadku jakichkolwiek wątpliwości zalecamy zapoznanie się z angielską/francuską wersją przewodnika. Jeśli chcesz przyczynić się do ulepszenia tłumaczenia, kliknij przycisk „Zaproponuj zmianę” na tej stronie.
+>
+
+**Ostatnia aktualizacja z dnia 04-06-2020**
+
+## Wprowadzenie
+
+API dostępne na stronie [https://api.ovh.com/](https://api.ovh.com/){.external} pozwalają na zakup, zarządzanie i konfigurowanie produktów OVHcloud bez konieczności korzystania z interfejsu graficznego, takiego jak Panel klienta.
+
+**Dowiedz się, jak korzystać z API OVHcloud oraz jak je łączyć z Twoimi aplikacjami**
+
+## Wymagania początkowe
+
+- Posiadanie aktywnego konta OVHcloud i znanie jego identyfikatorów
+- Bycie na stronie WWW [API OVHcloud](https://api.ovh.com/){.external}.
+
+## W praktyce
+
+> [!warning]
+>
+> OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
+> 
+> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVH nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji „Sprawdź również”.
+> 
+
+### Proste użytkowanie
+
+#### Logowanie do API OVHcloud
+
+Na stronie [API OVHcloud](https://api.ovh.com/) kliknij `Explore the OVH API`{.action}, aby wyświetlić listę API. 
+
+Aby korzystać z API na produktach, należy zalogować się na tej stronie za pomocą identyfikatora OVHcloud.
+
+- W prawym górnym rogu kliknij `Login`{.action}. 
+- Wpisz dane dostępowe OVHcloud. 
+- Określ czas, z określeniem **Validity**, podczas którego zezwalasz na wykonywanie operacji przez API OVHcloud.
+
+![API](images/login.png){.thumbnail} 
+
+> [!primary]
+>
+> Jeśli Twoje konto OVHcloud jest chronione [weryfikacją dwuetapową](https://docs.ovh.com/pl/customer/zabezpieczenie-konta-za-pomoca-2FA/), wpisz również kod wygenerowany w wiadomości SMS lub aplikacji OTP lub klucz U2F.
+>
+
+#### Sprawdź produkty dostępne na API
+
+Po zalogowaniu się znajdziesz listę produktów OVHcloud wyposażonych w API. Wykaz ten jest uporządkowany alfabetycznie.
+
+![API](images/api-list.png){.thumbnail} 
+
+Aby wyświetlić na przykład API powiązane z domenami, kliknij na **/domain** na liście.
+
+Po kliknięciu na produkt lista API tego produktu wyświetla się poniżej. 
+
+![API](images/api-displayed.png){.thumbnail} 
+
+#### Uruchom API
+
+Dostępne są 4 rodzaje API, które wykorzystują tak zwane metody HTTP: 
+
+**GET** 
+
+Metoda GET ma na celu odzyskanie danych z zasobu.
+
+Na przykład, aby pobrać listę Twoich domen, użyj następującego API:
+ 
+> [!api]
+>
+> @api {GET} /domena
+>
+
+**POST**
+
+Metoda POST jest wykorzystywana do wysyłania dodatkowych danych do zasobu. 
+
+Na przykład, aby dodać rekord do strefy DNS, użyj następującego API:
+
+> [!api]
+>
+> @api {POST} /domena/zone/{zoneName}/record
+>
+
+**PUT**
+
+Metoda PUT służy do zastąpienia aktualnych danych dotyczących zasobu danymi zapytania.
+
+Na przykład, jeśli popełniłeś błąd podczas zapisywania strefy DNS, użyj następującego API:
+
+> [!api]
+>
+> @api {PUT} /domena/zone/{zoneName}/record/{id}
+>
+
+**DELETE**
+
+Metoda DELETE jest używana do usuwania nazwanego zasobu.
+
+Na przykład, jeśli nie chcesz zachować rekordu DNS, który dodałeś do strefy DNS, użyj następującego API:
+
+> [!api]
+>
+> @api {DELETE} /domena/zone/{zoneName}/record/{id}
+>
+
+##### **Parametry API**
+
+Po kliknięciu na API w wybranej przez Ciebie sekcji **Parameters** możesz przypisać zmienne związane z aplikacją.
+ 
+Na przykład, aby dodać rekord TXT do strefy DNS, zoptymalizujesz następujące parametry:
+
+![API](images/parameters.png){.thumbnail} 
+ 
+Po zdefiniowaniu ustawień możesz uruchomić API klikając `Execute`{.action}. 
+
+W zakładce `Result` wyświetli się raport z realizacji API.
+
+![API](images/result.png){.thumbnail} 
+
+Zakładki `PHP` i `Python` zawierają elementy, które należy dodać do skryptu w zależności od używanego języka.
+
+### Zaawansowane wykorzystanie: łączenie API OVHcloud z aplikacją
+
+#### Utwórz klucze aplikacji
+
+Każda aplikacja, która chce komunikować się z API OVHcloud, musi zostać zgłoszona z wyprzedzeniem.
+
+W tym celu kliknij link: [https://eu.api.ovh.com/createToken/](https://eu.api.ovh.com/createToken/){.external}.
+
+Wpisz identyfikator klienta, hasło i nazwę aplikacji. Nazwa będzie pomocna później, jeśli chcesz zezwolić innym na jej używanie.
+
+Możesz również dodać opis aplikacji oraz czas jej trwania. 
+
+Zakres `Rights` pozwala na ograniczenie korzystania z aplikacji do niektórych API.
+<br> Aby zezwolić wszystkim API OVHcloud dla metody HTTP, wprowadź gwiazdkę `*` w polu, jak w poniższym przykładzie, w którym metoda GET jest dozwolona dla wszystkich API:
+
+![API keys](images/api-keys.png){.thumbnail} 
+
+Po kliknięciu `Create keys`{.action} otrzymasz trzy klucze:
+
+- Klucz aplikacji zwany **AK**. Przykład:
+
+```sh
+7kbG7Bk7S9Nt7ZSV
+```
+
+- klucza aplikacji, który nie zostanie ujawniony, o nazwie **AS**. Przykład:
+
+```sh
+EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
+```
+
+- tajnej "**consumer key**", której nie ujawnia się, zwanej **CK**. Przykład:
+
+```sh
+MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
+```
+
+W tym przypadku klucz **CK** jest przypisany do Twojego konta.
+
+Token **CK** może być wykorzystywany do przekazywania uprawnień. Więcej informacji znajdziesz w przewodniku: [Jak zarządzać kontem klienta OVHcloud za pomocą API](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (przewodnik po języku angielskim).
+
+#### Pierwsze wykorzystanie API
+
+Po uzyskaniu trzech kluczy (**AK**, **AS**, **CK**) możesz podpisać zlecenia API. Podpis oblicza się w następujący sposób:
+
+```sh
+"$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
+```
+
+Aby uprościć programowanie aplikacji, OVHcloud udostępnia wrappery API w kilku językach.
+Dzięki nim nie będziesz martwił się o obliczenia podpisu i będziesz mógł skupić się na rozwoju Twojej aplikacji.
+
+- *Perl* : <https://eu.api.ovh.com/wrappers/OvhApi-perl-1.1.zip>
+- *Python* : <https://github.com/ovh/python-ovh>
+- *PHP* : <https://github.com/ovh/php-ovh>
+- *Node.js* : <https://github.com/ovh/node-ovh>
+- *Swift* : <https://github.com/ovh/swift-ovh>
+- *C#* : <https://github.com/ovh/csharp-ovh>
+
+Przykład zastosowania sekcji `/me`, która pozwala na zarządzanie kontem OVHcloud:
+
+```python
+import ovh
+
+# Instantiate. Visit https://api.ovh.com/createToken/?GET=/me
+# to get your credentials
+client = ovh.Client(
+    endpoint='ovh-eu',
+    application_key='<application key>',
+    application_secret='<application secret>',
+    consumer_key='<consumer key>',
+)
+
+# Print nice welcome message
+print("Welcome", client.get('/me')['firstname'])
+```
+
+## Sprawdź również
+
+[Zarządzanie domeną poprzez API OVHcloud](https://docs.ovh.com/it/domains/api/) (przewodnik po angielsku)
+
+[Jak zarządzać kontem klienta OVHcloud za pomocą API](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (przewodnik po angielsku)
+
+Przyłącz się do społeczności naszych użytkowników na stronie [https://community.ovh.com/en/](https://community.ovh.com/en/)

--- a/pages/account/api/first-steps/guide.pt-pt.md
+++ b/pages/account/api/first-steps/guide.pt-pt.md
@@ -1,0 +1,214 @@
+---
+title: 'Primeiros passos com as API OVHcloud'
+slug: first-steps-with-ovh-api
+excerpt: 'Saiba como utilizar as API da OVHcloud'
+section: Introdução
+---
+
+> [!primary]
+> Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certos casos, poderão ocorrer formulações imprecisas, como por exemplo nomes de botões ou detalhes técnicos. Recomendamos que consulte a versão inglesa ou francesa do manual, caso tenha alguma dúvida. Se nos quiser ajudar a melhorar esta tradução, clique em "Contribuir" nesta página.
+>
+
+**Última atualização: 04/06/2020**
+
+## Objetivo
+
+As API disponíveis em [https://api.ovh.com/](https://api.ovh.com/){.external} permitem-lhe adquirir, gerir, atualizar e configurar produtos OVHcloud sem utilizar uma interface gráfica como a Área de Cliente.
+
+**Saiba como utilizar as API da OVHcloud e como associá-las às suas aplicações**
+
+## Requisitos
+
+- Ter uma conta OVHcloud ativa e conhecer os seus identificadores.
+- Estar na página web das [API OVHcloud](https://api.ovh.com/){.external}.
+
+## Instruções
+
+> [!warning]
+>
+> A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
+> 
+> Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um prestador de serviços especializado e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção «Quer saber mais?» deste guia.
+> 
+
+
+### Utilização simples
+
+#### Ligar-se às API OVHcloud
+
+Na página das [API OVHcloud](https://api.ovh.com/), clique em `Explore the OVH API`{.action} para apresentar a lista das API. 
+
+Para utilizar as API nos seus produtos, deve ligar-se a este site graças aos seus identificadores OVHcloud.
+
+- Clique em `Login`{.action} no canto superior direito. 
+- Introduza as suas credenciais OVHcloud. 
+- Defina uma duração, sob a menção **Validity**, durante a qual autoriza as ações através das API OVHcloud.
+
+![API](images/login.png){.thumbnail} 
+
+> [!primary]
+>
+> Se a sua conta OVHcloud estiver protegida por uma [dupla autenticação](https://docs.ovh.com/pt/customer/proteger-a-sua-conta-com-uma-2FA/), deverá também introduzir o código gerado por SMS ou aplicação OTP ou chave U2F.
+>
+
+#### Explorar os produtos disponíveis nas API
+
+Uma vez ligado, encontrará a lista dos produtos da OVHcloud que dispõem das API. Esta lista será classificada por ordem alfabética.
+
+![API](images/api-list.png){.thumbnail} 
+
+Para apresentar, por exemplo, as API associadas aos nomes de domínio, clique em **/domain** na lista.
+
+Depois de clicar no produto, a lista das API deste último é apresentada por baixo. 
+
+![API](images/api-displayed.png){.thumbnail} 
+
+#### Executar uma API
+
+Existem 4 tipos de API disponíveis que utilizam os chamados métodos HTTP: 
+
+**GET** 
+
+O método GET tem como objetivo recuperar os dados de um recurso.
+
+Por exemplo, para obter a lista dos seus nomes de domínio, utilize a seguinte API:
+ 
+> [!api]
+>
+> @api {GET} /domain
+>
+
+**POST**
+
+O método POST é utilizado para enviar dados suplementares para o recurso. 
+
+Por exemplo, para adicionar um registo à sua zona DNS, utilize a seguinte API:
+
+> [!api]
+>
+> @api {POST} /domain/zone/{zoneName}/record
+>
+
+**PUT**
+
+O método PUT serve para substituir os dados atuais do recurso pelos dados do pedido.
+
+Por exemplo, se se enganou num registo da sua zona DNS, utilize a seguinte API:
+
+> [!api]
+>
+> @api {PUT} /domain/zone/{zoneName}/record/{id}
+>
+
+**LETE**
+
+O método DELETE é utilizado para eliminar o recurso chamado.
+
+Por exemplo, se não deseja conservar o registo DNS que adicionou à sua zona DNS, utilize a seguinte API:
+
+> [!api]
+>
+> @api {DELETE}  /domain/zone/{zoneName}/record/{id}
+>
+
+##### Parâmetros da API
+
+Depois de clicar na API à sua escolha, a secção **Parameters** permite atribuir as variáveis relativas à sua aplicação.
+
+Por exemplo, para adicionar um registo TXT à sua zona DNS, poderá escolher os seguintes parâmetros:
+
+![API](images/parameters.png){.thumbnail} 
+
+Depois de definir os parâmetros, pode lançar a API clicando em `Execute`{.action}. 
+
+O separador `Result` apresentado dar-lhe-á o relatório de execução da API.
+
+![API](images/result.png){.thumbnail} 
+
+Os separadores `PHP` e `Python` contêm os elementos que devem ser adicionados no script em função da linguagem utilizada.
+
+### Utilização avançada: associar as API OVHcloud a uma aplicação
+
+#### Criar as chaves da sua aplicação
+
+Qualquer aplicação que pretenda comunicar com a API da OVHcloud deve ser declarada previamente.
+
+Para isso, clique na seguinte ligação: [https://eu.api.ovh.com/createToken/](https://eu.api.ovh.com/createToken/){.external}.
+
+Indique o seu ID de cliente, a sua palavra-passe e o nome da sua aplicação. O nome será útil mais tarde se quiser autorizar outras pessoas a utilizá-lo.
+
+Também pode adicionar uma descrição da aplicação, bem como um calendário. 
+
+O campo `Rights` permite-lhe limitar a utilização da aplicação a certas API.
+<br> Para autorizar todas as API da OVHcloud para um método HTTP, insira uma estrela `*` no campo, como no exemplo abaixo onde o método GET é autorizado para todas as API:
+
+![API keys](images/api-keys.png){.thumbnail} 
+
+Depois de clicar em `Create keys`{.action}, irá obter três chaves:
+
+- a chave de aplicação, chamada **AK**. Por exemplo:
+
+```sh
+7kbG7Bk7S9Nt7ZSV
+```
+
+- a sua chave de aplicação secreta, para não divulgar, chamada **AS**. Por exemplo:
+
+```sh
+EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
+```
+
+- um "**consumer key**" secreto, a não divulgar, chamado **CK**. Por exemplo:
+
+```sh
+MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
+```
+
+Neste caso, a chave **CK** está associada à sua conta.
+
+O token **CK** pode ser utilizado para a delegação de direitos. Para saber mais, consulte o seguinte guia: [Como gerir a conta de um cliente OVHcloud através das API](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (guia em inglês).
+
+
+#### Primeira utilização da API
+
+Depois de obter as três chaves (**AK**, **AS**, **CK**), pode assinar os pedidos de API. A assinatura é calculada do seguinte modo:
+
+```sh
+"$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
+```
+
+Para simplificar o desenvolvimento das suas aplicações, a OVHcloud fornece-lhe wrappers API em várias linguagens.
+Utilizá-los-á para que não se preocupe com o cálculo da assinatura e se concentre no desenvolvimento da sua aplicação.
+
+- *Perl* : <https://eu.api.ovh.com/wrappers/OvhApi-perl-1.1.zip>
+- *Python* : <https://github.com/ovh/python-ovh>
+- *PHP* : <https://github.com/ovh/php-ovh>
+- *Node.js* : <https://github.com/ovh/node-ovh>
+- *Swift* : <https://github.com/ovh/swift-ovh>
+- *C#* : <https://github.com/ovh/csharp-ovh>
+
+Eis um exemplo de utilização da secção `/me` que permite gerir a sua conta OVHcloud:
+
+```python
+import ovh
+
+# Instantiate. Visit https://api.ovh.com/createToken/?GET=/me
+# to get your credentials
+client = ovh.Client(
+    endpoint='ovh-eu',
+    application_key='<application key>',
+    application_secret='<application secret>',
+    consumer_key='<consumer key>',
+)
+
+# Print nice welcome message
+print("Welcome", client.get('/me')['firstname'])
+```
+
+## Saiba mais
+
+[Gerir um domínio através das API OVHcloud](https://docs.ovh.com/pt/domains/api/) (guia em inglês)
+
+[Como gerir a conta de um cliente OVHcloud através das API](https://docs.ovh.com/gb/en/api/api-rights-delegation/) (guia em inglês)
+
+Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/).

--- a/pages/account/api/first-steps/guide.pt-pt.md
+++ b/pages/account/api/first-steps/guide.pt-pt.md
@@ -9,7 +9,7 @@ section: Introdução
 > Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certos casos, poderão ocorrer formulações imprecisas, como por exemplo nomes de botões ou detalhes técnicos. Recomendamos que consulte a versão inglesa ou francesa do manual, caso tenha alguma dúvida. Se nos quiser ajudar a melhorar esta tradução, clique em "Contribuir" nesta página.
 >
 
-**Última atualização: 04/06/2020**
+**Última atualização: 30/05/2022**
 
 ## Objetivo
 
@@ -28,7 +28,7 @@ As API disponíveis em [https://api.ovh.com/](https://api.ovh.com/){.external} p
 >
 > A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
 > 
-> Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um prestador de serviços especializado e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção «Quer saber mais?» deste guia.
+> Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades, recomendamos que recorra a um prestador de serviços especializado e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção «[Quer saber mais?](#gofurther)» deste guia.
 > 
 
 
@@ -148,19 +148,19 @@ Depois de clicar em `Create keys`{.action}, irá obter três chaves:
 
 - a chave de aplicação, chamada **AK**. Por exemplo:
 
-```sh
+```console
 7kbG7Bk7S9Nt7ZSV
 ```
 
 - a sua chave de aplicação secreta, para não divulgar, chamada **AS**. Por exemplo:
 
-```sh
+```console
 EXEgWIz07P0HYwtQDs7cNIqCiQaWSuHF
 ```
 
 - um "**consumer key**" secreto, a não divulgar, chamado **CK**. Por exemplo:
 
-```sh
+```console
 MtSwSrPpNjqfVSmJhLbPyr2i45lSwPU1
 ```
 
@@ -173,7 +173,7 @@ O token **CK** pode ser utilizado para a delegação de direitos. Para saber mai
 
 Depois de obter as três chaves (**AK**, **AS**, **CK**), pode assinar os pedidos de API. A assinatura é calculada do seguinte modo:
 
-```sh
+```console
 "$1$" + SHA1_HEX(AS+"+"+CK+"+"+METHOD+"+"+QUERY+"+"+BODY+"+"+TSTAMP)
 ```
 
@@ -205,7 +205,7 @@ client = ovh.Client(
 print("Welcome", client.get('/me')['firstname'])
 ```
 
-## Saiba mais
+## Saiba mais <a name="gofurther"></a>
 
 [Gerir um domínio através das API OVHcloud](https://docs.ovh.com/pt/domains/api/) (guia em inglês)
 

--- a/pages/account/api/product.de-de.md
+++ b/pages/account/api/product.de-de.md
@@ -1,0 +1,7 @@
+---
+title: API
+slug: api
+excerpt: OVHcloud und Products APIv6
+sections: Erste Schritte, APIv6
+order: 03
+---

--- a/pages/account/api/product.es-es.md
+++ b/pages/account/api/product.es-es.md
@@ -1,0 +1,7 @@
+---
+title: API
+slug: api
+excerpt: Utilizar las APIv6 de OVHcloud
+sections: Primeros pasos, APIv6 OVHcloud
+order: 03
+---

--- a/pages/account/api/product.es-us.md
+++ b/pages/account/api/product.es-us.md
@@ -1,0 +1,7 @@
+---
+title: API
+slug: api
+excerpt: Utilizar las APIv6 de OVHcloud
+sections: Primeros pasos, APIv6 OVHcloud
+order: 03
+---

--- a/pages/account/api/product.it-it.md
+++ b/pages/account/api/product.it-it.md
@@ -1,0 +1,7 @@
+---
+title: API
+slug: api
+excerpt: Utilizzatore le APIv6 OVHcloud
+sections: Per iniziare, APIv6
+order: 03
+---

--- a/pages/account/api/product.pl-pl.md
+++ b/pages/account/api/product.pl-pl.md
@@ -1,0 +1,7 @@
+---
+title: API
+slug: api
+excerpt: Korzystanie z APIv6 OVHcloud
+Sections: Pierwsze kroki, APIv6
+order: 03
+---

--- a/pages/account/api/product.pt-pt.md
+++ b/pages/account/api/product.pt-pt.md
@@ -1,0 +1,7 @@
+---
+title: API
+slug: api
+excerpt: OVHcloud e Produtos APIv6
+Sections: Introdução, APIv6
+order: 03
+---

--- a/pages/account/universe.de-de.md
+++ b/pages/account/universe.de-de.md
@@ -1,5 +1,5 @@
 ---
-title: Accountverwaltung
+title: API / Accountverwaltung
 slug: account
 excerpt: Verwalten Sie Ihren Account und die dazugehörigen Rechnungsinformationen bei OVHcloud
 color: grey

--- a/pages/account/universe.es-es.md
+++ b/pages/account/universe.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: API / Gestión de cuenta 
 slug: account
-excerpt: Gestione sus cuentas y su facturación de OVH
+excerpt: Gestione sus cuentas y su facturacion de OVHcloud
 color: grey
 img: icone-user.png
 order: 4

--- a/pages/account/universe.es-us.md
+++ b/pages/account/universe.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: API / Gestion de cuenta
 slug: account
-excerpt: Gestione sus cuentas y su facturacion de OVH
+excerpt: Gestione sus cuentas y su facturacion de OVHcloud
 color: grey
 img: icone-user.png
 order: 1

--- a/pages/account/universe.fr-ca.md
+++ b/pages/account/universe.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: API / Gestion de compte 
 slug: account
-excerpt: Gérez vos comptes et votre facturation chez OVH
+excerpt: Gérez vos comptes et votre facturation chez OVHcloud
 color: grey
 img: icone-user.png
 order: 4

--- a/pages/account/universe.fr-fr.md
+++ b/pages/account/universe.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: API / Gestion de compte 
 slug: account
-excerpt: Gérez vos comptes et votre facturation chez OVH
+excerpt: Gérez vos comptes et votre facturation chez OVHcloud
 color: grey
 img: icone-user.png
 order: 4

--- a/pages/account/universe.fr-ma.md
+++ b/pages/account/universe.fr-ma.md
@@ -1,8 +1,0 @@
----
-title: API / Gestion de compte 
-slug: account
-excerpt: Gérez vos comptes et votre facturation chez OVH
-color: grey
-img: icone-user.png
-order: 4
----

--- a/pages/account/universe.fr-sn.md
+++ b/pages/account/universe.fr-sn.md
@@ -1,8 +1,0 @@
----
-title: API / Gestion de compte 
-slug: account
-excerpt: Gérez vos comptes et votre facturation chez OVH
-color: grey
-img: icone-user.png
-order: 4
----

--- a/pages/account/universe.fr-tn.md
+++ b/pages/account/universe.fr-tn.md
@@ -1,8 +1,0 @@
----
-title: API / Gestion de compte 
-slug: account
-excerpt: Gérez vos comptes et votre facturation chez OVH
-color: grey
-img: icone-user.png
-order: 4
----

--- a/pages/account/universe.it-it.md
+++ b/pages/account/universe.it-it.md
@@ -1,7 +1,7 @@
 ---
-title: API / Account management
+title: API / Gestione account
 slug: account
-excerpt: Manage your accounts and billing preferences at OVH
+excerpt: Gestisci i tuoi account e la tua fatturazione in OVHcloud
 color: grey
 img: icone-user.png
 order: 4

--- a/pages/account/universe.pl-pl.md
+++ b/pages/account/universe.pl-pl.md
@@ -1,7 +1,7 @@
 ---
-title: 'Zarządzanie kontem'
+title: API / Zarządzanie kontem
 slug: account
-excerpt: 'Zarządzaj kontem klienta i płatnościami'
+excerpt: Zarządzanie kontami i płatnościami w OVHcloud
 color: grey
 img: icone-user.png
 order: 4

--- a/pages/account/universe.pt-pt.md
+++ b/pages/account/universe.pt-pt.md
@@ -1,7 +1,7 @@
 ---
-title: API / Account management
+title: API / Gestão de conta
 slug: account
-excerpt: Manage your accounts and billing preferences at OVH
+excerpt: Faça a gestão das suas contas e faturação na OVHcloud
 color: grey
 img: icone-user.png
 order: 4


### PR DESCRIPTION
- Missing translations for First steps with the OVHcloud API
- Missing API product pages
- Updates of the API / Account universe pages
- Deletion of deprecated API product pages
- Slugs edition of fr-fr and fr-ca First Steps with the OVHcloud API pages - redirections to be added