### PR TITLE
fix broken links and french typo

### DIFF
--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.de-de.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.de-de.md
@@ -89,7 +89,7 @@ Various backup solutions compatible with **Tanzu Kubernetes Grid** exist, includ
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-asia.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-asia.md
@@ -87,7 +87,7 @@ Various backup solutions compatible with **Tanzu Kubernetes Grid** exist, includ
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-au.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-au.md
@@ -87,7 +87,7 @@ Various backup solutions compatible with **Tanzu Kubernetes Grid** exist, includ
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-ca.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-ca.md
@@ -87,7 +87,7 @@ Various backup solutions compatible with **Tanzu Kubernetes Grid** exist, includ
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-gb.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-gb.md
@@ -87,7 +87,7 @@ Various backup solutions compatible with **Tanzu Kubernetes Grid** exist, includ
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-ie.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-ie.md
@@ -87,7 +87,7 @@ Various backup solutions compatible with **Tanzu Kubernetes Grid** exist, includ
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-sg.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-sg.md
@@ -87,7 +87,7 @@ Various backup solutions compatible with **Tanzu Kubernetes Grid** exist, includ
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-us.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.en-us.md
@@ -87,7 +87,7 @@ Various backup solutions compatible with **Tanzu Kubernetes Grid** exist, includ
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.es-es.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.es-es.md
@@ -89,7 +89,7 @@ Various backup solutions compatible with **Tanzu Kubernetes Grid** exist, includ
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.es-us.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.es-us.md
@@ -89,7 +89,7 @@ Various backup solutions compatible with **Tanzu Kubernetes Grid** exist, includ
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.fr-ca.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.fr-ca.md
@@ -65,7 +65,7 @@ Une application peut être constituée de plusieurs **pods** qui communiquent en
 
 ### Gestion des volumes persistants
 
-Par défaut, lors de l'arrêt ou d'un crash d'un **pod**, les données contenues dans ce **pod** sont perdues. Pour pouvoir stocker des données de manière permanente, il est nécessaire de créér des volumes persistants et de les associer aux applications.
+Par défaut, lors de l'arrêt ou d'un crash d'un **pod**, les données contenues dans ce **pod** sont perdues. Pour pouvoir stocker des données de manière permanente, il est nécessaire de créer des volumes persistants et de les associer aux applications.
 
 Les volumes persistants sont stockés par défaut sur le stockage VMware (vSAN ou NFS) qui a servi pour le déploiement du cluster de *WorkLoad*, en utilisant les API VMware (vSphere Cloud Native Storage).
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.fr-ca.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.fr-ca.md
@@ -87,7 +87,7 @@ Diverses solutions de sauvegarde compatibles avec **Tanzu Kubernetes Grid** exis
 
 [Présentation de VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Installation manuelle de l'outil CLI pour le déploiement de Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.fr-fr.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.fr-fr.md
@@ -65,7 +65,7 @@ Une application peut être constituée de plusieurs **pods** qui communiquent en
 
 ### Gestion des volumes persistants
 
-Par défaut, lors de l'arrêt ou d'un crash d'un **pod**, les données contenues dans ce **pod** sont perdues. Pour pouvoir stocker des données de manière permanente, il est nécessaire de créér des volumes persistants et de les associer aux applications.
+Par défaut, lors de l'arrêt ou d'un crash d'un **pod**, les données contenues dans ce **pod** sont perdues. Pour pouvoir stocker des données de manière permanente, il est nécessaire de créer des volumes persistants et de les associer aux applications.
 
 Les volumes persistants sont stockés par défaut sur le stockage VMware (vSAN ou NFS) qui a servi pour le déploiement du cluster de *WorkLoad*, en utilisant les API VMware (vSphere Cloud Native Storage).
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.fr-fr.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.fr-fr.md
@@ -87,7 +87,7 @@ Diverses solutions de sauvegarde compatibles avec **Tanzu Kubernetes Grid** exis
 
 [Présentation de VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Installation manuelle de l'outil CLI pour le déploiement de Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.it-it.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.it-it.md
@@ -89,7 +89,7 @@ Various backup solutions compatible with **Tanzu Kubernetes Grid** exist, includ
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.pl-pl.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.pl-pl.md
@@ -89,7 +89,7 @@ Various backup solutions compatible with **Tanzu Kubernetes Grid** exist, includ
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.pt-pt.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_01presentation/guide.pt-pt.md
@@ -89,7 +89,7 @@ Various backup solutions compatible with **Tanzu Kubernetes Grid** exist, includ
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.de-de.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.de-de.md
@@ -363,7 +363,7 @@ Go to the vCenter interface to see the seven virtual machines created.
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-asia.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-asia.md
@@ -361,7 +361,7 @@ Go to the vCenter interface to see the seven virtual machines created.
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-au.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-au.md
@@ -361,7 +361,7 @@ Go to the vCenter interface to see the seven virtual machines created.
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-ca.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-ca.md
@@ -361,7 +361,7 @@ Go to the vCenter interface to see the seven virtual machines created.
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-gb.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-gb.md
@@ -361,7 +361,7 @@ Go to the vCenter interface to see the seven virtual machines created.
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-ie.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-ie.md
@@ -361,7 +361,7 @@ Go to the vCenter interface to see the seven virtual machines created.
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-sg.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-sg.md
@@ -361,7 +361,7 @@ Go to the vCenter interface to see the seven virtual machines created.
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-us.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.en-us.md
@@ -361,7 +361,7 @@ Go to the vCenter interface to see the seven virtual machines created.
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.es-es.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.es-es.md
@@ -363,7 +363,7 @@ Go to the vCenter interface to see the seven virtual machines created.
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.es-us.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.es-us.md
@@ -363,7 +363,7 @@ Go to the vCenter interface to see the seven virtual machines created.
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.fr-ca.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.fr-ca.md
@@ -361,7 +361,7 @@ Allez sur l'interface vCenter pour voir les sept machines virtuelles créées.
 
 [Présentation de VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Installation manuelle de l'outil CLI pour le déploiement de Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.fr-fr.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.fr-fr.md
@@ -361,7 +361,7 @@ Allez sur l'interface vCenter pour voir les sept machines virtuelles créées.
 
 [Présentation de VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Installation manuelle de l'outil CLI pour le déploiement de Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.it-it.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.it-it.md
@@ -363,7 +363,7 @@ Go to the vCenter interface to see the seven virtual machines created.
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.pl-pl.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.pl-pl.md
@@ -363,7 +363,7 @@ Go to the vCenter interface to see the seven virtual machines created.
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.pt-pt.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_02installation/guide.pt-pt.md
@@ -363,7 +363,7 @@ Go to the vCenter interface to see the seven virtual machines created.
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.de-de.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.de-de.md
@@ -149,7 +149,7 @@ An application can consist of multiple pods that communicate with each other thr
 
 [Tanzu Kubernetes Grid VMware Overview](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware de Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware de Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-asia.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-asia.md
@@ -147,7 +147,7 @@ An application can consist of multiple pods that communicate with each other thr
 
 [Tanzu Kubernetes Grid VMware Overview](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware de Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware de Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-au.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-au.md
@@ -147,7 +147,7 @@ An application can consist of multiple pods that communicate with each other thr
 
 [Tanzu Kubernetes Grid VMware Overview](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware de Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware de Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-ca.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-ca.md
@@ -147,7 +147,7 @@ An application can consist of multiple pods that communicate with each other thr
 
 [Tanzu Kubernetes Grid VMware Overview](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware de Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware de Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-gb.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-gb.md
@@ -147,7 +147,7 @@ An application can consist of multiple pods that communicate with each other thr
 
 [Tanzu Kubernetes Grid VMware Overview](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware de Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware de Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-ie.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-ie.md
@@ -147,7 +147,7 @@ An application can consist of multiple pods that communicate with each other thr
 
 [Tanzu Kubernetes Grid VMware Overview](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware de Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware de Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-sg.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-sg.md
@@ -147,7 +147,7 @@ An application can consist of multiple pods that communicate with each other thr
 
 [Tanzu Kubernetes Grid VMware Overview](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware de Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware de Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-us.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.en-us.md
@@ -147,7 +147,7 @@ An application can consist of multiple pods that communicate with each other thr
 
 [Tanzu Kubernetes Grid VMware Overview](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware de Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware de Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.es-es.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.es-es.md
@@ -149,7 +149,7 @@ An application can consist of multiple pods that communicate with each other thr
 
 [Tanzu Kubernetes Grid VMware Overview](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware de Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware de Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.es-us.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.es-us.md
@@ -149,7 +149,7 @@ An application can consist of multiple pods that communicate with each other thr
 
 [Tanzu Kubernetes Grid VMware Overview](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware de Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware de Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.fr-ca.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.fr-ca.md
@@ -147,7 +147,7 @@ Une application peut être constituée de plusieurs pods qui communiquent entre 
 
 [Présentation VMware de Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation VMware de Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation VMware de Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Installation manuelle de l'outil CLI pour le déploiement de Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.fr-ca.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Administrer Tanzu Management Cluster Grid
 slug: tanzu-tkgm-management
-excerpt: Administration de TKG pour créér un cluster de Workload et ajouter des applications dans ce cluster
+excerpt: Administration de TKG pour créer un cluster de Workload et ajouter des applications dans ce cluster
 section: Tanzu
 order: 04
 ---
@@ -10,7 +10,7 @@ order: 04
 
 ## Objectif
 
-**Ce guide vous permet de créér un cluster de *Workload* et ajouter des applications dans ce cluster.**
+**Ce guide vous permet de créer un cluster de *Workload* et ajouter des applications dans ce cluster.**
 
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.fr-fr.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.fr-fr.md
@@ -147,7 +147,7 @@ Une application peut être constituée de plusieurs pods qui communiquent entre 
 
 [Présentation VMware de Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation VMware de Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation VMware de Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Installation manuelle de l'outil CLI pour le déploiement de Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.fr-fr.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Administrer Tanzu Management Cluster Grid
 slug: tanzu-tkgm-management
-excerpt: Administration de TKG pour créér un cluster de Workload et ajouter des applications dans ce cluster
+excerpt: Administration de TKG pour créer un cluster de Workload et ajouter des applications dans ce cluster
 section: Tanzu
 order: 04
 ---
@@ -10,7 +10,7 @@ order: 04
 
 ## Objectif
 
-**Ce guide vous permet de créér un cluster de *Workload* et ajouter des applications dans ce cluster.**
+**Ce guide vous permet de créer un cluster de *Workload* et ajouter des applications dans ce cluster.**
 
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.it-it.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.it-it.md
@@ -149,7 +149,7 @@ An application can consist of multiple pods that communicate with each other thr
 
 [Tanzu Kubernetes Grid VMware Overview](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware de Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware de Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.pl-pl.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.pl-pl.md
@@ -149,7 +149,7 @@ An application can consist of multiple pods that communicate with each other thr
 
 [Tanzu Kubernetes Grid VMware Overview](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware de Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware de Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.pt-pt.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_03manage/guide.pt-pt.md
@@ -149,7 +149,7 @@ An application can consist of multiple pods that communicate with each other thr
 
 [Tanzu Kubernetes Grid VMware Overview](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware de Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware de Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.de-de.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.de-de.md
@@ -222,7 +222,7 @@ Go back to the `Datacenter`{.action} at the root of the datacenters, click on th
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-asia.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-asia.md
@@ -220,7 +220,7 @@ Go back to the `Datacenter`{.action} at the root of the datacenters, click on th
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-au.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-au.md
@@ -220,7 +220,7 @@ Go back to the `Datacenter`{.action} at the root of the datacenters, click on th
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-ca.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-ca.md
@@ -220,7 +220,7 @@ Go back to the `Datacenter`{.action} at the root of the datacenters, click on th
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-gb.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-gb.md
@@ -220,7 +220,7 @@ Go back to the `Datacenter`{.action} at the root of the datacenters, click on th
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-ie.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-ie.md
@@ -220,7 +220,7 @@ Go back to the `Datacenter`{.action} at the root of the datacenters, click on th
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-sg.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-sg.md
@@ -220,7 +220,7 @@ Go back to the `Datacenter`{.action} at the root of the datacenters, click on th
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-us.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.en-us.md
@@ -220,7 +220,7 @@ Go back to the `Datacenter`{.action} at the root of the datacenters, click on th
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.es-es.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.es-es.md
@@ -222,7 +222,7 @@ Go back to the `Datacenter`{.action} at the root of the datacenters, click on th
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.es-us.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.es-us.md
@@ -222,7 +222,7 @@ Go back to the `Datacenter`{.action} at the root of the datacenters, click on th
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.fr-ca.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.fr-ca.md
@@ -220,7 +220,7 @@ Revenez dans le `Datacenter`{.action} à la racine des datacenters, cliquez sur 
 
 [Présentation de VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Installation manuelle de l'outil CLI pour le déploiement de Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.fr-fr.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.fr-fr.md
@@ -220,7 +220,7 @@ Revenez dans le `Datacenter`{.action} à la racine des datacenters, cliquez sur 
 
 [Présentation de VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[Documentation de VMware Tanzu Kubenetes Grid](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[Documentation de VMware Tanzu Kubenetes Grid](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Installation manuelle de l'outil CLI pour le déploiement de Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.it-it.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.it-it.md
@@ -222,7 +222,7 @@ Go back to the `Datacenter`{.action} at the root of the datacenters, click on th
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.pl-pl.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.pl-pl.md
@@ -222,7 +222,7 @@ Go back to the `Datacenter`{.action} at the root of the datacenters, click on th
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.pt-pt.md
+++ b/pages/cloud/private-cloud/tanzu_tkgm_04persistent-volumes/guide.pt-pt.md
@@ -222,7 +222,7 @@ Go back to the `Datacenter`{.action} at the root of the datacenters, click on th
 
 [Introducing VMware Tanzu Kubernetes Grid](https://tanzu.vmware.com/kubernetes-grid)
 
-[VMware Tanzu Kubenetes Grid documentation](https://https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
+[VMware Tanzu Kubenetes Grid documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html)
 
 [Manual installation of the CLI tool for the deployment of Tanzu Kubernetes GRID](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.5/vmware-tanzu-kubernetes-grid-15/GUID-install-cli.html)
 

--- a/pages/cloud/vps/using-snapshots-on-a-vps/guide.fr-ca.md
+++ b/pages/cloud/vps/using-snapshots-on-a-vps/guide.fr-ca.md
@@ -52,7 +52,7 @@ Si vous êtes sûr de vouloir restaurer votre VPS à l'état du snapshot, clique
 
 > [!alert]
 >
-> Lorsque vous restaurez un VPS à partir d’un snapshot, ce dernier sera supprimé. Si vous souhaitez conserver le même snapshot, vous devez en créér un nouveau avant d'apporter des modifications au système restauré.
+> Lorsque vous restaurez un VPS à partir d’un snapshot, ce dernier sera supprimé. Si vous souhaitez conserver le même snapshot, vous devez en créer un nouveau avant d'apporter des modifications au système restauré.
 >
 
 ### Bonnes pratiques pour la création d'un snapshot


### PR DESCRIPTION
- Double scheme in bottom link of Tanzu documentation
- Typo "créér" fixed to "créer"