### PR TITLE
KS - Cust Feedback - Hosting - Composer guide - Add "SSH" guide link

### DIFF
--- a/pages/web/hosting/composer_install_composer/guide.de-de.md
+++ b/pages/web/hosting/composer_install_composer/guide.de-de.md
@@ -10,7 +10,7 @@ order: 02
 > Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In manchen Fällen können ungenaue Formulierungen verwendet worden sein, z.B. bei der Beschriftung von Schaltflächen oder technischen Details. Bitte ziehen Sie beim geringsten Zweifel die englische oder französische Fassung der Anleitung zu Rate. Möchten Sie mithelfen, diese Übersetzung zu verbessern? Dann nutzen Sie dazu bitte den Button «Mitmachen» auf dieser Seite.
 >
 
-**Letzte Aktualisierung am 30.11.2020**
+**Letzte Aktualisierung am 09.12.2022**
 
 ## Ziel 
 
@@ -31,6 +31,8 @@ Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister]
 
 
 ## In der praktischen Anwendung
+
+Verbinden Sie sich via SSH mit Ihrem Shared Hosting mithilfe unserer Anleitung zu [Verwendung von SSH mit Ihrem OVHcloud Webhosting](https://docs.ovh.com/de/hosting/webhosting_ssh_auf_ihren_webhostings/).
 
 Verwenden Sie die Kommandozeile, um zu überprüfen, ob die PHP-Version kompatibel ist:
 

--- a/pages/web/hosting/composer_install_composer/guide.de-de.md
+++ b/pages/web/hosting/composer_install_composer/guide.de-de.md
@@ -14,7 +14,7 @@ order: 02
 
 ## Ziel 
 
-[Composer](https://getcomposer.org/){.external} ist ein für PHP erstellter Dependency Manager. PHP-Entwickler können externe Bibliotheken in ihre Programme einbinden. Composer vereinfacht die Verteilung von Bibliotheken und die Wartung des Codes von PHP-Projekten . Seit der Veröffentlichung dieses Tools wurden zahlreiche Best Practices für die Entwickliung vorgeschlagen und somit die Bibliotheken der PHP-Community verbessert. Diese bewährten Verfahren werden in der Form [SRP](http://www.php-fig.org/){.external} dokumentiert.
+[Composer](https://getcomposer.org/){.external} ist ein für PHP erstellter Dependency Manager. PHP-Entwickler können externe Bibliotheken in ihre Programme einbinden. Composer vereinfacht die Verteilung von Bibliotheken und die Wartung des Codes von PHP-Projekten. Seit der Veröffentlichung dieses Tools wurden zahlreiche Best Practices für die Entwicklung etabliert und somit die Bibliotheken der PHP-Community verbessert. Diese bewährten Verfahren werden in der Form [SRP](http://www.php-fig.org/){.external} dokumentiert.
 
 **Diese Anleitung erklärt, wie Sie Composer installieren und gibt ein Anwendungsbeispiel.**
 
@@ -32,7 +32,7 @@ Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister]
 
 ## In der praktischen Anwendung
 
-Verbinden Sie sich via SSH mit Ihrem Shared Hosting mithilfe unserer Anleitung zu [Verwendung von SSH mit Ihrem OVHcloud Webhosting](https://docs.ovh.com/de/hosting/webhosting_ssh_auf_ihren_webhostings/).
+Verbinden Sie sich via SSH mit Ihrem Hosting mithilfe unserer Anleitung zur [Verwendung von SSH mit Ihrem OVHcloud Webhosting](https://docs.ovh.com/de/hosting/webhosting_ssh_auf_ihren_webhostings/).
 
 Verwenden Sie die Kommandozeile, um zu überprüfen, ob die PHP-Version kompatibel ist:
 

--- a/pages/web/hosting/composer_install_composer/guide.en-asia.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-asia.md
@@ -6,7 +6,7 @@ section: PHP
 order: 02
 ---
 
-**Last updated 30th November 2020**
+**Last updated 09th December 2022**
 
 ## Objective
 
@@ -26,6 +26,8 @@ If you encounter any difficulties performing these actions, please contact a [sp
 - access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
 
 ## Instructions
+
+Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/asia/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
 
 Use the command line to check if the PHP version is compatible:
 

--- a/pages/web/hosting/composer_install_composer/guide.en-asia.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-asia.md
@@ -22,12 +22,12 @@ If you encounter any difficulties performing these actions, please contact a [sp
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](https://www.ovhcloud.com/asia/web-hosting/) with SSH access
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- An [OVHcloud Web Hosting plan](https://www.ovhcloud.com/asia/web-hosting/) with SSH access
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
 
 ## Instructions
 
-Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/asia/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
+Access your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/asia/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
 
 Use the command line to check if the PHP version is compatible:
 

--- a/pages/web/hosting/composer_install_composer/guide.en-au.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-au.md
@@ -22,12 +22,12 @@ If you encounter any difficulties performing these actions, please contact a [sp
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-au/web-hosting/) with SSH access
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- An [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-au/web-hosting/) with SSH access
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
 
 ## Instructions
 
-Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/au/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
+Access your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/au/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
 
 Use the command line to check if the PHP version is compatible:
 

--- a/pages/web/hosting/composer_install_composer/guide.en-au.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-au.md
@@ -6,7 +6,7 @@ section: PHP
 order: 02
 ---
 
-**Last updated 30th November 2020**
+**Last updated 09th December 2022**
 
 ## Objective
 
@@ -26,6 +26,8 @@ If you encounter any difficulties performing these actions, please contact a [sp
 - access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
 
 ## Instructions
+
+Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/au/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
 
 Use the command line to check if the PHP version is compatible:
 

--- a/pages/web/hosting/composer_install_composer/guide.en-ca.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-ca.md
@@ -6,7 +6,7 @@ section: PHP
 order: 02
 ---
 
-**Last updated 30th November 2020**
+**Last updated 09th December 2022**
 
 ## Objective
 
@@ -26,6 +26,8 @@ If you encounter any difficulties performing these actions, please contact a [sp
 - access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
 
 ## Instructions
+
+Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/ca/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
 
 Use the command line to check if the PHP version is compatible:
 

--- a/pages/web/hosting/composer_install_composer/guide.en-ca.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-ca.md
@@ -22,12 +22,12 @@ If you encounter any difficulties performing these actions, please contact a [sp
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-ca/web-hosting/) with SSH access
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- An [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-ca/web-hosting/) with SSH access
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
 
 ## Instructions
 
-Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/ca/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
+Access your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/ca/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
 
 Use the command line to check if the PHP version is compatible:
 

--- a/pages/web/hosting/composer_install_composer/guide.en-gb.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-gb.md
@@ -6,7 +6,7 @@ section: PHP
 order: 02
 ---
 
-**Last updated 30th November 2020**
+**Last updated 09th December 2022**
 
 ## Objective
 
@@ -26,6 +26,8 @@ If you encounter any difficulties performing these actions, please contact a [sp
 - access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
 
 ## Instructions
+
+Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/gb/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
 
 Use the command line to check if the PHP version is compatible:
 

--- a/pages/web/hosting/composer_install_composer/guide.en-gb.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-gb.md
@@ -22,12 +22,12 @@ If you encounter any difficulties performing these actions, please contact a [sp
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/) with SSH access
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- An [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-gb/web-hosting/) with SSH access
+- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
 
 ## Instructions
 
-Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/gb/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
+Access your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/gb/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
 
 Use the command line to check if the PHP version is compatible:
 

--- a/pages/web/hosting/composer_install_composer/guide.en-ie.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-ie.md
@@ -6,7 +6,7 @@ section: PHP
 order: 02
 ---
 
-**Last updated 30th November 2020**
+**Last updated 09th December 2022**
 
 ## Objective
 
@@ -26,6 +26,8 @@ If you encounter any difficulties performing these actions, please contact a [sp
 - access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
 
 ## Instructions
+
+Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/ie/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
 
 Use the command line to check if the PHP version is compatible:
 

--- a/pages/web/hosting/composer_install_composer/guide.en-ie.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-ie.md
@@ -22,12 +22,12 @@ If you encounter any difficulties performing these actions, please contact a [sp
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-ie/web-hosting/) with SSH access
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- An [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-ie/web-hosting/) with SSH access
+- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
 
 ## Instructions
 
-Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/ie/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
+Access your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/ie/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
 
 Use the command line to check if the PHP version is compatible:
 

--- a/pages/web/hosting/composer_install_composer/guide.en-sg.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-sg.md
@@ -22,12 +22,12 @@ If you encounter any difficulties performing these actions, please contact a [sp
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-sg/web-hosting/) with SSH access
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- An [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-sg/web-hosting/) with SSH access
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
 
 ## Instructions
 
-Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/sg/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
+Access your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/sg/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
 
 Use the command line to check if the PHP version is compatible:
 

--- a/pages/web/hosting/composer_install_composer/guide.en-sg.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-sg.md
@@ -6,77 +6,82 @@ section: PHP
 order: 02
 ---
 
-**Last updated 5th May 2020**
+**Last updated 09th December 2022**
 
-## Prerequisites
-You can use "Composer" on Professional hosting packages and above. You need to have SSH access because you need to use command lines.
+## Objective
+
+[Composer](https://getcomposer.org/){.external} is a dependency manager created for the PHP language. It allows PHP developers to include external libraries in their programmes. Composer allows PHP projects to simplify library distribution and code maintenance. Since the creation of this tool, many good development practices have been proposed and have improved the libraries of the PHP community. These good practices are documented in the form of [SRP](http://www.php-fig.org/){.external}.
+
+**This guide explains how to install Composer and provides an example of usage with a Web Hosting plan.**
+
+> [!warning]
+>This guide will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
+>
+If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+> 
+
+## Requirements
+
+- an [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en-sg/web-hosting/) with SSH access
+- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+
+## Instructions
+
+Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/sg/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
+
+Use the command line to check if the PHP version is compatible:
 
 
-## Installation
-
-## Log on in SSH
-Make sure that you have the latest version of PHP (5.6) via the command line:
-
-
-```
+```bash
 php --version
 ```
 
+If this is not a proper version, you can configure an alias:
 
-If you do not have the right version, you can configure an alias:
 
-
+```bash
+alias php='/usr/local/php8.0/bin/php'
 ```
-alias php='/usr/local/php5.6/bin/php'
-```
+
+We recommend staying in the root folder of your Web Hosting in order to prevent your Composer files from being publicly accessible. Run this command next to install Composer:
 
 
-We advise you to stay in the root folder of your website so that you do not make your "Composer" files publicly available.
-
-## Download and install
-Run this in your terminal:
-
-
-```
+```bash
 curl -sS https://getcomposer.org/installer | php
 ```
 
-
-Congratulations, "Composer" is now available on your web hosting package!
-
-
-## Example usage
-If you want to install Symfony, you can run this command:
+Composer is now available on your Web Hosting.
 
 
-```
+### Use cases
+
+For example, if you want to install Symfony 2 in a simple way, you can run the following command:
+
+```bash
 php composer.phar create-project symfony/framework-standard-edition my_project_name "2.7.*"
 ```
 
+Similarly, you can use the OVHcloud API from your Web Hosting by using the official wrapper. To do this, simply add a file named `composer.json` that contains the list of dependencies you need. Here is an example of this file with the OVHcloud API wrapper:
 
-Similarly, you can use the OVHcloud API from your web hosting package by using the offical wrapper. Just add a file called composer.json which contains the list of dependencies you need. Here is an example of this file with the OVHcloud API wrapper:
 
-
+```json
+1. {
+2.     "name": "Example Application",
+3.     "description": "This is an example of OVHcloud APIs wrapper usage",
+4.     "require": {
+5.         "ovh/ovh": "1.1.*"
+6.     }
+7. }
 ```
-{
-"name": "Example Application",
-"description": "This is an example of OVHcloud APIs wrapper usage",
-"require": {
-"ovh/ovh": "1.1.*"
-}
-}
-```
 
+To install it, simply run the following command in the same folder:
 
-To install, you just have to run the following in the same file. 
-
-
-```
+```bash
 php composer.phar install
 ```
 
+To use this library, you can refer to the documentation, as well as the code, available on [GitHub](https://github.com/ovh/php-ovh){.external}.
 
-To use this library, you can refer to the documentation and code available on [github](https://github.com/ovh/php-ovh)
 
 ## Go further
 

--- a/pages/web/hosting/composer_install_composer/guide.en-us.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-us.md
@@ -6,7 +6,7 @@ section: PHP
 order: 02
 ---
 
-**Last updated 30th November 2020**
+**Last updated 09th December 2022**
 
 ## Objective
 
@@ -26,6 +26,8 @@ If you encounter any difficulties performing these actions, please contact a [sp
 - access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
 
 ## Instructions
+
+Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/us/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
 
 Use the command line to check if the PHP version is compatible:
 

--- a/pages/web/hosting/composer_install_composer/guide.en-us.md
+++ b/pages/web/hosting/composer_install_composer/guide.en-us.md
@@ -22,12 +22,12 @@ If you encounter any difficulties performing these actions, please contact a [sp
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en/web-hosting/) with SSH access
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- An [OVHcloud Web Hosting plan](https://www.ovhcloud.com/en/web-hosting/) with SSH access
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
 
 ## Instructions
 
-Access to your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/us/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
+Access your hosting plan via SSH using our guide to [using SSH with your OVHcloud web hosting plan](https://docs.ovh.com/us/en/hosting/web_hosting_ssh_on_web_hosting_packages/).
 
 Use the command line to check if the PHP version is compatible:
 

--- a/pages/web/hosting/composer_install_composer/guide.es-es.md
+++ b/pages/web/hosting/composer_install_composer/guide.es-es.md
@@ -10,7 +10,7 @@ order: 02
 > Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón «Contribuir» de esta página.
 > 
 
-**Última actualización: 30/11/2020**
+**Última actualización: 09/12/2022**
 
 ## Objetivo
 
@@ -32,6 +32,8 @@ order: 02
 
 
 ## Procedimiento
+
+Conéctese a su alojamiento compartido por SSH con ayuda de nuestra guía sobre [el uso del SSH con su alojamiento web de OVHcloud](https://docs.ovh.com/es/hosting/web_hosting_ssh_en_alojamiento_compartido/).
 
 Compruebe que utiliza una versión de PHP compatible en línea de comandos:
 

--- a/pages/web/hosting/composer_install_composer/guide.es-us.md
+++ b/pages/web/hosting/composer_install_composer/guide.es-us.md
@@ -6,7 +6,7 @@ section: PHP
 order: 02
 ---
 
-**Última actualización: 30/11/2020**
+**Última actualización: 09/12/2022**
 
 ## Objetivo
 
@@ -28,6 +28,8 @@ order: 02
 
 
 ## Procedimiento
+
+Conéctese a su alojamiento compartido por SSH con ayuda de nuestra guía sobre [el uso del SSH con su alojamiento web de OVHcloud](https://docs.ovh.com/us/es/hosting/web_hosting_ssh_en_alojamiento_compartido/).
 
 Compruebe que utiliza una versión de PHP compatible en línea de comandos:
 

--- a/pages/web/hosting/composer_install_composer/guide.fr-ca.md
+++ b/pages/web/hosting/composer_install_composer/guide.fr-ca.md
@@ -6,7 +6,7 @@ section: PHP
 order: 02
 ---
 
-**Dernière mise à jour le 30/11/2020**
+**Dernière mise à jour le 09/12/2022**
 
 ## Objectif
 
@@ -28,6 +28,8 @@ order: 02
 
 
 ## En pratique
+
+Connectez-vous en SSH à votre hébergement mutualisé à l'aide de notre guide sur [l'utilisation du SSH avec votre hébergement web mutualisé OVHcloud](https://docs.ovh.com/ca/fr/hosting/mutualise-le-ssh-sur-les-hebergements-mutualises/).
 
 Vérifiez que vous utilisez bien une version de PHP compatible en ligne de commande :
 

--- a/pages/web/hosting/composer_install_composer/guide.fr-fr.md
+++ b/pages/web/hosting/composer_install_composer/guide.fr-fr.md
@@ -6,7 +6,7 @@ section: PHP
 order: 02
 ---
 
-**Dernière mise à jour le 30/11/2020**
+**Dernière mise à jour le 09/12/2022**
 
 ## Objectif
 
@@ -28,6 +28,8 @@ order: 02
 
 
 ## En pratique
+
+Connectez-vous en SSH à votre hébergement mutualisé à l'aide de notre guide sur [l'utilisation du SSH avec votre hébergement web mutualisé OVHcloud](https://docs.ovh.com/fr/hosting/mutualise-le-ssh-sur-les-hebergements-mutualises/).
 
 Vérifiez que vous utilisez bien une version de PHP compatible en ligne de commande :
 

--- a/pages/web/hosting/composer_install_composer/guide.it-it.md
+++ b/pages/web/hosting/composer_install_composer/guide.it-it.md
@@ -10,7 +10,7 @@ order: 02
 > Questa traduzione è stata generata automaticamente dal nostro partner SYSTRAN. I contenuti potrebbero presentare imprecisioni, ad esempio la nomenclatura dei pulsanti o alcuni dettagli tecnici. In caso di dubbi consigliamo di fare riferimento alla versione inglese o francese della guida. Per aiutarci a migliorare questa traduzione, utilizza il pulsante "Modifica" di questa pagina.
 >
 
-**Ultimo aggiornamento: 30/11/2020**
+**Ultimo aggiornamento: 09/12/2022**
 
 ## Obiettivo
 
@@ -32,6 +32,8 @@ order: 02
 
 
 ## Procedura
+
+Accedi in SSH al tuo hosting condiviso utilizzando la nostra guida su [l'utilizzo dell'SSH con il tuo hosting Web OVHcloud](https://docs.ovh.com/it/hosting/hosting_condiviso_il_protocollo_ssh/).
 
 Verifica di utilizzare una versione di PHP compatibile con il tuo ordine:
 

--- a/pages/web/hosting/composer_install_composer/guide.pl-pl.md
+++ b/pages/web/hosting/composer_install_composer/guide.pl-pl.md
@@ -10,7 +10,7 @@ order: 02
 > Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera SYSTRAN. W niektórych przypadkach mogą wystąpić nieprecyzyjne sformułowania, na przykład w tłumaczeniu nazw przycisków lub szczegółów technicznych. W przypadku jakichkolwiek wątpliwości zalecamy zapoznanie się z angielską/francuską wersją przewodnika. Jeśli chcesz przyczynić się do ulepszenia tłumaczenia, kliknij przycisk „Zaproponuj zmianę” na tej stronie.
 > 
 
-**Ostatnia aktualizacja z dnia 30-11-2020**
+**Ostatnia aktualizacja z dnia 09-12-2022**
 
 ## Wprowadzenie 
 
@@ -32,6 +32,8 @@ order: 02
 
 
 ## W praktyce
+
+Połącz się z hostingiem za pomocą SSH, korzystając z naszego przewodnika na temat [korzystanie z SSH przy pomocy hostingu www OVHcloud](https://docs.ovh.com/pl/hosting/hosting_www_ssh_na_hostingu/).
 
 Sprawdź, czy używasz kompatybilnej wersji PHP w wierszu poleceń:
 

--- a/pages/web/hosting/composer_install_composer/guide.pt-pt.md
+++ b/pages/web/hosting/composer_install_composer/guide.pt-pt.md
@@ -10,7 +10,7 @@ order: 02
 > Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certos casos, poderão ocorrer formulações imprecisas, como por exemplo nomes de botões ou detalhes técnicos. Recomendamos que consulte a versão inglesa ou francesa do manual, caso tenha alguma dúvida. Se nos quiser ajudar a melhorar esta tradução, clique em "Contribuir" nesta página.
 >
 
-**Última atualização: 30/11/2020**
+**Última atualização: 09/12/2022**
 
 ## Objetivo
 
@@ -32,6 +32,8 @@ order: 02
 
 
 ## Instruções
+
+Ligue-se ao seu alojamento partilhado através de SSH através do nosso manual sobre [a utilização do SSH com o seu alojamento web partilhado OVHcloud](https://docs.ovh.com/pt/hosting/partilhado_o_ssh_nos_alojamentos_partilhados/).
 
 Verifique se utiliza uma versão de PHP compatível em linha de comandos:
 


### PR DESCRIPTION
Cust feedback => manque ou executé la commande?

Action => Add a paragraph with a link to "how to connect in SSH with a shared hosting".

I update all guide in EN-SG version because it wasn't update during the last update.

Links checked and done

Update for alls subs done.

Need proof reading for EN DE Latin and PL versions.