### PR TITLE
Recycle ECDB migration guide to an on-premises migration guide

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -564,7 +564,7 @@
             + [Tutorials](public-cloud-databases-postgresql-tutorials)
                 + [PostgreSQL - Tutorial - Build a Strapi app connected to OVHcloud Managed PostgreSQL service](platform/databases/postgresql_tuto_01_connect_strapi_to_managed_postgresql)
                 + [PostgreSQL - Tutorial - Install Wagtail and connect it to OVHcloud Managed PostgreSQL service](platform/databases/postgresql_tuto_02_connect_wagtail_to_managed_postgresql)
-                + [PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases](platform/databases/postgresql_tuto_03_migrate_ecdb)
+                + [PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases](platform/databases/postgresql_tuto_03_migrate_ecdb)
         + [Redis](public-cloud-databases-redis)
             + [Guides](public-cloud-databases-redis-guides)
                 + [Redis - Capabilities and Limitations](platform/databases/redis_01_capabilities)

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.de-de.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.de-de.md
@@ -30,7 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/de/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.de-de.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.de-de.md
@@ -1,24 +1,24 @@
 ---
-title: PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+title: PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutorials
 order: 030
 routes:
-    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-ecdb-to-pcd/'
-updated: 2022-03-02
+    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-on-prem-to-pcd/'
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
@@ -30,12 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/de/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -51,8 +46,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -60,7 +55,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-asia.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-asia.md
@@ -1,22 +1,22 @@
 ---
-title: PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+title: PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutorials
 order: 030
-updated: 2022-03-02
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
@@ -28,12 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/asia/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -49,8 +44,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -58,7 +53,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-asia.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-asia.md
@@ -28,7 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/asia/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-au.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-au.md
@@ -1,22 +1,22 @@
 ---
-title: PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+title: PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutorials
 order: 030
-updated: 2022-03-02
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
@@ -28,12 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/en-au/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -49,8 +44,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -58,7 +53,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-au.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-au.md
@@ -28,7 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/en-au/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-ca.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-ca.md
@@ -1,22 +1,22 @@
 ---
-title: PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+title: PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutorials
 order: 030
-updated: 2022-03-02
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
@@ -28,12 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/en-ca/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -49,8 +44,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -58,7 +53,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-ca.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-ca.md
@@ -28,7 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/en-ca/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-gb.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-gb.md
@@ -1,22 +1,22 @@
 ---
-title: PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+title: PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutorials
 order: 030
-updated: 2022-03-02
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
@@ -28,12 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/en-gb/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-gb.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-gb.md
@@ -28,7 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/en-gb/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-ie.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-ie.md
@@ -1,22 +1,22 @@
 ---
-title: PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+title: PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutorials
 order: 030
-updated: 2022-03-02
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
@@ -28,12 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/en-ie/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -49,8 +44,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -58,7 +53,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-ie.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-ie.md
@@ -28,7 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/en-ie/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-sg.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-sg.md
@@ -28,7 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/en-sg/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-sg.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-sg.md
@@ -1,22 +1,22 @@
 ---
-title: PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+title: PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutorials
 order: 030
-updated: 2022-03-02
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
@@ -28,12 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/en-sg/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -49,8 +44,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -58,7 +53,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-us.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-us.md
@@ -1,22 +1,22 @@
 ---
-title: PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+title: PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutorials
 order: 030
-updated: 2022-03-02
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
@@ -28,12 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/en/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -49,8 +44,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -58,7 +53,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-us.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.en-us.md
@@ -28,7 +28,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/en/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.es-es.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.es-es.md
@@ -1,24 +1,24 @@
 ---
-title: PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+title: PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutorials
 order: 030
 routes:
-    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-ecdb-to-pcd/'
-updated: 2022-03-02
+    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-on-prem-to-pcd/'
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
@@ -30,12 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/es-es/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -51,8 +46,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -60,7 +55,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.es-es.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.es-es.md
@@ -30,7 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/es-es/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.es-us.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.es-us.md
@@ -1,24 +1,24 @@
 ---
-title: PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+title: PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutorials
 order: 030
 routes:
-    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-ecdb-to-pcd/'
-updated: 2022-03-02
+    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-on-prem-to-pcd/'
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/es/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
@@ -30,12 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/es/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -51,8 +46,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -60,7 +55,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.es-us.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.es-us.md
@@ -30,7 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/es/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.fr-ca.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.fr-ca.md
@@ -30,7 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/fr-ca/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.fr-ca.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.fr-ca.md
@@ -1,24 +1,24 @@
 ---
 title: PostgreSQL - Tutoriel - Comment migrer de Enterprise Cloud Databases vers Public Cloud Databases (EN)
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutoriels
 order: 080
 routes:
-    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-ecdb-to-pcd/'
-updated: 2022-03-02
+    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-on-prem-to-pcd/'
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/fr-ca/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
@@ -30,12 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/fr-ca/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -51,8 +46,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -60,7 +55,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.fr-fr.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.fr-fr.md
@@ -30,7 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/fr/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.fr-fr.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.fr-fr.md
@@ -1,24 +1,24 @@
 ---
 title: PostgreSQL - Tutoriel - Comment migrer de Enterprise Cloud Databases vers Public Cloud Databases (EN)
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutoriels
 order: 030
 routes:
-    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-ecdb-to-pcd/'
-updated: 2022-03-02
+    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-on-prem-to-pcd/'
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/fr/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
@@ -30,12 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/fr/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -51,8 +46,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -60,7 +55,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.it-it.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.it-it.md
@@ -30,7 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/it/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.it-it.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.it-it.md
@@ -1,24 +1,24 @@
 ---
-title: PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+title: PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutorials
 order: 030
 routes:
-    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-ecdb-to-pcd/'
-updated: 2022-03-02
+    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-on-prem-to-pcd/'
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
@@ -30,12 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/it/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -51,8 +46,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -60,7 +55,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.pl-pl.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.pl-pl.md
@@ -30,7 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/pl/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.pl-pl.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.pl-pl.md
@@ -1,24 +1,24 @@
 ---
-title: PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+title: PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutorials
 order: 030
 routes:
-    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-ecdb-to-pcd/'
-updated: 2022-03-02
+    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-on-prem-to-pcd/'
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
@@ -30,12 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/pl/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -51,8 +46,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -60,7 +55,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.pt-pt.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.pt-pt.md
@@ -1,24 +1,24 @@
 ---
-title: PostgreSQL - Tutorial - How to migrate from Enterprise Cloud Databases to Public Cloud Databases
-excerpt: Learn how to migrate a PostgreSQL Enterprise Cloud Databases instance to Public Cloud Databases for PostgreSQL
-slug: postgresql/howto-migrate-ecdb-to-pcd
+title: PostgreSQL - Tutorial - How to migrate an on-premises database to Public Cloud Databases
+excerpt: Learn how to migrate a on-premises PostgreSQL database instance to Public Cloud Databases for PostgreSQL
+slug: postgresql/howto-migrate-on-prem-to-pcd
 section: PostgreSQL - Tutorials
 order: 030
 routes:
-    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-ecdb-to-pcd/'
-updated: 2022-03-02
+    canonical: 'https://docs.ovh.com/gb/en/publiccloud/databases/postgresql/howto-migrate-on-prem-to-pcd/'
+updated: 2022-03-16
 ---
 
-**Last updated March 2nd 2022**
+**Last updated March 16th, 2023**
 
 ## Objective
 
-**This guide details a procedure to migrate a PostgreSQL instance running on OVHcloud Enterprise Cloud Databases (soon to be EOL) to OVHcloud Public Cloud Databases for PostgreSQL.**
+**This guide details a procedure to migrate a PostgreSQL instance running on-premises to OVHcloud Public Cloud Databases for PostgreSQL.**
 
 ## Requirements
 
 - A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/compute/) in your OVHcloud account
-- A PostgreSQL database running on OVHcloud Enterprise Cloud Databases (the "source" instance)
+- A PostgreSQL database running on-premises (the "source" instance)
 - A PostgreSQL database running on OVHcloud Public Cloud Databases (the "target" instance)
 - A PostgreSQL client that can connect to both database instances, source and target.
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
@@ -30,12 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-> [!warning]
->
-> While the Enterprise Cloud Databases offer granted you super user privilege, Public Cloud Databases for PostgreSQL only grants its user admin level privilege. Thus, any application or administrative task that may have utilized that super user access needs to be adapted so that it requires at most the privilege granted to the default `avnadmin` admin user.
->
-
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application and schedule for maintenance for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/pt/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.
@@ -51,8 +46,8 @@ Ensure client applications stop all write activity on the source database side. 
 Use the `pg_dump` command to export the database schema to the client machine, as an SQL plaintext file:
 
 ```bash
-$ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
-    --username "postgres" --verbose --format=p --schema-only "database-name"
+$ pg_dump --file "path/to/dump.sql" --host "<local network hostname>" --port "<write port>" \
+    --username "postgres" --verbose --format=p --schema-only "<database name>"
 ```
 
 ### Step 3: Export the data
@@ -60,7 +55,7 @@ $ pg_dump --file "path/to/dump.sql" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --p
 Use the `pg_dump` command to export the database data to the client machine, in a .tar archive file:
 
 ```bash
-$ pg_dump --file "path/to/dump.tar" --host "xxxxxxxxxxx.prm.clouddb.ovh.net" --port "<write port>" \
+$ pg_dump --file "path/to/dump.tar" --host "<local network hostname>" --port "<write port>" \
     --no-owner --username "postgres" --no-password --verbose --format=t --blobs --encoding "UTF8"
 ```
 

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.pt-pt.md
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/guide.pt-pt.md
@@ -30,7 +30,7 @@ These guides can help you to meet these requirements:
 
 ## Considerations
 
-- This document outlines an offline migration path for your database, which means you'll have to suspend all the writes from your application  for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
+- This document outlines an offline migration path for your database, which means you will have to suspend all the writes from your application for the duration of the migration. Ensure you plan sufficient downtime to carry out all the migration tasks.
 - Ensure the source and destination PostgreSQL versions match.
 - Ensure you have good enough bandwidth between the client machine and both source and destination databases.
 - Ensure you choose a [Database plan](https://www.ovhcloud.com/pt/public-cloud/prices/#databases) with appropriate compute, storage and memory resources.

--- a/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/meta.yaml
+++ b/pages/platform/databases/postgresql_tuto_03_migrate_ecdb/meta.yaml
@@ -1,2 +1,2 @@
 id: 0d027f1a-7b68-45fa-9cf3-c5fff5ace4ac
-full_slug: public-cloud-databases-postgresql-migrate-ecdb-to-pcd
+full_slug: public-cloud-databases-postgresql-migrate-on-prem-to-pcd


### PR DESCRIPTION
Update a guide initially written for the ECDB End Of Life to recycle it into a on-premises guide.

Old slug: `slug: postgresql/howto-migrate-ecdb-to-pcd`
New slug: `slug: postgresql/howto-migrate-on-prem-to-pcd`