### PR TITLE
Add kyverno resources for etcd quota error

### DIFF
--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.de-de.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.de-de.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.de-de.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.de-de.md
@@ -5,10 +5,10 @@ slug: etcd-quota-error
 section: Diagnostics
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
-updated: 2022-12-14
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -123,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -141,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-asia.md
@@ -3,10 +3,12 @@ title: ETCD Quotas, usage, troubleshooting and error
 excerpt: 'Find out how to view ETCD quotas, usage and fix errors'
 slug: etcd-quota-error
 section: Diagnostics
-updated: 2022-12-14
+routes:
+    canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -121,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -139,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-asia.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-asia.md
@@ -3,8 +3,6 @@ title: ETCD Quotas, usage, troubleshooting and error
 excerpt: 'Find out how to view ETCD quotas, usage and fix errors'
 slug: etcd-quota-error
 section: Diagnostics
-routes:
-    canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
 updated: 2023-04-06
 ---
 

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-au.md
@@ -3,10 +3,12 @@ title: ETCD Quotas, usage, troubleshooting and error
 excerpt: 'Find out how to view ETCD quotas, usage and fix errors'
 slug: etcd-quota-error
 section: Diagnostics
-updated: 2022-12-14
+routes:
+    canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -121,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -139,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-au.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-au.md
@@ -3,8 +3,6 @@ title: ETCD Quotas, usage, troubleshooting and error
 excerpt: 'Find out how to view ETCD quotas, usage and fix errors'
 slug: etcd-quota-error
 section: Diagnostics
-routes:
-    canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
 updated: 2023-04-06
 ---
 

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-ca.md
@@ -3,10 +3,12 @@ title: ETCD Quotas, usage, troubleshooting and error
 excerpt: 'Find out how to view ETCD quotas, usage and fix errors'
 slug: etcd-quota-error
 section: Diagnostics
-updated: 2022-12-14
+routes:
+    canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -121,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -139,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-ca.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-ca.md
@@ -3,8 +3,6 @@ title: ETCD Quotas, usage, troubleshooting and error
 excerpt: 'Find out how to view ETCD quotas, usage and fix errors'
 slug: etcd-quota-error
 section: Diagnostics
-routes:
-    canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
 updated: 2023-04-06
 ---
 

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-gb.md
@@ -145,7 +145,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-gb.md
@@ -3,10 +3,10 @@ title: ETCD Quotas, usage, troubleshooting and error
 excerpt: 'Find out how to view ETCD quotas, usage and fix errors'
 slug: etcd-quota-error
 section: Diagnostics
-updated: 2022-12-14
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -121,6 +121,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -139,10 +145,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-ie.md
@@ -3,10 +3,12 @@ title: ETCD Quotas, usage, troubleshooting and error
 excerpt: 'Find out how to view ETCD quotas, usage and fix errors'
 slug: etcd-quota-error
 section: Diagnostics
-updated: 2022-12-14
+routes:
+    canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -121,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -139,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-ie.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-ie.md
@@ -3,8 +3,6 @@ title: ETCD Quotas, usage, troubleshooting and error
 excerpt: 'Find out how to view ETCD quotas, usage and fix errors'
 slug: etcd-quota-error
 section: Diagnostics
-routes:
-    canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
 updated: 2023-04-06
 ---
 

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-sg.md
@@ -3,10 +3,12 @@ title: ETCD Quotas, usage, troubleshooting and error
 excerpt: 'Find out how to view ETCD quotas, usage and fix errors'
 slug: etcd-quota-error
 section: Diagnostics
-updated: 2022-12-14
+routes:
+    canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -121,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -139,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-sg.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-sg.md
@@ -3,8 +3,6 @@ title: ETCD Quotas, usage, troubleshooting and error
 excerpt: 'Find out how to view ETCD quotas, usage and fix errors'
 slug: etcd-quota-error
 section: Diagnostics
-routes:
-    canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
 updated: 2023-04-06
 ---
 

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-us.md
@@ -3,10 +3,12 @@ title: ETCD Quotas, usage, troubleshooting and error
 excerpt: 'Find out how to view ETCD quotas, usage and fix errors'
 slug: etcd-quota-error
 section: Diagnostics
-updated: 2022-12-14
+routes:
+    canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -121,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -139,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-us.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.en-us.md
@@ -3,8 +3,6 @@ title: ETCD Quotas, usage, troubleshooting and error
 excerpt: 'Find out how to view ETCD quotas, usage and fix errors'
 slug: etcd-quota-error
 section: Diagnostics
-routes:
-    canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
 updated: 2023-04-06
 ---
 

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.es-es.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.es-es.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.es-es.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.es-es.md
@@ -5,10 +5,10 @@ slug: etcd-quota-error
 section: Diagnostics
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
-updated: 2022-12-14
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -123,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -141,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.es-us.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.es-us.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.es-us.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.es-us.md
@@ -5,10 +5,10 @@ slug: etcd-quota-error
 section: Diagnostics
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
-updated: 2022-12-14
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -123,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -141,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.fr-ca.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.fr-ca.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.fr-ca.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.fr-ca.md
@@ -5,10 +5,10 @@ slug: etcd-quota-error
 section: Diagnostics
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
-updated: 2022-12-14
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -123,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -141,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.fr-fr.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.fr-fr.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.fr-fr.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.fr-fr.md
@@ -5,10 +5,10 @@ slug: etcd-quota-error
 section: Diagnostics
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
-updated: 2022-12-14
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -123,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -141,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.it-it.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.it-it.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.it-it.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.it-it.md
@@ -5,10 +5,10 @@ slug: etcd-quota-error
 section: Diagnostics
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
-updated: 2022-12-14
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -123,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -141,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.pl-pl.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.pl-pl.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.pl-pl.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.pl-pl.md
@@ -5,10 +5,10 @@ slug: etcd-quota-error
 section: Diagnostics
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
-updated: 2022-12-14
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -123,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -141,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.pt-pt.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.pt-pt.md
@@ -147,7 +147,7 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `reportchangerequest.kyverno.io
+- `reportchangerequest.kyverno.io`
 
 ```bash
 kubectl get reportchangerequest.kyverno.io -A | wc -l

--- a/pages/platform/kubernetes-k8s/etcd-quota-error/guide.pt-pt.md
+++ b/pages/platform/kubernetes-k8s/etcd-quota-error/guide.pt-pt.md
@@ -5,10 +5,10 @@ slug: etcd-quota-error
 section: Diagnostics
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/etcd-quota-error/'
-updated: 2022-12-14
+updated: 2023-04-06
 ---
 
-**Last updated 14th December 2022**
+**Last updated 06th April 2023**
 
 ## Objective
 
@@ -123,6 +123,12 @@ We have found that the following resources can sometimes be generated continuous
 kubectl get backups.velero.io -A | wc -l
 ```
 
+- `podvolumebackups.velero.io`
+
+```bash
+kubectl get podvolumebackups.velero.io -A | wc -l
+```
+
 - `ingress.networking.k8s.io`
 
 ```bash
@@ -141,10 +147,10 @@ kubectl get ingress.extensions -A | wc -l
 kubectl get authrequests.dex.coreos.com -A | wc -l
 ```
 
-- `podvolumebackups`
+- `reportchangerequest.kyverno.io
 
 ```bash
-kubectl get podvolumebackups -A | wc -l
+kubectl get reportchangerequest.kyverno.io -A | wc -l
 ```
 
 If that still does not cover your case, you can use a tool like [ketall](https://github.com/corneliusweig/ketall) to easily list and count resources in your cluster.  


### PR DESCRIPTION
- Add reportchangerequest.kyverno.io as a resource that can increase very fast on a cluster
- Specify podvolumebackups.velero.io instead of podvolumebackups to be more accurate
- Add missing canonical routes on some pages