### PR TITLE
FR VOIP 3CX - Configuration et utilisation - Majuscule fix

### DIFF
--- a/pages/telecom/voip/configuration_basique_dun_sip_trunk_ovh_sur_3cx_phone_system/guide.fr-fr.md
+++ b/pages/telecom/voip/configuration_basique_dun_sip_trunk_ovh_sur_3cx_phone_system/guide.fr-fr.md
@@ -34,7 +34,7 @@ Pour configurer le 3CX Phone System avec un SIP Trunk et deux DDI (**D**irect **
 
 Obtenez gratuitement 3CX [en cliquant ici](https://www.3cx.fr/pabx/download-pabx-ip/).
 
-## En Pratique
+## En pratique
 
 > [!warning]
 > 


### PR DESCRIPTION
Sous-titre "En Pratique" à corriger en "En pratique"