### PR TITLE
[web-power] fix typo in Flask install guide

### DIFF
--- a/pages/labs/web-power/python-install-flask/guide.en-gb.md
+++ b/pages/labs/web-power/python-install-flask/guide.en-gb.md
@@ -97,7 +97,7 @@ def hello_world():
     return 'Hello, World!'
 ```
 
-Then [restart your instance](../getting-started-with-power-web-hosting/#restart) and your Django will be online.
+Then [restart your instance](../getting-started-with-power-web-hosting/#restart) and your Flask project will be online.
 
 
 ![Flask](images/python-install-flask-01.png){.thumbnail}

--- a/pages/labs/web-power/python-install-flask/guide.en-gb.md
+++ b/pages/labs/web-power/python-install-flask/guide.en-gb.md
@@ -97,7 +97,7 @@ def hello_world():
     return 'Hello, World!'
 ```
 
-Then [restart your instance](../getting-started-with-power-web-hosting/#restart) and your Flask project will be online.
+Then [restart your instance](https://docs.ovh.com/gb/en/web-power/getting-started-with-power-web-hosting/#restart) and your Flask project will be online.
 
 
 ![Flask](images/python-install-flask-01.png){.thumbnail}

--- a/pages/labs/web-power/python-install-flask/guide.en-ie.md
+++ b/pages/labs/web-power/python-install-flask/guide.en-ie.md
@@ -97,7 +97,7 @@ def hello_world():
     return 'Hello, World!'
 ```
 
-Then [restart your instance](../getting-started-with-power-web-hosting/#restart) and your Flask project will be online.
+Then [restart your instance](https://docs.ovh.com/ie/en/web-power/getting-started-with-power-web-hosting/#restart) and your Flask project will be online.
 
 
 ![Flask](images/python-install-flask-01.png){.thumbnail}

--- a/pages/labs/web-power/python-install-flask/guide.en-ie.md
+++ b/pages/labs/web-power/python-install-flask/guide.en-ie.md
@@ -97,7 +97,7 @@ def hello_world():
     return 'Hello, World!'
 ```
 
-Then [restart your instance](../getting-started-with-power-web-hosting/#restart) and your Django will be online.
+Then [restart your instance](../getting-started-with-power-web-hosting/#restart) and your Flask project will be online.
 
 
 ![Flask](images/python-install-flask-01.png){.thumbnail}


### PR DESCRIPTION
The word Django was in the en-uk and en-ie guides.
French version was already correct.