### PR TITLE
KS-Custfeedback-BackupFTP-AddSentenceToContactSupportIfDelayExceed24hours

### DIFF
--- a/pages/web/hosting/ftp_save_and_backup/guide.de-de.md
+++ b/pages/web/hosting/ftp_save_and_backup/guide.de-de.md
@@ -10,7 +10,7 @@ order: 06
 > Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In manchen Fällen können ungenaue Formulierungen verwendet worden sein, z.B. bei der Beschriftung von Schaltflächen oder technischen Details. Bitte ziehen Sie beim geringsten Zweifel die englische oder französische Fassung der Anleitung zu Rate. Möchten Sie mithelfen, diese Übersetzung zu verbessern? Dann nutzen Sie dazu bitte den Button «Mitmachen» auf dieser Seite.
 >
 
-**Letzte Aktualisierung am 20.06.2022**
+**Letzte Aktualisierung am 09.12.2022**
 
 ## Ziel 
 
@@ -96,6 +96,11 @@ Klicken Sie nach der Auswahl auf den Button `Weiter`{.action}.
 Vergewissern Sie sich, dass bei der Wiederherstellung keine Datei verloren geht. Das könnte beispielsweise mit einer Datei passieren, die nach dem ausgewählten Datum in Ihren Speicherplatz hochgeladen wurde. Beachten Sie, dass bei der Wiederherstellung die aktuellen Daten vollständig mit den Backup-Daten überschrieben werden.
 
 Klicken Sie auf den Button `Bestätigen`{.action}, um die Wiederherstellung zu starten.
+
+> [!primary]
+>
+> Die automatische Wiederherstellung kann einige Minuten bis einige Stunden in Anspruch nehmen. Wenn die Verlängerung **über 24 Stunden*** dauert, kontaktieren Sie [OVHcloud Kundendienst](https://www.ovhcloud.com/de/support-levels/).
+>
 
 ### Datei mithilfe einer Software oder über ein Interface wiederherstellen
 

--- a/pages/web/hosting/ftp_save_and_backup/guide.de-de.md
+++ b/pages/web/hosting/ftp_save_and_backup/guide.de-de.md
@@ -99,7 +99,7 @@ Klicken Sie auf den Button `Bestätigen`{.action}, um die Wiederherstellung zu s
 
 > [!primary]
 >
-> Die automatische Wiederherstellung kann einige Minuten bis einige Stunden in Anspruch nehmen. Wenn die Verlängerung **über 24 Stunden*** dauert, kontaktieren Sie [OVHcloud Kundendienst](https://www.ovhcloud.com/de/support-levels/).
+> Die automatische Wiederherstellung kann einige Minuten bis einige Stunden in Anspruch nehmen. Wenn der Vorgang **über 24 Stunden*** dauert, kontaktieren Sie den [OVHcloud Support](https://www.ovhcloud.com/de/support-levels/).
 >
 
 ### Datei mithilfe einer Software oder über ein Interface wiederherstellen

--- a/pages/web/hosting/ftp_save_and_backup/guide.en-gb.md
+++ b/pages/web/hosting/ftp_save_and_backup/guide.en-gb.md
@@ -6,7 +6,7 @@ section: 'FTP and SSH'
 order: 06
 ---
 
-**Last updated 20th June 2022**
+**Last updated 09th December 2022**
 
 ## Objective
 
@@ -93,6 +93,11 @@ Once you have selected a date, click `Next`{.action}.
 Take a few minutes to check that none of your files will be lost after the restoration, e.g. any files saved on your storage space after the restore date you have selected. As a reminder, the restoration will effectively overwrite all of your current data, and replace it with the backup data.
 
 Once you are ready to start restoring the backup, click `Confirm`{.action}.
+
+> [!primary]
+>
+> Automatic restoration can take from a few minutes to a few hours. If it takes **more than 24 hours**, contact [OVHcloud support](https://www.ovhcloud.com/en-gb/support-levels/).
+>
 
 ### Restore a file using a software program or interface <a name="viainterface"></a>
 

--- a/pages/web/hosting/ftp_save_and_backup/guide.en-ie.md
+++ b/pages/web/hosting/ftp_save_and_backup/guide.en-ie.md
@@ -6,7 +6,7 @@ section: 'FTP and SSH'
 order: 06
 ---
 
-**Last updated 20th June 2022**
+**Last updated 09th December 2022**
 
 ## Objective
 
@@ -93,6 +93,11 @@ Once you have selected a date, click `Next`{.action}.
 Take a few minutes to check that none of your files will be lost after the restoration, e.g. any files saved on your storage space after the restore date you have selected. As a reminder, the restoration will effectively overwrite all of your current data, and replace it with the backup data.
 
 Once you are ready to start restoring the backup, click `Confirm`{.action}.
+
+> [!primary]
+>
+> Automatic restoration can take from a few minutes to a few hours. If it takes **more than 24 hours**, contact [OVHcloud support](https://www.ovhcloud.com/en-ie/support-levels/).
+>
 
 ### Restore a file using a software program or interface <a name="viainterface"></a>
 

--- a/pages/web/hosting/ftp_save_and_backup/guide.es-es.md
+++ b/pages/web/hosting/ftp_save_and_backup/guide.es-es.md
@@ -10,7 +10,7 @@ order: 06
 > Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón «Contribuir» de esta página.
 >
 
-**Última actualización: 20/06/2022**
+**Última actualización: 09/12/2022**
 
 ## Objetivo
 
@@ -96,6 +96,11 @@ Una vez seleccionada la fecha, haga clic en el botón `Siguiente`{.action}.
 Asegúrese de que no se ha perdido ningún archivo en el proceso de restauración (por ejemplo, cualquier archivo que hubiera guardado en su espacio de almacenamiento después de la fecha de restauración seleccionada). Como ya hemos indicado, la restauración borrará todos los datos actuales para sustituirlos por los de la copia de seguridad.
 
 Haga clic en `Aceptar`{.action} para restaurar la copia de seguridad.
+
+> [!primary]
+>
+> La restauración automática puede tardar desde unos minutos hasta unas horas. Si dura **más de 24 horas**, contacte con [el soporte de OVHcloud](https://www.ovhcloud.com/es-es/support-levels/).
+>
 
 ### Restaurar un archivo desde un programa o una interfaz web <a name="viainterface"></a>
 

--- a/pages/web/hosting/ftp_save_and_backup/guide.fr-fr.md
+++ b/pages/web/hosting/ftp_save_and_backup/guide.fr-fr.md
@@ -6,7 +6,7 @@ section: 'FTP et SSH'
 order: 06
 ---
 
-**Dernière mise à jour le 20/06/2022**
+**Dernière mise à jour le 09/12/2022**
 
 ## Objectif
 
@@ -92,6 +92,11 @@ Une fois la date sélectionnée, cliquez sur le bouton `Suivant`{.action}.
 Prenez quelques instants afin de vous assurer qu'aucun fichier ne sera perdu suite à la restauration, comme un fichier que vous auriez placé sur votre espace de stockage après la date de restauration choisie. Comme précisé, la restauration va en effet écraser l'ensemble des données actuelles afin de les remplacer par celles de la sauvegarde.
 
 Dès que vous êtes prêt à initier la sauvegarde, cliquez sur le bouton `Valider`{.action}.
+
+> [!primary]
+>
+> La restauration automatique peut prendre de quelques minutes à quelques heures. Si elle dure **plus de 24 heures**, contactez [le support d'OVHcloud](https://www.ovhcloud.com/fr/support-levels/).
+>
 
 ### Restaurer un fichier depuis un logiciel ou une interface <a name="viainterface"></a>
 

--- a/pages/web/hosting/ftp_save_and_backup/guide.it-it.md
+++ b/pages/web/hosting/ftp_save_and_backup/guide.it-it.md
@@ -10,7 +10,7 @@ order: 06
 > Questa traduzione è stata generata automaticamente dal nostro partner SYSTRAN. I contenuti potrebbero presentare imprecisioni, ad esempio la nomenclatura dei pulsanti o alcuni dettagli tecnici. In caso di dubbi consigliamo di fare riferimento alla versione inglese o francese della guida. Per aiutarci a migliorare questa traduzione, utilizza il pulsante "Modifica" di questa pagina.
 >
 
-**Ultimo aggiornamento: 20/06/2022**
+**Ultimo aggiornamento: 09/12/2022**
 
 ## Obiettivo
 
@@ -96,6 +96,11 @@ Una volta selezionata la data, clicca su `Seguente`{.action}.
 Assicurati che questa azione non comporti la perdita di dati, ad esempio di un file archiviato sullo spazio di storage dopo la data di ripristino selezionata. Come già precisato, il backup sovrascriverà i dati presenti nello storage.
 
 Clicca su `Conferma`{.action} per avviare l’operazione.
+
+> [!primary]
+>
+> Il ripristino automatico può richiedere da qualche minuto a qualche ora. Se dura **più di 24 ore**, contatta [il supporto OVHcloud](https://www.ovhcloud.com/it/support-levels/).
+>
 
 ### Ripristina un file da un software o un’interfaccia Web <a name="viainterface"></a>
 

--- a/pages/web/hosting/ftp_save_and_backup/guide.pl-pl.md
+++ b/pages/web/hosting/ftp_save_and_backup/guide.pl-pl.md
@@ -10,7 +10,7 @@ order: 06
 > Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera SYSTRAN. W niektórych przypadkach mogą wystąpić nieprecyzyjne sformułowania, na przykład w tłumaczeniu nazw przycisków lub szczegółów technicznych. W przypadku jakichkolwiek wątpliwości zalecamy zapoznanie się z angielską/francuską wersją przewodnika. Jeśli chcesz przyczynić się do ulepszenia tłumaczenia, kliknij przycisk „Zaproponuj zmianę” na tej stronie.
 >
 
-**Ostatnia aktualizacja dnia 20-06-2022**
+**Ostatnia aktualizacja dnia 09-12-2022**
 
 ## Wprowadzenie 
 
@@ -96,6 +96,11 @@ Po wybraniu daty, kliknij przycisk `Dalej`{.action}.
 Poświęć chwilę, aby upewnić się, że żaden plik nie zostanie usunięty w wyniku przywrócenia przestrzeni dyskowej, np. plik, który zapisałeś na przestrzeni po wybranej dacie przywrócenia. Jak zostało wspomniane wyżej, przywrócenie przestrzeni dyskowej spowoduje usunięcie wszystkich aktualnych danych, które zostaną zastąpione danymi z kopii zapasowej.
 
 Kiedy jesteś gotowy do uruchomienia przywracania kopii zapasowej, kliknij przycisk `Zatwierdź`{.action}.
+
+> [!primary]
+>
+> Automatyczne przywracanie może potrwać od kilku minut do kilku godzin. Jeśli trwa **dłużej niż 24 godziny**, skontaktuj się z [Działem Wsparcia Klienta OVHcloud](https://www.ovhcloud.com/pl/support-levels/).
+>
 
 ### Przywracanie pliku za pomocą programu lub interfejsu <a name="viainterface"></a>
 

--- a/pages/web/hosting/ftp_save_and_backup/guide.pl-pl.md
+++ b/pages/web/hosting/ftp_save_and_backup/guide.pl-pl.md
@@ -99,7 +99,7 @@ Kiedy jesteś gotowy do uruchomienia przywracania kopii zapasowej, kliknij przyc
 
 > [!primary]
 >
-> Automatyczne przywracanie może potrwać od kilku minut do kilku godzin. Jeśli trwa **dłużej niż 24 godziny**, skontaktuj się z [Działem Wsparcia Klienta OVHcloud](https://www.ovhcloud.com/pl/support-levels/).
+>Automatyczne przywracanie może trwać od kilku minut do kilku godzin. Jeśli trwa to **więcej niż 24 godziny**, skontaktuj się z [OVHcloud support](https://www.ovhcloud.com/pl/support-levels/).
 >
 
 ### Przywracanie pliku za pomocą programu lub interfejsu <a name="viainterface"></a>

--- a/pages/web/hosting/ftp_save_and_backup/guide.pt-pt.md
+++ b/pages/web/hosting/ftp_save_and_backup/guide.pt-pt.md
@@ -10,7 +10,7 @@ order: 06
 > Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certos casos, poderão ocorrer formulações imprecisas, como por exemplo nomes de botões ou detalhes técnicos. Recomendamos que consulte a versão inglesa ou francesa do manual, caso tenha alguma dúvida. Se nos quiser ajudar a melhorar esta tradução, clique em "Contribuir" nesta página.
 >
 
-**Última atualização: 20/06/2022***
+**Última atualização: 09/12/2022***
 
 ## Objetivo
 
@@ -96,6 +96,11 @@ Depois de selecionar a data, clique no botão `Seguinte`{.action}.
 Certifique-se de que não perdeu nenhum ficheiro no processo de restauração (por exemplo, qualquer ficheiro que guardou no seu espaço de armazenamento após a data de restauração selecionada). Tal como indicado, a restauração vai apagar todos os dados atuais para os substituir pelos dados da cópia de segurança.
 
 De seguida, clique no botão `Validar`{.action}.
+
+> [!primary]
+>
+> O restauro automático pode demorar alguns minutos a algumas horas. Se a duração da ação for **mais de 24 horas**, contacte [o suporte da OVHcloud](https://www.ovhcloud.com/pt/support-levels/).
+>
 
 ### Restaurar um ficheiro a partir de um programa ou uma interface <a name="viainterface"></a>
 


### PR DESCRIPTION
Cust feedback => Bonjour, quelle est la durée moyenne pour la restauration des fichiers ? Nous avons lancé une restauration vers 15h, il est 18h40, c'est toujours indiqué comme "en cours". Cordialement

Actions => Adding a sentence to precise that customer must contact the OVHcloud web support if the backup job exceeds 24 hours.

Done for all subs in step 2 of this guide

Updating also the "last update" date.