### PR TITLE
Added missing *nodes* URL information

### DIFF
--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-asia.md
@@ -71,6 +71,23 @@ Declaring a service of type `NodePort` exposes the `Service` on each Node’s IP
 
 It's rather cumbersome to use `NodePort` `Services` in production. As you are using non-standard ports, you often need to set up an external load balancer that listens on standard ports and redirects the traffic to the `<NodeIp>:<NodePort>`.
 
+> [!warning]
+> In our OVHcloud Managed Kubernetes you have an easy way to access `NodePort` services. You need to get the *nodes* URL, an URL solving via round-robin DNS to one random node of your cluster. As `NodePort` services are exposed in the same port on every Node, you can use this *nodes* URL to access them.
+> 
+> In order to get the nodes URL, you get the *control plane* URL (the one given on `kubectl cluster-info`) and add the `nodes` element between the first and the second element of the URL
+> 
+> Example:
+> 
+> ```
+> $ kubectl cluster-info
+> Kubernetes control plane is running at https://xxxxxx.c1.gra9.k8s.ovh.net
+> CoreDNS is running at https://xxxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+> Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
+> ```
+>
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-asia.md
@@ -5,7 +5,7 @@ slug: using-lb
 section: Getting started
 ---
 
-**Last updated 24th June 2022**
+**Last updated 31st October 2022**
 
 <style>
  pre {
@@ -85,7 +85,7 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 > Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
 > ```
 >
-> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
 
 ### Exposing services as LoadBalancer

--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-au.md
@@ -71,6 +71,23 @@ Declaring a service of type `NodePort` exposes the `Service` on each Node’s IP
 
 It's rather cumbersome to use `NodePort` `Services` in production. As you are using non-standard ports, you often need to set up an external load balancer that listens on standard ports and redirects the traffic to the `<NodeIp>:<NodePort>`.
 
+> [!warning]
+> In our OVHcloud Managed Kubernetes you have an easy way to access `NodePort` services. You need to get the *nodes* URL, an URL solving via round-robin DNS to one random node of your cluster. As `NodePort` services are exposed in the same port on every Node, you can use this *nodes* URL to access them.
+> 
+> In order to get the nodes URL, you get the *control plane* URL (the one given on `kubectl cluster-info`) and add the `nodes` element between the first and the second element of the URL
+> 
+> Example:
+> 
+> ```
+> $ kubectl cluster-info
+> Kubernetes control plane is running at https://xxxxxx.c1.gra9.k8s.ovh.net
+> CoreDNS is running at https://xxxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+> Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
+> ```
+>
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-au.md
@@ -5,7 +5,7 @@ slug: using-lb
 section: Getting started
 ---
 
-**Last updated 24th June 2022**
+**Last updated 31st October 2022**
 
 <style>
  pre {
@@ -85,7 +85,7 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 > Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
 > ```
 >
-> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
 
 ### Exposing services as LoadBalancer

--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-ca.md
@@ -5,7 +5,7 @@ slug: using-lb
 section: Getting started
 ---
 
-**Last updated 24th June 2022**
+**Last updated 31st October 2022**
 
 <style>
  pre {
@@ -85,7 +85,7 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 > Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
 > ```
 >
-> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
 
 ### Exposing services as LoadBalancer

--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-ca.md
@@ -71,6 +71,23 @@ Declaring a service of type `NodePort` exposes the `Service` on each Node’s IP
 
 It's rather cumbersome to use `NodePort` `Services` in production. As you are using non-standard ports, you often need to set up an external load balancer that listens on standard ports and redirects the traffic to the `<NodeIp>:<NodePort>`.
 
+> [!warning]
+> In our OVHcloud Managed Kubernetes you have an easy way to access `NodePort` services. You need to get the *nodes* URL, an URL solving via round-robin DNS to one random node of your cluster. As `NodePort` services are exposed in the same port on every Node, you can use this *nodes* URL to access them.
+> 
+> In order to get the nodes URL, you get the *control plane* URL (the one given on `kubectl cluster-info`) and add the `nodes` element between the first and the second element of the URL
+> 
+> Example:
+> 
+> ```
+> $ kubectl cluster-info
+> Kubernetes control plane is running at https://xxxxxx.c1.gra9.k8s.ovh.net
+> CoreDNS is running at https://xxxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+> Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
+> ```
+>
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.
@@ -103,6 +120,7 @@ OVHcloud Load Balancer services handle 4 ProxyProtocol modes:
 - `service.beta.kubernetes.io/ovh-loadbalancer-allowed-sources`: Used on the service to specify allowed client IP source ranges. Value: comma separated list of CIDRs. For example: `10.0.0.0/24,172.10.0.1`. **Deprecated**, please use `loadBalancerSourceRanges` spec instead, see [Restrict Access For LoadBalancer Service](https://kubernetes.io/docs/home/){.external}.
 
 - `service.beta.kubernetes.io/ovh-loadbalancer-balance`: Used on the service to set the algorithm to use for load balancing. Supported values: `first`, `leastconn`, `roundrobin`, `source`. Default: `roundrobin`.
+- 
 ### What about Ingress
 
 According to the [official documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/){.external}, an `Ingress` is an API object that manages external access to the services in a cluster, typically HTTP. What is the difference with the `LoadBalancer` or `NodePort`?

--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-gb.md
@@ -71,6 +71,23 @@ Declaring a service of type `NodePort` exposes the `Service` on each Node’s IP
 
 It's rather cumbersome to use `NodePort` `Services` in production. As you are using non-standard ports, you often need to set up an external load balancer that listens on standard ports and redirects the traffic to the `<NodeIp>:<NodePort>`.
 
+> [!warning]
+> In our OVHcloud Managed Kubernetes you have an easy way to access `NodePort` services. You need to get the *nodes* URL, an URL solving via round-robin DNS to one random node of your cluster. As `NodePort` services are exposed in the same port on every Node, you can use this *nodes* URL to access them.
+> 
+> In order to get the nodes URL, you get the *control plane* URL (the one given on `kubectl cluster-info`) and add the `nodes` element between the first and the second element of the URL
+> 
+> Example:
+> 
+> ```
+> $ kubectl cluster-info
+> Kubernetes control plane is running at https://xxxxxx.c1.gra9.k8s.ovh.net
+> CoreDNS is running at https://xxxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+> Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
+> ```
+>
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-gb.md
@@ -5,7 +5,7 @@ slug: using-lb
 section: Getting started
 ---
 
-**Last updated 24th June 2022**
+**Last updated 31st October 2022**
 
 <style>
  pre {
@@ -85,7 +85,7 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 > Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
 > ```
 >
-> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
 
 ### Exposing services as LoadBalancer

--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-ie.md
@@ -71,6 +71,23 @@ Declaring a service of type `NodePort` exposes the `Service` on each Node’s IP
 
 It's rather cumbersome to use `NodePort` `Services` in production. As you are using non-standard ports, you often need to set up an external load balancer that listens on standard ports and redirects the traffic to the `<NodeIp>:<NodePort>`.
 
+> [!warning]
+> In our OVHcloud Managed Kubernetes you have an easy way to access `NodePort` services. You need to get the *nodes* URL, an URL solving via round-robin DNS to one random node of your cluster. As `NodePort` services are exposed in the same port on every Node, you can use this *nodes* URL to access them.
+> 
+> In order to get the nodes URL, you get the *control plane* URL (the one given on `kubectl cluster-info`) and add the `nodes` element between the first and the second element of the URL
+> 
+> Example:
+> 
+> ```
+> $ kubectl cluster-info
+> Kubernetes control plane is running at https://xxxxxx.c1.gra9.k8s.ovh.net
+> CoreDNS is running at https://xxxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+> Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
+> ```
+>
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-ie.md
@@ -5,7 +5,7 @@ slug: using-lb
 section: Getting started
 ---
 
-**Last updated 24th June 2022**
+**Last updated 31st October 2022**
 
 <style>
  pre {
@@ -85,7 +85,7 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 > Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
 > ```
 >
-> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
 
 ### Exposing services as LoadBalancer

--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-sg.md
@@ -71,6 +71,23 @@ Declaring a service of type `NodePort` exposes the `Service` on each Node’s IP
 
 It's rather cumbersome to use `NodePort` `Services` in production. As you are using non-standard ports, you often need to set up an external load balancer that listens on standard ports and redirects the traffic to the `<NodeIp>:<NodePort>`.
 
+> [!warning]
+> In our OVHcloud Managed Kubernetes you have an easy way to access `NodePort` services. You need to get the *nodes* URL, an URL solving via round-robin DNS to one random node of your cluster. As `NodePort` services are exposed in the same port on every Node, you can use this *nodes* URL to access them.
+> 
+> In order to get the nodes URL, you get the *control plane* URL (the one given on `kubectl cluster-info`) and add the `nodes` element between the first and the second element of the URL
+> 
+> Example:
+> 
+> ```
+> $ kubectl cluster-info
+> Kubernetes control plane is running at https://xxxxxx.c1.gra9.k8s.ovh.net
+> CoreDNS is running at https://xxxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+> Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
+> ```
+>
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-sg.md
@@ -5,7 +5,7 @@ slug: using-lb
 section: Getting started
 ---
 
-**Last updated 24th June 2022**
+**Last updated 31st October 2022**
 
 <style>
  pre {
@@ -85,7 +85,7 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 > Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
 > ```
 >
-> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
 
 ### Exposing services as LoadBalancer

--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-us.md
@@ -71,6 +71,23 @@ Declaring a service of type `NodePort` exposes the `Service` on each Node’s IP
 
 It's rather cumbersome to use `NodePort` `Services` in production. As you are using non-standard ports, you often need to set up an external load balancer that listens on standard ports and redirects the traffic to the `<NodeIp>:<NodePort>`.
 
+> [!warning]
+> In our OVHcloud Managed Kubernetes you have an easy way to access `NodePort` services. You need to get the *nodes* URL, an URL solving via round-robin DNS to one random node of your cluster. As `NodePort` services are exposed in the same port on every Node, you can use this *nodes* URL to access them.
+> 
+> In order to get the nodes URL, you get the *control plane* URL (the one given on `kubectl cluster-info`) and add the `nodes` element between the first and the second element of the URL
+> 
+> Example:
+> 
+> ```
+> $ kubectl cluster-info
+> Kubernetes control plane is running at https://xxxxxx.c1.gra9.k8s.ovh.net
+> CoreDNS is running at https://xxxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+> Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
+> ```
+>
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/platform/kubernetes-k8s/using-lb/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/using-lb/guide.en-us.md
@@ -5,7 +5,7 @@ slug: using-lb
 section: Getting started
 ---
 
-**Last updated 24th June 2022**
+**Last updated 31st October 2022**
 
 <style>
  pre {
@@ -85,7 +85,7 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 > Metrics-server is running at https://xxxxxx.c1.gra9.k8s.ovh.net/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy
 > ```
 >
-> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`
+> In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
 
 ### Exposing services as LoadBalancer


### PR DESCRIPTION
Added missing *nodes* URL information, needed for NodePort services, following feedback from customer