### PR TITLE
KS-SK1054-UpdateAPACandCA-downgrade-unavailable-webhosting

### DIFF
--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-asia.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-asia.md
@@ -32,9 +32,9 @@ In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&fro
 ### Modifying your hosting plan <a name="modify"></a>
 
 > [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
+> Subscription downgrading is not available for customers whose services are hosted in a data centre outside Europe.
 >
-> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/asia/en/hosting/migrating-website-to-ovh/)”.
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrating your website and emails to OVHcloud](https://docs.ovh.com/asia/en/hosting/migrating-website-to-ovh/)”.
 >
 
 To change your subscription, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) in the `Web Cloud`{.action} section. Click `Hosting plans`{.action} and select the plan concerned.

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-asia.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-asia.md
@@ -6,7 +6,7 @@ section: Optimise your website
 order: 02
 ---
 
-**Last updated 3rd January 2023**
+**Last updated 30th January 2023**
 
 ## Objective
 
@@ -43,10 +43,10 @@ Then select your new subscription and its duration. Confirm the corresponding co
 ### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
 
 > [!warning]
+> Subscription changes for lower plans are not available for customers whose services are hosted outside Europe.
 >
-> You can only change your subscription to a lower range plan if it is the **immediate lower range** plan.
-> For example, you cannot switch from *Performance 2* to *Professional* in a single operation.
-> You will **first** need to downgrade your web hosting plan from the *Performance 2* plan to the *Performance 1* plan, **and then** to the *Professional* plan.
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/asia/en/hosting/migrating-website-to-ovh/)”.
+>
 
 Before you make your switch to a lower range, check the following 5 items:
 

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-asia.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-asia.md
@@ -43,7 +43,7 @@ Then select your new subscription and its duration. Confirm the corresponding co
 ### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
 
 > [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted outside Europe.
+> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
 >
 > If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/asia/en/hosting/migrating-website-to-ovh/)”.
 >

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-asia.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-asia.md
@@ -23,14 +23,19 @@ In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&fro
 
 > [!warning]
 >
-> **Before** you make any changes to your current subscription, check to see if you have any of these questions:
+> **Before** you make any changes to your current subscription, check to see if these questions apply to your situation:
 >
 > - [How do I get a temporary performance boost on my Performance hosting plan?](#boost)
 > - [Will I waste the time remaining on my current hosting plan when I change plans?](#billing)
-> - [Can I upgrade my current plan to a lower plan?](#checks)
 >
 
 ### Modifying your hosting plan <a name="modify"></a>
+
+> [!warning]
+> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
+>
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/asia/en/hosting/migrating-website-to-ovh/)”.
+>
 
 To change your subscription, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) in the `Web Cloud`{.action} section. Click `Hosting plans`{.action} and select the plan concerned.
 
@@ -39,60 +44,6 @@ In the `Plan` box, click the `...`{.action} button to the right of `Solution`, t
 ![change_plan](images/change_plan.png){.thumbnail}
 
 Then select your new subscription and its duration. Confirm the corresponding contracts, then click `Send`{.action}.
-
-### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
-
-> [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
->
-> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/asia/en/hosting/migrating-website-to-ovh/)”.
->
-
-Before you make your switch to a lower range, check the following 5 items:
-
-#### 1 - Number of sites
-
-With the [Kimsufi Web](https://www.ovhcloud.com/asia/web-hosting/old-web-hosting-offers/) solution, you cannot have more than one domain name on your hosting plan’s [multisite](https://docs.ovh.com/asia/en/hosting/multisites-configuring-multiple-websites/).
-
-Before you switch from the [Personal](https://www.ovhcloud.com/asia/web-hosting/personal-offer/) solution to the [Kimsufi Web](https://www.ovhcloud.com/asia/web-hosting/old-web-hosting-offers/) solution, please check that your web hosting plan only has one website.
-
-#### 2 - Start SQL databases
-
-Before moving your hosting to a lower plan, please ensure that the new plan has enough [databases](https://www.ovhcloud.com/asia/web-hosting/options/start-sql/). Also make sure they are of sufficient size.
-
-Otherwise, delete unused databases and reduce the amount of data they contain, if necessary. This quantity must not exceed the maximum size of the databases in the new solution (for any requests for assistance with the operations to be carried out, contact the [OVHcloud partners](https://partner.ovhcloud.com/asia/directory/)).
-
-If you have deleted data from your databases, you can recalculate the quota from the `Databases`{.action} tab in the `Hosting plans`{.action} section of the OVHcloud Control Panel. Click on the `...`{.action} button to the right of the database concerned, then `Recalculate the quota`{.action}.
-
-![quota](images/quota.png){.thumbnail}
-
-#### 3 - FTP space
-
-Before switching your hosting plan to a lower plan, please ensure that the new plan includes enough [FTP storage space](https://docs.ovh.com/asia/en/hosting/log-in-to-storage-ftp-web-hosting/) so that you can import files from your current hosting plan.
-
-The quota used on your FTP hosting plan is visible in the `Hosting plans`{.action} section of the OVHcloud Control Panel. Click on the `General information`{.action} tab, and you will see the quota under `Disk space`.
-
-![ftp](images/ftp.png){.thumbnail}
-
-#### 4 - Email accounts
-
-Please also check that your new solution has a sufficient number of available email accounts. Otherwise, delete the extra accounts, after you have [backed up](https://docs.ovh.com/asia/en/emails/migrate-email-addresses-manually/) the contents if necessary.
-
-If you would like to keep the same number of email accounts, before moving your web hosting to a lower plan, you can also order a new **MX Plan** email solution. In the `Emails`{.action} section of the OVHcloud Control Panel, click on the solution concerned, then on the `...`{.action} button to the right of `Solution`. Next, click `Change solution`{.action}.
-
-![mxplan](images/mxplan.png){.thumbnail}
-
-#### 5 - Mailing lists
-
-The [Mailing lists](https://docs.ovh.com/asia/en/emails/guide-dutilisation-mailing-list/) feature is optional on [Personal](https://www.ovhcloud.com/asia/web-hosting/personal-offer/) and [Kimsufi Web](https://www.ovhcloud.com/asia/web-hosting/old-web-hosting-offers/) hosting plans.
-
-To set up your hosting plan on a [Personal](https://www.ovhcloud.com/asia/web-hosting/personal-offer/) solution, you will need to delete the mailing lists first, or order an email solution with this feature (**MX Plan 100** or **MX Plan Full**) from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia).
-
-In the `Emails`{.action} section of your Control Panel, select the solution concerned, then click on `...`{.action} to the right of `Solution`{.action}. Next, click `Change solution`{.action}.
-
-#### Completion
-
-Once you have checked these 6 elements, you can [change your plan](#modify).
 
 ### Special cases
 

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-au.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-au.md
@@ -6,7 +6,7 @@ section: Optimise your website
 order: 02
 ---
 
-**Last updated 3rd January 2023**
+**Last updated 30th January 2023**
 
 ## Objective
 
@@ -43,10 +43,10 @@ Then select your new subscription and its duration. Confirm the corresponding co
 ### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
 
 > [!warning]
+> Subscription changes for lower plans are not available for customers whose services are hosted outside Europe.
 >
-> You can only change your subscription to a lower range plan if it is the **immediate lower range** plan.
-> For example, you cannot switch from *Performance 2* to *Professional* in a single operation.
-> You will **first** need to downgrade your web hosting plan from the *Performance 2* plan to the *Performance 1* plan, **and then** to the *Professional* plan.
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/au/en/hosting/migrating-website-to-ovh/)”.
+>
 
 Before you make your switch to a lower range, check the following 6 items:
 

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-au.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-au.md
@@ -32,9 +32,9 @@ In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&fro
 ### Modifying your hosting plan <a name="modify"></a>
 
 > [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
+> Subscription downgrading is not available for customers whose services are hosted in a data centre outside Europe.
 >
-> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/au/en/hosting/migrating-website-to-ovh/)”.
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrating your website and emails to OVHcloud](https://docs.ovh.com/au/en/hosting/migrating-website-to-ovh/)”.
 >
 
 To change your subscription, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) in the `Web Cloud`{.action} section. Click `Hosting plans`{.action} and select the plan concerned.

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-au.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-au.md
@@ -23,14 +23,19 @@ In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&fro
 
 > [!warning]
 >
-> **Before** you make any changes to your current subscription, check to see if you have any of these questions:
+> **Before** you make any changes to your current subscription, check to see if these questions apply to your situation:
 >
 > - [How do I get a temporary performance boost on my Performance hosting plan?](#boost)
 > - [Will I waste the time remaining on my current hosting plan when I change plans?](#billing)
-> - [Can I upgrade my current plan to a lower plan?](#checks)
 >
 
 ### Modifying your hosting plan <a name="modify"></a>
+
+> [!warning]
+> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
+>
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/au/en/hosting/migrating-website-to-ovh/)”.
+>
 
 To change your subscription, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) in the `Web Cloud`{.action} section. Click `Hosting plans`{.action} and select the plan concerned.
 
@@ -39,60 +44,6 @@ In the `Plan` box, click the `...`{.action} button to the right of `Solution`, t
 ![change_plan](images/change_plan.png){.thumbnail}
 
 Then select your new subscription and its duration. Confirm the corresponding contracts, then click `Send`{.action}.
-
-### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
-
-> [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
->
-> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/au/en/hosting/migrating-website-to-ovh/)”.
->
-
-Before you make your switch to a lower range, check the following 6 items:
-
-#### 1 - Number of sites
-
-With the [Kimsufi Web](https://www.ovhcloud.com/en-au/web-hosting/old-web-hosting-offers/) solution, you cannot have more than one domain name on your hosting plan’s [multisite](https://docs.ovh.com/au/en/hosting/multisites-configuring-multiple-websites/).
-
-Before you switch from the [Personal](https://www.ovhcloud.com/en-au/web-hosting/personal-offer/) solution to the [Kimsufi Web](https://www.ovhcloud.com/en-au/web-hosting/old-web-hosting-offers/) solution, please check that your web hosting plan only has one website.
-
-#### 2 - Start SQL databases
-
-Before moving your hosting to a lower plan, please ensure that the new plan has enough [databases](https://www.ovhcloud.com/en-au/web-hosting/options/start-sql/). Also make sure they are of sufficient size.
-
-Otherwise, delete unused databases and reduce the amount of data they contain, if necessary. This quantity must not exceed the maximum size of the databases in the new solution (for any requests for assistance with the operations to be carried out, contact the [OVHcloud partners](https://partner.ovhcloud.com/en-au/directory/)).
-
-If you have deleted data from your databases, you can recalculate the quota from the `Databases`{.action} tab in the `Hosting plans`{.action} section of the OVHcloud Control Panel. Click on the `...`{.action} button to the right of the database concerned, then `Recalculate the quota`{.action}.
-
-![quota](images/quota.png){.thumbnail}
-
-#### 3 - FTP space
-
-Before switching your hosting plan to a lower plan, please ensure that the new plan includes enough [FTP storage space](https://docs.ovh.com/au/en/hosting/log-in-to-storage-ftp-web-hosting/) so that you can import files from your current hosting plan.
-
-The quota used on your FTP hosting plan is visible in the `Hosting plans`{.action} section of the OVHcloud Control Panel. Click on the `General information`{.action} tab, and you will see the quota under `Disk space`.
-
-![ftp](images/ftp.png){.thumbnail}
-
-#### 4 - Email accounts
-
-Please also check that your new solution has a sufficient number of available email accounts. Otherwise, delete the extra accounts, after you have [backed up](https://docs.ovh.com/au/en/emails/migrate-email-addresses-manually/) the contents if necessary.
-
-If you would like to keep the same number of email accounts, before moving your web hosting to a lower plan, you can also order a new **MX Plan** email solution. In the `Emails`{.action} section of the OVHcloud Control Panel, click on the solution concerned, then on the `...`{.action} button to the right of `Solution`. Next, click `Change solution`{.action}.
-
-![mxplan](images/mxplan.png){.thumbnail}
-
-#### 5 - Mailing lists
-
-The [Mailing lists](https://docs.ovh.com/au/en/emails/guide-dutilisation-mailing-list/) feature is optional on [Personal](https://www.ovhcloud.com/en-au/web-hosting/personal-offer/) and [Kimsufi Web](https://www.ovhcloud.com/en-au/web-hosting/old-web-hosting-offers/) hosting plans.
-
-To set up your hosting plan on a [Personal](https://www.ovhcloud.com/en-au/web-hosting/personal-offer/) solution, you will need to delete the mailing lists first, or order an email solution with this feature (**MX Plan 100** or **MX Plan Full**) from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au).
-
-In the `Emails`{.action} section of your Control Panel, select the solution concerned, then click on `...`{.action} to the right of `Solution`{.action}. Next, click `Change solution`{.action}.
-
-#### Completion
-
-Once you have checked these 6 elements, you can [change your plan](#modify).
 
 ### Special cases
 

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-au.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-au.md
@@ -43,7 +43,7 @@ Then select your new subscription and its duration. Confirm the corresponding co
 ### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
 
 > [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted outside Europe.
+> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
 >
 > If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/au/en/hosting/migrating-website-to-ovh/)”.
 >

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-ca.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-ca.md
@@ -32,9 +32,9 @@ In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&fro
 ### Modifying your hosting plan <a name="modify"></a>
 
 > [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
+> Subscription downgrades are not available for customers whose services are hosted in a data centre outside Europe.
 >
-> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/ca/en/hosting/migrating-website-to-ovh/)”.
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrating your website and emails to OVHcloud](https://docs.ovh.com/ca/en/hosting/migrating-website-to-ovh/)”.
 >
 
 To change your subscription, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) in the `Web Cloud`{.action} section. Click `Hosting plans`{.action} and select the plan concerned.

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-ca.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-ca.md
@@ -43,7 +43,7 @@ Then select your new subscription and its duration. Confirm the corresponding co
 ### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
 
 > [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted outside Europe.
+> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
 >
 > If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/ca/en/hosting/migrating-website-to-ovh/)”.
 >

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-ca.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-ca.md
@@ -6,7 +6,7 @@ section: Optimise your website
 order: 02
 ---
 
-**Last updated 3rd January 2023**
+**Last updated 30th January 2023**
 
 ## Objective
 
@@ -43,10 +43,10 @@ Then select your new subscription and its duration. Confirm the corresponding co
 ### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
 
 > [!warning]
+> Subscription changes for lower plans are not available for customers whose services are hosted outside Europe.
 >
-> You can only change your subscription to a lower range plan if it is the **immediate lower range** plan.
-> For example, you cannot switch from *Performance 2* to *Professional* in a single operation.
-> You will **first** need to downgrade your web hosting plan from the *Performance 2* plan to the *Performance 1* plan, **and then** to the *Professional* plan.
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/ca/en/hosting/migrating-website-to-ovh/)”.
+>
 
 Before you make your switch to a lower range, check the following 6 items:
 

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-ca.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-ca.md
@@ -32,7 +32,7 @@ In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&fro
 ### Modifying your hosting plan <a name="modify"></a>
 
 > [!warning]
-> Subscription downgrades are not available for customers whose services are hosted in a data centre outside Europe.
+> Subscription downgrading is not available for customers whose services are hosted in a data centre outside Europe.
 >
 > If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrating your website and emails to OVHcloud](https://docs.ovh.com/ca/en/hosting/migrating-website-to-ovh/)”.
 >

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-ca.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-ca.md
@@ -23,14 +23,19 @@ In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&fro
 
 > [!warning]
 >
-> **Before** you make any changes to your current subscription, check to see if you have any of these questions:
+> **Before** you make any changes to your current subscription, check to see if these questions apply to your situation:
 >
 > - [How do I get a temporary performance boost on my Performance hosting plan?](#boost)
 > - [Will I waste the time remaining on my current hosting plan when I change plans?](#billing)
-> - [Can I upgrade my current plan to a lower plan?](#checks)
 >
 
 ### Modifying your hosting plan <a name="modify"></a>
+
+> [!warning]
+> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
+>
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/ca/en/hosting/migrating-website-to-ovh/)”.
+>
 
 To change your subscription, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) in the `Web Cloud`{.action} section. Click `Hosting plans`{.action} and select the plan concerned.
 
@@ -39,60 +44,6 @@ In the `Plan` box, click the `...`{.action} button to the right of `Solution`, t
 ![change_plan](images/change_plan.png){.thumbnail}
 
 Then select your new subscription and its duration. Confirm the corresponding contracts, then click `Send`{.action}.
-
-### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
-
-> [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
->
-> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/ca/en/hosting/migrating-website-to-ovh/)”.
->
-
-Before you make your switch to a lower range, check the following 6 items:
-
-#### 1 - Number of sites
-
-With the [Kimsufi Web](https://www.ovhcloud.com/en-ca/web-hosting/old-web-hosting-offers/) solution, you cannot have more than one domain name on your hosting plan’s [multisite](https://docs.ovh.com/ca/en/hosting/multisites-configuring-multiple-websites/).
-
-Before you switch from the [Personal](https://www.ovhcloud.com/en-ca/web-hosting/personal-offer/) solution to the [Kimsufi Web](https://www.ovhcloud.com/en-ca/web-hosting/old-web-hosting-offers/) solution, please check that your web hosting plan only has one website.
-
-#### 2 - Start SQL databases
-
-Before moving your hosting to a lower plan, please ensure that the new plan has enough [databases](https://www.ovhcloud.com/en-ca/web-hosting/options/start-sql/). Also make sure they are of sufficient size.
-
-Otherwise, delete unused databases and reduce the amount of data they contain, if necessary. This quantity must not exceed the maximum size of the databases in the new solution (for any requests for assistance with the operations to be carried out, contact the [OVHcloud partners](https://partner.ovhcloud.com/en-ca/directory/)).
-
-If you have deleted data from your databases, you can recalculate the quota from the `Databases`{.action} tab in the `Hosting plans`{.action} section of the OVHcloud Control Panel. Click on the `...`{.action} button to the right of the database concerned, then `Recalculate the quota`{.action}.
-
-![quota](images/quota.png){.thumbnail}
-
-#### 3 - FTP space
-
-Before switching your hosting plan to a lower plan, please ensure that the new plan includes enough [FTP storage space](https://docs.ovh.com/ca/en/hosting/log-in-to-storage-ftp-web-hosting/) so that you can import files from your current hosting plan.
-
-The quota used on your FTP hosting plan is visible in the `Hosting plans`{.action} section of the OVHcloud Control Panel. Click on the `General information`{.action} tab, and you will see the quota under `Disk space`.
-
-![ftp](images/ftp.png){.thumbnail}
-
-#### 4 - Email accounts
-
-Please also check that your new solution has a sufficient number of available email accounts. Otherwise, delete the extra accounts, after you have [backed up](https://docs.ovh.com/ca/en/emails/migrate-email-addresses-manually/) the contents if necessary.
-
-If you would like to keep the same number of email accounts, before moving your web hosting to a lower plan, you can also order a new **MX Plan** email solution. In the `Emails`{.action} section of the OVHcloud Control Panel, click on the solution concerned, then on the `...`{.action} button to the right of `Solution`. Next, click `Change solution`{.action}.
-
-![mxplan](images/mxplan.png){.thumbnail}
-
-#### 5 - Mailing lists
-
-The [Mailing lists](https://docs.ovh.com/ca/en/emails/guide-dutilisation-mailing-list/) feature is optional on [Personal](https://www.ovhcloud.com/en-ca/web-hosting/personal-offer/) and [Kimsufi Web](https://www.ovhcloud.com/en-ca/web-hosting/old-web-hosting-offers/) hosting plans.
-
-To set up your hosting plan on a [Personal](https://www.ovhcloud.com/en-ca/web-hosting/personal-offer/) solution, you will need to delete the mailing lists first, or order an email solution with this feature (**MX Plan 100** or **MX Plan Full**) from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca).
-
-In the `Emails`{.action} section of your Control Panel, select the solution concerned, then click on `...`{.action} to the right of `Solution`{.action}. Next, click `Change solution`{.action}.
-
-#### Completion
-
-Once you have checked these 6 elements, you can [change your plan](#modify).
 
 ### Special cases
 

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-sg.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-sg.md
@@ -23,14 +23,19 @@ In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&fro
 
 > [!warning]
 >
-> **Before** you make any changes to your current subscription, check to see if you have any of these questions:
+> **Before** you make any changes to your current subscription, check to see if these questions apply to your situation:
 >
 > - [How do I get a temporary performance boost on my Performance hosting plan?](#boost)
 > - [Will I waste the time remaining on my current hosting plan when I change plans?](#billing)
-> - [Can I upgrade my current plan to a lower plan?](#checks)
 >
 
 ### Modifying your hosting plan <a name="modify"></a>
+
+> [!warning]
+> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
+>
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/sg/en/hosting/migrating-website-to-ovh/)”.
+>
 
 To change your subscription, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) in the `Web Cloud`{.action} section. Click `Hosting plans`{.action} and select the plan concerned.
 
@@ -39,60 +44,6 @@ In the `Plan` box, click the `...`{.action} button to the right of `Solution`, t
 ![change_plan](images/change_plan.png){.thumbnail}
 
 Then select your new subscription and its duration. Confirm the corresponding contracts, then click `Send`{.action}.
-
-### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
-
-> [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
->
-> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/sg/en/hosting/migrating-website-to-ovh/)”.
->
-
-Before you make your switch to a lower range, check the following 6 items:
-
-#### 1 - Number of sites
-
-With the [Kimsufi Web](https://www.ovhcloud.com/en-sg/web-hosting/old-web-hosting-offers/) solution, you cannot have more than one domain name on your hosting plan’s [multisite](https://docs.ovh.com/sg/en/hosting/multisites-configuring-multiple-websites/).
-
-Before you switch from the [Personal](https://www.ovhcloud.com/en-sg/web-hosting/personal-offer/) solution to the [Kimsufi Web](https://www.ovhcloud.com/en-sg/web-hosting/old-web-hosting-offers/) solution, please check that your web hosting plan only has one website.
-
-#### 2 - Start SQL databases
-
-Before moving your hosting to a lower plan, please ensure that the new plan has enough [databases](https://www.ovhcloud.com/en-sg/web-hosting/options/start-sql/). Also make sure they are of sufficient size.
-
-Otherwise, delete unused databases and reduce the amount of data they contain, if necessary. This quantity must not exceed the maximum size of the databases in the new solution (for any requests for assistance with the operations to be carried out, contact the [OVHcloud partners](https://partner.ovhcloud.com/en-sg/directory/)).
-
-If you have deleted data from your databases, you can recalculate the quota from the `Databases`{.action} tab in the `Hosting plans`{.action} section of the OVHcloud Control Panel. Click on the `...`{.action} button to the right of the database concerned, then `Recalculate the quota`{.action}.
-
-![quota](images/quota.png){.thumbnail}
-
-#### 3 - FTP space
-
-Before switching your hosting plan to a lower plan, please ensure that the new plan includes enough [FTP storage space](https://docs.ovh.com/sg/en/hosting/log-in-to-storage-ftp-web-hosting/) so that you can import files from your current hosting plan.
-
-The quota used on your FTP hosting plan is visible in the `Hosting plans`{.action} section of the OVHcloud Control Panel. Click on the `General information`{.action} tab, and you will see the quota under `Disk space`.
-
-![ftp](images/ftp.png){.thumbnail}
-
-#### 4 - Email accounts
-
-Please also check that your new solution has a sufficient number of available email accounts. Otherwise, delete the extra accounts, after you have [backed up](https://docs.ovh.com/sg/en/emails/migrate-email-addresses-manually/) the contents if necessary.
-
-If you would like to keep the same number of email accounts, before moving your web hosting to a lower plan, you can also order a new **MX Plan** email solution. In the `Emails`{.action} section of the OVHcloud Control Panel, click on the solution concerned, then on the `...`{.action} button to the right of `Solution`. Next, click `Change solution`{.action}.
-
-![mxplan](images/mxplan.png){.thumbnail}
-
-#### 5 - Mailing lists
-
-The [Mailing lists](https://docs.ovh.com/sg/en/emails/guide-dutilisation-mailing-list/) feature is optional on [Personal](https://www.ovhcloud.com/en-sg/web-hosting/personal-offer/) and [Kimsufi Web](https://www.ovhcloud.com/en-sg/web-hosting/old-web-hosting-offers/) hosting plans.
-
-To set up your hosting plan on a [Personal](https://www.ovhcloud.com/en-sg/web-hosting/personal-offer/) solution, you will need to delete the mailing lists first, or order an email solution with this feature (**MX Plan 100** or **MX Plan Full**) from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg).
-
-In the `Emails`{.action} section of your Control Panel, select the solution concerned, then click on `...`{.action} to the right of `Solution`{.action}. Next, click `Change solution`{.action}.
-
-#### Completion
-
-Once you have checked these 6 elements, you can [change your plan](#modify).
 
 ### Special cases
 

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-sg.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-sg.md
@@ -6,7 +6,7 @@ section: Optimise your website
 order: 02
 ---
 
-**Last updated 3rd January 2023**
+**Last updated 30th January 2023**
 
 ## Objective
 
@@ -43,10 +43,10 @@ Then select your new subscription and its duration. Confirm the corresponding co
 ### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
 
 > [!warning]
+> Subscription changes for lower plans are not available for customers whose services are hosted outside Europe.
 >
-> You can only change your subscription to a lower range plan if it is the **immediate lower range** plan.
-> For example, you cannot switch from *Performance 2* to *Professional* in a single operation.
-> You will **first** need to downgrade your web hosting plan from the *Performance 2* plan to the *Performance 1* plan, **and then** to the *Professional* plan.
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/sg/en/hosting/migrating-website-to-ovh/)”.
+>
 
 Before you make your switch to a lower range, check the following 6 items:
 

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-sg.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-sg.md
@@ -43,7 +43,7 @@ Then select your new subscription and its duration. Confirm the corresponding co
 ### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
 
 > [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted outside Europe.
+> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
 >
 > If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/sg/en/hosting/migrating-website-to-ovh/)”.
 >

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-sg.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-sg.md
@@ -32,9 +32,9 @@ In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&fro
 ### Modifying your hosting plan <a name="modify"></a>
 
 > [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
+> Subscription downgrading is not available for customers whose services are hosted in a data centre outside Europe.
 >
-> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/sg/en/hosting/migrating-website-to-ovh/)”.
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrating your website and emails to OVHcloud](https://docs.ovh.com/sg/en/hosting/migrating-website-to-ovh/)”.
 >
 
 To change your subscription, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) in the `Web Cloud`{.action} section. Click `Hosting plans`{.action} and select the plan concerned.

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-us.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-us.md
@@ -23,14 +23,19 @@ In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&fro
 
 > [!warning]
 >
-> **Before** you make any changes to your current subscription, check to see if you have any of these questions:
+> **Before** you make any changes to your current subscription, check to see if these questions apply to your situation:
 >
 > - [How do I get a temporary performance boost on my Performance hosting plan?](#boost)
 > - [Will I waste the time remaining on my current hosting plan when I change plans?](#billing)
-> - [Can I upgrade my current plan to a lower plan?](#checks)
 >
 
 ### Modifying your hosting plan <a name="modify"></a>
+
+> [!warning]
+> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
+>
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/us/en/hosting/migrating-website-to-ovh/)”.
+>
 
 To change your subscription, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) in the `Web Cloud`{.action} section. Click `Hosting plans`{.action} and select the plan concerned.
 
@@ -39,60 +44,6 @@ In the `Plan` box, click the `...`{.action} button to the right of `Solution`, t
 ![change_plan](images/change_plan.png){.thumbnail}
 
 Then select your new subscription and its duration. Confirm the corresponding contracts, then click `Send`{.action}.
-
-### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
-
-> [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
->
-> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/us/en/hosting/migrating-website-to-ovh/)”.
->
-
-Before you make your switch to a lower range, check the following 6 items:
-
-#### 1 - Number of sites
-
-With the [Kimsufi Web](https://www.ovhcloud.com/en/web-hosting/old-web-hosting-offers/) solution, you cannot have more than one domain name on your hosting plan’s [multisite](https://docs.ovh.com/us/en/hosting/multisites-configuring-multiple-websites/).
-
-Before you switch from the [Personal](https://www.ovhcloud.com/en/web-hosting/personal-offer/) solution to the [Kimsufi Web](https://www.ovhcloud.com/en/web-hosting/old-web-hosting-offers/) solution, please check that your web hosting plan only has one website.
-
-#### 2 - Start SQL databases
-
-Before moving your hosting to a lower plan, please ensure that the new plan has enough [databases](https://www.ovhcloud.com/en/web-hosting/options/start-sql/). Also make sure they are of sufficient size.
-
-Otherwise, delete unused databases and reduce the amount of data they contain, if necessary. This quantity must not exceed the maximum size of the databases in the new solution (for any requests for assistance with the operations to be carried out, contact the [OVHcloud partners](https://partner.ovhcloud.com/en/directory/)).
-
-If you have deleted data from your databases, you can recalculate the quota from the `Databases`{.action} tab in the `Hosting plans`{.action} section of the OVHcloud Control Panel. Click on the `...`{.action} button to the right of the database concerned, then `Recalculate the quota`{.action}.
-
-![quota](images/quota.png){.thumbnail}
-
-#### 3 - FTP space
-
-Before switching your hosting plan to a lower plan, please ensure that the new plan includes enough [FTP storage space](https://docs.ovh.com/us/en/hosting/log-in-to-storage-ftp-web-hosting/) so that you can import files from your current hosting plan.
-
-The quota used on your FTP hosting plan is visible in the `Hosting plans`{.action} section of the OVHcloud Control Panel. Click on the `General information`{.action} tab, and you will see the quota under `Disk space`.
-
-![ftp](images/ftp.png){.thumbnail}
-
-#### 4 - Email accounts
-
-Please also check that your new solution has a sufficient number of available email accounts. Otherwise, delete the extra accounts, after you have [backed up](https://docs.ovh.com/us/en/emails/migrate-email-addresses-manually/) the contents if necessary.
-
-If you would like to keep the same number of email accounts, before moving your web hosting to a lower plan, you can also order a new **MX Plan** email solution. In the `Emails`{.action} section of the OVHcloud Control Panel, click on the solution concerned, then on the `...`{.action} button to the right of `Solution`. Next, click `Change solution`{.action}.
-
-![mxplan](images/mxplan.png){.thumbnail}
-
-#### 5 - Mailing lists
-
-The [Mailing lists](https://docs.ovh.com/us/en/emails/guide-dutilisation-mailing-list/) feature is optional on [Personal](https://www.ovhcloud.com/en/web-hosting/personal-offer/) and [Kimsufi Web](https://www.ovhcloud.com/en/web-hosting/old-web-hosting-offers/) hosting plans.
-
-To set up your hosting plan on a [Personal](https://www.ovhcloud.com/en/web-hosting/personal-offer/) solution, you will need to delete the mailing lists first, or order an email solution with this feature (**MX Plan 100** or **MX Plan Full**) from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we).
-
-In the `Emails`{.action} section of your Control Panel, select the solution concerned, then click on `...`{.action} to the right of `Solution`{.action}. Next, click `Change solution`{.action}.
-
-#### Completion
-
-Once you have checked these 6 elements, you can [change your plan](#modify).
 
 ### Special cases
 

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-us.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-us.md
@@ -6,7 +6,7 @@ section: Optimise your website
 order: 02
 ---
 
-**Last updated 3rd January 2023**
+**Last updated 30th January 2023**
 
 ## Objective
 
@@ -43,10 +43,10 @@ Then select your new subscription and its duration. Confirm the corresponding co
 ### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
 
 > [!warning]
+> Subscription changes for lower plans are not available for customers whose services are hosted outside Europe.
 >
-> You can only change your subscription to a lower range plan if it is the **immediate lower range** plan.
-> For example, you cannot switch from *Performance 2* to *Professional* in a single operation.
-> You will **first** need to downgrade your web hosting plan from the *Performance 2* plan to the *Performance 1* plan, **and then** to the *Professional* plan.
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/us/en/hosting/migrating-website-to-ovh/)”.
+>
 
 Before you make your switch to a lower range, check the following 6 items:
 

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-us.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-us.md
@@ -43,7 +43,7 @@ Then select your new subscription and its duration. Confirm the corresponding co
 ### Checking that your hosting plan is compatible with a lower plan <a name="checks"></a>
 
 > [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted outside Europe.
+> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
 >
 > If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/us/en/hosting/migrating-website-to-ovh/)”.
 >

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-us.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.en-us.md
@@ -32,9 +32,9 @@ In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&fro
 ### Modifying your hosting plan <a name="modify"></a>
 
 > [!warning]
-> Subscription changes for lower plans are not available for customers whose services are hosted in a datacentre outside Europe.
+> Subscription downgrading is not available for customers whose services are hosted in a data centre outside Europe.
 >
-> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrate your website and emails to OVHcloud](https://docs.ovh.com/us/en/hosting/migrating-website-to-ovh/)”.
+> If you would like to change your subscription to a lower plan, please follow the steps in our guide “[Migrating your website and emails to OVHcloud](https://docs.ovh.com/us/en/hosting/migrating-website-to-ovh/)”.
 >
 
 To change your subscription, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) in the `Web Cloud`{.action} section. Click `Hosting plans`{.action} and select the plan concerned.

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.es-us.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.es-us.md
@@ -10,7 +10,7 @@ order: 02
 > Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón "Contribuir" de esta página.
 >
 
-**Última actualización: 22/06/2022**
+**Última actualización: 30/01/2023**
 
 ## Objetivo
 
@@ -47,10 +47,9 @@ A continuación, seleccione la nueva suscripción y la duración de la misma. Ac
 ### Comprobar que el alojamiento es compatible con un producto inferior <a name="checks"></a>
 
 > [!warning]
+> El cambio de la suscripción para una oferta inferior no está disponible para nuestros clientes que están alojados fuera de Europa.
 >
-> Solo es posible modificar la suscripción para un producto que ofrezca menos recursos si se trata del producto **inmediatamente inferior**. 
-> Por ejemplo, no podrá pasar de una fórmula *Performance 2* a una fórmula *Profesional* en una sola operación.
-> **En primer lugar**, deberá migrar su alojamiento desde la fórmula *Performance 2* al plan *Performance 1* y **después** al plan *Profesional*.
+> Si desea cambiar la suscripción a un plan inferior, siga los pasos de nuestra guía "[Migrar un sitio web y el correo a OVHcloud](https://docs.ovh.com/us/es/hosting/web_hosting_transferir_un_sitio_web_y_el_correo_sin_cortes_del_servicio/)".
 >
 
 Antes de realizar el cambio a una gama inferior, compruebe los siguientes 6 elementos:

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.es-us.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.es-us.md
@@ -31,10 +31,15 @@ Su [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&fr
 >
 > - [¿Cómo disfrutar de un aumento temporal del rendimiento de mi plan de hosting Performance?](#boost)
 > - [¿Voy a perder el tiempo restante de mi actual plan de hosting al cambiar de plan?](#billing)
-> - [¿Es posible cambiar mi solución actual a una inferior?](#checks)
 >
 
 ### Modificar el plan de hosting <a name="modify"></a>
+
+> [!warning]
+> La modificación de la suscripción para una oferta inferior no está disponible para nuestros clientes, ya que sus servicios están alojados en un datacenter situado fuera de Europa.
+>
+> Si desea cambiar la suscripción a un plan inferior, siga los pasos de nuestra guía "[Migrar un sitio web y el correo a OVHcloud](https://docs.ovh.com/us/es/hosting/web_hosting_transferir_un_sitio_web_y_el_correo_sin_cortes_del_servicio/)".
+>
 
 Para modificar su suscripción, vaya a su [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) en la sección `Web Cloud`{.action}. Haga clic en `Alojamientos`{.action} y seleccione el alojamiento correspondiente.
 
@@ -43,60 +48,6 @@ En el recuadro `Suscripción`, haga clic en el botón `...`{.action} a la derech
 ![change_plan](images/change_plan.png){.thumbnail}
 
 A continuación, seleccione la nueva suscripción y la duración de la misma. Acepte los contratos correspondientes y haga clic en `Enviar`{.action}.
-
-### Comprobar que el alojamiento es compatible con un producto inferior <a name="checks"></a>
-
-> [!warning]
-> La modificación de la suscripción para una oferta inferior no está disponible para nuestros clientes, ya que sus servicios están alojados en un datacenter situado fuera de Europa.
->
-> Si desea cambiar la suscripción a un plan inferior, siga los pasos de nuestra guía "[Migrar un sitio web y el correo a OVHcloud](https://docs.ovh.com/us/es/hosting/web_hosting_transferir_un_sitio_web_y_el_correo_sin_cortes_del_servicio/)".
->
-
-Antes de realizar el cambio a una gama inferior, compruebe los siguientes 6 elementos:
-
-#### 1 - Número de sitios
-
-El producto [Kimsufi Web](https://www.ovhcloud.com/es/web-hosting/old-web-hosting-offers/) no permite tener más de un dominio en el [multisitio](https://docs.ovh.com/us/es/hosting/configurar-un-multisitio-en-un-alojamiento-web/) de su alojamiento.
-
-Antes de cambiar del plan [Personal](https://www.ovhcloud.com/es/web-hosting/personal-offer/) al plan [Kimsufi Web](https://www.ovhcloud.com/es/web-hosting/old-web-hosting-offers/), compruebe que el alojamiento solo tenga un sitio web.
-
-#### 2 - Bases de datos Start SQL
-
-Antes de cambiar al plan de hosting inferior, asegúrese de que el nuevo plan incluya suficientes [bases de datos](https://www.ovhcloud.com/es/web-hosting/options/start-sql/). Compruebe también que sean de tamaño suficiente.
-
-En caso contrario, elimine las bases de datos no utilizadas y reduzca la cantidad de datos que contienen. Esta cantidad no deberá exceder del tamaño máximo de las bases de datos de la nueva oferta (para cualquier solicitud de soporte sobre las operaciones a realizar, contacte con los [partners de OVHcloud](https://partner.ovhcloud.com/es/)).
-
-Una vez que haya eliminado los datos de sus bases de datos, vuelva a calcular el espacio utilizado en la pestaña `Bases de datos`{.action} de la sección `Alojamientos`{.action} del área de cliente. Haga clic en el botón `...`{.action} a la derecha de la base de que se trate y, seguidamente, `Recalcular el espacio utilizado`{.action}.
-
-![cuota](images/quota.png){.thumbnail}
-
-#### 3 - Espacio FTP
-
-Antes de cambiar al plan de hosting inferior, asegúrese de que el nuevo plan incluye suficiente [espacio de almacenamiento FTP](https://docs.ovh.com/us/es/hosting/conexion-espacio-almacenamiento-ftp-alojamiento-web/) para poder importar los archivos de su alojamiento actual.
-
-La cuota utilizada en su alojamiento FTP puede verse en la sección `Alojamientos`{.action} del área de cliente. Haga clic en la pestaña `Información general`{.action} y encontrará el límite en el `Espacio en disco`.
-
-![ftp](images/ftp.png){.thumbnail}
-
-#### 4 - Direcciones de correo
-
-Compruebe también que la nueva solución ofrezca un número suficiente de direcciones de correo electrónico disponibles. En caso contrario, elimine las direcciones superfluas después de haberlas [guardado](https://docs.ovh.com/us/es/emails/migrar-sus-direcciones-de-correo-manualmente/) si es necesario.
-
-Si quiere conservar el mismo número de cuentas de correo antes de pasar el alojamiento a una solución inferior, puede contratar una nueva solución de correo **MX Plan**. En la sección `Correo electrónico`{.action} del área de cliente, haga clic en el producto correspondiente y, seguidamente, en el botón `...`{.action} a la derecha del `Producto`{.action}. Haga clic en `Cambiar de plan`{.action}.
-
-![mxplan](images/mxplan.png){.thumbnail}
-
-#### 5 - Mailing lists
-
-La funcionalidad [Mailing lists](https://docs.ovh.com/us/es/emails/guia_de_utilizacion_de_listas_de_difusion/) está opcional en los alojamientos [Personal](https://www.ovhcloud.com/es/web-hosting/personal-offer/) y [Kimsufi Web](https://www.ovhcloud.com/es/web-hosting/old-web-hosting-offers/).
-
-Para migrar a un plan de hosting [Personal](https://www.ovhcloud.com/es/web-hosting/personal-offer/), primero deberá eliminar las listas de correo o contratar un servicio de correo que incluya esta funcionalidad (**MX Plan 100** o **MX Plan Full**) desde su [área de cliente OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
-
-En la sección `Correo electrónico`{.action} del área de cliente, seleccione el servicio correspondiente y haga clic en `...`{.action} a la derecha del `Producto`{.action}. Haga clic en `Cambiar de plan`{.action}.
-
-#### Finalización
-
-Una vez que haya comprobado estos 6 elementos, puede realizar el [cambio de producto](#modify).
 
 ### Casos particulares
 

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.es-us.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.es-us.md
@@ -47,7 +47,7 @@ A continuación, seleccione la nueva suscripción y la duración de la misma. Ac
 ### Comprobar que el alojamiento es compatible con un producto inferior <a name="checks"></a>
 
 > [!warning]
-> El cambio de la suscripción para una oferta inferior no está disponible para nuestros clientes que están alojados fuera de Europa.
+> La modificación de la suscripción para una oferta inferior no está disponible para nuestros clientes, ya que sus servicios están alojados en un datacenter situado fuera de Europa.
 >
 > Si desea cambiar la suscripción a un plan inferior, siga los pasos de nuestra guía "[Migrar un sitio web y el correo a OVHcloud](https://docs.ovh.com/us/es/hosting/web_hosting_transferir_un_sitio_web_y_el_correo_sin_cortes_del_servicio/)".
 >

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.fr-ca.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.fr-ca.md
@@ -6,7 +6,7 @@ section: Optimiser son site
 order: 02
 ---
 
-**Dernière mise à jour le 19/05/2022**
+**Dernière mise à jour le 30/01/2023**
 
 ## Objectif
 
@@ -39,19 +39,11 @@ Celui-ci durera de ce fait **un peu plus d'un an**, jusqu'à son prochain renouv
 
 ### Modifier votre offre d'hébergement <a name="modify"></a>
 
-> [!primary]
->
-> La modification de votre abonnement pour une offre délivrant moins de ressources n'est possible que s'il s'agit de l'offre **immédiatement inférieure**. 
-> Par exemple, vous ne pourrez pas passer d'une formule *Performance 2* à une formule *Pro* en une seule opération.
-> Vous devrez **d'abord** faire évoluer votre hébergement depuis la formule *Performance 2* vers l'offre *Performance 1* **puis** vers l'offre *Pro*.
->
-
 > [!warning]
+> Le changement d'abonnement pour une offre inférieure est indisponible pour nos clients dont les services sont hébergés hors Europe.
 >
-> **Avant** tout changement de votre abonnement pour une offre inférieure, vérifiez que l'utilisation de votre offre actuelle est compatible avec les caractéristiques de votre prochaine [offre d'hébergement](https://www.ovhcloud.com/fr-ca/web-hosting/).
->
-> Pour ce faire, suivez [ces instructions](#checks), effectuez le changement d'offre puis répétez ces opérations autant de fois que nécessaire.
->
+> Si vous souhaitez modifiez votre abonnement pour passer à une offre inférieure, veuillez suivre les étapes de notre guide « [Migrer son site et ses e-mails vers OVHcloud](https://docs.ovh.com/ca/fr/hosting/migrer-mon-site-chez-ovh/) ».
+> 
 
 Pour modifier votre abonnement, rendez-vous dans votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc) dans la partie `Web Cloud`{.action}. Cliquez sur `Hébergements`{.action} et sélectionnez l'hébergement concerné.
 

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.fr-ca.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.fr-ca.md
@@ -21,28 +21,21 @@ Votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=
 
 ## En pratique
 
-> [!success]
-> 
-> **Besoin de booster temporairement votre hébergement ?**
+> [!warning]
 >
-> Avec l'[OPTION BOOST](https://www.ovhcloud.com/fr-ca/web-hosting/options/boost/), disponible sur nos offres *Performance*, vous pouvez faire évoluer temporairement les ressources de votre hébergement pour absorber une augmentation ponctuelle du trafic. Si cette augmentation se prolonge dans le temps, vous pouvez également migrer vers une solution supérieure afin de disposer de davantage de ressources de manière permanente.
+> **Avant** tout changement sur votre abonnement actuel, vérifiez si vous êtes concerné par l'une de ces questions :
+>
+> - [Comment bénéficier d'un gain de performance temporaire sur mon offre d'hébergement performance ?](#boost)
+> - [Vais-je perdre le temps restant sur mon offre d'hébergement actuelle lors de mon changement d'offre ?](#billing)
 >
 
-### Important - La facturation en cas de changement d'offre
-
-Lorsque vous modifiez votre formule en cours d'abonnement, un *report de temps* s'applique sur votre nouvelle offre. Ce report correspond à la durée restante d'abonnement sur votre offre actuelle.
-
-**Exemple :**<br>
-Vous passez d'une offre [Perso](https://www.ovhcloud.com/fr-ca/web-hosting/personal-offer/) à une offre [Pro](https://www.ovhcloud.com/fr-ca/web-hosting/professional-offer/), alors que l'abonnement en cours n'est pas terminé.<br>
-Par conséquent, la durée restante sera automatiquement **ajoutée** au pro rata temporis à votre nouvel abonnement **Pro**.<br>
-Celui-ci durera de ce fait **un peu plus d'un an**, jusqu'à son prochain renouvellement.
 
 ### Modifier votre offre d'hébergement <a name="modify"></a>
 
 > [!warning]
-> Le changement d'abonnement pour une offre inférieure est indisponible pour nos clients dont les services sont hébergés dans un Datacentre en dehors de l'Europe.
+> Le changement d'abonnement pour une offre inférieure est indisponible pour nos clients dont les services sont hébergés dans un datacenter en dehors de l'Europe.
 >
-> Si vous souhaitez modifiez votre abonnement pour passer à une offre inférieure, veuillez suivre les étapes de notre guide « [Migrer son site et ses e-mails vers OVHcloud](https://docs.ovh.com/ca/fr/hosting/migrer-mon-site-chez-ovh/) ».
+> Si vous souhaitez modifier votre abonnement pour passer à une offre inférieure, veuillez suivre les étapes de notre guide « [Migrer son site et ses e-mails vers OVHcloud](https://docs.ovh.com/ca/fr/hosting/migrer-mon-site-chez-ovh/) ».
 > 
 
 Pour modifier votre abonnement, rendez-vous dans votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc) dans la partie `Web Cloud`{.action}. Cliquez sur `Hébergements`{.action} et sélectionnez l'hébergement concerné.
@@ -53,47 +46,45 @@ Dans le cadre `Abonnement`, cliquez sur le bouton `...`{.action} à droite de `O
 
 Sélectionnez ensuite votre nouvel abonnement, ainsi que sa durée. Validez les contrats correspondants puis cliquez sur `Valider`{.action}.
 
-### Vérifier que votre hébergement est compatible avec une offre inférieure <a name="checks"></a>
+### Cas particuliers
 
-#### Nombre de sites
+#### Booster temporairement votre hébergement Performance <a name="boost"></a>
 
-L'offre [Kimsufi Web](https://www.ovhcloud.com/fr-ca/web-hosting/old-web-hosting-offers/) ne permet pas d'avoir plus d'un nom de domaine sur le [multisite](https://docs.ovh.com/ca/fr/hosting/multisites-configurer-un-multisite-sur-mon-hebergement-web/) de votre hébergement.
+Avec l'[option Boost](https://www.ovhcloud.com/fr-ca/web-hosting/options/boost/), disponible sur nos offres *Performance*, vous pouvez augmenter temporairement les ressources CPU et RAM de votre hébergement pour absorber une augmentation ponctuelle du trafic. Si cette augmentation se prolonge dans le temps, vous pouvez également [basculer vers l'offre Performance de niveau supérieur](#modify) afin de disposer de ces ressources de manière permanente.
 
-Avant de passer de l'offre [Perso](https://www.ovhcloud.com/fr-ca/web-hosting/personal-offer/) à l'offre [Kimsufi Web](https://www.ovhcloud.com/fr-ca/web-hosting/old-web-hosting-offers/), vérifiez donc que votre hébergement ne comporte qu'un seul site.
+> [!warning]
+>
+> Lorsque vous décidez d'activer l'option Boost, celle-ci reste active et facturée **tant que vous ne l'avez pas désactivée**.
 
-#### Bases de données Start SQL
+Si l'option **Boost** convient à votre besoin, vous trouverez ci-dessous les instructions pour **activer** ou **désactiver** cette option sur votre hébergement.
 
-Avant de passer votre hébergement sur une offre inférieure, assurez-vous que la nouvelle offre comporte assez de [bases de données](https://www.ovhcloud.com/fr-ca/web-hosting/options/start-sql/). Vérifiez aussi qu'elles sont de tailles suffisantes.
+> [!tabs]
+> **Activer l'option Boost**
+>>
+>> Dans le cadre `Informations générales` de votre hébergement, cliquez sur le bouton `...`{.action} à droite de `Boost` puis sur `Booster mon offre`{.action}.<br><br>
+>> ![boost](images/enable_boost.png){.thumbnail}<br>
+>>
+> **Désactiver l'option Boost**
+>>
+>> Dans l'onglet `Plus` de votre hébergement, cliquez sur `Booster mon offre`{.action}.<br>
+>> Le tableau d'utilisation de l'option Boost s'affiche, cliquez sur `Désactiver l'offre boost`{.action}.<br><br>
+>> ![boost](images/disable_boost.png){.thumbnail}<br>
 
-Dans le cas contraire, supprimez les bases de données inutilisées et réduisez, si nécessaire, la quantité de données qu'elles contiennent. Cette quantité ne devra pas dépasser la taille maximale des bases de données de la nouvelle offre (pour toute demande d'assistance sur les manipulations à effectuer, contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr-ca/)).
+#### La facturation en cas de changement d'offre <a name="billing"></a>
 
-Suite à la suppression de données sur vos bases, pensez à recalculer le quota utilisé depuis l'onglet `Bases de données`{.action} dans la partie `Hébergements`{.action} de votre espace client. Cliquez sur le bouton `...`{.action} à droite de la base concernée puis sur `Recalculer le quota`{.action}.
+Lorsque vous modifiez votre offre initiale vers une offre supérieure, un calcul au *prorata temporis* est alors appliqué jusqu'à la prochaine date de renouvellement de cet abonnement initial.
+Ce calcul correspond à la différence de tarif entre votre offre initiale et votre nouvelle offre.
 
-![quota](images/quota.png){.thumbnail}
+> **Exemple :**<br>
+>
+> Vous avez souscrit à un abonnement [Perso](https://www.ovhcloud.com/fr-ca/web-hosting/personal-offer/) au 1er janvier 2022.
+>
+> Le 31 octobre 2022, vous passez de cette offre **Perso** à un abonnement sur l'offre [Pro](https://www.ovhcloud.com/fr-ca/web-hosting/professional-offer/).<br>
+>
+> Par conséquent, le montant correspondant à la durée restante sur l'abonnement **Perso** (2 mois, du 1er novembre 2022 au 1er janvier 2023) est automatiquement soustrait du coût du nouvel abonnement **Pro**, jusqu'au 1er janvier 2023. Vous ne paierez que la différence.
+> À partir du 1er janvier 2023, l'abonnement Pro vous est ensuite facturé à son tarif en vigueur.
 
-#### Espace FTP
-
-Avant de passer votre hébergement sur une offre inférieure, assurez-vous que la nouvelle offre propose suffisamment [d'espace de stockage FTP](https://docs.ovh.com/ca/fr/hosting/connexion-espace-stockage-ftp-hebergement-web/) pour que l'import des fichiers de votre hébergement actuel soit possible.
-
-Le quota utilisé sur votre hébergement FTP est visible dans la partie `Hébergements`{.action} de votre espace client. Cliquez sur l'onglet `Informations générales`{.action}, vous retrouverez le quota sous `Espace Disque`.
-
-![ftp](images/ftp.png){.thumbnail}
-
-#### Adresses e-mail
-
-Vérifiez également que votre nouvelle offre propose un nombre suffisant d'adresses e-mail disponibles. Dans le cas contraire, supprimez les adresses superflues, après les avoir [sauvegardées](https://docs.ovh.com/ca/fr/emails/migrer-ses-adresses-email-manuellement/) si nécessaire.
-
-Si vous souhaitez conserver le même nombre de boîtes e-mail, avant de passer votre hébergement sur une offre inférieure, vous pouvez également commander une nouvelle offre de messagerie **MX Plan**. Dans la partie `Emails`{.action} de votre espace client, cliquez sur l'offre concernée puis sur le bouton  `...`{.action} à droite de `Offre`. Cliquez enfin sur `Changer d'offre`{.action}.
-
-![mxplan](images/mxplan.png){.thumbnail}
-
-#### Mailing lists
-
-La fonctionnalité [Mailing lists](https://docs.ovh.com/ca/fr/emails/guide-dutilisation-mailing-list/) est en option sur les hébergements [Perso](https://www.ovhcloud.com/fr-ca/web-hosting/personal-offer/) et [Kimsufi Web](https://www.ovhcloud.com/fr-ca/web-hosting/old-web-hosting-offers/).
-
-Pour passer votre hébergement sur une offre [Perso](https://www.ovhcloud.com/fr-ca/web-hosting/personal-offer/), vous devrez donc dans un premier temps en supprimer les mailing lists ou commander une offre de messagerie comprenant cette fonctionnalité (**MX Plan 100** ou **MX Plan Full**) depuis votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
-
-Dans la partie `Emails`{.action} de votre espace client, sélectionnez l'offre concernée puis cliquez sur `...`{.action} à droite de `Offre`{.action}. Cliquez enfin sur `Changer d'offre`{.action}.
+Suivez [ces instructions](#modify) pour réaliser votre changement d'offre.
 
 ## Aller plus loin <a name="gofurther"></a>
 

--- a/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.fr-ca.md
+++ b/pages/web/hosting/how_to_upgrade_web_hosting_offer/guide.fr-ca.md
@@ -40,7 +40,7 @@ Celui-ci durera de ce fait **un peu plus d'un an**, jusqu'à son prochain renouv
 ### Modifier votre offre d'hébergement <a name="modify"></a>
 
 > [!warning]
-> Le changement d'abonnement pour une offre inférieure est indisponible pour nos clients dont les services sont hébergés hors Europe.
+> Le changement d'abonnement pour une offre inférieure est indisponible pour nos clients dont les services sont hébergés dans un Datacentre en dehors de l'Europe.
 >
 > Si vous souhaitez modifiez votre abonnement pour passer à une offre inférieure, veuillez suivre les étapes de notre guide « [Migrer son site et ses e-mails vers OVHcloud](https://docs.ovh.com/ca/fr/hosting/migrer-mon-site-chez-ovh/) ».
 > 


### PR DESCRIPTION
Updates for APAC/CA :

Dates of last update
Paragraphs about the availability to downgrade offer deleted 
paragraph  which explain the unavailability added for all APAC/CA subs

Need proofreding for EN subs (except IE and GB) and for US-ES subs by @Y0Coss / @OVH-Team-Guides and/or @tcpdumpfbacke when they've time.