### PR TITLE
Add a warning regarding mandatory ACL to load sample data

### DIFF
--- a/pages/platform/databases/opensearch_02_getting_Started/guide.de-de.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.de-de.md
@@ -207,7 +207,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.de-de.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.de-de.md
@@ -6,10 +6,10 @@ section: OpenSearch - Guides
 order: 020
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/opensearch/getting-started/'
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -199,6 +199,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-asia.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-asia.md
@@ -205,7 +205,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-asia.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-asia.md
@@ -4,10 +4,10 @@ excerpt: Find out how to set up and manage your Public Cloud Databases for OpenS
 slug: opensearch/getting-started
 section: OpenSearch - Guides
 order: 020
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -197,6 +197,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-au.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-au.md
@@ -205,7 +205,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-au.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-au.md
@@ -4,10 +4,10 @@ excerpt: Find out how to set up and manage your Public Cloud Databases for OpenS
 slug: opensearch/getting-started
 section: OpenSearch - Guides
 order: 020
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -197,6 +197,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-ca.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-ca.md
@@ -205,7 +205,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-ca.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-ca.md
@@ -4,10 +4,10 @@ excerpt: Find out how to set up and manage your Public Cloud Databases for OpenS
 slug: opensearch/getting-started
 section: OpenSearch - Guides
 order: 020
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -197,6 +197,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-gb.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-gb.md
@@ -205,7 +205,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-gb.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-gb.md
@@ -4,10 +4,10 @@ excerpt: Find out how to set up and manage your Public Cloud Databases for OpenS
 slug: opensearch/getting-started
 section: OpenSearch - Guides
 order: 020
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -197,6 +197,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-ie.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-ie.md
@@ -205,7 +205,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-ie.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-ie.md
@@ -4,10 +4,10 @@ excerpt: Find out how to set up and manage your Public Cloud Databases for OpenS
 slug: opensearch/getting-started
 section: OpenSearch - Guides
 order: 020
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -197,6 +197,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-sg.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-sg.md
@@ -205,7 +205,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-sg.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-sg.md
@@ -4,10 +4,10 @@ excerpt: Find out how to set up and manage your Public Cloud Databases for OpenS
 slug: opensearch/getting-started
 section: OpenSearch - Guides
 order: 020
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -197,6 +197,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-us.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-us.md
@@ -205,7 +205,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.en-us.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.en-us.md
@@ -4,10 +4,10 @@ excerpt: Find out how to set up and manage your Public Cloud Databases for OpenS
 slug: opensearch/getting-started
 section: OpenSearch - Guides
 order: 020
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -197,6 +197,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.es-es.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.es-es.md
@@ -207,7 +207,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.es-es.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.es-es.md
@@ -6,10 +6,10 @@ section: OpenSearch - Guides
 order: 020
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/opensearch/getting-started/'
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -199,6 +199,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.es-us.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.es-us.md
@@ -207,7 +207,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.es-us.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.es-us.md
@@ -6,10 +6,10 @@ section: OpenSearch - Guides
 order: 020
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/opensearch/getting-started/'
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -199,6 +199,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.fr-ca.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.fr-ca.md
@@ -207,7 +207,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.fr-ca.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.fr-ca.md
@@ -6,10 +6,10 @@ section: OpenSearch - Guides
 order: 020
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/opensearch/getting-started/'
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -199,6 +199,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.fr-fr.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.fr-fr.md
@@ -207,7 +207,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.fr-fr.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.fr-fr.md
@@ -6,10 +6,10 @@ section: OpenSearch - Guides
 order: 020
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/opensearch/getting-started/'
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -199,6 +199,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.it-it.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.it-it.md
@@ -207,7 +207,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.it-it.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.it-it.md
@@ -6,10 +6,10 @@ section: OpenSearch - Guides
 order: 020
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/opensearch/getting-started/'
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -199,6 +199,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.pl-pl.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.pl-pl.md
@@ -207,7 +207,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.pl-pl.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.pl-pl.md
@@ -6,10 +6,10 @@ section: OpenSearch - Guides
 order: 020
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/opensearch/getting-started/'
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -199,6 +199,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.pt-pt.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.pt-pt.md
@@ -207,7 +207,7 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 > - _bulk
 > - _mget
 >
-> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
+> Without these permissions you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 

--- a/pages/platform/databases/opensearch_02_getting_Started/guide.pt-pt.md
+++ b/pages/platform/databases/opensearch_02_getting_Started/guide.pt-pt.md
@@ -6,10 +6,10 @@ section: OpenSearch - Guides
 order: 020
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/opensearch/getting-started/'
-updated: 2021-12-06
+updated: 2023-03-03
 ---
 
-**Last updated 06<sup>th</sup> December 2021**
+**Last updated March 3rd, 2023**
 
 ## Objectives
 
@@ -199,6 +199,15 @@ From the *General information* tab from the Public Cloud Databases for OpenSearc
 ![First connection to Kibana](images/kibana_first_page.png){.thumbnail}
 
 #### Load sample data
+
+> [!warning]
+> If you have enabled ACLs in a previous step and don't want to disable them, then make sure your user is granted read and write permissions to:
+>
+> - opensearch_dashboards_sample_data_*
+> - _bulk
+> - _mget
+>
+> Without these permission you will not be able to add the sample data and view the corresponding dashboard.
 
 As proposed natively in OpenSearch, we can load sample data to the OpenSearch database:
 


### PR DESCRIPTION
Following a question on Discord from an Opensearch user, we add a warning to the Getting Started Opensearch guide telling users that specific ACL needs to be defined in order to use the sample data.