### PR TITLE
Cloud db update backup information

### DIFF
--- a/pages/platform/databases/databases_05_automated_backups/guide.de-de.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.de-de.md
@@ -6,10 +6,10 @@ section: General guides
 order: 17
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/backups'
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -25,20 +25,20 @@ We back up our managed public cloud databases every 1 (incremental snapshots), 1
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
 ## Engine Specifications
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
-OpenSearch | Incremental | On-Site | Hourly | 1h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
+OpenSearch | Incremental | On-Site, Off-Site | Hourly | 1h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.en-asia.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.en-asia.md
@@ -4,10 +4,10 @@ slug: backups
 excerpt: Discover the automated backup methods for each engine
 section: General guides
 order: 17
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -23,20 +23,20 @@ We back up our managed public cloud databases every 1 (incremental snapshots), 1
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
 ## Engine Specifications
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
-OpenSearch | Incremental | On-Site | Hourly | 1h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
+OpenSearch | Incremental | On-Site, Off-Site | Hourly | 1h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.en-au.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.en-au.md
@@ -4,10 +4,10 @@ slug: backups
 excerpt: Discover the automated backup methods for each engine
 section: General guides
 order: 17
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -23,20 +23,20 @@ We back up our managed public cloud databases every 1 (incremental snapshots), 1
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
 ## Engine Specifications
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
-OpenSearch | Incremental | On-Site | Hourly | 1h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
+OpenSearch | Incremental | On-Site, Off-Site | Hourly | 1h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.en-ca.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.en-ca.md
@@ -4,10 +4,10 @@ slug: backups
 excerpt: Discover the automated backup methods for each engine
 section: General guides
 order: 17
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -23,20 +23,20 @@ We back up our managed public cloud databases every 1 (incremental snapshots), 1
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
 ## Engine Specifications
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
-OpenSearch | Incremental | On-Site | Hourly | 1h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
+OpenSearch | Incremental | On-Site, Off-Site | Hourly | 1h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.en-gb.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.en-gb.md
@@ -4,10 +4,10 @@ slug: backups
 excerpt: Discover the automated backup methods for each engine
 section: General guides
 order: 17
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -23,20 +23,20 @@ We back up our managed public cloud databases every 1 (incremental snapshots), 1
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
 ## Engine Specifications
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
-OpenSearch | Incremental | On-Site | Hourly | 1h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
+OpenSearch | Incremental | On-Site, Off-Site | Hourly | 1h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.en-ie.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.en-ie.md
@@ -4,10 +4,10 @@ slug: backups
 excerpt: Discover the automated backup methods for each engine
 section: General guides
 order: 17
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -23,20 +23,20 @@ We back up our managed public cloud databases every 1 (incremental snapshots), 1
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
 ## Engine Specifications
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
-OpenSearch | Incremental | On-Site | Hourly | 1h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
+OpenSearch | Incremental | On-Site, Off-Site | Hourly | 1h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.en-sg.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.en-sg.md
@@ -4,10 +4,10 @@ slug: backups
 excerpt: Discover the automated backup methods for each engine
 section: General guides
 order: 17
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -23,20 +23,20 @@ We back up our managed public cloud databases every 1 (incremental snapshots), 1
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
 ## Engine Specifications
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
-OpenSearch | Incremental | On-Site | Hourly | 1h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
+OpenSearch | Incremental | On-Site, Off-Site | Hourly | 1h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.en-us.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.en-us.md
@@ -4,10 +4,10 @@ slug: backups
 excerpt: Discover the automated backup methods for each engine
 section: General guides
 order: 17
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -23,20 +23,20 @@ We back up our managed public cloud databases every 1 (incremental snapshots), 1
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
 ## Engine Specifications
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
-OpenSearch | Incremental | On-Site | Hourly | 1h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
+OpenSearch | Incremental | On-Site, Off-Site | Hourly | 1h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.es-es.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.es-es.md
@@ -6,10 +6,10 @@ section: General guides
 order: 17
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/backups'
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -25,18 +25,18 @@ We back up our managed public cloud databases every 1 (incremental), 12 or 24 ho
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
 OpenSearch | Hourly Incremental / Backup on object storage | On-Site | Hourly / Daily | 1h / 24h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.es-us.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.es-us.md
@@ -6,10 +6,10 @@ section: General guides
 order: 17
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/backups'
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -25,18 +25,18 @@ We back up our managed public cloud databases every 1 (incremental), 12 or 24 ho
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
 OpenSearch | Hourly Incremental / Backup on object storage | On-Site | Hourly / Daily | 1h / 24h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.fr-ca.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.fr-ca.md
@@ -6,10 +6,10 @@ section: Guides généraux
 order: 17
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/backups'
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -25,20 +25,20 @@ We back up our managed public cloud databases every 1 (incremental snapshots), 1
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
 ## Engine Specifications
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
-OpenSearch | Incremental | On-Site | Hourly | 1h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
+OpenSearch | Incremental | On-Site, Off-Site | Hourly | 1h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.fr-fr.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.fr-fr.md
@@ -6,10 +6,10 @@ section: Guides généraux
 order: 17
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/backups'
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -25,20 +25,20 @@ We back up our managed public cloud databases every 1 (incremental snapshots), 1
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
 ## Engine Specifications
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
-OpenSearch | Incremental | On-Site | Hourly | 1h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
+OpenSearch | Incremental | On-Site, Off-Site | Hourly | 1h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.it-it.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.it-it.md
@@ -6,10 +6,10 @@ section: General guides
 order: 17
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/backups'
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -25,20 +25,20 @@ We back up our managed public cloud databases every 1 (incremental snapshots), 1
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
 ## Engine Specifications
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
-OpenSearch | Incremental | On-Site | Hourly | 1h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
+OpenSearch | Incremental | On-Site, Off-Site | Hourly | 1h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.pl-pl.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.pl-pl.md
@@ -6,10 +6,10 @@ section: General guides
 order: 17
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/backups'
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -25,20 +25,20 @@ We back up our managed public cloud databases every 1 (incremental snapshots), 1
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
 ## Engine Specifications
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
-OpenSearch | Incremental | On-Site | Hourly | 1h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
+OpenSearch | Incremental | On-Site, Off-Site | Hourly | 1h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/databases_05_automated_backups/guide.pt-pt.md
+++ b/pages/platform/databases/databases_05_automated_backups/guide.pt-pt.md
@@ -6,10 +6,10 @@ section: General guides
 order: 17
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/backups'
-updated: 2022-04-26
+updated: 2023-03-09
 ---
 
-**Last updated April 26, 2022**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -25,20 +25,20 @@ We back up our managed public cloud databases every 1 (incremental snapshots), 1
 
 * PITR:
 
-Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan.
+Either you run into a problem or you just want to see what your data looked like at a prior date, you can restore your data to any point in time within the retention period of the chosen customer plan for PostgreSQL and MySQL. For MongoDB Enterprise the point in time must be within the last 24 hours.
 
 ## Engine Specifications
 
-Engine | Backup Method(s) | Location | Frequency | RPO | Encrypted
+Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
 MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
-PostgreSQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-MySQL | PITR on object storage | On-Site | Continuous | Few minutes | Yes
-Redis | Backup on object storage | On-Site | 2 times a day | 12h | Yes
-OpenSearch | Incremental | On-Site | Hourly | 1h | Yes
-M3 | Backup on object storage | On-Site | Daily | 24h | Yes
-Cassandra | Backup on object storage | On-Site | Daily | 24h | Yes
+PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
+Redis | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes
+OpenSearch | Incremental | On-Site, Off-Site | Hourly | 1h | Yes
+M3 | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
+Cassandra | Backup on object storage | On-Site, Off-Site | Daily | 24h | Yes
 Kafka | N/A | N/A | N/A | N/A | N/A
 
 ## Lexicon

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.de-de.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.de-de.md
@@ -6,10 +6,10 @@ section: MongoDB - Guides
 order: 010
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/mongodb/capabilities/'
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -131,7 +131,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-asia.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-asia.md
@@ -4,10 +4,10 @@ slug: mongodb/capabilities
 excerpt: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
 section: MongoDB - Guides
 order: 010
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -129,7 +129,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-au.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-au.md
@@ -4,10 +4,10 @@ slug: mongodb/capabilities
 excerpt: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
 section: MongoDB - Guides
 order: 010
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -128,7 +128,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-ca.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-ca.md
@@ -4,10 +4,10 @@ slug: mongodb/capabilities
 excerpt: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
 section: MongoDB - Guides
 order: 010
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -129,7 +129,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-gb.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-gb.md
@@ -4,10 +4,10 @@ slug: mongodb/capabilities
 excerpt: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
 section: MongoDB - Guides
 order: 010
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -129,7 +129,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-ie.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-ie.md
@@ -4,10 +4,10 @@ slug: mongodb/capabilities
 excerpt: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
 section: MongoDB - Guides
 order: 010
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -129,7 +129,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-sg.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-sg.md
@@ -4,10 +4,10 @@ slug: mongodb/capabilities
 excerpt: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
 section: MongoDB - Guides
 order: 010
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -129,7 +129,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-us.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.en-us.md
@@ -4,10 +4,10 @@ slug: mongodb/capabilities
 excerpt: Find out what are the capabilities and limitations of the Public Cloud Databases for MongoDB offer
 section: MongoDB - Guides
 order: 010
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -129,7 +129,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.es-es.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.es-es.md
@@ -6,10 +6,10 @@ section: MongoDB - Guides
 order: 010
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/mongodb/capabilities/'
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -131,7 +131,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.es-us.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.es-us.md
@@ -6,10 +6,10 @@ section: MongoDB - Guides
 order: 010
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/mongodb/capabilities/'
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -131,7 +131,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.fr-ca.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.fr-ca.md
@@ -6,10 +6,10 @@ section: MongoDB - Guides
 order: 010
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/mongodb/capabilities/'
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -131,7 +131,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.fr-fr.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.fr-fr.md
@@ -6,10 +6,10 @@ section: MongoDB - Guides
 order: 010
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/mongodb/capabilities/'
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -131,7 +131,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.it-it.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.it-it.md
@@ -6,10 +6,10 @@ section: MongoDB - Guides
 order: 010
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/mongodb/capabilities/'
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -131,7 +131,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.pl-pl.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.pl-pl.md
@@ -6,10 +6,10 @@ section: MongoDB - Guides
 order: 010
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/mongodb/capabilities/'
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -131,7 +131,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 

--- a/pages/platform/databases/mongodb_01_concept_capabilities/guide.pt-pt.md
+++ b/pages/platform/databases/mongodb_01_concept_capabilities/guide.pt-pt.md
@@ -6,10 +6,10 @@ section: MongoDB - Guides
 order: 010
 routes:
     canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/mongodb/capabilities/'
-updated: 2023-03-02
+updated: 2023-03-09
 ---
 
-**Last updated March 2nd, 2023**
+**Last updated March 9th, 2023**
 
 ## Objective
 
@@ -131,7 +131,7 @@ Here are some considerations to take into account when using private network:
 
 *Business* plan clusters are automatically backed up daily during their maintenance window. Backup retention is 7 days.
 
-*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days.
+*Enterprise* plan clusters are automatically backed up daily during their maintenance window, with [PITR](https://en.wikipedia.org/wiki/Point-in-time_recovery){.external} support. Backup retention is 30 days with PITR capability for the last 24 hours.
 
 #### Logs and Metrics
 


### PR DESCRIPTION
Update backup documentation to:
* Add PITR limitation window of 24h for MongoDB Enterprise
* Update backup location for Aiven engine as they are now available Off-Site on top of On-Site