### PR TITLE
[ai notebooks] - tuto speech to text - links update

### DIFF
--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.de-de.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.de-de.md
@@ -40,7 +40,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) or via the ovhai [CLI](https://docs.ovh.com/de/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -112,9 +112,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-asia.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-asia.md
@@ -38,7 +38,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) or via the ovhai [CLI](https://docs.ovh.com/asia/en/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -110,9 +110,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-au.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-au.md
@@ -38,7 +38,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) or via the ovhai [CLI](https://docs.ovh.com/au/en/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -110,9 +110,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-ca.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-ca.md
@@ -38,7 +38,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) or via the ovhai [CLI](https://docs.ovh.com/ca/en/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -110,9 +110,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-gb.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-gb.md
@@ -38,7 +38,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) or via the ovhai [CLI](https://docs.ovh.com/gb/en/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -110,9 +110,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-ie.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-ie.md
@@ -38,7 +38,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) or via the ovhai [CLI](https://docs.ovh.com/ie/en/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -110,9 +110,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-sg.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-sg.md
@@ -38,7 +38,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) or via the ovhai [CLI](https://docs.ovh.com/sg/en/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -110,9 +110,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-us.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.en-us.md
@@ -38,7 +38,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) or via the ovhai [CLI](https://docs.ovh.com/us/en/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -110,9 +110,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.es-es.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.es-es.md
@@ -40,7 +40,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) or via the ovhai [CLI](https://docs.ovh.com/es/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -112,9 +112,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.es-us.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.es-us.md
@@ -40,7 +40,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) or via the ovhai [CLI](https://docs.ovh.com/us/es/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -112,9 +112,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.fr-ca.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.fr-ca.md
@@ -40,7 +40,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc) or via the ovhai [CLI](https://docs.ovh.com/ca/fr/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -112,9 +112,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.fr-fr.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.fr-fr.md
@@ -40,7 +40,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) or via the ovhai [CLI](https://docs.ovh.com/fr/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -112,9 +112,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.it-it.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.it-it.md
@@ -40,7 +40,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) or via the ovhai [CLI](https://docs.ovh.com/it/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -112,9 +112,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.pl-pl.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.pl-pl.md
@@ -40,7 +40,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) or via the ovhai [CLI](https://docs.ovh.com/pl/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -112,9 +112,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.pt-pt.md
+++ b/pages/platform/ai/notebook_tuto_08_speech_to_text/guide.pt-pt.md
@@ -40,7 +40,7 @@ This documentation allows you to test and launch **3 AI Notebooks** allowing you
 
 You can launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt) or via the ovhai [CLI](https://docs.ovh.com/pt/publiccloud/ai/cli/getting-started-cli/).
 
-Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/conda).
+Direct link to the full code can be found [here](https://github.com/ovh/ai-training-examples/tree/main/notebooks/natural-language-processing/speech-to-text/miniconda).
 
 ### Launching a Jupyter notebook with "Miniconda" via UI
 
@@ -112,9 +112,9 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `natural-language-processing` > `speech-to-text`.
 
-1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/basics/speech-to-text-basics.ipynb).
-2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/advanced/speech-to-text-advanced.ipynb).
-3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/conda/compare-models/speech-to-text-compare-models.ipynb).
+1. You can find the first tutorial in the `basics` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/basics/speech-to-text-basics.ipynb).
+2. The second tutorial corresponds to the `advanced` folder. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/advanced/speech-to-text-advanced.ipynb).
+3. The last folder, named `compare-models`, contains the third tutorial. A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/natural-language-processing/speech-to-text/miniconda/compare-models/speech-to-text-compare-models.ipynb).
 
 ## Go further
 


### PR DESCRIPTION
Conda framework has been renamed Miniconda. This change has had an impact on some links.

Here is an update so that they are still clickable.