### PR TITLE
KS-SK1001-Create-Overquota-BDD-APAC-CA-Translations

### DIFF
--- a/pages/web/hosting/sql_overquota_database/guide.en-asia.md
+++ b/pages/web/hosting/sql_overquota_database/guide.en-asia.md
@@ -1,0 +1,198 @@
+---
+title: "Tutorial - What do I do when my database is full?"
+slug: database-overquota
+excerpt: "Find out what to do when your database is saturated"
+section: Databases
+order: 06
+---
+
+**Last updated 26th January 2023**
+
+## Objective
+
+A database can, for example, store data related to a website and its functionalities. This information is structured so that your website can easily access it, allowing for optimal and customised access for users/visitors to your website. 
+
+During its use, a database can acquire, modify or delete information (connection data, user data, display data, data necessary for your website to work properly, etc.). 
+
+In some cases, the database stores such a large amount of information that it will saturate its allocated storage space. When a database is full, this state is called **overquota**.
+
+This tutorial will show you the actions you can take when your OVHcloud shared database is close to saturation, or is already in **overquota**.
+
+**This guide explains possible actions when your database is full.**
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- An [OVHcloud web hosting plan](https://www.ovhcloud.com/asia/web-hosting/) with an associated OVHcloud shared database
+  
+## Instructions
+
+> [!warning]
+>
+> OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
+> 
+> If you experience any difficulties following the steps in this tutorial, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/asia/directory/) or reach out to the OVHcloud community. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+>
+
+When your OVHcloud shared database reaches a certain saturation level (**overquota**), our robots will send a notification to the email address of the database’s [administrator contact](https://docs.ovh.com/asia/en/customer/managing-contacts/). 
+
+The first email will be sent when your database has consumed more than **80%** of its storage capacity. A second email is sent when **90%** of this storage capacity is reached.
+
+When your database is in **overquota**, you will be sent a third warning email. Your database will then switch to *READ ONLY*. You can no longer add or modify your database entries, but they are still accessible to **read** and **delete**. 
+
+### Step 1: Identify large tables
+
+A database is made up of one or more **tables**, themselves consisting of one or more **rows** organised using predetermined **columns**.
+
+The first step is to identify the large table or tables in your database.
+
+> [!primary]
+>
+> All the following actions described in this tutorial will be performed from the **phpMyAdmin** interface.
+>
+> [phpMyAdmin](https://www.phpmyadmin.net/){.external} is available on all OVHcloud shared databases.
+> This database management application makes it easy to perform the manual actions you can perform with your database.
+>
+
+#### 1.1 - Connect to the database via phpMyAdmin
+
+Retrieve the password for accessing your database directly from your website’s configuration file. Perform this action using **step 1** in our guide to [changing a database password](https://docs.ovh.com/asia/en/hosting/change-password-database/).
+
+Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) and select `Web Cloud`{.action} in the navigation bar at the top of the screen. Click on `Hosting plans`{.action} and choose the web hosting plan associated with your OVHcloud shared database. Next, go to the `Databases`{.action} tab.
+
+![phpMyAdmin Access](images/pma_access.png){.thumbnail}
+
+From the `Databases`{.action} tab, click on the button `...`{.action} to the right of the database that is full, then `Go to phpMyAdmin`{.action}.
+
+![phpMyAdmin Go Login](images/pma_interface.png){.thumbnail}
+
+Enter your database password in addition to the pre-filled information, then click `Run`{.action}.
+
+#### 1.2 - Find the largest tables
+
+> [!alert]
+>
+> From here on, your actions affect the content of your database. The changes you make in **phpMyAdmin** can have irreversible consequences if they are not carried out correctly.
+>
+> Be sure about each command you execute on the database. If you experience any difficulties, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/asia/directory/). OVHcloud cannot assist you with the content of your database.
+>
+
+Once connected, the following page is displayed:
+
+![phpMyAdmin Login](images/pma_login.png){.thumbnail}
+
+Click on `"Your database name"`{.action} in the left-hand column, then on `Size`{.action} in the top right-hand corner of the table that appears:
+
+![phpMyAdmin Tables](images/pma_show_table.png){.thumbnail}
+
+The largest tables appear at the top of the sorted list. Identify them, then go to **Step 2**.
+
+### Step 2: Determine the usefulness of the content in the large table(s)
+
+Once you have identified the large tables, determine whether all of their content is required for your site to work.
+
+> [!primary]
+>
+> If you are using a Content Management System (CMS) such as WordPress, Joomla!, PrestaShop or Drupal, make sure that your large tables are not linked to a recently installed or updated plugin/theme.
+>
+> In this case, contact the developer of the plugin/theme to determine appropriate actions to take on your CMS.
+>
+ 
+For other CMS types, we recommend that you contact your CMS publisher before you perform the following actions.
+
+Below are links to the official CMS websites for the OVHcloud 1-click modules:
+
+- [WordPress](https://wordpress.org/){.external}
+- [Joomla!](https://www.joomla.org){.external}
+- [PrestaShop](https://www.prestashop.com/){.external}
+- [Drupal](https://drupal.org){.external}
+
+> [!primary]
+>
+> If your website is a **customised** software, developed by a specialist provider, we recommend that you contact them for support.
+>
+
+### Step 3: Take corrective action
+
+Once you have determined whether or not the contents of your tables are necessary for your site to work, you have several options:
+
+#### Case 1 - All of the contents of the large table are required for your website to work properly
+
+You will need to upgrade your database service to one that includes more space for databases.
+
+Consult our [Private SQL/CloudDB](https://www.ovhcloud.com/asia/web-hosting/options/) offer to choose your new database service. 
+
+We recommend this solution for large databases.
+
+Then follow our guides to move the content from your old database to the new one:
+
+- [Export your existing database](https://docs.ovh.com/asia/en/hosting/web_hosting_database_export_guide/)
+- [First steps with Private SQL/CloudDB](https://docs.ovh.com/gb/en/clouddb/getting-started-with-clouddb/)
+- [Import your old database into your Private SQL/CloudDB](https://docs.ovh.com/gb/en/clouddb/restore-import-database/)
+
+#### Case 2 - Some or all of the contents of the large table are not necessary for your site to work
+
+Before you do the following, check if the data in the large table corresponds to items that can be deleted from your CMS admin panel. 
+
+**Examples**:
+
+- Old comments/posts
+- Items in your CMS's `Trash` menu
+- Data related to an old theme and/or plugin
+
+> [!alert]
+>
+> The rest of this tutorial will show you how to delete data stored in your database. Be sure of the actions you need to take or contact a [specialist provider](https://partner.ovhcloud.com/asia/directory/) if in doubt.
+>
+
+OVHcloud shared databases have several SQL commands to influence their content.
+
+In the case of an overquota or large table, **three commands** are available.
+
+You can perform these requests from the **phpMyAdmin** interface, via the `SQL`{.action} tab:
+
+![phpMyAdmin SQL request](images/pma_sql_request.png){.thumbnail}
+
+- The **DELETE** command
+
+You can use it to remove **one or more rows** from a given table. This command is useful if part of the table content is required for your website to work properly.
+
+**Example**:
+
+```sql
+DELETE FROM `table_1` WHERE `id` = 1
+```
+
+> In this example, the command deletes the row or rows in the **table_1** whose value in the **id** column is **1**.
+
+- The **TRUNCATE** command
+
+This command deletes **all rows** from a given table.
+
+**Example**:
+
+```sql
+TRUNCATE TABLE `table_1`
+```
+
+> In this example, the command deletes all rows from the **table_1** without exception.
+
+- The **DROP** command
+
+It allows you to completely remove **a table and all the rows it contains**. This command should not be used if the table is still required.
+
+**Example**:
+
+```sql
+DROP TABLE `table_1`
+```
+
+> In this example, the command deletes the table **table_1** and all rows in it.
+
+## Go further <a name="go-further"></a>
+
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/asia/directory/).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/asia/support-levels/).
+
+Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/web/hosting/sql_overquota_database/guide.en-au.md
+++ b/pages/web/hosting/sql_overquota_database/guide.en-au.md
@@ -1,0 +1,198 @@
+---
+title: "Tutorial - What do I do when my database is full?"
+slug: database-overquota
+excerpt: "Find out what to do when your database is saturated"
+section: Databases
+order: 06
+---
+
+**Last updated 26th January 2023**
+
+## Objective
+
+A database can, for example, store data related to a website and its functionalities. This information is structured so that your website can easily access it, allowing for optimal and customised access for users/visitors to your website. 
+
+During its use, a database can acquire, modify or delete information (connection data, user data, display data, data necessary for your website to work properly, etc.). 
+
+In some cases, the database stores such a large amount of information that it will saturate its allocated storage space. When a database is full, this state is called **overquota**.
+
+This tutorial will show you the actions you can take when your OVHcloud shared database is close to saturation, or is already in **overquota**.
+
+**This guide explains possible actions when your database is full.**
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- An [OVHcloud web hosting plan](https://www.ovhcloud.com/en-au/web-hosting/) with an associated OVHcloud shared database
+  
+## Instructions
+
+> [!warning]
+>
+> OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
+> 
+> If you experience any difficulties following the steps in this tutorial, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/en-au/directory/) or reach out to the OVHcloud community. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+>
+
+When your OVHcloud shared database reaches a certain saturation level (**overquota**), our robots will send a notification to the email address of the database’s [administrator contact](https://docs.ovh.com/au/en/customer/managing-contacts/). 
+
+The first email will be sent when your database has consumed more than **80%** of its storage capacity. A second email is sent when **90%** of this storage capacity is reached.
+
+When your database is in **overquota**, you will be sent a third warning email. Your database will then switch to *READ ONLY*. You can no longer add or modify your database entries, but they are still accessible to **read** and **delete**. 
+
+### Step 1: Identify large tables
+
+A database is made up of one or more **tables**, themselves consisting of one or more **rows** organised using predetermined **columns**.
+
+The first step is to identify the large table or tables in your database.
+
+> [!primary]
+>
+> All the following actions described in this tutorial will be performed from the **phpMyAdmin** interface.
+>
+> [phpMyAdmin](https://www.phpmyadmin.net/){.external} is available on all OVHcloud shared databases.
+> This database management application makes it easy to perform the manual actions you can perform with your database.
+>
+
+#### 1.1 - Connect to the database via phpMyAdmin
+
+Retrieve the password for accessing your database directly from your website’s configuration file. Perform this action using **step 1** in our guide to [changing a database password](https://docs.ovh.com/au/en/hosting/change-password-database/).
+
+Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) and select `Web Cloud`{.action} in the navigation bar at the top of the screen. Click on `Hosting plans`{.action} and choose the web hosting plan associated with your OVHcloud shared database. Next, go to the `Databases`{.action} tab.
+
+![phpMyAdmin Access](images/pma_access.png){.thumbnail}
+
+From the `Databases`{.action} tab, click on the button `...`{.action} to the right of the database that is full, then `Go to phpMyAdmin`{.action}.
+
+![phpMyAdmin Go Login](images/pma_interface.png){.thumbnail}
+
+Enter your database password in addition to the pre-filled information, then click `Run`{.action}.
+
+#### 1.2 - Find the largest tables
+
+> [!alert]
+>
+> From here on, your actions affect the content of your database. The changes you make in **phpMyAdmin** can have irreversible consequences if they are not carried out correctly.
+>
+> Be sure about each command you execute on the database. If you experience any difficulties, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/en-au/directory/). OVHcloud cannot assist you with the content of your database.
+>
+
+Once connected, the following page is displayed:
+
+![phpMyAdmin Login](images/pma_login.png){.thumbnail}
+
+Click on `"Your database name"`{.action} in the left-hand column, then on `Size`{.action} in the top right-hand corner of the table that appears:
+
+![phpMyAdmin Tables](images/pma_show_table.png){.thumbnail}
+
+The largest tables appear at the top of the sorted list. Identify them, then go to **Step 2**.
+
+### Step 2: Determine the usefulness of the content in the large table(s)
+
+Once you have identified the large tables, determine whether all of their content is required for your site to work.
+
+> [!primary]
+>
+> If you are using a Content Management System (CMS) such as WordPress, Joomla!, PrestaShop or Drupal, make sure that your large tables are not linked to a recently installed or updated plugin/theme.
+>
+> In this case, contact the developer of the plugin/theme to determine appropriate actions to take on your CMS.
+>
+ 
+For other CMS types, we recommend that you contact your CMS publisher before you perform the following actions.
+
+Below are links to the official CMS websites for the OVHcloud 1-click modules:
+
+- [WordPress](https://wordpress.org/){.external}
+- [Joomla!](https://www.joomla.org){.external}
+- [PrestaShop](https://www.prestashop.com/){.external}
+- [Drupal](https://drupal.org){.external}
+
+> [!primary]
+>
+> If your website is a **customised** software, developed by a specialist provider, we recommend that you contact them for support.
+>
+
+### Step 3: Take corrective action
+
+Once you have determined whether or not the contents of your tables are necessary for your site to work, you have several options:
+
+#### Case 1 - All of the contents of the large table are required for your website to work properly
+
+You will need to upgrade your database service to one that includes more space for databases.
+
+Consult our [Private SQL/CloudDB](https://www.ovhcloud.com/en-au/web-hosting/options/) offer to choose your new database service. 
+
+We recommend this solution for large databases.
+
+Then follow our guides to move the content from your old database to the new one:
+
+- [Export your existing database](https://docs.ovh.com/au/en/hosting/web_hosting_database_export_guide/)
+- [First steps with Private SQL/CloudDB](https://docs.ovh.com/gb/en/clouddb/getting-started-with-clouddb/)
+- [Import your old database into your Private SQL/CloudDB](https://docs.ovh.com/gb/en/clouddb/restore-import-database/)
+
+#### Case 2 - Some or all of the contents of the large table are not necessary for your site to work
+
+Before you do the following, check if the data in the large table corresponds to items that can be deleted from your CMS admin panel. 
+
+**Examples**:
+
+- Old comments/posts
+- Items in your CMS's `Trash` menu
+- Data related to an old theme and/or plugin
+
+> [!alert]
+>
+> The rest of this tutorial will show you how to delete data stored in your database. Be sure of the actions you need to take or contact a [specialist provider](https://partner.ovhcloud.com/en-au/directory/) if in doubt.
+>
+
+OVHcloud shared databases have several SQL commands to influence their content.
+
+In the case of an overquota or large table, **three commands** are available.
+
+You can perform these requests from the **phpMyAdmin** interface, via the `SQL`{.action} tab:
+
+![phpMyAdmin SQL request](images/pma_sql_request.png){.thumbnail}
+
+- The **DELETE** command
+
+You can use it to remove **one or more rows** from a given table. This command is useful if part of the table content is required for your website to work properly.
+
+**Example**:
+
+```sql
+DELETE FROM `table_1` WHERE `id` = 1
+```
+
+> In this example, the command deletes the row or rows in the **table_1** whose value in the **id** column is **1**.
+
+- The **TRUNCATE** command
+
+This command deletes **all rows** from a given table.
+
+**Example**:
+
+```sql
+TRUNCATE TABLE `table_1`
+```
+
+> In this example, the command deletes all rows from the **table_1** without exception.
+
+- The **DROP** command
+
+It allows you to completely remove **a table and all the rows it contains**. This command should not be used if the table is still required.
+
+**Example**:
+
+```sql
+DROP TABLE `table_1`
+```
+
+> In this example, the command deletes the table **table_1** and all rows in it.
+
+## Go further <a name="go-further"></a>
+
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-au/directory/).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-au/support-levels/).
+
+Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/web/hosting/sql_overquota_database/guide.en-ca.md
+++ b/pages/web/hosting/sql_overquota_database/guide.en-ca.md
@@ -1,0 +1,198 @@
+---
+title: "Tutorial - What do I do when my database is full?"
+slug: database-overquota
+excerpt: "Find out what to do when your database is saturated"
+section: Databases
+order: 06
+---
+
+**Last updated 26th January 2023**
+
+## Objective
+
+A database can, for example, store data related to a website and its functionalities. This information is structured so that your website can easily access it, allowing for optimal and customised access for users/visitors to your website. 
+
+During its use, a database can acquire, modify or delete information (connection data, user data, display data, data necessary for your website to work properly, etc.). 
+
+In some cases, the database stores such a large amount of information that it will saturate its allocated storage space. When a database is full, this state is called **overquota**.
+
+This tutorial will show you the actions you can take when your OVHcloud shared database is close to saturation, or is already in **overquota**.
+
+**This guide explains possible actions when your database is full.**
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- An [OVHcloud web hosting plan](https://www.ovhcloud.com/en-ca/web-hosting/) with an associated OVHcloud shared database
+  
+## Instructions
+
+> [!warning]
+>
+> OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
+> 
+> If you experience any difficulties following the steps in this tutorial, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/en-ca/directory/) or reach out to the OVHcloud community. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+>
+
+When your OVHcloud shared database reaches a certain saturation level (**overquota**), our robots will send a notification to the email address of the database’s [administrator contact](https://docs.ovh.com/ca/en/customer/managing-contacts/). 
+
+The first email will be sent when your database has consumed more than **80%** of its storage capacity. A second email is sent when **90%** of this storage capacity is reached.
+
+When your database is in **overquota**, you will be sent a third warning email. Your database will then switch to *READ ONLY*. You can no longer add or modify your database entries, but they are still accessible to **read** and **delete**. 
+
+### Step 1: Identify large tables
+
+A database is made up of one or more **tables**, themselves consisting of one or more **rows** organised using predetermined **columns**.
+
+The first step is to identify the large table or tables in your database.
+
+> [!primary]
+>
+> All the following actions described in this tutorial will be performed from the **phpMyAdmin** interface.
+>
+> [phpMyAdmin](https://www.phpmyadmin.net/){.external} is available on all OVHcloud shared databases.
+> This database management application makes it easy to perform the manual actions you can perform with your database.
+>
+
+#### 1.1 - Connect to the database via phpMyAdmin
+
+Retrieve the password for accessing your database directly from your website’s configuration file. Perform this action using **step 1** in our guide to [changing a database password](https://docs.ovh.com/ca/en/hosting/change-password-database/).
+
+Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) and select `Web Cloud`{.action} in the navigation bar at the top of the screen. Click on `Hosting plans`{.action} and choose the web hosting plan associated with your OVHcloud shared database. Next, go to the `Databases`{.action} tab.
+
+![phpMyAdmin Access](images/pma_access.png){.thumbnail}
+
+From the `Databases`{.action} tab, click on the button `...`{.action} to the right of the database that is full, then `Go to phpMyAdmin`{.action}.
+
+![phpMyAdmin Go Login](images/pma_interface.png){.thumbnail}
+
+Enter your database password in addition to the pre-filled information, then click `Run`{.action}.
+
+#### 1.2 - Find the largest tables
+
+> [!alert]
+>
+> From here on, your actions affect the content of your database. The changes you make in **phpMyAdmin** can have irreversible consequences if they are not carried out correctly.
+>
+> Be sure about each command you execute on the database. If you experience any difficulties, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/en-ca/directory/). OVHcloud cannot assist you with the content of your database.
+>
+
+Once connected, the following page is displayed:
+
+![phpMyAdmin Login](images/pma_login.png){.thumbnail}
+
+Click on `"Your database name"`{.action} in the left-hand column, then on `Size`{.action} in the top right-hand corner of the table that appears:
+
+![phpMyAdmin Tables](images/pma_show_table.png){.thumbnail}
+
+The largest tables appear at the top of the sorted list. Identify them, then go to **Step 2**.
+
+### Step 2: Determine the usefulness of the content in the large table(s)
+
+Once you have identified the large tables, determine whether all of their content is required for your site to work.
+
+> [!primary]
+>
+> If you are using a Content Management System (CMS) such as WordPress, Joomla!, PrestaShop or Drupal, make sure that your large tables are not linked to a recently installed or updated plugin/theme.
+>
+> In this case, contact the developer of the plugin/theme to determine appropriate actions to take on your CMS.
+>
+ 
+For other CMS types, we recommend that you contact your CMS publisher before you perform the following actions.
+
+Below are links to the official CMS websites for the OVHcloud 1-click modules:
+
+- [WordPress](https://wordpress.org/){.external}
+- [Joomla!](https://www.joomla.org){.external}
+- [PrestaShop](https://www.prestashop.com/){.external}
+- [Drupal](https://drupal.org){.external}
+
+> [!primary]
+>
+> If your website is a **customised** software, developed by a specialist provider, we recommend that you contact them for support.
+>
+
+### Step 3: Take corrective action
+
+Once you have determined whether or not the contents of your tables are necessary for your site to work, you have several options:
+
+#### Case 1 - All of the contents of the large table are required for your website to work properly
+
+You will need to upgrade your database service to one that includes more space for databases.
+
+Consult our [Private SQL/CloudDB](https://www.ovhcloud.com/en-ca/web-hosting/options/) offer to choose your new database service. 
+
+We recommend this solution for large databases.
+
+Then follow our guides to move the content from your old database to the new one:
+
+- [Export your existing database](https://docs.ovh.com/ca/en/hosting/web_hosting_database_export_guide/)
+- [First steps with Private SQL/CloudDB](https://docs.ovh.com/gb/en/clouddb/getting-started-with-clouddb/)
+- [Import your old database into your Private SQL/CloudDB](https://docs.ovh.com/gb/en/clouddb/restore-import-database/)
+
+#### Case 2 - Some or all of the contents of the large table are not necessary for your site to work
+
+Before you do the following, check if the data in the large table corresponds to items that can be deleted from your CMS admin panel. 
+
+**Examples**:
+
+- Old comments/posts
+- Items in your CMS's `Trash` menu
+- Data related to an old theme and/or plugin
+
+> [!alert]
+>
+> The rest of this tutorial will show you how to delete data stored in your database. Be sure of the actions you need to take or contact a [specialist provider](https://partner.ovhcloud.com/en-ca/directory/) if in doubt.
+>
+
+OVHcloud shared databases have several SQL commands to influence their content.
+
+In the case of an overquota or large table, **three commands** are available.
+
+You can perform these requests from the **phpMyAdmin** interface, via the `SQL`{.action} tab:
+
+![phpMyAdmin SQL request](images/pma_sql_request.png){.thumbnail}
+
+- The **DELETE** command
+
+You can use it to remove **one or more rows** from a given table. This command is useful if part of the table content is required for your website to work properly.
+
+**Example**:
+
+```sql
+DELETE FROM `table_1` WHERE `id` = 1
+```
+
+> In this example, the command deletes the row or rows in the **table_1** whose value in the **id** column is **1**.
+
+- The **TRUNCATE** command
+
+This command deletes **all rows** from a given table.
+
+**Example**:
+
+```sql
+TRUNCATE TABLE `table_1`
+```
+
+> In this example, the command deletes all rows from the **table_1** without exception.
+
+- The **DROP** command
+
+It allows you to completely remove **a table and all the rows it contains**. This command should not be used if the table is still required.
+
+**Example**:
+
+```sql
+DROP TABLE `table_1`
+```
+
+> In this example, the command deletes the table **table_1** and all rows in it.
+
+## Go further <a name="go-further"></a>
+
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-ca/directory/).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-ca/support-levels/).
+
+Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/web/hosting/sql_overquota_database/guide.en-sg.md
+++ b/pages/web/hosting/sql_overquota_database/guide.en-sg.md
@@ -1,0 +1,198 @@
+---
+title: "Tutorial - What do I do when my database is full?"
+slug: database-overquota
+excerpt: "Find out what to do when your database is saturated"
+section: Databases
+order: 06
+---
+
+**Last updated 26th January 2023**
+
+## Objective
+
+A database can, for example, store data related to a website and its functionalities. This information is structured so that your website can easily access it, allowing for optimal and customised access for users/visitors to your website. 
+
+During its use, a database can acquire, modify or delete information (connection data, user data, display data, data necessary for your website to work properly, etc.). 
+
+In some cases, the database stores such a large amount of information that it will saturate its allocated storage space. When a database is full, this state is called **overquota**.
+
+This tutorial will show you the actions you can take when your OVHcloud shared database is close to saturation, or is already in **overquota**.
+
+**This guide explains possible actions when your database is full.**
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- An [OVHcloud web hosting plan](https://www.ovhcloud.com/en-sg/web-hosting/) with an associated OVHcloud shared database
+  
+## Instructions
+
+> [!warning]
+>
+> OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
+> 
+> If you experience any difficulties following the steps in this tutorial, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/en-sg/directory/) or reach out to the OVHcloud community. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+>
+
+When your OVHcloud shared database reaches a certain saturation level (**overquota**), our robots will send a notification to the email address of the database’s [administrator contact](https://docs.ovh.com/sg/en/customer/managing-contacts/). 
+
+The first email will be sent when your database has consumed more than **80%** of its storage capacity. A second email is sent when **90%** of this storage capacity is reached.
+
+When your database is in **overquota**, you will be sent a third warning email. Your database will then switch to *READ ONLY*. You can no longer add or modify your database entries, but they are still accessible to **read** and **delete**. 
+
+### Step 1: Identify large tables
+
+A database is made up of one or more **tables**, themselves consisting of one or more **rows** organised using predetermined **columns**.
+
+The first step is to identify the large table or tables in your database.
+
+> [!primary]
+>
+> All the following actions described in this tutorial will be performed from the **phpMyAdmin** interface.
+>
+> [phpMyAdmin](https://www.phpmyadmin.net/){.external} is available on all OVHcloud shared databases.
+> This database management application makes it easy to perform the manual actions you can perform with your database.
+>
+
+#### 1.1 - Connect to the database via phpMyAdmin
+
+Retrieve the password for accessing your database directly from your website’s configuration file. Perform this action using **step 1** in our guide to [changing a database password](https://docs.ovh.com/sg/en/hosting/change-password-database/).
+
+Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) and select `Web Cloud`{.action} in the navigation bar at the top of the screen. Click on `Hosting plans`{.action} and choose the web hosting plan associated with your OVHcloud shared database. Next, go to the `Databases`{.action} tab.
+
+![phpMyAdmin Access](images/pma_access.png){.thumbnail}
+
+From the `Databases`{.action} tab, click on the button `...`{.action} to the right of the database that is full, then `Go to phpMyAdmin`{.action}.
+
+![phpMyAdmin Go Login](images/pma_interface.png){.thumbnail}
+
+Enter your database password in addition to the pre-filled information, then click `Run`{.action}.
+
+#### 1.2 - Find the largest tables
+
+> [!alert]
+>
+> From here on, your actions affect the content of your database. The changes you make in **phpMyAdmin** can have irreversible consequences if they are not carried out correctly.
+>
+> Be sure about each command you execute on the database. If you experience any difficulties, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/en-sg/directory/). OVHcloud cannot assist you with the content of your database.
+>
+
+Once connected, the following page is displayed:
+
+![phpMyAdmin Login](images/pma_login.png){.thumbnail}
+
+Click on `"Your database name"`{.action} in the left-hand column, then on `Size`{.action} in the top right-hand corner of the table that appears:
+
+![phpMyAdmin Tables](images/pma_show_table.png){.thumbnail}
+
+The largest tables appear at the top of the sorted list. Identify them, then go to **Step 2**.
+
+### Step 2: Determine the usefulness of the content in the large table(s)
+
+Once you have identified the large tables, determine whether all of their content is required for your site to work.
+
+> [!primary]
+>
+> If you are using a Content Management System (CMS) such as WordPress, Joomla!, PrestaShop or Drupal, make sure that your large tables are not linked to a recently installed or updated plugin/theme.
+>
+> In this case, contact the developer of the plugin/theme to determine appropriate actions to take on your CMS.
+>
+ 
+For other CMS types, we recommend that you contact your CMS publisher before you perform the following actions.
+
+Below are links to the official CMS websites for the OVHcloud 1-click modules:
+
+- [WordPress](https://wordpress.org/){.external}
+- [Joomla!](https://www.joomla.org){.external}
+- [PrestaShop](https://www.prestashop.com/){.external}
+- [Drupal](https://drupal.org){.external}
+
+> [!primary]
+>
+> If your website is a **customised** software, developed by a specialist provider, we recommend that you contact them for support.
+>
+
+### Step 3: Take corrective action
+
+Once you have determined whether or not the contents of your tables are necessary for your site to work, you have several options:
+
+#### Case 1 - All of the contents of the large table are required for your website to work properly
+
+You will need to upgrade your database service to one that includes more space for databases.
+
+Consult our [Private SQL/CloudDB](https://www.ovhcloud.com/en-sg/web-hosting/options/) offer to choose your new database service. 
+
+We recommend this solution for large databases.
+
+Then follow our guides to move the content from your old database to the new one:
+
+- [Export your existing database](https://docs.ovh.com/sg/en/hosting/web_hosting_database_export_guide/)
+- [First steps with Private SQL/CloudDB](https://docs.ovh.com/gb/en/clouddb/getting-started-with-clouddb/)
+- [Import your old database into your Private SQL/CloudDB](https://docs.ovh.com/gb/en/clouddb/restore-import-database/)
+
+#### Case 2 - Some or all of the contents of the large table are not necessary for your site to work
+
+Before you do the following, check if the data in the large table corresponds to items that can be deleted from your CMS admin panel. 
+
+**Examples**:
+
+- Old comments/posts
+- Items in your CMS's `Trash` menu
+- Data related to an old theme and/or plugin
+
+> [!alert]
+>
+> The rest of this tutorial will show you how to delete data stored in your database. Be sure of the actions you need to take or contact a [specialist provider](https://partner.ovhcloud.com/en-sg/directory/) if in doubt.
+>
+
+OVHcloud shared databases have several SQL commands to influence their content.
+
+In the case of an overquota or large table, **three commands** are available.
+
+You can perform these requests from the **phpMyAdmin** interface, via the `SQL`{.action} tab:
+
+![phpMyAdmin SQL request](images/pma_sql_request.png){.thumbnail}
+
+- The **DELETE** command
+
+You can use it to remove **one or more rows** from a given table. This command is useful if part of the table content is required for your website to work properly.
+
+**Example**:
+
+```sql
+DELETE FROM `table_1` WHERE `id` = 1
+```
+
+> In this example, the command deletes the row or rows in the **table_1** whose value in the **id** column is **1**.
+
+- The **TRUNCATE** command
+
+This command deletes **all rows** from a given table.
+
+**Example**:
+
+```sql
+TRUNCATE TABLE `table_1`
+```
+
+> In this example, the command deletes all rows from the **table_1** without exception.
+
+- The **DROP** command
+
+It allows you to completely remove **a table and all the rows it contains**. This command should not be used if the table is still required.
+
+**Example**:
+
+```sql
+DROP TABLE `table_1`
+```
+
+> In this example, the command deletes the table **table_1** and all rows in it.
+
+## Go further <a name="go-further"></a>
+
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-sg/directory/).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-sg/support-levels/).
+
+Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/web/hosting/sql_overquota_database/guide.en-us.md
+++ b/pages/web/hosting/sql_overquota_database/guide.en-us.md
@@ -1,0 +1,198 @@
+---
+title: "Tutorial - What do I do when my database is full?"
+slug: database-overquota
+excerpt: "Find out what to do when your database is saturated"
+section: Databases
+order: 06
+---
+
+**Last updated 26th January 2023**
+
+## Objective
+
+A database can, for example, store data related to a website and its functionalities. This information is structured so that your website can easily access it, allowing for optimal and customised access for users/visitors to your website. 
+
+During its use, a database can acquire, modify or delete information (connection data, user data, display data, data necessary for your website to work properly, etc.). 
+
+In some cases, the database stores such a large amount of information that it will saturate its allocated storage space. When a database is full, this state is called **overquota**.
+
+This tutorial will show you the actions you can take when your OVHcloud shared database is close to saturation, or is already in **overquota**.
+
+**This guide explains possible actions when your database is full.**
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- An [OVHcloud web hosting plan](https://www.ovhcloud.com/en/web-hosting/) with an associated OVHcloud shared database
+  
+## Instructions
+
+> [!warning]
+>
+> OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
+> 
+> If you experience any difficulties following the steps in this tutorial, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/en/directory/) or reach out to the OVHcloud community. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+>
+
+When your OVHcloud shared database reaches a certain saturation level (**overquota**), our robots will send a notification to the email address of the database’s [administrator contact](https://docs.ovh.com/us/en/customer/managing-contacts/). 
+
+The first email will be sent when your database has consumed more than **80%** of its storage capacity. A second email is sent when **90%** of this storage capacity is reached.
+
+When your database is in **overquota**, you will be sent a third warning email. Your database will then switch to *READ ONLY*. You can no longer add or modify your database entries, but they are still accessible to **read** and **delete**. 
+
+### Step 1: Identify large tables
+
+A database is made up of one or more **tables**, themselves consisting of one or more **rows** organised using predetermined **columns**.
+
+The first step is to identify the large table or tables in your database.
+
+> [!primary]
+>
+> All the following actions described in this tutorial will be performed from the **phpMyAdmin** interface.
+>
+> [phpMyAdmin](https://www.phpmyadmin.net/){.external} is available on all OVHcloud shared databases.
+> This database management application makes it easy to perform the manual actions you can perform with your database.
+>
+
+#### 1.1 - Connect to the database via phpMyAdmin
+
+Retrieve the password for accessing your database directly from your website’s configuration file. Perform this action using **step 1** in our guide to [changing a database password](https://docs.ovh.com/us/en/hosting/change-password-database/).
+
+Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) and select `Web Cloud`{.action} in the navigation bar at the top of the screen. Click on `Hosting plans`{.action} and choose the web hosting plan associated with your OVHcloud shared database. Next, go to the `Databases`{.action} tab.
+
+![phpMyAdmin Access](images/pma_access.png){.thumbnail}
+
+From the `Databases`{.action} tab, click on the button `...`{.action} to the right of the database that is full, then `Go to phpMyAdmin`{.action}.
+
+![phpMyAdmin Go Login](images/pma_interface.png){.thumbnail}
+
+Enter your database password in addition to the pre-filled information, then click `Run`{.action}.
+
+#### 1.2 - Find the largest tables
+
+> [!alert]
+>
+> From here on, your actions affect the content of your database. The changes you make in **phpMyAdmin** can have irreversible consequences if they are not carried out correctly.
+>
+> Be sure about each command you execute on the database. If you experience any difficulties, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/en/directory/). OVHcloud cannot assist you with the content of your database.
+>
+
+Once connected, the following page is displayed:
+
+![phpMyAdmin Login](images/pma_login.png){.thumbnail}
+
+Click on `"Your database name"`{.action} in the left-hand column, then on `Size`{.action} in the top right-hand corner of the table that appears:
+
+![phpMyAdmin Tables](images/pma_show_table.png){.thumbnail}
+
+The largest tables appear at the top of the sorted list. Identify them, then go to **Step 2**.
+
+### Step 2: Determine the usefulness of the content in the large table(s)
+
+Once you have identified the large tables, determine whether all of their content is required for your site to work.
+
+> [!primary]
+>
+> If you are using a Content Management System (CMS) such as WordPress, Joomla!, PrestaShop or Drupal, make sure that your large tables are not linked to a recently installed or updated plugin/theme.
+>
+> In this case, contact the developer of the plugin/theme to determine appropriate actions to take on your CMS.
+>
+ 
+For other CMS types, we recommend that you contact your CMS publisher before you perform the following actions.
+
+Below are links to the official CMS websites for the OVHcloud 1-click modules:
+
+- [WordPress](https://wordpress.org/){.external}
+- [Joomla!](https://www.joomla.org){.external}
+- [PrestaShop](https://www.prestashop.com/){.external}
+- [Drupal](https://drupal.org){.external}
+
+> [!primary]
+>
+> If your website is a **customised** software, developed by a specialist provider, we recommend that you contact them for support.
+>
+
+### Step 3: Take corrective action
+
+Once you have determined whether or not the contents of your tables are necessary for your site to work, you have several options:
+
+#### Case 1 - All of the contents of the large table are required for your website to work properly
+
+You will need to upgrade your database service to one that includes more space for databases.
+
+Consult our [Private SQL/CloudDB](https://www.ovhcloud.com/en/web-hosting/options/) offer to choose your new database service. 
+
+We recommend this solution for large databases.
+
+Then follow our guides to move the content from your old database to the new one:
+
+- [Export your existing database](https://docs.ovh.com/us/en/hosting/web_hosting_database_export_guide/)
+- [First steps with Private SQL/CloudDB](https://docs.ovh.com/gb/en/clouddb/getting-started-with-clouddb/)
+- [Import your old database into your Private SQL/CloudDB](https://docs.ovh.com/gb/en/clouddb/restore-import-database/)
+
+#### Case 2 - Some or all of the contents of the large table are not necessary for your site to work
+
+Before you do the following, check if the data in the large table corresponds to items that can be deleted from your CMS admin panel. 
+
+**Examples**:
+
+- Old comments/posts
+- Items in your CMS's `Trash` menu
+- Data related to an old theme and/or plugin
+
+> [!alert]
+>
+> The rest of this tutorial will show you how to delete data stored in your database. Be sure of the actions you need to take or contact a [specialist provider](https://partner.ovhcloud.com/en/directory/) if in doubt.
+>
+
+OVHcloud shared databases have several SQL commands to influence their content.
+
+In the case of an overquota or large table, **three commands** are available.
+
+You can perform these requests from the **phpMyAdmin** interface, via the `SQL`{.action} tab:
+
+![phpMyAdmin SQL request](images/pma_sql_request.png){.thumbnail}
+
+- The **DELETE** command
+
+You can use it to remove **one or more rows** from a given table. This command is useful if part of the table content is required for your website to work properly.
+
+**Example**:
+
+```sql
+DELETE FROM `table_1` WHERE `id` = 1
+```
+
+> In this example, the command deletes the row or rows in the **table_1** whose value in the **id** column is **1**.
+
+- The **TRUNCATE** command
+
+This command deletes **all rows** from a given table.
+
+**Example**:
+
+```sql
+TRUNCATE TABLE `table_1`
+```
+
+> In this example, the command deletes all rows from the **table_1** without exception.
+
+- The **DROP** command
+
+It allows you to completely remove **a table and all the rows it contains**. This command should not be used if the table is still required.
+
+**Example**:
+
+```sql
+DROP TABLE `table_1`
+```
+
+> In this example, the command deletes the table **table_1** and all rows in it.
+
+## Go further <a name="go-further"></a>
+
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en/directory/).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en/support-levels/).
+
+Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/web/hosting/sql_overquota_database/guide.es-us.md
+++ b/pages/web/hosting/sql_overquota_database/guide.es-us.md
@@ -1,0 +1,202 @@
+---
+title: "Tutorial - ¿Qué hacer cuando la base de datos está saturada?"
+slug: database-overquota
+excerpt: "Cómo actuar cuando la base de datos está saturada"
+section: 'Bases de datos'
+order: 06
+---
+
+**Última actualización: 26/01/2023**
+
+> [!primary]
+> Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón «Contribuir» de esta página.
+>
+
+## Objetivo
+
+Una base de datos permite, por ejemplo, almacenar información relativa a su sitio web y a su funcionamiento. Estos datos están organizados para que su sitio web acceda fácilmente a ellos, lo que permite una consulta óptima y personalizada para los usuarios/visitantes de su sitio web. 
+
+Durante su uso, una base de datos puede adquirir, modificar o eliminar información (datos de conexión, datos de usuarios, datos de visualización, datos necesarios para el buen funcionamiento de su sitio web, etc.). 
+
+En algunos casos, la base de datos registra tal cantidad de información, lo que provoca una saturación del espacio de almacenamiento que se le asigna. Cuando la base de datos está saturada, se habla de **overquota**.
+
+Este tutorial explica las acciones que debe realizar cuando la base de datos en alojamiento compartido de OVHcloud está cerca de la saturación o ya está en **overquota*.
+
+**Descubra cómo actuar cuando la base de datos está saturada.**
+
+## Requisitos
+
+- Estar conectado a su [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+- Disponer de un [plan de hosting de OVHcloud](https://www.ovhcloud.com/es/web-hosting/) con una base de datos en alojamiento compartido de OVHcloud asociada.
+  
+## Procedimiento
+
+> [!warning]
+>
+La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
+> 
+> Ponemos a su disposición este tutorial para ayudarle lo mejor posible en tareas habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es/). Nosotros no podremos asistirle. Más información en la sección ["Más información"](#go-further) de esta guía.
+>
+
+Cuando su base de datos en alojamiento compartido OVHcloud se satura (**overquota**), nuestros robots le advierten por correo electrónico en la dirección de correo electrónico del [contacto "Administrador"](https://docs.ovh.com/us/es/customer/gestion-de-los-contactos/) de la base de datos. 
+
+Cuando la base de datos ha consumido más de **80%** de su capacidad de almacenamiento, recibirá un primer mensaje de correo electrónico. Cuando **90%** de esta capacidad de almacenamiento se alcanza, se envía un segundo mensaje de correo.
+
+Cuando su base de datos está en **overquota**, se le enviará un tercer mensaje de aviso. A continuación, la base de datos pasará a "*READ ONLY*" (solo lectura). Ya no puede añadir ni modificar los registros de la base de datos, pero sigue estando disponible en **lectura** y **supresión**. 
+
+### Etapa 1: identificar las tablas voluminosas
+
+Una base de datos se compone de una o más **tablas**, compuestas a su vez por una o varias **filas** organizadas con **columnas** predeterminadas.
+
+En primer lugar, es necesario identificar las tablas de gran tamaño de la base de datos.
+
+> [!primary]
+>
+> Todas las acciones siguientes descritas en este tutorial se realizarán a partir de **phpMyAdmin**.
+>
+> [phpMyAdmin](https://www.phpmyadmin.net/){.external} está disponible en todas las bases de datos compartidas de OVHcloud.
+> Esta aplicación de gestión de bases de datos facilita la realización de las acciones manuales que puede realizar con su base de datos.
+>
+
+#### 1.1 - Conectarse a la base de datos a través de phpMyAdmin
+
+Descargue la contraseña de acceso a su base de datos directamente en el archivo de configuración de su sitio web. Para ello, consulte el apartado [Cambio de la contraseña de una base de datos](https://docs.ovh.com/us/es/hosting/cambiar-contrasena-base-de-datos/) de nuestra guía (**etapa 1**) .
+
+Conéctese a su [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) y seleccione `Web Cloud`{.action} en la barra de navegación en la parte superior de la pantalla. Haga clic en `Alojamientos`{.action} y seleccione el alojamiento web asociado a la base de datos en alojamiento compartido de OVHcloud. A continuación, abra la pestaña `Bases de datos`{.action}.
+
+![phpMyAdmin Access](images/pma_access.png){.thumbnail}
+
+Abra la pestaña `Base de datos`{.action} y haga clic en el botón `...`{.action} a la derecha de la base de datos saturada y después seleccione `Acceder a phpMyAdmin`{.action}.
+
+![phpMyAdmin Go Login](images/pma_interface.png){.thumbnail}
+
+Introduzca la contraseña de acceso a la base de datos, completando la información que se haya completado, y haga clic en `Ejecutar`{.action}.
+
+#### 1.2 - Buscar las tablas más voluminosas
+
+> [!alert]
+>
+> Desde ahora, usted interviene directamente en el contenido de su base de datos. Las operaciones que realice en phpMyAdmin pueden tener consecuencias irreversibles si no se realizan correctamente.
+>
+> Asegúrese de realizar las operaciones que desee. Si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es/). OVHcloud no podrá ayudarle con el contenido de su base de datos.
+>
+
+Una vez que se haya conectado, se abrirá la siguiente página:
+
+![phpMyAdmin Login](images/pma_login.png){.thumbnail}
+
+Haga clic en el botón `"Nombre de la base de datos"`{.action} en la columna izquierda y seleccione `Tamaño`{.action} en la parte superior derecha de la tabla que aparece:
+
+![phpMyAdmin Tablas](images/pma_show_table.png){.thumbnail}
+
+Las tablas más voluminosas aparecen en la parte superior de la tabla. Identifique estas y vaya al **etapa 2**.
+
+### Etapa 2: determinar la utilidad del contenido de la tabla o tablas voluminosas
+
+Una vez que haya identificado las tablas voluminosas, deberá determinar si todo su contenido es necesario para el funcionamiento de su sitio web.
+
+> [!primary]
+>
+Si utiliza un sistema de gestión de contenidos (CMS) como WordPress, Joomla, PrestaShop o Drupal, compruebe que sus tablas voluminosas no estén relacionadas con un plugin o tema recientemente instalado o actualizado.
+>
+> En ese caso, contacte con el editor del plugin/tema para que le comunique las acciones a realizar en su CMS.
+>
+ 
+Si tiene algún otro CMS, le recomendamos que contacte directamente con el editor del CMS antes de realizar las siguientes acciones.
+
+A continuación se muestran los enlaces a los sitios web oficiales de los CMS que OVHcloud ofrece instalados **en un clic**:
+
+- [WordPress](https://wordpress.org/){.external}
+- [Joomla!](https://www.joomla.org){.external}
+- [PrestaShop](https://www.prestashop.com/){.external}
+- [Drupal](https://drupal.org){.external}
+
+> [!primary]
+>
+Si su sitio ha sido desarrollado "**manualmente**" por un proveedor especializado, le recomendamos que contacte con él para que le acompañe.
+>
+
+### Etapa 3: realizar una acción correctiva
+
+Una vez que haya determinado si el contenido de las tablas es necesario para el funcionamiento del sitio web, podrá elegir entre varias opciones:
+
+#### Caso n°1 - Todo el contenido de la tabla voluminosa es necesario para el buen funcionamiento de su sitio web
+
+Deberá bascular su base de datos con una base de datos más voluminosa.
+
+Consulte nuestra oferta de bases de datos [SQL Privado/CloudDB](https://www.ovhcloud.com/es/web-hosting/options/) para elegir su nuevo servicio de bases de datos. 
+
+Es recomendable para bases de datos de gran tamaño.
+
+Consulte nuestras guías para mover el contenido de su antigua base de datos a la nueva:
+
+- [Exportar la base de datos existente](https://docs.ovh.com/us/es/hosting/web_hosting_exportacion_de_una_base_de_datos/)
+- [Primeros pasos con SQL Privado/CloudDB](https://docs.ovh.com/es/clouddb/empezar-con-clouddb/)
+- [Importar su antigua base de datos a su solución SQL Privado/CloudDB](https://docs.ovh.com/es/clouddb/restaurar-importar-base-de-datos/)
+
+#### Caso n°2 - No es necesario para el funcionamiento de su sitio web una parte o el conjunto del contenido de la tabla voluminosa
+
+Antes de realizar esta operación, compruebe si los datos de la tabla de tamaño considerable corresponden a elementos que pueden eliminarse desde el área de administración de su CMS. 
+
+**Ejemplos**:
+
+- comentarios/publicaciones antiguos;
+- elementos presentes en el menú `Papelera` de su CMS;
+- datos relacionados con un tema antiguo y/o plugin.
+
+> [!alert]
+>
+> Esta guía explica cómo eliminar datos de la base de datos. En caso de duda, asegúrese de lo que está haciendo o contacte con un [proveedor especializado](https://partner.ovhcloud.com/es/).
+>
+
+Las bases de datos compartidas de OVHcloud disponen de varios comandos SQL para modificar su contenido.
+
+Si se trata de una tabla de overquota o de una voluminosa, puede elegir entre **tres comandos**.
+
+Puede realizar estas consultas directamente desde la interfaz **phpMyAdmin**, a través de la pestaña `SQL`{.action} :
+
+![phpMyAdmin SQL request](images/pma_sql_request.png){.thumbnail}
+
+- El pedido **DELETE**: 
+
+Permite eliminar **una o más filas** de una tabla dada. Este comando es útil si una parte del contenido de la tabla es necesaria para que su sitio web funcione correctamente.
+
+**Ejemplo**:
+
+```sql
+DELETE FROM `table_1` WHERE `id` = 1
+```
+
+> En este ejemplo, el comando elimina la(s) línea(s) de **table_1** cuyo valor de columna **id** es igual a **1**.
+
+- El comando **TRUNCATE**: 
+
+Permite eliminar **todas las filas** de una tabla dada.
+
+**Ejemplo**:
+
+```sql
+TRUNCATE TABLE `table_1`
+```
+
+> En este ejemplo, la orden elimina todas las líneas de la **table_1** sin excepción.
+
+- El comando **DROP**: 
+
+Permite eliminar completamente **una tabla y todas las filas que contiene**. Este comando no se puede utilizar si la tabla debe seguir existiendo.
+
+**Ejemplo**:
+
+```sql
+DROP TABLE `table_1`
+```
+
+> En este ejemplo, la orden elimina la tabla **table_1** y todas las filas que contiene.
+
+## Más información <a name="go-further"></a>
+
+Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con [partners de OVHcloud](https://partner.ovhcloud.com/es/).
+
+Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es/support-levels/).
+
+Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/web/hosting/sql_overquota_database/guide.fr-ca.md
+++ b/pages/web/hosting/sql_overquota_database/guide.fr-ca.md
@@ -1,0 +1,199 @@
+---
+title: "Tutoriel - Que faire lorsque ma base de données est saturée ?"
+slug: database-overquota
+excerpt: "Découvrez comment agir lorsque votre base de données est saturée"
+section: 'Bases de données'
+order: 06
+---
+
+**Dernière mise à jour le 26/01/2023**
+
+## Objectif
+
+Une base de données permet, par exemple, de stocker des informations relatives à votre site web et à son fonctionnement. Ces informations sont structurées pour que votre site web y accède facilement, ce qui permet une consultation optimale et personnalisée pour les utilisateurs/visiteurs de votre site web. 
+
+Au cours de son utilisation, une base de données peut acquérir, modifier ou supprimer des informations (données de connexion, données utilisateurs, données d'affichage, données nécessaires au bon fonctionnement de votre site web, etc.). 
+
+Dans certains cas, la base de données enregistre une telle quantité d'informations que cela entraîne une saturation de l'espace de stockage qui lui est alloué. Lorsque la base de données est saturée, on parle d'**overquota**.
+
+Ce tutoriel vous propose des actions à entreprendre lorsque votre base de données mutualisée OVHcloud est proche de la saturation ou est déjà en **overquota**.
+
+**Découvrez comment agir lorsque votre base de données est saturée.**
+
+## Prérequis
+
+- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Disposer d'une [offre d'hébergement web OVHcloud](https://www.ovhcloud.com/fr-ca/web-hosting/) avec une base de données mutualisée OVHcloud associée.
+  
+## En pratique
+
+> [!warning]
+>
+> OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
+> 
+> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [« Aller plus loin »](#go-further) de ce guide.
+>
+
+Lorsque votre base de données mutualisée OVHcloud arrive à saturation (**overquota**), nos robots vous avertissent par e-mail sur l'adresse e-mail du [contact « Administrateur »](https://docs.ovh.com/ca/fr/customer/gestion-des-contacts/) de la base de données. 
+
+Un premier e-mail est envoyé lorsque votre base de données a consommé plus de **80%** de sa capacité de stockage. Un deuxième e-mail est envoyé lorsque **90%** de cette capacité de stockage sont atteints.
+
+Lorsque votre base de données est en **overquota**, un troisième e-mail d'avertissement vous est envoyé. Votre base de données bascule alors en « *READ ONLY* » (lecture seule). Vous ne pouvez plus ajouter ou modifier les entrées de votre base de données mais elle reste accessible en **lecture** et en **suppression**. 
+
+### Etape 1 : identifier la ou les table(s) volumineuse(s)
+
+Une base de données est constituée d'une ou plusieurs **tables**, elles-mêmes constituées d'une ou plusieurs **lignes** organisées à l'aide de **colonnes** prédéterminées.
+
+La première étape consiste à identifier la ou les tables volumineuses présentes dans votre base de données.
+
+> [!primary]
+>
+> Toutes les actions suivantes décrites dans ce tutoriel seront réalisées à partir de **phpMyAdmin**.
+>
+> [phpMyAdmin](https://www.phpmyadmin.net/){.external} est disponible sur l'ensemble des bases de données mutualisées OVHcloud.
+> Cette application de gestion de base de données facilite la réalisation des actions manuelles que vous pouvez effectuer avec votre base de données.
+>
+
+#### 1.1 - Se connecter à la base de données via phpMyAdmin
+
+Récupérez le mot de passe d'accès à votre base de données directement dans le fichier de configuration de votre site web. Réalisez cette action à l'aide de l'**étape 1** de notre guide sur [le changement du mot de passe d'une base de données](https://docs.ovh.com/ca/fr/hosting/modifier-mot-de-passe-base-de-donnees/).
+
+Connectez-vous à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc) et sélectionnez `Web Cloud`{.action} dans la barre de navigation en haut de l’écran. Cliquez sur `Hébergements`{.action} puis choisissez l’hébergement web associé à votre base de données mutualisée OVHcloud. Positionnez-vous enfin sur l'onglet `Bases de données`{.action}.
+
+![phpMyAdmin Access](images/pma_access.png){.thumbnail}
+
+Toujours depuis l'onglet `Bases de données`{.action}, cliquez sur le bouton `...`{.action} à droite de la base de données qui est saturée puis sur `Accéder à phpMyAdmin`{.action}.
+
+![phpMyAdmin Go Login](images/pma_interface.png){.thumbnail}
+
+Renseignez le mot de passe d'accès à votre base de données en complément des informations pré-remplies puis cliquez sur `Exécuter`{.action}.
+
+#### 1.2 - Rechercher les tables les plus volumineuses
+
+> [!alert]
+>
+> Désormais, vous intervenez directement sur le contenu de votre base de données. Les manipulations que vous réalisez dans phpMyAdmin peuvent avoir des conséquences irréversibles si celles-ci ne sont pas réalisées correctement.
+>
+> Assurez-vous des manipulations que vous effectuez. Si vous éprouvez la moindre difficulté, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/). En effet, OVHcloud ne pourra pas vous fournir une assistance sur le contenu de votre base de données.
+>
+
+Une fois connecté, la page suivante s'affiche :
+
+![phpMyAdmin Login](images/pma_login.png){.thumbnail}
+
+Cliquez sur le `« Nom de votre base de données »`{.action} dans la colonne de gauche puis sur `Taille`{.action} en haut à droite du tableau qui s'affiche :
+
+![phpMyAdmin Tables](images/pma_show_table.png){.thumbnail}
+
+Les tables les plus volumineuses apparaissent en haut du tableau. Identifiez celles-ci puis passez à l'**étape 2**.
+
+### Etape 2 : déterminer l'utilité du contenu présent dans la ou les table(s) volumineuse(s)
+
+Une fois les tables volumineuses identifiées, déterminez si l'intégralité de leur contenu est nécessaire au fonctionnement de votre site.
+
+> [!primary]
+>
+> Si vous utilisez un Content Managment System (CMS) tel que WordPress, Joomla!, PrestaShop ou Drupal, vérifiez que vos tables volumineuses ne sont pas liées à un plugin/thème récemment installé ou mis à jour.
+>
+> Dans ce cas, contactez l'éditeur du plugin/thème pour qu'il vous communique les actions à mener sur votre CMS.
+>
+ 
+Pour les autres cas liés aux CMS, nous vous recommandons de contacter directement l'éditeur de votre CMS avant de réaliser les actions qui suivent.
+
+Retrouvez ci-dessous les liens vers les sites officiels des CMS proposés en installation « **En un clic** » par OVHcloud :
+
+- [WordPress](https://wordpress.org/){.external}
+- [Joomla!](https://www.joomla.org){.external}
+- [PrestaShop](https://www.prestashop.com/){.external}
+- [Drupal](https://drupal.org){.external}
+
+> [!primary]
+>
+> Si votre site a été développé « **manuellement** » par un prestataire spécialisé, nous vous recommandons de contacter ce dernier afin qu'il vous accompagne.
+>
+
+### Etape 3 : mener une action corrective
+
+Une fois que vous avez déterminé si le contenu de vos tables est nécessaire ou non au fonctionnement de votre site, plusieurs options s'offrent à vous :
+
+#### Cas n°1 - L'ensemble du contenu de la table volumineuse est nécessaire au bon fonctionnement de votre site
+
+Vous devrez basculer votre base de données sur une base de données plus volumineuse.
+
+Consultez notre offre de bases de données [SQL Privé/CloudDB](https://www.ovhcloud.com/fr-ca/web-hosting/options/) pour choisir votre nouveau service de base de données. 
+
+Nous recommandons cette offre pour les bases de données volumineuses.
+
+Suivez ensuite nos guides pour déplacer le contenu de votre ancienne base de données vers la nouvelle :
+
+- [Exporter votre base de données existante](https://docs.ovh.com/ca/fr/hosting/exportation-bases-donnees/)
+- [Premiers pas avec l'offre SQL Privé/CloudDB](https://docs.ovh.com/fr/clouddb/debuter-avec-clouddb/)
+- [Importer votre ancienne base de données dans votre offre SQL Privé/CloudDB](https://docs.ovh.com/fr/clouddb/restaurer-importer-base-de-donnees/)
+
+#### Cas n°2 - Une partie ou l'ensemble du contenu de la table volumineuse n'est pas nécessaire au fonctionnement de votre site
+
+Avant d'effectuer ce qui suit, vérifiez si les données contenues dans la table volumineuse correspondent à des éléments qui peuvent être supprimés depuis l'espace d'administration de votre CMS. 
+
+**Exemples** :
+
+- anciens commentaires/posts ;
+- éléments présents dans le menu `Corbeille` de votre CMS ;
+- données liées à un ancien thème et/ou plugin.
+
+> [!alert]
+>
+> La suite de ce guide vous décrit comment supprimer des données présentes dans votre base de données. Assurez-vous de ce que vous faites ou contactez un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/) en cas de doute.
+>
+
+Les bases de données mutualisées OVHcloud disposent de plusieurs commandes SQL pour agir sur leur contenu.
+
+Dans le cas d'un overquota ou d'une table volumineuse, **trois commandes** sont disponibles.
+
+Vous pouvez directement effectuer ces requêtes depuis l'interface **phpMyAdmin**, via l'onglet `SQL`{.action} :
+
+![phpMyAdmin SQL request](images/pma_sql_request.png){.thumbnail}
+
+- La commande **DELETE** : 
+
+Elle permet de supprimer **une ou plusieurs lignes** d'une table donnée. Cette commande est utile si une partie du contenu de la table est nécessaire au bon fonctionnement de votre site web.
+
+**Exemple** :
+
+```sql
+DELETE FROM `table_1` WHERE `id` = 1
+```
+
+> Dans cet exemple, la commande supprime la ou les ligne(s) de la **table_1** dont la valeur de la colonne **id** est égale à **1**.
+
+- La commande **TRUNCATE** : 
+
+Elle permet de supprimer **toutes les lignes** d'une table donnée.
+
+**Exemple** :
+
+```sql
+TRUNCATE TABLE `table_1`
+```
+
+> Dans cet exemple, la commande supprime l'ensemble des lignes de la **table_1** sans exception.
+
+- La commande **DROP** : 
+
+Elle permet de supprimer complètement **une table et l'ensemble des lignes qu'elle contient**. Cette commande n'est pas à utiliser si la table doit continuer d'exister.
+
+**Exemple** :
+
+```sql
+DROP TABLE `table_1`
+```
+
+> Dans cet exemple, la commande supprime la table **table_1** et l'ensemble des lignes qu'elle contient.
+
+## Aller plus loin <a name="go-further"></a>
+
+
+Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr-ca/).
+
+Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr-ca/support-levels/).
+
+Échangez avec notre communauté d'utilisateurs sur <https://community.ovh.com>.


### PR DESCRIPTION
Translations for EN subs, FR-CA and ES-US adapted and done

Duplications realized and based from EN-GB, FR-FR and ES-ES versions.

Links replaced for all subs (except links about CloudDB) => all other links in 200 ok.
Adding "Private SQL" for subs where CloudDB offer doesn't rename Private SQL offer => replaced "CloudDB" terms by "Private SQL/CloudDB". This for don't loose the customers located on APAC/CA during their reading.

Update the dates of "last update".

No need proofreading because it's just a duplication of some existing content and just a replacement of links.
