### PR TITLE
Adding link for the HG and Scale configuration help

### DIFF
--- a/pages/cloud/dedicated/network_bridging/guide.en-gb.md
+++ b/pages/cloud/dedicated/network_bridging/guide.en-gb.md
@@ -6,7 +6,7 @@ section: 'Network management'
 updated: 2022-12-20
 ---
 
-**Last updated 20th December 2022**
+**Last updated 23rd February 2023**
 
 > [!primary]
 >

--- a/pages/cloud/dedicated/network_bridging/guide.en-gb.md
+++ b/pages/cloud/dedicated/network_bridging/guide.en-gb.md
@@ -32,9 +32,9 @@ Bridged networking can be used to configure your virtual machines. Some tweaking
 >
 > Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
 >
-> This feature isn't available on servers of the [Scale](https://www.ovhcloud.com/en-gb/bare-metal/scale/) and [High Grade](https://www.ovhcloud.com/en-gb/bare-metal/high-grade/) product lines.
+> This guide is not applicable to servers of the ranges [Scale](https://www.ovhcloud.com/en-gb/bare-metal/scale/) and [High Grade](https://www.ovhcloud.com/en-gb/bare-metal/high-grade/).
 > 
-> Please visit the dedicated [configuration page](https://docs.ovh.com/ca/en/dedicated/proxmox-network-hg-scale/)
+> Please visit the dedicated [configuration page](https://docs.ovh.com/gb/en/dedicated/proxmox-network-hg-scale/).
 
 ## Instructions
 

--- a/pages/cloud/dedicated/network_bridging/guide.en-gb.md
+++ b/pages/cloud/dedicated/network_bridging/guide.en-gb.md
@@ -31,6 +31,10 @@ Bridged networking can be used to configure your virtual machines. Some tweaking
 > This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
 >
 > Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+>
+> This feature isn't available on servers of the [Scale](https://www.ovhcloud.com/en-gb/bare-metal/scale/) and [High Grade](https://www.ovhcloud.com/en-gb/bare-metal/high-grade/) product lines.
+> 
+> Please visit the dedicated [configuration page](https://docs.ovh.com/ca/en/dedicated/proxmox-network-hg-scale/)
 
 ## Instructions
 


### PR DESCRIPTION
The HG and Scale servers aren't on the same network as the others and this documentation doesn't work. Adding the information about those servers exception and the link to the Additionnal IP configuration page for the HG and Scale server will probably help direct people to the right page.