### PR TITLE
Update guide.fr-fr.md de "cryptée" à "chiffrée"

### DIFF
--- a/pages/platform/public-cloud/public-cloud-first-steps/guide.fr-fr.md
+++ b/pages/platform/public-cloud/public-cloud-first-steps/guide.fr-fr.md
@@ -25,7 +25,7 @@ Les instances Pubic Cloud OVHcloud nécessitent une approche différente de cell
 
 ### Étape 1 :  Créer des clés SSH
 
-Le protocole SSH assure une communication client-serveur cryptée. L'utilisation des clés SSH améliore encore la sécurité en empêchant toute connexion à partir d'un périphérique qui ne possède pas la clé correspondante. La création d'un jeu de clés SSH vous fournit une clé publique et une clé privée.
+Le protocole SSH assure une communication client-serveur chiffrée. L'utilisation des clés SSH améliore encore la sécurité en empêchant toute connexion à partir d'un périphérique qui ne possède pas la clé correspondante. La création d'un jeu de clés SSH vous fournit une clé publique et une clé privée.
 
 - La **clé publique** sera ajoutée à votre instance Public Cloud lors de son installation.
 


### PR DESCRIPTION
Salut à toute l'équipe OVH!
Tout d'abord un grand merci pour votre travail et vos efforts formidables pour proposer à vos clients public cloud des offres équivalentes aux offres qu'on pourraient voir ailleurs. Etant moi meme client OVH depuis longtemps et cette année 2022 client public cloud, je commence à m'habituer aux fonctionnalités que je trouve simple à utiliser. Quant à la facturation unifiée, c'est un "game changer" comme on dit dans le milieu anglo-saxon. Pour en venir au sujet:
Possible typo entre "cryptée" et "chiffrée". J'ai voulu garder le terme des puristes et correct pour que le grand public s'habitue au terme correct.
Cependant cela dépend de votre charte éditoriale et du vocabulaire que vous préférez employer. Je reste ouvert à vos remarques et propositions.