### PR TITLE
[AI docs] - 404 fixed

### DIFF
--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.de-de.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.de-de.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/deploy/tuto-streamlit-sounds-classification/'
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -122,7 +122,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/de/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/de/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -261,7 +261,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-asia.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-asia.md
@@ -6,7 +6,7 @@ section: AI Deploy - Tutorials
 order: 03
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -120,7 +120,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/asia/en/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/asia/en/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -259,7 +259,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-au.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-au.md
@@ -6,7 +6,7 @@ section: AI Deploy - Tutorials
 order: 03
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -120,7 +120,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/au/en/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/au/en/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -259,7 +259,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-ca.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-ca.md
@@ -6,7 +6,7 @@ section: AI Deploy - Tutorials
 order: 03
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -120,7 +120,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/ca/en/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/ca/en/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -259,7 +259,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-gb.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-gb.md
@@ -6,7 +6,7 @@ section: AI Deploy - Tutorials
 order: 03
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -120,7 +120,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/gb/en/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/gb/en/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -259,7 +259,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-ie.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-ie.md
@@ -6,7 +6,7 @@ section: AI Deploy - Tutorials
 order: 03
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -120,7 +120,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/ie/en/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/ie/en/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -259,7 +259,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-sg.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-sg.md
@@ -6,7 +6,7 @@ section: AI Deploy - Tutorials
 order: 03
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -120,7 +120,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/sg/en/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/sg/en/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -259,7 +259,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-us.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.en-us.md
@@ -6,7 +6,7 @@ section: AI Deploy - Tutorials
 order: 03
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -120,7 +120,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/us/en/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/us/en/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -259,7 +259,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.es-es.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.es-es.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/deploy/tuto-streamlit-sounds-classification/'
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -122,7 +122,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/es/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/es/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -261,7 +261,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.es-us.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.es-us.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/deploy/tuto-streamlit-sounds-classification/'
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -122,7 +122,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/us/es/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/us/es/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -261,7 +261,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.fr-ca.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.fr-ca.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/deploy/tuto-streamlit-sounds-classification/'
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -122,7 +122,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/ca/fr/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/ca/fr/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -261,7 +261,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.fr-fr.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.fr-fr.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/deploy/tuto-streamlit-sounds-classification/'
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -122,7 +122,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/fr/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/fr/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -261,7 +261,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.it-it.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.it-it.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/deploy/tuto-streamlit-sounds-classification/'
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -122,7 +122,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/it/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/it/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -261,7 +261,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.pl-pl.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.pl-pl.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/deploy/tuto-streamlit-sounds-classification/'
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -122,7 +122,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/pl/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/pl/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -261,7 +261,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.pt-pt.md
+++ b/pages/platform/ai/deploy_tuto_03_streamlit_sounds_classification/guide.pt-pt.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/deploy/tuto-streamlit-sounds-classification/'
 ---
 
-**Last updated 3rd November, 2022.**
+**Last updated 24th November, 2022.**
 
 > [!primary]
 >
@@ -122,7 +122,7 @@ Define the function that classifies the sounds from the previously trained model
 
 > [!primary]
 >
-> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/pt/ai-training/data-cli/) to learn more about Object Storage.
+> Here you will use your trained model, then save it in an Object Container. Click [here](https://docs.ovh.com/pt/publiccloud/ai/cli/data-cli/) to learn more about Object Storage.
 >
 
 ```python
@@ -261,7 +261,7 @@ docker build . -t streamlit_app:latest
 >
 > The dot `.` argument indicates that your build context (place of the **Dockerfile** and other needed files) is the current directory.
 >
-> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **sreamlit_app:latest**.
+> The `-t` argument allows you to choose the identifier to give to your image. Usually image identifiers are composed of a **name** and a **version tag** `<name>:<version>`. For this example we chose **streamlit_app:latest**.
 >
 
 ### Test it locally (optional)

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.de-de.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.de-de.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/definition/'
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -24,16 +24,16 @@ The OVHcloud AI Notebooks service provides you Jupyter or VSCode notebooks, link
 
 **Notebooks** are files which contain both computer code (e.g. python) and rich text elements (paragraph, equations, figures, links, etc…). Notebooks are both human-readable documents containing the analysis description and the results (figures, tables, etc..) as well as executable files which can be run to perform data analysis. It's vastly used across developer world, especially in the data and artificial intelligence fields.
 
-**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need. 
+**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need.
 You also get secure user access, simplified use of your data, and the most popular artificial intelligence frameworks (TensorFlow, PyTorch, Hugging Face, Scikit-learn, ...).
 
 The advantage compared to doing your own setup is that everything is already installed for you, and that you pay only for your notebooks while they are running.
 
 Each notebook is linked to a **Public Cloud** project and specifies hardware resources along with a machine learning framework and an editor among those available.
 
-You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/de/publiccloud/ai/cli/getting-started-cli/). 
+You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/de/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/de/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/de/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 
@@ -69,7 +69,7 @@ Choose the AI framework you want to use and click on the `Next`{.action} button.
 > [!primary]
 >
 > As you can see a lot of fameworks are available. This guide uses one of the most famous, _PyTorch_.
-> As you can guess all of these Frameworks are _deployed_ as container based on images. 
+> As you can guess all of these Frameworks are _deployed_ as container based on images.
 >
 
 Next, select your privacy settings and click on the `Next`{.action} button.
@@ -179,4 +179,4 @@ During its lifetime the AI Notebook will transition between the following status
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9) 
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.en-asia.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.en-asia.md
@@ -6,7 +6,7 @@ section: AI Notebooks - Guides
 order: 02
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -22,14 +22,14 @@ The OVHcloud AI Notebooks service provides you Jupyter or VSCode notebooks, link
 
 **Notebooks** are files which contain both computer code (e.g. python) and rich text elements (paragraph, equations, figures, links, etc…). Notebooks are both human-readable documents containing the analysis description and the results (figures, tables, etc..) as well as executable files which can be run to perform data analysis. It's vastly used across developer world, especially in the data and artificial intelligence fields.
 
-**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need. 
+**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need.
 You also get secure user access, simplified use of your data, and the most popular artificial intelligence frameworks (TensorFlow, PyTorch, Hugging Face, Scikit-learn, ...).
 
 The advantage compared to doing your own setup is that everything is already installed for you, and that you pay only for your notebooks while they are running.
 
 Each notebook is linked to a **Public Cloud** project and specifies hardware resources along with a machine learning framework and an editor among those available.
 
-You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/asia/en/publiccloud/ai/cli/getting-started-cli/). 
+You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/asia/en/publiccloud/ai/cli/getting-started-cli/).
 
 AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/asia/en/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
 
@@ -66,7 +66,7 @@ Choose the AI framework you want to use and click on the `Next`{.action} button.
 > [!primary]
 >
 > As you can see a lot of fameworks are available. This guide uses one of the most famous, _PyTorch_.
-> As you can guess all of these Frameworks are _deployed_ as container based on images. 
+> As you can guess all of these Frameworks are _deployed_ as container based on images.
 >
 
 Next, select your privacy settings and click on the `Next`{.action} button.
@@ -176,4 +176,4 @@ During its lifetime the AI Notebook will transition between the following status
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9) 
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.en-au.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.en-au.md
@@ -6,7 +6,7 @@ section: AI Notebooks - Guides
 order: 02
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -22,16 +22,16 @@ The OVHcloud AI Notebooks service provides you Jupyter or VSCode notebooks, link
 
 **Notebooks** are files which contain both computer code (e.g. python) and rich text elements (paragraph, equations, figures, links, etc…). Notebooks are both human-readable documents containing the analysis description and the results (figures, tables, etc..) as well as executable files which can be run to perform data analysis. It's vastly used across developer world, especially in the data and artificial intelligence fields.
 
-**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need. 
+**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need.
 You also get secure user access, simplified use of your data, and the most popular artificial intelligence frameworks (TensorFlow, PyTorch, Hugging Face, Scikit-learn, ...).
 
 The advantage compared to doing your own setup is that everything is already installed for you, and that you pay only for your notebooks while they are running.
 
 Each notebook is linked to a **Public Cloud** project and specifies hardware resources along with a machine learning framework and an editor among those available.
 
-You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/au/en/publiccloud/ai/cli/getting-started-cli/). 
+You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/au/en/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/au/en/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/au/en/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 
@@ -67,7 +67,7 @@ Choose the AI framework you want to use and click on the `Next`{.action} button.
 > [!primary]
 >
 > As you can see a lot of fameworks are available. This guide uses one of the most famous, _PyTorch_.
-> As you can guess all of these Frameworks are _deployed_ as container based on images. 
+> As you can guess all of these Frameworks are _deployed_ as container based on images.
 >
 
 Next, select your privacy settings and click on the `Next`{.action} button.
@@ -177,4 +177,4 @@ During its lifetime the AI Notebook will transition between the following status
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9) 
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.en-ca.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.en-ca.md
@@ -6,7 +6,7 @@ section: AI Notebooks - Guides
 order: 02
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -22,16 +22,16 @@ The OVHcloud AI Notebooks service provides you Jupyter or VSCode notebooks, link
 
 **Notebooks** are files which contain both computer code (e.g. python) and rich text elements (paragraph, equations, figures, links, etc…). Notebooks are both human-readable documents containing the analysis description and the results (figures, tables, etc..) as well as executable files which can be run to perform data analysis. It's vastly used across developer world, especially in the data and artificial intelligence fields.
 
-**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need. 
+**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need.
 You also get secure user access, simplified use of your data, and the most popular artificial intelligence frameworks (TensorFlow, PyTorch, Hugging Face, Scikit-learn, ...).
 
 The advantage compared to doing your own setup is that everything is already installed for you, and that you pay only for your notebooks while they are running.
 
 Each notebook is linked to a **Public Cloud** project and specifies hardware resources along with a machine learning framework and an editor among those available.
 
-You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/ca/en/publiccloud/ai/cli/getting-started-cli/). 
+You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/ca/en/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/ca/en/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/ca/en/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 
@@ -67,7 +67,7 @@ Choose the AI framework you want to use and click on the `Next`{.action} button.
 > [!primary]
 >
 > As you can see a lot of fameworks are available. This guide uses one of the most famous, _PyTorch_.
-> As you can guess all of these Frameworks are _deployed_ as container based on images. 
+> As you can guess all of these Frameworks are _deployed_ as container based on images.
 >
 
 Next, select your privacy settings and click on the `Next`{.action} button.
@@ -177,4 +177,4 @@ During its lifetime the AI Notebook will transition between the following status
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9) 
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.en-gb.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.en-gb.md
@@ -6,7 +6,7 @@ section: AI Notebooks - Guides
 order: 02
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -22,16 +22,16 @@ The OVHcloud AI Notebooks service provides you Jupyter or VSCode notebooks, link
 
 **Notebooks** are files which contain both computer code (e.g. python) and rich text elements (paragraph, equations, figures, links, etc…). Notebooks are both human-readable documents containing the analysis description and the results (figures, tables, etc..) as well as executable files which can be run to perform data analysis. It's vastly used across developer world, especially in the data and artificial intelligence fields.
 
-**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need. 
+**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need.
 You also get secure user access, simplified use of your data, and the most popular artificial intelligence frameworks (TensorFlow, PyTorch, Hugging Face, Scikit-learn, ...).
 
 The advantage compared to doing your own setup is that everything is already installed for you, and that you pay only for your notebooks while they are running.
 
 Each notebook is linked to a **Public Cloud** project and specifies hardware resources along with a machine learning framework and an editor among those available.
 
-You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/gb/en/publiccloud/ai/cli/getting-started-cli/). 
+You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/gb/en/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 
@@ -67,7 +67,7 @@ Choose the AI framework you want to use and click on the `Next`{.action} button.
 > [!primary]
 >
 > As you can see a lot of fameworks are available. This guide uses one of the most famous, _PyTorch_.
-> As you can guess all of these Frameworks are _deployed_ as container based on images. 
+> As you can guess all of these Frameworks are _deployed_ as container based on images.
 >
 
 Next, select your privacy settings and click on the `Next`{.action} button.
@@ -177,4 +177,4 @@ During its lifetime the AI Notebook will transition between the following status
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9) 
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.en-ie.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.en-ie.md
@@ -6,7 +6,7 @@ section: AI Notebooks - Guides
 order: 02
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -22,16 +22,16 @@ The OVHcloud AI Notebooks service provides you Jupyter or VSCode notebooks, link
 
 **Notebooks** are files which contain both computer code (e.g. python) and rich text elements (paragraph, equations, figures, links, etc…). Notebooks are both human-readable documents containing the analysis description and the results (figures, tables, etc..) as well as executable files which can be run to perform data analysis. It's vastly used across developer world, especially in the data and artificial intelligence fields.
 
-**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need. 
+**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need.
 You also get secure user access, simplified use of your data, and the most popular artificial intelligence frameworks (TensorFlow, PyTorch, Hugging Face, Scikit-learn, ...).
 
 The advantage compared to doing your own setup is that everything is already installed for you, and that you pay only for your notebooks while they are running.
 
 Each notebook is linked to a **Public Cloud** project and specifies hardware resources along with a machine learning framework and an editor among those available.
 
-You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/ie/en/publiccloud/ai/cli/getting-started-cli/). 
+You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/ie/en/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/ie/en/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/ie/en/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 
@@ -67,7 +67,7 @@ Choose the AI framework you want to use and click on the `Next`{.action} button.
 > [!primary]
 >
 > As you can see a lot of fameworks are available. This guide uses one of the most famous, _PyTorch_.
-> As you can guess all of these Frameworks are _deployed_ as container based on images. 
+> As you can guess all of these Frameworks are _deployed_ as container based on images.
 >
 
 Next, select your privacy settings and click on the `Next`{.action} button.
@@ -177,4 +177,4 @@ During its lifetime the AI Notebook will transition between the following status
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9) 
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.en-sg.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.en-sg.md
@@ -6,7 +6,7 @@ section: AI Notebooks - Guides
 order: 02
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -22,16 +22,16 @@ The OVHcloud AI Notebooks service provides you Jupyter or VSCode notebooks, link
 
 **Notebooks** are files which contain both computer code (e.g. python) and rich text elements (paragraph, equations, figures, links, etc…). Notebooks are both human-readable documents containing the analysis description and the results (figures, tables, etc..) as well as executable files which can be run to perform data analysis. It's vastly used across developer world, especially in the data and artificial intelligence fields.
 
-**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need. 
+**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need.
 You also get secure user access, simplified use of your data, and the most popular artificial intelligence frameworks (TensorFlow, PyTorch, Hugging Face, Scikit-learn, ...).
 
 The advantage compared to doing your own setup is that everything is already installed for you, and that you pay only for your notebooks while they are running.
 
 Each notebook is linked to a **Public Cloud** project and specifies hardware resources along with a machine learning framework and an editor among those available.
 
-You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/sg/en/publiccloud/ai/cli/getting-started-cli/). 
+You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/sg/en/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/sg/en/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/sg/en/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 
@@ -67,7 +67,7 @@ Choose the AI framework you want to use and click on the `Next`{.action} button.
 > [!primary]
 >
 > As you can see a lot of fameworks are available. This guide uses one of the most famous, _PyTorch_.
-> As you can guess all of these Frameworks are _deployed_ as container based on images. 
+> As you can guess all of these Frameworks are _deployed_ as container based on images.
 >
 
 Next, select your privacy settings and click on the `Next`{.action} button.
@@ -177,4 +177,4 @@ During its lifetime the AI Notebook will transition between the following status
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9) 
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.en-us.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.en-us.md
@@ -6,7 +6,7 @@ section: AI Notebooks - Guides
 order: 02
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -22,16 +22,16 @@ The OVHcloud AI Notebooks service provides you Jupyter or VSCode notebooks, link
 
 **Notebooks** are files which contain both computer code (e.g. python) and rich text elements (paragraph, equations, figures, links, etc…). Notebooks are both human-readable documents containing the analysis description and the results (figures, tables, etc..) as well as executable files which can be run to perform data analysis. It's vastly used across developer world, especially in the data and artificial intelligence fields.
 
-**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need. 
+**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need.
 You also get secure user access, simplified use of your data, and the most popular artificial intelligence frameworks (TensorFlow, PyTorch, Hugging Face, Scikit-learn, ...).
 
 The advantage compared to doing your own setup is that everything is already installed for you, and that you pay only for your notebooks while they are running.
 
 Each notebook is linked to a **Public Cloud** project and specifies hardware resources along with a machine learning framework and an editor among those available.
 
-You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/us/en/publiccloud/ai/cli/getting-started-cli/). 
+You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/us/en/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/us/en/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/us/en/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 
@@ -67,7 +67,7 @@ Choose the AI framework you want to use and click on the `Next`{.action} button.
 > [!primary]
 >
 > As you can see a lot of fameworks are available. This guide uses one of the most famous, _PyTorch_.
-> As you can guess all of these Frameworks are _deployed_ as container based on images. 
+> As you can guess all of these Frameworks are _deployed_ as container based on images.
 >
 
 Next, select your privacy settings and click on the `Next`{.action} button.
@@ -177,4 +177,4 @@ During its lifetime the AI Notebook will transition between the following status
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9) 
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.es-es.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.es-es.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/definition/'
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -24,16 +24,16 @@ The OVHcloud AI Notebooks service provides you Jupyter or VSCode notebooks, link
 
 **Notebooks** are files which contain both computer code (e.g. python) and rich text elements (paragraph, equations, figures, links, etc…). Notebooks are both human-readable documents containing the analysis description and the results (figures, tables, etc..) as well as executable files which can be run to perform data analysis. It's vastly used across developer world, especially in the data and artificial intelligence fields.
 
-**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need. 
+**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need.
 You also get secure user access, simplified use of your data, and the most popular artificial intelligence frameworks (TensorFlow, PyTorch, Hugging Face, Scikit-learn, ...).
 
 The advantage compared to doing your own setup is that everything is already installed for you, and that you pay only for your notebooks while they are running.
 
 Each notebook is linked to a **Public Cloud** project and specifies hardware resources along with a machine learning framework and an editor among those available.
 
-You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/es/publiccloud/ai/cli/getting-started-cli/). 
+You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/es/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/es/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/es/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 
@@ -69,7 +69,7 @@ Choose the AI framework you want to use and click on the `Next`{.action} button.
 > [!primary]
 >
 > As you can see a lot of fameworks are available. This guide uses one of the most famous, _PyTorch_.
-> As you can guess all of these Frameworks are _deployed_ as container based on images. 
+> As you can guess all of these Frameworks are _deployed_ as container based on images.
 >
 
 Next, select your privacy settings and click on the `Next`{.action} button.
@@ -179,4 +179,4 @@ During its lifetime the AI Notebook will transition between the following status
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9) 
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.es-us.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.es-us.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/definition/'
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -24,16 +24,16 @@ The OVHcloud AI Notebooks service provides you Jupyter or VSCode notebooks, link
 
 **Notebooks** are files which contain both computer code (e.g. python) and rich text elements (paragraph, equations, figures, links, etc…). Notebooks are both human-readable documents containing the analysis description and the results (figures, tables, etc..) as well as executable files which can be run to perform data analysis. It's vastly used across developer world, especially in the data and artificial intelligence fields.
 
-**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need. 
+**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need.
 You also get secure user access, simplified use of your data, and the most popular artificial intelligence frameworks (TensorFlow, PyTorch, Hugging Face, Scikit-learn, ...).
 
 The advantage compared to doing your own setup is that everything is already installed for you, and that you pay only for your notebooks while they are running.
 
 Each notebook is linked to a **Public Cloud** project and specifies hardware resources along with a machine learning framework and an editor among those available.
 
-You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/us/es/publiccloud/ai/cli/getting-started-cli/). 
+You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/us/es/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/us/es/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/us/es/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 
@@ -69,7 +69,7 @@ Choose the AI framework you want to use and click on the `Next`{.action} button.
 > [!primary]
 >
 > As you can see a lot of fameworks are available. This guide uses one of the most famous, _PyTorch_.
-> As you can guess all of these Frameworks are _deployed_ as container based on images. 
+> As you can guess all of these Frameworks are _deployed_ as container based on images.
 >
 
 Next, select your privacy settings and click on the `Next`{.action} button.
@@ -179,4 +179,4 @@ During its lifetime the AI Notebook will transition between the following status
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9) 
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.fr-ca.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.fr-ca.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/definition/'
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -33,7 +33,7 @@ Each notebook is linked to a **Public Cloud** project and specifies hardware res
 
 You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/ca/fr/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/ca/fr/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/ca/fr/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.fr-fr.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.fr-fr.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/definition/'
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -33,7 +33,7 @@ Each notebook is linked to a **Public Cloud** project and specifies hardware res
 
 You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/fr/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/fr/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/fr/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.it-it.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.it-it.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/definition/'
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -24,16 +24,16 @@ The OVHcloud AI Notebooks service provides you Jupyter or VSCode notebooks, link
 
 **Notebooks** are files which contain both computer code (e.g. python) and rich text elements (paragraph, equations, figures, links, etc…). Notebooks are both human-readable documents containing the analysis description and the results (figures, tables, etc..) as well as executable files which can be run to perform data analysis. It's vastly used across developer world, especially in the data and artificial intelligence fields.
 
-**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need. 
+**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need.
 You also get secure user access, simplified use of your data, and the most popular artificial intelligence frameworks (TensorFlow, PyTorch, Hugging Face, Scikit-learn, ...).
 
 The advantage compared to doing your own setup is that everything is already installed for you, and that you pay only for your notebooks while they are running.
 
 Each notebook is linked to a **Public Cloud** project and specifies hardware resources along with a machine learning framework and an editor among those available.
 
-You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/it/publiccloud/ai/cli/getting-started-cli/). 
+You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/it/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/it/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/it/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 
@@ -69,7 +69,7 @@ Choose the AI framework you want to use and click on the `Next`{.action} button.
 > [!primary]
 >
 > As you can see a lot of fameworks are available. This guide uses one of the most famous, _PyTorch_.
-> As you can guess all of these Frameworks are _deployed_ as container based on images. 
+> As you can guess all of these Frameworks are _deployed_ as container based on images.
 >
 
 Next, select your privacy settings and click on the `Next`{.action} button.
@@ -179,4 +179,4 @@ During its lifetime the AI Notebook will transition between the following status
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9) 
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.pl-pl.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.pl-pl.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/definition/'
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -24,16 +24,16 @@ The OVHcloud AI Notebooks service provides you Jupyter or VSCode notebooks, link
 
 **Notebooks** are files which contain both computer code (e.g. python) and rich text elements (paragraph, equations, figures, links, etc…). Notebooks are both human-readable documents containing the analysis description and the results (figures, tables, etc..) as well as executable files which can be run to perform data analysis. It's vastly used across developer world, especially in the data and artificial intelligence fields.
 
-**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need. 
+**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need.
 You also get secure user access, simplified use of your data, and the most popular artificial intelligence frameworks (TensorFlow, PyTorch, Hugging Face, Scikit-learn, ...).
 
 The advantage compared to doing your own setup is that everything is already installed for you, and that you pay only for your notebooks while they are running.
 
 Each notebook is linked to a **Public Cloud** project and specifies hardware resources along with a machine learning framework and an editor among those available.
 
-You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/pl/publiccloud/ai/cli/getting-started-cli/). 
+You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/pl/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/pl/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/pl/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 
@@ -69,7 +69,7 @@ Choose the AI framework you want to use and click on the `Next`{.action} button.
 > [!primary]
 >
 > As you can see a lot of fameworks are available. This guide uses one of the most famous, _PyTorch_.
-> As you can guess all of these Frameworks are _deployed_ as container based on images. 
+> As you can guess all of these Frameworks are _deployed_ as container based on images.
 >
 
 Next, select your privacy settings and click on the `Next`{.action} button.
@@ -179,4 +179,4 @@ During its lifetime the AI Notebook will transition between the following status
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9) 
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_guide_introduction_definition/guide.pt-pt.md
+++ b/pages/platform/ai/notebook_guide_introduction_definition/guide.pt-pt.md
@@ -8,7 +8,7 @@ routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/ai/notebooks/definition/'
 ---
 
-**Last updated 11th April, 2022.**
+**Last updated 24th November, 2022.**
 
 ## Objective
 
@@ -24,16 +24,16 @@ The OVHcloud AI Notebooks service provides you Jupyter or VSCode notebooks, link
 
 **Notebooks** are files which contain both computer code (e.g. python) and rich text elements (paragraph, equations, figures, links, etc…). Notebooks are both human-readable documents containing the analysis description and the results (figures, tables, etc..) as well as executable files which can be run to perform data analysis. It's vastly used across developer world, especially in the data and artificial intelligence fields.
 
-**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need. 
+**OVHcloud AI Notebook** is our solution for managed Jupyter or VSCode notebooks. You can launch your notebooks quickly with the CPUs and GPUs resources you need.
 You also get secure user access, simplified use of your data, and the most popular artificial intelligence frameworks (TensorFlow, PyTorch, Hugging Face, Scikit-learn, ...).
 
 The advantage compared to doing your own setup is that everything is already installed for you, and that you pay only for your notebooks while they are running.
 
 Each notebook is linked to a **Public Cloud** project and specifies hardware resources along with a machine learning framework and an editor among those available.
 
-You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/pt/publiccloud/ai/cli/getting-started-cli/). 
+You can create notebooks with the OVHcloud Control Panel (see below in this tutorial) or use the [ovhai CLI](https://docs.ovh.com/pt/publiccloud/ai/cli/getting-started-cli/).
 
-AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/pt/publiccloud/ai/notebooks/tuto-access-object-storage-data/).
+AI Notebooks also provide an easy way to access data from your Object Storage, you can read more about it [here](https://docs.ovh.com/pt/publiccloud/ai/notebooks/manage-data-ui/).
 
 ## Launch your first AI Notebook
 
@@ -69,7 +69,7 @@ Choose the AI framework you want to use and click on the `Next`{.action} button.
 > [!primary]
 >
 > As you can see a lot of fameworks are available. This guide uses one of the most famous, _PyTorch_.
-> As you can guess all of these Frameworks are _deployed_ as container based on images. 
+> As you can guess all of these Frameworks are _deployed_ as container based on images.
 >
 
 Next, select your privacy settings and click on the `Next`{.action} button.
@@ -179,4 +179,4 @@ During its lifetime the AI Notebook will transition between the following status
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9) 
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)


### PR DESCRIPTION
Yesterday, two 404 were found by @fpillotovh in AI docs (internal links):

- https://docs.ovh.com/de/ai-training/data-cli/ in an AI Deploy tutorial about [audio classification](https://docs.ovh.com/de/publiccloud/ai/deploy/tuto-streamlit-sounds)

- https://docs.ovh.com/fr/publiccloud/ai/notebooks/tuto-access-object-storage-data/  in AI Notebooks [getting started](https://docs.ovh.com/fr/publiccloud/ai/notebooks/definition/-classification/)

✅ Links were changed for ALL the documentations (duplicatas ok)
✅ Date updated




