### PR TITLE
EN-GB: add section about service account tokens to installing-kubernetes-dashboard

### DIFF
--- a/pages/platform/kubernetes-k8s/installing-kubernetes-dashboard/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/installing-kubernetes-dashboard/guide.en-gb.md
@@ -152,6 +152,35 @@ It should display something like this:
 clusterrolebinding.rbac.authorization.k8s.io/admin-user created
 </code></pre>
 
+### Create a Secret ServiceAccountToken
+
+In Kubernetes v1.24.0 Secret API objects containing service account tokens are no longer auto-generated for every ServiceAccount. Because of this, we'll need to create it ourselves.
+
+To do this, please copy the following YAML into `service-account-token.yml` file:
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: admin-user-token
+  namespace: kubernetes-dashboard
+  annotations:
+    kubernetes.io/service-account.name: admin-user
+```
+
+You should then apply the file to add the `Secret` to your cluster:
+
+```bash
+kubectl apply -f service-account-token.yml
+```
+
+It should display something like this
+
+<pre class="console"><code>$ kubectl apply -f dashboard-cluster-role-binding.yml
+secret/admin-user-token created
+</code></pre>
+
 ### Bearer Token
 
 Next step is recovering the bearer token you will use to log in your Dashboard. Execute the following command:


### PR DESCRIPTION
From versions of Kubernetes v1.24.0 onwards, a new feature `LegacyServiceAccountTokenNoAutoGeneration` is in beta, and enabled by default. This feature, when enabled means Secret API objects containing service account tokens are no longer auto-generated for every `ServiceAccount`.

Because of this, the current guide for getting a bearer token will no longer work. The documentation added creates a token for the service account (as it is now needed), so that a bearer token can be retrieved for authentication