### PR TITLE
fix(LDP): change minimum TLS version in documentation

### DIFF
--- a/pages/platform/logs-data-platform/quick_start/guide.de-de.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.de-de.md
@@ -5,10 +5,10 @@ order: 1
 section: Get Started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/logs-data-platform/quick-start/'
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.de-de.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.de-de.md
@@ -80,7 +80,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.en-asia.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-asia.md
@@ -78,7 +78,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.en-asia.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-asia.md
@@ -3,10 +3,10 @@ title: Quick start
 slug: quick-start
 order: 1
 section: Get Started
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.en-au.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-au.md
@@ -78,7 +78,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.en-au.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-au.md
@@ -3,10 +3,10 @@ title: Quick start
 slug: quick-start
 order: 1
 section: Get Started
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.en-ca.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-ca.md
@@ -78,7 +78,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.en-ca.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-ca.md
@@ -3,10 +3,10 @@ title: Quick start
 slug: quick-start
 order: 1
 section: Get Started
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.en-gb.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-gb.md
@@ -78,7 +78,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.en-gb.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-gb.md
@@ -3,10 +3,10 @@ title: Quick start
 slug: quick-start
 order: 1
 section: Get Started
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.en-ie.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-ie.md
@@ -78,7 +78,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.en-ie.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-ie.md
@@ -3,10 +3,10 @@ title: Quick start
 slug: quick-start
 order: 1
 section: Get Started
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.en-sg.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-sg.md
@@ -78,7 +78,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.en-sg.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-sg.md
@@ -3,10 +3,10 @@ title: Quick start
 slug: quick-start
 order: 1
 section: Get Started
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.en-us.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-us.md
@@ -78,7 +78,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.en-us.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.en-us.md
@@ -3,10 +3,10 @@ title: Quick start
 slug: quick-start
 order: 1
 section: Get Started
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.es-es.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.es-es.md
@@ -5,10 +5,10 @@ order: 1
 section: Get Started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/logs-data-platform/quick-start/'
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.es-es.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.es-es.md
@@ -80,7 +80,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.es-us.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.es-us.md
@@ -5,10 +5,10 @@ order: 1
 section: Get Started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/logs-data-platform/quick-start/'
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.es-us.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.es-us.md
@@ -80,7 +80,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.fr-ca.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.fr-ca.md
@@ -78,7 +78,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.fr-ca.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.fr-ca.md
@@ -3,10 +3,10 @@ title: Quick start
 slug: quick-start
 order: 1
 section: Get Started
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.fr-fr.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.fr-fr.md
@@ -78,7 +78,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.fr-fr.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.fr-fr.md
@@ -3,10 +3,10 @@ title: Quick start
 slug: quick-start
 order: 1
 section: Get Started
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.it-it.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.it-it.md
@@ -5,10 +5,10 @@ order: 1
 section: Get Started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/logs-data-platform/quick-start/'
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.it-it.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.it-it.md
@@ -80,7 +80,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.pl-pl.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.pl-pl.md
@@ -5,10 +5,10 @@ order: 1
 section: Get Started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/logs-data-platform/quick-start/'
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.pl-pl.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.pl-pl.md
@@ -80,7 +80,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|

--- a/pages/platform/logs-data-platform/quick_start/guide.pt-pt.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.pt-pt.md
@@ -5,10 +5,10 @@ order: 1
 section: Get Started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/logs-data-platform/quick-start/'
-updated: 2023-01-16
+updated: 2023-03-30
 ---
 
-**Last updated 16th January, 2023**
+**Last updated 30th March, 2023**
 
 ## Objective
 

--- a/pages/platform/logs-data-platform/quick_start/guide.pt-pt.md
+++ b/pages/platform/logs-data-platform/quick_start/guide.pt-pt.md
@@ -80,7 +80,7 @@ Logs Data Platform supports several logs formats, each one of them has its own a
 - **Cap'n'Proto**: The most efficient log format. this is a binary format that allows you to maintain a low footprint and high speed performance. For more information, check out the official website: [Cap'n'Proto](https://capnproto.org/){.external}.
 - **Beats**: A secure and reliable protocol used by the beats family in the Elasticsearch ecosystem (Ex: [Filebeat](../filebeat-logs){.ref}, [Metricbeat](https://www.elastic.co/beats/metricbeat){.external}, [Winlogbeat](https://www.elastic.co/beats/winlogbeat){.external}).
 
-Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.1) or use the plain unsecured ones if you can't use a SSL transport.
+Here are the ports you can use on your cluster to send your logs. You can either use the secured ones with SSL Enabled (TLS >= 1.2) or use the plain unsecured ones if you can't use a SSL transport.
 
 ||Syslog RFC5424|Gelf|LTSV line|LTSV nul|Cap’n’Proto|Beats|
 |---|---|---|---|---|---|---|


### PR DESCRIPTION
This PR update on teh quick start the minimum version of the TLS protocol supported by LDP (from 1.1 to 1.2)