### PR TITLE
Hb update security section

### DIFF
--- a/pages/account/responsibility-sharing/product.en-gb.md
+++ b/pages/account/responsibility-sharing/product.en-gb.md
@@ -2,7 +2,7 @@
 title: Responsibility sharing
 slug: responsibility-sharing
 excerpt: Responsibility sharing between OVHcloud and its customers
-sections: RACI Bare Metal Cloud, RACI Public Cloud
+sections: RACI Bare Metal Cloud, RACI Public Cloud, RACI Microsoft collaborative solutions, RACI Web Cloud
 order: 6
 ---
 
@@ -12,3 +12,17 @@ order: 6
 >
 >  - [RACI DBaaS](https://docs.ovh.com/gb/en/publiccloud/databases/responsibility-model/)
 >
+>  - [RACI Instances](TBC)
+>
+>  - [RACI Block Storage](TBC)
+>
+>  - [RACI Log Data Platform](https://docs.ovh.com/fr/logs-data-platform/responsibility-model/)
+>
+> ### RACI Microsoft collaborative solutions
+>
+>  - [RACI Hosted Exchange](https://docs.ovh.com/gb/en/microsoft-collaborative-solutions/responsibility-model/)
+>
+> ### RACI Web Cloud
+> 
+>  - [RACI Email Pro](https://docs.ovh.com/gb/en/emails-pro/responsibility-model/)
+>   

--- a/pages/account/responsibility-sharing/product.en-gb.md
+++ b/pages/account/responsibility-sharing/product.en-gb.md
@@ -12,9 +12,9 @@ order: 6
 >
 >  - [RACI DBaaS](https://docs.ovh.com/gb/en/publiccloud/databases/responsibility-model/)
 >
->  - [RACI Instances](TBC)
+>  - [RACI Instances](https://docs.ovh.com/gb/en/public-cloud/raci-instances-public-cloud/)
 >
->  - [RACI Block Storage](TBC)
+>  - [RACI Block Storage](https://docs.ovh.com/gb/en/public-cloud/raci-block-storage-public-cloud/)
 >
 >  - [RACI Log Data Platform](https://docs.ovh.com/fr/logs-data-platform/responsibility-model/)
 >

--- a/pages/account/responsibility-sharing/product.en-gb.md
+++ b/pages/account/responsibility-sharing/product.en-gb.md
@@ -10,13 +10,13 @@ order: 6
 >
 > ### RACI Public Cloud
 >
->  - [RACI DBaaS](https://docs.ovh.com/gb/en/publiccloud/databases/responsibility-model/)
+>  - [RACI Public Cloud Databases](https://docs.ovh.com/gb/en/publiccloud/databases/responsibility-model/)
 >
->  - [RACI Instances](https://docs.ovh.com/gb/en/public-cloud/raci-instances-public-cloud/)
+>  - [RACI Public Cloud Instances](https://docs.ovh.com/gb/en/public-cloud/raci-instances-public-cloud/)
 >
 >  - [RACI Block Storage](https://docs.ovh.com/gb/en/public-cloud/raci-block-storage-public-cloud/)
 >
->  - [RACI Log Data Platform](https://docs.ovh.com/fr/logs-data-platform/responsibility-model/)
+>  - [RACI Log Data Platform](https://docs.ovh.com/gb/en/logs-data-platform/responsibility-model/)
 >
 > ### RACI Microsoft collaborative solutions
 >

--- a/pages/account/responsibility-sharing/product.fr-fr.md
+++ b/pages/account/responsibility-sharing/product.fr-fr.md
@@ -2,7 +2,7 @@
 title: Partage de responsabilités
 slug: partage-responsabilite
 excerpt: Partage de responsabilités entre OVHcloud et ses clients
-sections: RACI Bare Metal Cloud, RACI Public Cloud
+sections: RACI Bare Metal Cloud, RACI Public Cloud, Microsoft collaborative solutions, Web Cloud 
 order: 6
 ---
 
@@ -12,3 +12,17 @@ order: 6
 >
 >  - [RACI DBaaS](https://docs.ovh.com/gb/en/publiccloud/databases/responsibility-model/)
 >
+>  - [RACI Instances](https://docs.ovh.com/fr/public-cloud/raci-instances-public-cloud/)
+>
+>  - [RACI Block Storage](https://docs.ovh.com/fr/public-cloud/raci-block-storage-public-cloud/)
+>
+>  - [RACI Log Data Platform](https://docs.ovh.com/fr/logs-data-platform/responsibility-model/)
+>
+> ### RACI Microsoft collaborative solutions
+>
+>  - [RACI Hosted Exchange](https://docs.ovh.com/gb/en/microsoft-collaborative-solutions/responsibility-model/)
+>
+> ### RACI Web Cloud
+> 
+>  - [RACI Email Pro](https://docs.ovh.com/gb/en/emails-pro/responsibility-model/)
+>   

--- a/pages/account/responsibility-sharing/product.fr-fr.md
+++ b/pages/account/responsibility-sharing/product.fr-fr.md
@@ -2,7 +2,7 @@
 title: Partage de responsabilités
 slug: partage-responsabilite
 excerpt: Partage de responsabilités entre OVHcloud et ses clients
-sections: RACI Bare Metal Cloud, RACI Public Cloud, Microsoft collaborative solutions, Web Cloud 
+sections: RACI Bare Metal Cloud, RACI Public Cloud, Solutions collaborative Microsoft, Web Cloud 
 order: 6
 ---
 

--- a/pages/account/responsibility-sharing/product.fr-fr.md
+++ b/pages/account/responsibility-sharing/product.fr-fr.md
@@ -2,7 +2,7 @@
 title: Partage de responsabilités
 slug: partage-responsabilite
 excerpt: Partage de responsabilités entre OVHcloud et ses clients
-sections: RACI Bare Metal Cloud, RACI Public Cloud, Solutions collaborative Microsoft, Web Cloud 
+sections: RACI Bare Metal Cloud, RACI Public Cloud, RACI Microsoft collaborative solutions, RACI Web Cloud
 order: 6
 ---
 
@@ -10,9 +10,9 @@ order: 6
 >
 > ### RACI Public Cloud
 >
->  - [RACI DBaaS](https://docs.ovh.com/gb/en/publiccloud/databases/responsibility-model/)
+>  - [RACI Public Cloud Databases](https://docs.ovh.com/fr/publiccloud/databases/responsibility-model/)
 >
->  - [RACI Instances](https://docs.ovh.com/fr/public-cloud/raci-instances-public-cloud/)
+>  - [RACI Public Cloud Instances](https://docs.ovh.com/fr/public-cloud/raci-instances-public-cloud/)
 >
 >  - [RACI Block Storage](https://docs.ovh.com/fr/public-cloud/raci-block-storage-public-cloud/)
 >


### PR DESCRIPTION
update the Responisbility sharing section with RACI links for those already published : 

EN : https://docs.ovh.com/gb/en/responsibility-sharing/

FR : https://docs.ovh.com/fr/partage-responsabilite/

this section (links) will published after 4 or 5 new RACIs publications. 

PS : I don't know if it could be done at each new RACI publication in the same Pull Request but if the team-guides have any advice or suggestion on it, I take it into account

thanks for your actions :) 
 

