### PR TITLE
KS-SK1109-WHGR-Update-IP-clusters-mutus

### DIFF
--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
@@ -4,10 +4,10 @@ excerpt: 'Erfahren Sie hier, welche IP-Adresse für Ihr OVHcloud Webhosting zu v
 slug: verzeichnis-der-ip-adressen-web-hosting-cluster
 section: 'Webhosting-Konfiguration'
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Letzte Aktualisierung am 14.04.2023**
+**Letzte Aktualisierung am 03.05.2023**
 
 > [!primary]
 > Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In manchen Fällen können ungenaue Formulierungen verwendet worden sein, z.B. bei der Beschriftung von Schaltflächen oder technischen Details. Bitte ziehen Sie beim geringsten Zweifel die englische oder französische Fassung der Anleitung zu Rate. Möchten Sie mithelfen, diese Übersetzung zu verbessern? Dann nutzen Sie dazu bitte den Button «Mitmachen» auf dieser Seite.
@@ -360,12 +360,6 @@ Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webh
 46.105.204.13
 ```
 
-Wenn Sie ein **Sectigo SSL Zertifikat (kostenpflichtig)** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-46.105.174.41
-```
-
 Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie diese IP-Adresse:
 
 ```bash
@@ -543,7 +537,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Belgien|BE|178.32.40.72|2001:41d0:301:10::21|
 
 Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
 
 ```bash
 213.186.33.177

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
@@ -879,11 +879,12 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 
 ## Weiterführende Informationen
 
-[Mehrere Websites auf einem Webhosting einrichten](../multisites-mehrere-websites-konfigurieren/)
+[Mehrere Websites auf einem Webhosting einrichten](/pages/web/hosting/multisites_configure_multisite)
 
-[Website mit SSL-Zertifikat auf HTTPS umstellen](../website-umstellen-https-ssl)
+[Website mit SSL-Zertifikat auf HTTPS umstellen](/pages/web/hosting/ssl-activate-https-website)
 
-[Optimierung der Performance Ihrer Website](../webhosting_optimierung_der_performance_ihrer_webseite)
+[Optimierung der Performance Ihrer Website](/pages/web/hosting/optimise_your_website_performance)
+
 
 Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](https://partner.ovhcloud.com/de/directory/).
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
@@ -4,10 +4,14 @@ excerpt: 'Erfahren Sie hier, welche IP-Adresse für Ihr OVHcloud Webhosting zu v
 slug: verzeichnis-der-ip-adressen-web-hosting-cluster
 section: 'Webhosting-Konfiguration'
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
 **Letzte Aktualisierung am 08.01.2021**
+
+> [!primary]
+> Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In manchen Fällen können ungenaue Formulierungen verwendet worden sein, z.B. bei der Beschriftung von Schaltflächen oder technischen Details. Bitte ziehen Sie beim geringsten Zweifel die englische oder französische Fassung der Anleitung zu Rate. Möchten Sie mithelfen, diese Übersetzung zu verbessern? Dann nutzen Sie dazu bitte den Button «Mitmachen» auf dieser Seite.
+>
 
 ## Ziel 
 
@@ -977,5 +981,9 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 [Website mit SSL-Zertifikat auf HTTPS umstellen](../website-umstellen-https-ssl)
 
 [Optimierung der Performance Ihrer Website](../webhosting_optimierung_der_performance_ihrer_webseite)
+
+Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](https://partner.ovhcloud.com/de/directory/).
+
+Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
@@ -7,7 +7,7 @@ order: 01
 updated: 2023-04-14
 ---
 
-**Letzte Aktualisierung am 08.01.2021**
+**Letzte Aktualisierung am 14.04.2023**
 
 > [!primary]
 > Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In manchen Fällen können ungenaue Formulierungen verwendet worden sein, z.B. bei der Beschriftung von Schaltflächen oder technischen Details. Bitte ziehen Sie beim geringsten Zweifel die englische oder französische Fassung der Anleitung zu Rate. Möchten Sie mithelfen, diese Übersetzung zu verbessern? Dann nutzen Sie dazu bitte den Button «Mitmachen» auf dieser Seite.
@@ -37,7 +37,6 @@ Um herauszufinden, auf welchem Webhosting Cluster Ihr Dienst liegt, loggen Sie s
 
 #### IP-Adressen der Cluster nach Land
 
-
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
 |Frankreich|FR|213.186.33.2|2001:41d0:1:1b00:213:186:33:2|
@@ -65,23 +64,15 @@ Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webh
 46.105.204.2
 ```
 
-Wenn Sie ein **Sectigo SSL Zertifikat (kostenpflichtig)** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-46.105.174.33
-```
-
 Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie diese IP-Adresse:
 
 ```bash
 51.68.11.191
 ```
 
-
 ## Cluster 003
 
 #### IP-Adressen der Cluster nach Land
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -110,23 +101,15 @@ Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webh
 46.105.204.3
 ```
 
-Wenn Sie ein **Sectigo SSL Zertifikat (kostenpflichtig)** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-46.105.174.34
-```
-
 Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie diese IP-Adresse:
 
 ```bash
 51.68.11.195
 ```
 
-
 ## Cluster 005
 
 #### IP-Adressen der Cluster nach Land
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -155,23 +138,15 @@ Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webh
 46.105.204.5
 ```
 
-Wenn Sie ein **Sectigo SSL Zertifikat (kostenpflichtig)** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-46.105.174.35
-```
-
 Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie diese IP-Adresse:
 
 ```bash
 51.68.11.199
 ```
 
-
 ## Cluster 006
 
 #### IP-Adressen der Cluster nach Land
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -200,12 +175,6 @@ Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webh
 46.105.204.6
 ```
 
-Wenn Sie ein **Sectigo SSL Zertifikat (kostenpflichtig)** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-46.105.174.36
-```
-
 Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie diese IP-Adresse:
 
 ```bash
@@ -215,7 +184,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 ## Cluster 007
 
 #### IP-Adressen der Cluster nach Land
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -244,23 +212,15 @@ Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webh
 46.105.204.7
 ```
 
-Wenn Sie ein **Sectigo SSL Zertifikat (kostenpflichtig)** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-46.105.174.37
-```
-
 Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie diese IP-Adresse:
 
 ```bash
 51.68.11.207
 ```
 
-
 ## Cluster 010
 
 #### IP-Adressen der Cluster nach Land
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -289,23 +249,15 @@ Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webh
 46.105.204.10
 ```
 
-Wenn Sie ein **Sectigo SSL Zertifikat (kostenpflichtig)** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-46.105.174.38
-```
-
 Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie diese IP-Adresse:
 
 ```bash
 51.68.11.211
 ```
 
-
 ## Cluster 011
 
 #### IP-Adressen der Cluster nach Land
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -334,23 +286,15 @@ Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webh
 46.105.204.11
 ```
 
-Wenn Sie ein **Sectigo SSL Zertifikat (kostenpflichtig)** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-46.105.174.39
-```
-
 Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie diese IP-Adresse:
 
 ```bash
 51.68.11.215
 ```
 
-
 ## Cluster 012
 
 #### IP-Adressen der Cluster nach Land
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -379,18 +323,11 @@ Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webh
 46.105.204.12
 ```
 
-Wenn Sie ein **Sectigo SSL Zertifikat (kostenpflichtig)** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-46.105.174.40
-```
-
 Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie diese IP-Adresse:
 
 ```bash
 51.68.11.219
 ```
-
 
 ## Cluster 013
 
@@ -435,11 +372,9 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.68.11.223
 ```
 
-
 ## Cluster 014
 
 #### IP-Adressen der Cluster nach Land
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -468,23 +403,15 @@ Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webh
 46.105.204.14
 ```
 
-Wenn Sie ein **Sectigo SSL Zertifikat (kostenpflichtig)** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-46.105.174.42
-```
-
 Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie diese IP-Adresse:
 
 ```bash
 51.68.11.227
 ```
 
-
 ## Cluster 015
 
 #### IP-Adressen der Cluster nach Land
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -513,23 +440,15 @@ Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webh
 46.105.204.15
 ```
 
-Wenn Sie ein **Sectigo SSL Zertifikat (kostenpflichtig)** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-46.105.174.43
-```
-
 Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie diese IP-Adresse:
 
 ```bash
 51.68.11.231
 ```
 
-
 ## Cluster 017
 
 #### IP-Adressen der Cluster nach Land
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -558,23 +477,15 @@ Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webh
 46.105.204.17
 ```
 
-Wenn Sie ein **Sectigo SSL Zertifikat (kostenpflichtig)** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-46.105.174.44
-```
-
 Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie diese IP-Adresse:
 
 ```bash
 51.68.11.239
 ```
 
-
 ## Cluster 020
 
 #### IP-Adressen der Cluster nach Land
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -609,7 +520,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 ```bash
 91.134.248.253
 ```
-
 
 ## Cluster 021
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
@@ -70,7 +70,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.68.11.191
 ```
 
-## Cluster 003
+### Cluster 003
 
 #### IP-Adressen der Cluster nach Land
 
@@ -107,7 +107,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.68.11.195
 ```
 
-## Cluster 005
+### Cluster 005
 
 #### IP-Adressen der Cluster nach Land
 
@@ -144,7 +144,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.68.11.199
 ```
 
-## Cluster 006
+### Cluster 006
 
 #### IP-Adressen der Cluster nach Land
 
@@ -181,7 +181,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.68.11.203
 ```
 
-## Cluster 007
+### Cluster 007
 
 #### IP-Adressen der Cluster nach Land
 
@@ -218,7 +218,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.68.11.207
 ```
 
-## Cluster 010
+### Cluster 010
 
 #### IP-Adressen der Cluster nach Land
 
@@ -255,7 +255,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.68.11.211
 ```
 
-## Cluster 011
+### Cluster 011
 
 #### IP-Adressen der Cluster nach Land
 
@@ -292,7 +292,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.68.11.215
 ```
 
-## Cluster 012
+### Cluster 012
 
 #### IP-Adressen der Cluster nach Land
 
@@ -329,7 +329,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.68.11.219
 ```
 
-## Cluster 013
+### Cluster 013
 
 #### IP-Adressen der Cluster nach Land
 
@@ -366,7 +366,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.68.11.223
 ```
 
-## Cluster 014
+### Cluster 014
 
 #### IP-Adressen der Cluster nach Land
 
@@ -403,7 +403,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.68.11.227
 ```
 
-## Cluster 015
+### Cluster 015
 
 #### IP-Adressen der Cluster nach Land
 
@@ -440,7 +440,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.68.11.231
 ```
 
-## Cluster 017
+### Cluster 017
 
 #### IP-Adressen der Cluster nach Land
 
@@ -477,7 +477,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.68.11.239
 ```
 
-## Cluster 020
+### Cluster 020
 
 #### IP-Adressen der Cluster nach Land
 
@@ -515,7 +515,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 91.134.248.253
 ```
 
-## Cluster 021
+### Cluster 021
 
 #### IP-Adressen der Cluster nach Land
 
@@ -554,7 +554,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 91.134.248.245
 ```
 
-## Cluster 023
+### Cluster 023
 
 #### IP-Adressen der Cluster nach Land
 
@@ -592,7 +592,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 91.134.248.235
 ```
 
-## Cluster 024
+### Cluster 024
 
 #### IP-Adressen der Cluster nach Land
 
@@ -629,7 +629,8 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 ```bash
 91.134.248.230
 ```
-## Cluster 026
+
+### Cluster 026
 
 #### IP-Adressen der Cluster nach Land
 
@@ -667,7 +668,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 91.134.248.211
 ```
 
-## Cluster 027
+### Cluster 027
 
 #### IP-Adressen der Cluster nach Land
 
@@ -705,7 +706,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 54.37.121.239
 ```
 
-## Cluster 028
+### Cluster 028
 
 #### IP-Adressen der Cluster nach Land
 
@@ -743,7 +744,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 91.134.248.249
 ```
 
-## Cluster 029
+### Cluster 029
 
 #### IP-Adressen der Cluster nach Land
 
@@ -781,7 +782,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 91.134.248.192
 ```
 
-## Cluster 030
+### Cluster 030
 
 #### IP-Adressen der Cluster nach Land
 
@@ -819,7 +820,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 51.178.146.199
 ```
 
-## Cluster 031
+### Cluster 031
 
 #### IP-Adressen der Cluster nach Land
 
@@ -851,7 +852,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 141.94.87.67
 ```
 
-## Cluster 051
+### Cluster 051
 
 #### IP-Adressen der Cluster nach Land
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
@@ -876,11 +876,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 ## Go further
 
-[Hosting multiple websites on your Web Hosting plan](../multisites-configuring-multiple-websites)
+[Hosting multiple websites on your Web Hosting plan](/pages/web/hosting/multisites_configure_multisite)
 
-[Activating HTTPS on your website with an SSL certificate](../activate-https-website-ssl)
+[Activating HTTPS on your website with an SSL certificate](/pages/web/hosting/ssl-activate-https-website)
 
-[Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
+[Optimise your website’s performance](/pages/web/hosting/optimise_your_website_performance)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/asia/directory/).
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
@@ -67,7 +67,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.191
 ```
 
-## Cluster 003
+### Cluster 003
 
 #### Cluster IP addresses per country
 
@@ -104,7 +104,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.195
 ```
 
-## Cluster 005
+### Cluster 005
 
 #### Cluster IP addresses per country
 
@@ -141,7 +141,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.199
 ```
 
-## Cluster 006
+### Cluster 006
 
 #### Cluster IP addresses per country
 
@@ -178,7 +178,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.203
 ```
 
-## Cluster 007
+### Cluster 007
 
 #### Cluster IP addresses per country
 
@@ -215,7 +215,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.207
 ```
 
-## Cluster 010
+### Cluster 010
 
 #### Cluster IP addresses per country
 
@@ -252,7 +252,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.211
 ```
 
-## Cluster 011
+### Cluster 011
 
 #### Cluster IP addresses per country
 
@@ -289,7 +289,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.215
 ```
 
-## Cluster 012
+### Cluster 012
 
 #### Cluster IP addresses per country
 
@@ -326,7 +326,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.219
 ```
 
-## Cluster 013
+### Cluster 013
 
 #### Cluster IP addresses per country
 
@@ -363,7 +363,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.223
 ```
 
-## Cluster 014
+### Cluster 014
 
 #### Cluster IP addresses per country
 
@@ -400,7 +400,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.227
 ```
 
-## Cluster 015
+### Cluster 015
 
 #### Cluster IP addresses per country
 
@@ -437,7 +437,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.231
 ```
 
-## Cluster 017
+### Cluster 017
 
 #### Cluster IP addresses per country
 
@@ -474,7 +474,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.239
 ```
 
-## Cluster 020
+### Cluster 020
 
 #### Cluster IP addresses per country
 
@@ -512,7 +512,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-## Cluster 021
+### Cluster 021
 
 #### Cluster IP addresses per country
 
@@ -550,7 +550,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.245
 ```
 
-## Cluster 023
+### Cluster 023
 
 #### Cluster IP addresses per country
 
@@ -588,7 +588,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.235
 ```
 
-## Cluster 024
+### Cluster 024
 
 #### Cluster IP addresses per country
 
@@ -626,7 +626,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.230
 ```
 
-## Cluster 026
+### Cluster 026
 
 #### Cluster IP addresses per country
 
@@ -664,7 +664,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.211
 ```
 
-## Cluster 027
+### Cluster 027
 
 #### Cluster IP addresses per country
 
@@ -702,7 +702,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 54.37.121.239
 ```
 
-## Cluster 028
+### Cluster 028
 
 #### Cluster IP addresses per country
 
@@ -740,7 +740,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.249
 ```
 
-## Cluster 029
+### Cluster 029
 
 #### Cluster IP addresses per country
 
@@ -778,7 +778,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.192
 ```
 
-## Cluster 030
+### Cluster 030
 
 #### Cluster IP addresses per country
 
@@ -816,7 +816,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.178.146.199
 ```
 
-## Cluster 031
+### Cluster 031
 
 #### Cluster IP addresses per country
 
@@ -848,7 +848,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 141.94.87.67
 ```
 
-## Cluster 051
+### Cluster 051
 
 #### Cluster IP addresses per country
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: 'Web Hosting configuration'
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Last updated 20th May 2020**
+**Last updated 14th April 2023**
 
 ## Objective
 
@@ -980,5 +980,9 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 [Activating HTTPS on your website with an SSL certificate](../activate-https-website-ssl)
 
 [Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
+
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/asia/directory/).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/asia/support-levels/).
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: 'Web Hosting configuration'
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Last updated 14th April 2023**
+**Last updated 03rd May 2023**
 
 ## Objective
 
@@ -33,7 +33,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 ### Cluster 002
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -62,23 +61,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.2
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.33
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.191
 ```
 
-
 ## Cluster 003
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -107,23 +98,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.3
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.34
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.195
 ```
 
-
 ## Cluster 005
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -152,23 +135,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.5
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.35
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.199
 ```
 
-
 ## Cluster 006
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -197,12 +172,6 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.6
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.36
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
@@ -212,7 +181,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 ## Cluster 007
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -241,23 +209,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.7
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.37
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.207
 ```
 
-
 ## Cluster 010
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -286,23 +246,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.10
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.38
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.211
 ```
 
-
 ## Cluster 011
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -331,23 +283,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.11
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.39
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.215
 ```
 
-
 ## Cluster 012
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -376,18 +320,11 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.12
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.40
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.219
 ```
-
 
 ## Cluster 013
 
@@ -420,23 +357,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.13
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.41
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.223
 ```
 
-
 ## Cluster 014
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -465,23 +394,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.14
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.42
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.227
 ```
 
-
 ## Cluster 015
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -510,23 +431,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.15
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.43
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.231
 ```
 
-
 ## Cluster 017
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -555,23 +468,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.17
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.44
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.239
 ```
 
-
 ## Cluster 020
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -607,11 +512,9 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-
 ## Cluster 021
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -630,7 +533,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
 If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
 
 ```bash
 213.186.33.177
@@ -723,7 +625,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 ```bash
 91.134.248.230
 ```
-
 
 ## Cluster 026
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
@@ -67,7 +67,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.191
 ```
 
-## Cluster 003
+### Cluster 003
 
 #### Cluster IP addresses per country
 
@@ -104,7 +104,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.195
 ```
 
-## Cluster 005
+### Cluster 005
 
 #### Cluster IP addresses per country
 
@@ -141,7 +141,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.199
 ```
 
-## Cluster 006
+### Cluster 006
 
 #### Cluster IP addresses per country
 
@@ -178,7 +178,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.203
 ```
 
-## Cluster 007
+### Cluster 007
 
 #### Cluster IP addresses per country
 
@@ -215,7 +215,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.207
 ```
 
-## Cluster 010
+### Cluster 010
 
 #### Cluster IP addresses per country
 
@@ -252,7 +252,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.211
 ```
 
-## Cluster 011
+### Cluster 011
 
 #### Cluster IP addresses per country
 
@@ -289,7 +289,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.215
 ```
 
-## Cluster 012
+### Cluster 012
 
 #### Cluster IP addresses per country
 
@@ -326,7 +326,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.219
 ```
 
-## Cluster 013
+### Cluster 013
 
 #### Cluster IP addresses per country
 
@@ -363,7 +363,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.223
 ```
 
-## Cluster 014
+### Cluster 014
 
 #### Cluster IP addresses per country
 
@@ -400,7 +400,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.227
 ```
 
-## Cluster 015
+### Cluster 015
 
 #### Cluster IP addresses per country
 
@@ -437,7 +437,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.231
 ```
 
-## Cluster 017
+### Cluster 017
 
 #### Cluster IP addresses per country
 
@@ -474,7 +474,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.239
 ```
 
-## Cluster 020
+### Cluster 020
 
 #### Cluster IP addresses per country
 
@@ -512,7 +512,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-## Cluster 021
+### Cluster 021
 
 #### Cluster IP addresses per country
 
@@ -550,7 +550,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.245
 ```
 
-## Cluster 023
+### Cluster 023
 
 #### Cluster IP addresses per country
 
@@ -588,7 +588,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.235
 ```
 
-## Cluster 024
+### Cluster 024
 
 #### Cluster IP addresses per country
 
@@ -626,7 +626,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.230
 ```
 
-## Cluster 026
+### Cluster 026
 
 #### Cluster IP addresses per country
 
@@ -664,7 +664,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.211
 ```
 
-## Cluster 027
+### Cluster 027
 
 #### Cluster IP addresses per country
 
@@ -702,7 +702,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 54.37.121.239
 ```
 
-## Cluster 028
+### Cluster 028
 
 #### Cluster IP addresses per country
 
@@ -740,7 +740,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.249
 ```
 
-## Cluster 029
+### Cluster 029
 
 #### Cluster IP addresses per country
 
@@ -778,7 +778,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.192
 ```
 
-## Cluster 030
+### Cluster 030
 
 #### Cluster IP addresses per country
 
@@ -816,7 +816,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.178.146.199
 ```
 
-## Cluster 031
+### Cluster 031
 
 #### Cluster IP addresses per country
 
@@ -848,7 +848,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 141.94.87.67
 ```
 
-## Cluster 051
+### Cluster 051
 
 #### Cluster IP addresses per country
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: Web Hosting configuration
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Last updated 20th May 2020**
+**Last updated 14th April 2023**
 
 ## Objective
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
@@ -876,11 +876,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 ## Go further
 
-[Hosting multiple websites on your Web Hosting plan](../multisites-configuring-multiple-websites)
+[Hosting multiple websites on your Web Hosting plan](/pages/web/hosting/multisites_configure_multisite)
 
-[Activating HTTPS on your website with an SSL certificate](../activate-https-website-ssl)
+[Activating HTTPS on your website with an SSL certificate](/pages/web/hosting/ssl-activate-https-website)
 
-[Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
+[Optimise your website’s performance](/pages/web/hosting/optimise_your_website_performance)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-au/directory/).
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: Web Hosting configuration
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Last updated 14th April 2023**
+**Last updated 03rd May 2023**
 
 ## Objective
 
@@ -33,7 +33,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 ### Cluster 002
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -62,23 +61,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.2
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.33
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.191
 ```
 
-
 ## Cluster 003
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -107,23 +98,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.3
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.34
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.195
 ```
 
-
 ## Cluster 005
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -152,23 +135,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.5
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.35
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.199
 ```
 
-
 ## Cluster 006
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -197,12 +172,6 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.6
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.36
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
@@ -212,7 +181,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 ## Cluster 007
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -241,23 +209,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.7
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.37
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.207
 ```
 
-
 ## Cluster 010
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -286,23 +246,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.10
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.38
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.211
 ```
 
-
 ## Cluster 011
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -331,23 +283,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.11
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.39
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.215
 ```
 
-
 ## Cluster 012
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -376,18 +320,11 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.12
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.40
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.219
 ```
-
 
 ## Cluster 013
 
@@ -420,23 +357,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.13
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.41
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.223
 ```
 
-
 ## Cluster 014
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -465,23 +394,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.14
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.42
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.227
 ```
 
-
 ## Cluster 015
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -510,23 +431,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.15
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.43
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.231
 ```
 
-
 ## Cluster 017
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -555,23 +468,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.17
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.44
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.239
 ```
 
-
 ## Cluster 020
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -607,11 +512,9 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-
 ## Cluster 021
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -630,7 +533,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
 If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
 
 ```bash
 213.186.33.177
@@ -723,7 +625,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 ```bash
 91.134.248.230
 ```
-
 
 ## Cluster 026
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
@@ -981,4 +981,8 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 [Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
 
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-au/directory/).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-au/support-levels/).
+
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
@@ -67,7 +67,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.191
 ```
 
-## Cluster 003
+### Cluster 003
 
 #### Cluster IP addresses per country
 
@@ -104,7 +104,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.195
 ```
 
-## Cluster 005
+### Cluster 005
 
 #### Cluster IP addresses per country
 
@@ -141,7 +141,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.199
 ```
 
-## Cluster 006
+### Cluster 006
 
 #### Cluster IP addresses per country
 
@@ -178,7 +178,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.203
 ```
 
-## Cluster 007
+### Cluster 007
 
 #### Cluster IP addresses per country
 
@@ -215,7 +215,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.207
 ```
 
-## Cluster 010
+### Cluster 010
 
 #### Cluster IP addresses per country
 
@@ -252,7 +252,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.211
 ```
 
-## Cluster 011
+### Cluster 011
 
 #### Cluster IP addresses per country
 
@@ -289,7 +289,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.215
 ```
 
-## Cluster 012
+### Cluster 012
 
 #### Cluster IP addresses per country
 
@@ -326,7 +326,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.219
 ```
 
-## Cluster 013
+### Cluster 013
 
 #### Cluster IP addresses per country
 
@@ -363,7 +363,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.223
 ```
 
-## Cluster 014
+### Cluster 014
 
 #### Cluster IP addresses per country
 
@@ -400,7 +400,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.227
 ```
 
-## Cluster 015
+### Cluster 015
 
 #### Cluster IP addresses per country
 
@@ -437,7 +437,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.231
 ```
 
-## Cluster 017
+### Cluster 017
 
 #### Cluster IP addresses per country
 
@@ -474,7 +474,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.239
 ```
 
-## Cluster 020
+### Cluster 020
 
 #### Cluster IP addresses per country
 
@@ -512,7 +512,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-## Cluster 021
+### Cluster 021
 
 #### Cluster IP addresses per country
 
@@ -550,7 +550,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.245
 ```
 
-## Cluster 023
+### Cluster 023
 
 #### Cluster IP addresses per country
 
@@ -588,7 +588,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.235
 ```
 
-## Cluster 024
+### Cluster 024
 
 #### Cluster IP addresses per country
 
@@ -626,7 +626,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.230
 ```
 
-## Cluster 026
+### Cluster 026
 
 #### Cluster IP addresses per country
 
@@ -664,7 +664,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.211
 ```
 
-## Cluster 027
+### Cluster 027
 
 #### Cluster IP addresses per country
 
@@ -702,7 +702,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 54.37.121.239
 ```
 
-## Cluster 028
+### Cluster 028
 
 #### Cluster IP addresses per country
 
@@ -740,7 +740,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.249
 ```
 
-## Cluster 029
+### Cluster 029
 
 #### Cluster IP addresses per country
 
@@ -778,7 +778,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.192
 ```
 
-## Cluster 030
+### Cluster 030
 
 #### Cluster IP addresses per country
 
@@ -816,7 +816,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.178.146.199
 ```
 
-## Cluster 031
+### Cluster 031
 
 #### Cluster IP addresses per country
 
@@ -848,7 +848,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 141.94.87.67
 ```
 
-## Cluster 051
+### Cluster 051
 
 #### Cluster IP addresses per country
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
@@ -876,11 +876,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 ## Go further
 
-[Hosting multiple websites on your Web Hosting plan](../multisites-configuring-multiple-websites)
+[Hosting multiple websites on your Web Hosting plan](/pages/web/hosting/multisites_configure_multisite)
 
-[Activating HTTPS on your website with an SSL certificate](../activate-https-website-ssl)
+[Activating HTTPS on your website with an SSL certificate](/pages/web/hosting/ssl-activate-https-website)
 
-[Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
+[Optimise your website’s performance](/pages/web/hosting/optimise_your_website_performance)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-ca/directory/).
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: 'Web Hosting configuration'
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Last updated 14th April 2023**
+**Last updated 03rd May 2023**
 
 ## Objective
 
@@ -33,7 +33,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 ### Cluster 002
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -62,23 +61,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.2
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.33
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.191
 ```
 
-
 ## Cluster 003
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -107,23 +98,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.3
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.34
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.195
 ```
 
-
 ## Cluster 005
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -152,23 +135,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.5
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.35
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.199
 ```
 
-
 ## Cluster 006
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -197,12 +172,6 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.6
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.36
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
@@ -212,7 +181,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 ## Cluster 007
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -241,23 +209,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.7
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.37
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.207
 ```
 
-
 ## Cluster 010
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -286,23 +246,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.10
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.38
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.211
 ```
 
-
 ## Cluster 011
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -331,23 +283,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.11
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.39
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.215
 ```
 
-
 ## Cluster 012
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -376,18 +320,11 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.12
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.40
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.219
 ```
-
 
 ## Cluster 013
 
@@ -420,23 +357,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.13
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.41
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.223
 ```
 
-
 ## Cluster 014
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -465,23 +394,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.14
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.42
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.227
 ```
 
-
 ## Cluster 015
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -510,23 +431,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.15
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.43
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.231
 ```
 
-
 ## Cluster 017
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -555,23 +468,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.17
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.44
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.239
 ```
 
-
 ## Cluster 020
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -607,11 +512,9 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-
 ## Cluster 021
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -630,7 +533,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
 If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
 
 ```bash
 213.186.33.177
@@ -723,7 +625,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 ```bash
 91.134.248.230
 ```
-
 
 ## Cluster 026
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: 'Web Hosting configuration'
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Last updated 20th July 2020**
+**Last updated 14th April 2023**
 
 ## Objective
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
@@ -981,4 +981,8 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 [Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
 
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-ca/directory/).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-ca/support-levels/).
+
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
@@ -67,7 +67,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.191
 ```
 
-## Cluster 003
+### Cluster 003
 
 #### Cluster IP addresses per country
 
@@ -104,7 +104,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.195
 ```
 
-## Cluster 005
+### Cluster 005
 
 #### Cluster IP addresses per country
 
@@ -141,7 +141,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.199
 ```
 
-## Cluster 006
+### Cluster 006
 
 #### Cluster IP addresses per country
 
@@ -178,7 +178,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.203
 ```
 
-## Cluster 007
+### Cluster 007
 
 #### Cluster IP addresses per country
 
@@ -215,7 +215,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.207
 ```
 
-## Cluster 010
+### Cluster 010
 
 #### Cluster IP addresses per country
 
@@ -252,7 +252,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.211
 ```
 
-## Cluster 011
+### Cluster 011
 
 #### Cluster IP addresses per country
 
@@ -289,7 +289,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.215
 ```
 
-## Cluster 012
+### Cluster 012
 
 #### Cluster IP addresses per country
 
@@ -326,7 +326,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.219
 ```
 
-## Cluster 013
+### Cluster 013
 
 #### Cluster IP addresses per country
 
@@ -363,7 +363,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.223
 ```
 
-## Cluster 014
+### Cluster 014
 
 #### Cluster IP addresses per country
 
@@ -400,7 +400,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.227
 ```
 
-## Cluster 015
+### Cluster 015
 
 #### Cluster IP addresses per country
 
@@ -437,7 +437,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.231
 ```
 
-## Cluster 017
+### Cluster 017
 
 #### Cluster IP addresses per country
 
@@ -474,7 +474,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.239
 ```
 
-## Cluster 020
+### Cluster 020
 
 #### Cluster IP addresses per country
 
@@ -512,7 +512,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-## Cluster 021
+### Cluster 021
 
 #### Cluster IP addresses per country
 
@@ -550,7 +550,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.245
 ```
 
-## Cluster 023
+### Cluster 023
 
 #### Cluster IP addresses per country
 
@@ -588,7 +588,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.235
 ```
 
-## Cluster 024
+### Cluster 024
 
 #### Cluster IP addresses per country
 
@@ -626,7 +626,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.230
 ```
 
-## Cluster 026
+### Cluster 026
 
 #### Cluster IP addresses per country
 
@@ -664,7 +664,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.211
 ```
 
-## Cluster 027
+### Cluster 027
 
 #### Cluster IP addresses per country
 
@@ -702,7 +702,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 54.37.121.239
 ```
 
-## Cluster 028
+### Cluster 028
 
 #### Cluster IP addresses per country
 
@@ -740,7 +740,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.249
 ```
 
-## Cluster 029
+### Cluster 029
 
 #### Cluster IP addresses per country
 
@@ -778,7 +778,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.192
 ```
 
-## Cluster 030
+### Cluster 030
 
 #### Cluster IP addresses per country
 
@@ -816,7 +816,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.178.146.199
 ```
 
-## Cluster 031
+### Cluster 031
 
 #### Cluster IP addresses per country
 
@@ -848,7 +848,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 141.94.87.67
 ```
 
-## Cluster 051
+### Cluster 051
 
 #### Cluster IP addresses per country
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
@@ -981,4 +981,8 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 [Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
 
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-gb/support-levels/).
+
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: Web Hosting configuration
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Last updated 8th January 2021**
+**Last updated 14th April 2023**
 
 ## Objective
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
@@ -876,11 +876,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 ## Go further
 
-[Hosting multiple websites on your Web Hosting plan](../multisites-configuring-multiple-websites)
+[Hosting multiple websites on your Web Hosting plan](/pages/web/hosting/multisites_configure_multisite)
 
-[Activating HTTPS on your website with an SSL certificate](../activate-https-website-ssl)
+[Activating HTTPS on your website with an SSL certificate](/pages/web/hosting/ssl-activate-https-website)
 
-[Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
+[Optimise your website’s performance](/pages/web/hosting/optimise_your_website_performance)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: Web Hosting configuration
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Last updated 14th April 2023**
+**Last updated 03rd May 2023**
 
 ## Objective
 
@@ -33,7 +33,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 ### Cluster 002
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -62,23 +61,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.2
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.33
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.191
 ```
 
-
 ## Cluster 003
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -107,23 +98,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.3
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.34
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.195
 ```
 
-
 ## Cluster 005
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -152,23 +135,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.5
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.35
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.199
 ```
 
-
 ## Cluster 006
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -197,12 +172,6 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.6
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.36
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
@@ -212,7 +181,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 ## Cluster 007
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -241,23 +209,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.7
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.37
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.207
 ```
 
-
 ## Cluster 010
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -286,23 +246,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.10
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.38
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.211
 ```
 
-
 ## Cluster 011
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -331,23 +283,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.11
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.39
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.215
 ```
 
-
 ## Cluster 012
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -376,18 +320,11 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.12
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.40
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.219
 ```
-
 
 ## Cluster 013
 
@@ -420,23 +357,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.13
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.41
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.223
 ```
 
-
 ## Cluster 014
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -465,23 +394,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.14
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.42
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.227
 ```
 
-
 ## Cluster 015
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -510,23 +431,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.15
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.43
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.231
 ```
 
-
 ## Cluster 017
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -555,23 +468,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.17
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.44
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.239
 ```
 
-
 ## Cluster 020
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -607,11 +512,9 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-
 ## Cluster 021
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -630,7 +533,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
 If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
 
 ```bash
 213.186.33.177
@@ -723,7 +625,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 ```bash
 91.134.248.230
 ```
-
 
 ## Cluster 026
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
@@ -67,7 +67,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.191
 ```
 
-## Cluster 003
+### Cluster 003
 
 #### Cluster IP addresses per country
 
@@ -104,7 +104,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.195
 ```
 
-## Cluster 005
+### Cluster 005
 
 #### Cluster IP addresses per country
 
@@ -141,7 +141,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.199
 ```
 
-## Cluster 006
+### Cluster 006
 
 #### Cluster IP addresses per country
 
@@ -178,7 +178,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.203
 ```
 
-## Cluster 007
+### Cluster 007
 
 #### Cluster IP addresses per country
 
@@ -215,7 +215,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.207
 ```
 
-## Cluster 010
+### Cluster 010
 
 #### Cluster IP addresses per country
 
@@ -252,7 +252,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.211
 ```
 
-## Cluster 011
+### Cluster 011
 
 #### Cluster IP addresses per country
 
@@ -289,7 +289,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.215
 ```
 
-## Cluster 012
+### Cluster 012
 
 #### Cluster IP addresses per country
 
@@ -326,7 +326,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.219
 ```
 
-## Cluster 013
+### Cluster 013
 
 #### Cluster IP addresses per country
 
@@ -363,7 +363,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.223
 ```
 
-## Cluster 014
+### Cluster 014
 
 #### Cluster IP addresses per country
 
@@ -400,7 +400,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.227
 ```
 
-## Cluster 015
+### Cluster 015
 
 #### Cluster IP addresses per country
 
@@ -437,7 +437,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.231
 ```
 
-## Cluster 017
+### Cluster 017
 
 #### Cluster IP addresses per country
 
@@ -474,7 +474,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.239
 ```
 
-## Cluster 020
+### Cluster 020
 
 #### Cluster IP addresses per country
 
@@ -512,7 +512,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-## Cluster 021
+### Cluster 021
 
 #### Cluster IP addresses per country
 
@@ -550,7 +550,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.245
 ```
 
-## Cluster 023
+### Cluster 023
 
 #### Cluster IP addresses per country
 
@@ -588,7 +588,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.235
 ```
 
-## Cluster 024
+### Cluster 024
 
 #### Cluster IP addresses per country
 
@@ -626,7 +626,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.230
 ```
 
-## Cluster 026
+### Cluster 026
 
 #### Cluster IP addresses per country
 
@@ -664,7 +664,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.211
 ```
 
-## Cluster 027
+### Cluster 027
 
 #### Cluster IP addresses per country
 
@@ -702,7 +702,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 54.37.121.239
 ```
 
-## Cluster 028
+### Cluster 028
 
 #### Cluster IP addresses per country
 
@@ -740,7 +740,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.249
 ```
 
-## Cluster 029
+### Cluster 029
 
 #### Cluster IP addresses per country
 
@@ -778,7 +778,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.192
 ```
 
-## Cluster 030
+### Cluster 030
 
 #### Cluster IP addresses per country
 
@@ -816,7 +816,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.178.146.199
 ```
 
-## Cluster 031
+### Cluster 031
 
 #### Cluster IP addresses per country
 
@@ -848,7 +848,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 141.94.87.67
 ```
 
-## Cluster 051
+### Cluster 051
 
 #### Cluster IP addresses per country
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
@@ -876,11 +876,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 ## Go further
 
-[Hosting multiple websites on your Web Hosting plan](../multisites-configuring-multiple-websites)
+[Hosting multiple websites on your Web Hosting plan](/pages/web/hosting/multisites_configure_multisite)
 
-[Activating HTTPS on your website with an SSL certificate](../activate-https-website-ssl)
+[Activating HTTPS on your website with an SSL certificate](/pages/web/hosting/ssl-activate-https-website)
 
-[Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
+[Optimise your website’s performance](/pages/web/hosting/optimise_your_website_performance)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-ie/directory/).
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: 'Web Hosting configuration'
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Last updated 14th April 2023**
+**Last updated 03rd May 2023**
 
 ## Objective
 
@@ -33,7 +33,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 ### Cluster 002
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -62,23 +61,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.2
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.33
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.191
 ```
 
-
 ## Cluster 003
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -107,23 +98,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.3
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.34
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.195
 ```
 
-
 ## Cluster 005
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -152,23 +135,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.5
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.35
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.199
 ```
 
-
 ## Cluster 006
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -197,12 +172,6 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.6
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.36
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
@@ -212,7 +181,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 ## Cluster 007
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -241,23 +209,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.7
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.37
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.207
 ```
 
-
 ## Cluster 010
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -286,23 +246,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.10
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.38
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.211
 ```
 
-
 ## Cluster 011
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -331,23 +283,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.11
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.39
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.215
 ```
 
-
 ## Cluster 012
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -376,18 +320,11 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.12
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.40
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.219
 ```
-
 
 ## Cluster 013
 
@@ -420,23 +357,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.13
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.41
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.223
 ```
 
-
 ## Cluster 014
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -465,23 +394,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.14
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.42
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.227
 ```
 
-
 ## Cluster 015
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -510,23 +431,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.15
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.43
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.231
 ```
 
-
 ## Cluster 017
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -555,23 +468,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.17
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.44
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.239
 ```
 
-
 ## Cluster 020
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -607,11 +512,9 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-
 ## Cluster 021
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -630,7 +533,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
 If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
 
 ```bash
 213.186.33.177
@@ -723,7 +625,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 ```bash
 91.134.248.230
 ```
-
 
 ## Cluster 026
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: 'Web Hosting configuration'
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Last updated 20th July 2020**
+**Last updated 14th April 2023**
 
 ## Objective
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
@@ -981,4 +981,8 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 [Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
 
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-ie/directory/).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-ie/support-levels/).
+
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
@@ -876,11 +876,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 ## Go further
 
-[Hosting multiple websites on your Web Hosting plan](../multisites-configuring-multiple-websites)
+[Hosting multiple websites on your Web Hosting plan](/pages/web/hosting/multisites_configure_multisite)
 
-[Activating HTTPS on your website with an SSL certificate](../activate-https-website-ssl)
+[Activating HTTPS on your website with an SSL certificate](/pages/web/hosting/ssl-activate-https-website)
 
-[Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
+[Optimise your website’s performance](/pages/web/hosting/optimise_your_website_performance)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-sg/directory/).
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
@@ -67,7 +67,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.191
 ```
 
-## Cluster 003
+### Cluster 003
 
 #### Cluster IP addresses per country
 
@@ -104,7 +104,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.195
 ```
 
-## Cluster 005
+### Cluster 005
 
 #### Cluster IP addresses per country
 
@@ -141,7 +141,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.199
 ```
 
-## Cluster 006
+### Cluster 006
 
 #### Cluster IP addresses per country
 
@@ -178,7 +178,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.203
 ```
 
-## Cluster 007
+### Cluster 007
 
 #### Cluster IP addresses per country
 
@@ -215,7 +215,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.207
 ```
 
-## Cluster 010
+### Cluster 010
 
 #### Cluster IP addresses per country
 
@@ -252,7 +252,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.211
 ```
 
-## Cluster 011
+### Cluster 011
 
 #### Cluster IP addresses per country
 
@@ -289,7 +289,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.215
 ```
 
-## Cluster 012
+### Cluster 012
 
 #### Cluster IP addresses per country
 
@@ -326,7 +326,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.219
 ```
 
-## Cluster 013
+### Cluster 013
 
 #### Cluster IP addresses per country
 
@@ -363,7 +363,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.223
 ```
 
-## Cluster 014
+### Cluster 014
 
 #### Cluster IP addresses per country
 
@@ -400,7 +400,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.227
 ```
 
-## Cluster 015
+### Cluster 015
 
 #### Cluster IP addresses per country
 
@@ -437,7 +437,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.231
 ```
 
-## Cluster 017
+### Cluster 017
 
 #### Cluster IP addresses per country
 
@@ -474,7 +474,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.239
 ```
 
-## Cluster 020
+### Cluster 020
 
 #### Cluster IP addresses per country
 
@@ -512,7 +512,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-## Cluster 021
+### Cluster 021
 
 #### Cluster IP addresses per country
 
@@ -550,7 +550,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.245
 ```
 
-## Cluster 023
+### Cluster 023
 
 #### Cluster IP addresses per country
 
@@ -588,7 +588,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.235
 ```
 
-## Cluster 024
+### Cluster 024
 
 #### Cluster IP addresses per country
 
@@ -626,7 +626,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.230
 ```
 
-## Cluster 026
+### Cluster 026
 
 #### Cluster IP addresses per country
 
@@ -664,7 +664,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.211
 ```
 
-## Cluster 027
+### Cluster 027
 
 #### Cluster IP addresses per country
 
@@ -702,7 +702,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 54.37.121.239
 ```
 
-## Cluster 028
+### Cluster 028
 
 #### Cluster IP addresses per country
 
@@ -740,7 +740,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.249
 ```
 
-## Cluster 029
+### Cluster 029
 
 #### Cluster IP addresses per country
 
@@ -778,7 +778,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.192
 ```
 
-## Cluster 030
+### Cluster 030
 
 #### Cluster IP addresses per country
 
@@ -816,7 +816,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.178.146.199
 ```
 
-## Cluster 031
+### Cluster 031
 
 #### Cluster IP addresses per country
 
@@ -848,7 +848,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 141.94.87.67
 ```
 
-## Cluster 051
+### Cluster 051
 
 #### Cluster IP addresses per country
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: 'Web Hosting configuration'
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Last updated 14th April 2023**
+**Last updated 03rd May 2023**
 
 ## Objective
 
@@ -33,7 +33,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 ### Cluster 002
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -62,23 +61,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.2
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.33
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.191
 ```
 
-
 ## Cluster 003
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -107,23 +98,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.3
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.34
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.195
 ```
 
-
 ## Cluster 005
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -152,23 +135,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.5
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.35
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.199
 ```
 
-
 ## Cluster 006
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -197,12 +172,6 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.6
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.36
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
@@ -212,7 +181,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 ## Cluster 007
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -241,23 +209,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.7
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.37
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.207
 ```
 
-
 ## Cluster 010
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -286,23 +246,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.10
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.38
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.211
 ```
 
-
 ## Cluster 011
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -331,23 +283,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.11
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.39
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.215
 ```
 
-
 ## Cluster 012
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -376,18 +320,11 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.12
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.40
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.219
 ```
-
 
 ## Cluster 013
 
@@ -420,23 +357,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.13
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.41
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.223
 ```
 
-
 ## Cluster 014
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -465,23 +394,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.14
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.42
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.227
 ```
 
-
 ## Cluster 015
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -510,23 +431,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.15
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.43
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.231
 ```
 
-
 ## Cluster 017
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -555,23 +468,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.17
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.44
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.239
 ```
 
-
 ## Cluster 020
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -607,11 +512,9 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-
 ## Cluster 021
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -630,7 +533,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
 If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
 
 ```bash
 213.186.33.177

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
@@ -980,4 +980,8 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 [Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
 
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-sg/directory/).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-sg/support-levels/).
+
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: 'Web Hosting configuration'
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Last updated 20th July 2020**
+**Last updated 14th April 2023**
 
 ## Objective
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
@@ -67,7 +67,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.191
 ```
 
-## Cluster 003
+### Cluster 003
 
 #### Cluster IP addresses per country
 
@@ -104,7 +104,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.195
 ```
 
-## Cluster 005
+### Cluster 005
 
 #### Cluster IP addresses per country
 
@@ -141,7 +141,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.199
 ```
 
-## Cluster 006
+### Cluster 006
 
 #### Cluster IP addresses per country
 
@@ -178,7 +178,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.203
 ```
 
-## Cluster 007
+### Cluster 007
 
 #### Cluster IP addresses per country
 
@@ -215,7 +215,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.207
 ```
 
-## Cluster 010
+### Cluster 010
 
 #### Cluster IP addresses per country
 
@@ -252,7 +252,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.211
 ```
 
-## Cluster 011
+### Cluster 011
 
 #### Cluster IP addresses per country
 
@@ -289,7 +289,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.215
 ```
 
-## Cluster 012
+### Cluster 012
 
 #### Cluster IP addresses per country
 
@@ -326,7 +326,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.219
 ```
 
-## Cluster 013
+### Cluster 013
 
 #### Cluster IP addresses per country
 
@@ -363,7 +363,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.223
 ```
 
-## Cluster 014
+### Cluster 014
 
 #### Cluster IP addresses per country
 
@@ -400,7 +400,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.227
 ```
 
-## Cluster 015
+### Cluster 015
 
 #### Cluster IP addresses per country
 
@@ -437,7 +437,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.231
 ```
 
-## Cluster 017
+### Cluster 017
 
 #### Cluster IP addresses per country
 
@@ -474,7 +474,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.68.11.239
 ```
 
-## Cluster 020
+### Cluster 020
 
 #### Cluster IP addresses per country
 
@@ -512,7 +512,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-## Cluster 021
+### Cluster 021
 
 #### Cluster IP addresses per country
 
@@ -550,7 +550,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.245
 ```
 
-## Cluster 023
+### Cluster 023
 
 #### Cluster IP addresses per country
 
@@ -588,7 +588,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.235
 ```
 
-## Cluster 024
+### Cluster 024
 
 #### Cluster IP addresses per country
 
@@ -626,7 +626,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.230
 ```
 
-## Cluster 026
+### Cluster 026
 
 #### Cluster IP addresses per country
 
@@ -664,7 +664,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.211
 ```
 
-## Cluster 027
+### Cluster 027
 
 #### Cluster IP addresses per country
 
@@ -702,7 +702,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 54.37.121.239
 ```
 
-## Cluster 028
+### Cluster 028
 
 #### Cluster IP addresses per country
 
@@ -740,7 +740,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.249
 ```
 
-## Cluster 029
+### Cluster 029
 
 #### Cluster IP addresses per country
 
@@ -778,7 +778,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.192
 ```
 
-## Cluster 030
+### Cluster 030
 
 #### Cluster IP addresses per country
 
@@ -816,7 +816,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 51.178.146.199
 ```
 
-## Cluster 031
+### Cluster 031
 
 #### Cluster IP addresses per country
 
@@ -848,7 +848,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 141.94.87.67
 ```
 
-## Cluster 051
+### Cluster 051
 
 #### Cluster IP addresses per country
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: 'Web Hosting configuration'
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Last updated 14th April 2023**
+**Last updated 03rd May 2023**
 
 ## Objective
 
@@ -33,7 +33,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 ### Cluster 002
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -62,23 +61,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.2
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.33
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.191
 ```
 
-
 ## Cluster 003
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -107,23 +98,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.3
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.34
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.195
 ```
 
-
 ## Cluster 005
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -152,23 +135,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.5
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.35
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.199
 ```
 
-
 ## Cluster 006
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -197,12 +172,6 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.6
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.36
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
@@ -212,7 +181,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 ## Cluster 007
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -241,23 +209,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.7
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.37
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.207
 ```
 
-
 ## Cluster 010
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -286,23 +246,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.10
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.38
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.211
 ```
 
-
 ## Cluster 011
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -331,23 +283,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.11
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.39
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.215
 ```
 
-
 ## Cluster 012
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -376,18 +320,11 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.12
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.40
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.219
 ```
-
 
 ## Cluster 013
 
@@ -420,23 +357,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.13
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.41
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.223
 ```
 
-
 ## Cluster 014
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -465,23 +394,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.14
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.42
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.227
 ```
 
-
 ## Cluster 015
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -510,23 +431,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.15
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.43
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.231
 ```
 
-
 ## Cluster 017
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -555,23 +468,15 @@ If you have activated the **Shared CDN** option (released on 19/11/2020) on your
 46.105.204.17
 ```
 
-If you have enabled a **Sectigo SSL certificate (paid option)** on your Web Hosting, use this IP address:
-
-```bash
-46.105.174.44
-```
-
 If you need the **outgoing IP address** of the Web Hosting cluster (gateway), use this IP address:
 
 ```bash
 51.68.11.239
 ```
 
-
 ## Cluster 020
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -607,11 +512,9 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 91.134.248.253
 ```
 
-
 ## Cluster 021
 
 #### Cluster IP addresses per country
-
 
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
@@ -630,7 +533,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
 If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
 
 ```bash
 213.186.33.177

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
@@ -876,11 +876,11 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 ## Go further
 
-[Hosting multiple websites on your Web Hosting plan](../multisites-configuring-multiple-websites)
+[Hosting multiple websites on your Web Hosting plan](/pages/web/hosting/multisites_configure_multisite)
 
-[Activating HTTPS on your website with an SSL certificate](../activate-https-website-ssl)
+[Activating HTTPS on your website with an SSL certificate](/pages/web/hosting/ssl-activate-https-website)
 
-[Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
+[Optimise your website’s performance](/pages/web/hosting/optimise_your_website_performance)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en/directory/).
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
@@ -980,4 +980,8 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 
 [Optimise your website’s performance](../web_hosting_optimise_your_website_performance)
 
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en/directory/).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en/support-levels/).
+
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
@@ -4,10 +4,10 @@ slug: list-of-ip-addresses-of-web-hosting-clusters
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
 section: 'Web Hosting configuration'
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Last updated 20th May 2020**
+**Last updated 14th April 2023**
 
 ## Objective
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-es.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-es.md
@@ -886,6 +886,12 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 ## Más información
 
+[Crear un multisitio en un alojamiento web](/pages/web/hosting/multisites_configure_multisite)
+
+[Activar el HTTPS con el certificado SSL en un alojamiento web](/pages/web/hosting/ssl-activate-https-website)
+
+[Optimizar el rendimiento de su sitio web](/pages/web/hosting/optimise_your_website_performance)
+
 Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con [partners de OVHcloud](https://partner.ovhcloud.com/es-es/directory/).
 
 Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es-es/support-levels/).

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-es.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-es.md
@@ -3,10 +3,10 @@ title: 'Direcciones IP de los clusters y alojamientos web'
 slug: lista-de-direcciones-ip-de-los-clusters-y-alojamientos-web
 section: 'Configuración del alojamiento'
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Última actualización: 14/04/2023**
+**Última actualización: 03/05/2023**
 
 > [!primary]
 > Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón «Contribuir» de esta página.
@@ -40,7 +40,6 @@ Puede comprobar el número de cluster del alojamiento web en esta página bajo *
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
-
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
 |Francia|FR|213.186.33.2|2001:41d0:1:1b00:213:186:33:2|
@@ -58,7 +57,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.69
 ```
@@ -69,25 +67,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.2
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.33
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.191
 ```
 
-
 ### Cluster 003
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -106,7 +94,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.85
 ```
@@ -117,25 +104,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.3
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.34
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.195
 ```
 
-
 ### Cluster 005
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -154,7 +131,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.95
 ```
@@ -165,25 +141,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.5
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.35
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.199
 ```
 
-
 ### Cluster 006
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -202,7 +168,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.97
 ```
@@ -213,15 +178,7 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.6
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.36
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.203
@@ -230,7 +187,6 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 ### Cluster 007
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -249,7 +205,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.105
 ```
@@ -260,25 +215,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.7
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.37
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.207
 ```
 
-
 ### Cluster 010
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -297,7 +242,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.107
 ```
@@ -308,25 +252,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.10
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.38
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.211
 ```
 
-
 ### Cluster 011
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -345,7 +279,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.151
 ```
@@ -356,25 +289,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.11
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.39
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.215
 ```
 
-
 ### Cluster 012
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -393,7 +316,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.153
 ```
@@ -404,20 +326,11 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.12
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.40
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.219
 ```
-
 
 ### Cluster 013
 
@@ -440,7 +353,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.83
 ```
@@ -451,25 +363,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.13
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.41
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.223
 ```
 
-
 ### Cluster 014
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -488,7 +390,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.169
 ```
@@ -499,25 +400,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.14
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.42
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.227
 ```
 
-
 ### Cluster 015
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -536,7 +427,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.171
 ```
@@ -547,25 +437,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.15
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.43
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.231
 ```
 
-
 ### Cluster 017
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -584,7 +464,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.173
 ```
@@ -595,25 +474,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.17
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.44
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.239
 ```
 
-
 ### Cluster 020
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -633,7 +502,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.176
 ```
@@ -646,16 +514,13 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 91.134.248.253
 ```
 
-
 ### Cluster 021
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -674,7 +539,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Bélgica|BE|178.32.40.72|2001:41d0:301:10::21|
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 213.186.33.177
@@ -764,11 +628,9 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 91.134.248.230
 ```
-
 
 ### Cluster 026
 
@@ -803,7 +665,6 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 ```
 
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 91.134.248.211
@@ -843,7 +704,6 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 54.37.121.239
 ```
@@ -881,7 +741,6 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 ```
 
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 91.134.248.249

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-es.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-es.md
@@ -3,10 +3,14 @@ title: 'Direcciones IP de los clusters y alojamientos web'
 slug: lista-de-direcciones-ip-de-los-clusters-y-alojamientos-web
 section: 'Configuración del alojamiento'
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Última actualización: 08/01/2021**
+**Última actualización: 14/04/2023**
+
+> [!primary]
+> Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón «Contribuir» de esta página.
+>
 
 ## Objetivo
 
@@ -1023,4 +1027,8 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/){.external}.
+Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con [partners de OVHcloud](https://partner.ovhcloud.com/es-es/directory/).
+
+Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
+
+Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-us.md
@@ -884,6 +884,12 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 ## Más información
 
+[Crear un multisitio en un alojamiento web](/pages/web/hosting/multisites_configure_multisite)
+
+[Activar el HTTPS con el certificado SSL en un alojamiento web](/pages/web/hosting/ssl-activate-https-website)
+
+[Optimizar el rendimiento de su sitio web](/pages/web/hosting/optimise_your_website_performance)
+
 Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con [partners de OVHcloud](https://partner.ovhcloud.com/es/directory/).
 
 Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es/support-levels/).

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-us.md
@@ -3,10 +3,10 @@ title: 'Direcciones IP de los clusters y alojamientos web'
 slug: lista-de-direcciones-ip-de-los-clusters-y-alojamientos-web
 section: 'Configuración del alojamiento'
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Última actualización: 14/04/2023**
+**Última actualización: 03/05/2023**
 
 > [!primary]
 > Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón «Contribuir» de esta página.
@@ -40,7 +40,6 @@ Puede comprobar el número de cluster del alojamiento web en esta página bajo *
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
 
-
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
 |Francia|FR|213.186.33.2|2001:41d0:1:1b00:213:186:33:2|
@@ -58,7 +57,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.69
 ```
@@ -69,25 +67,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.2
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.33
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.191
 ```
 
-
 ### Cluster 003
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -106,7 +94,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.85
 ```
@@ -117,25 +104,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.3
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.34
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.195
 ```
 
-
 ### Cluster 005
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -154,7 +131,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.95
 ```
@@ -165,25 +141,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.5
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.35
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.199
 ```
 
-
 ### Cluster 006
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -202,7 +168,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.97
 ```
@@ -213,15 +178,7 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.6
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.36
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.203
@@ -230,7 +187,6 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 ### Cluster 007
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -249,7 +205,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.105
 ```
@@ -260,25 +215,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.7
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.37
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.207
 ```
 
-
 ### Cluster 010
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -297,7 +242,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.107
 ```
@@ -308,25 +252,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.10
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.38
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.211
 ```
 
-
 ### Cluster 011
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -345,7 +279,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.151
 ```
@@ -356,25 +289,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.11
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.39
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.215
 ```
 
-
 ### Cluster 012
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -393,7 +316,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.153
 ```
@@ -404,20 +326,11 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.12
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.40
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.219
 ```
-
 
 ### Cluster 013
 
@@ -440,7 +353,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.83
 ```
@@ -451,25 +363,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.13
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.41
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.223
 ```
 
-
 ### Cluster 014
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -488,7 +390,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.169
 ```
@@ -499,25 +400,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.14
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.42
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.227
 ```
 
-
 ### Cluster 015
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -536,7 +427,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.171
 ```
@@ -547,25 +437,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.15
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.43
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.231
 ```
 
-
 ### Cluster 017
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -584,7 +464,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.173
 ```
@@ -595,25 +474,15 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 46.105.204.17
 ```
 
-Si tiene el **certificado SSL GlobalSign (de pago)** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-
-```bash
-46.105.174.44
-```
-
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 51.68.11.239
 ```
 
-
 ### Cluster 020
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -633,7 +502,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 213.186.33.176
 ```
@@ -646,16 +514,13 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 91.134.248.253
 ```
 
-
 ### Cluster 021
 
 A continuación se indican las direcciones IP del **cluster** para cada país (para la geolocalización):
-
 
 |País|Código del país|IPv4|IPv6|
 |---|---|----|---|
@@ -674,7 +539,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Bélgica|BE|178.32.40.72|2001:41d0:301:10::21|
 
 Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 213.186.33.177
@@ -764,7 +628,6 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 91.134.248.230
 ```
@@ -802,7 +665,6 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 ```
 
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 91.134.248.211
@@ -842,7 +704,6 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
 
-
 ```bash
 54.37.121.239
 ```
@@ -880,7 +741,6 @@ Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su aloja
 ```
 
 Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe utilizar la siguiente dirección IP:
-
 
 ```bash
 91.134.248.249

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-us.md
@@ -3,10 +3,14 @@ title: 'Direcciones IP de los clusters y alojamientos web'
 slug: lista-de-direcciones-ip-de-los-clusters-y-alojamientos-web
 section: 'Configuración del alojamiento'
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Última actualización: 08/01/2021**
+**Última actualización: 14/04/2023**
+
+> [!primary]
+> Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón «Contribuir» de esta página.
+>
 
 ## Objetivo
 
@@ -1020,4 +1024,8 @@ Si necesita la IP de la **puerta de enlace** (gateway) del alojamiento, debe uti
 
 ## Más información
 
-Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/){.external}.
+Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con [partners de OVHcloud](https://partner.ovhcloud.com/es/directory/).
+
+Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es/support-levels/).
+
+Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
@@ -875,6 +875,12 @@ Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre héb
 ```
 ## Aller plus loin
 
+[Mettre en place un multisite sur votre hébergement Web](/pages/web/hosting/multisites_configure_multisite)
+
+[Activer le HTTPS avec votre certificat SSL sur votre hébergement Web](/pages/web/hosting/ssl-activate-https-website)
+
+[Optimiser les performances de votre site Web](/pages/web/hosting/optimise_your_website_performance)
+
 Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr-ca/directory/).
 
 Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr-ca/support-levels/).

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
@@ -34,7 +34,6 @@ Vous pouvez vérifier le numéro de cluster de l'hébergement Web sur cette page
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
-
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
 |France|FR|213.186.33.2|2001:41d0:1:1b00:213:186:33:2|
@@ -52,37 +51,25 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.69
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.2
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-
-```bash
-46.105.174.33
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 51.68.11.191
 ```
 
-
 ### Cluster 003
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
-
 
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
@@ -101,37 +88,25 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.85
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.3
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-
-```bash
-46.105.174.34
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 51.68.11.195
 ```
 
-
 ### Cluster 005
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
-
 
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
@@ -150,37 +125,25 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.95
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.5
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-
-```bash
-46.105.174.35
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 51.68.11.199
 ```
 
-
 ### Cluster 006
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
-
 
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
@@ -199,27 +162,17 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.97
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.6
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-
-```bash
-46.105.174.36
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 51.68.11.203
@@ -228,7 +181,6 @@ Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre héb
 ### Cluster 007
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
-
 
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
@@ -247,37 +199,25 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.105
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.7
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-
-```bash
-46.105.174.37
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 51.68.11.207
 ```
 
-
 ### Cluster 010
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
-
 
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
@@ -296,37 +236,25 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.107
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.10
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-
-```bash
-46.105.174.38
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 51.68.11.211
 ```
 
-
 ### Cluster 011
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
-
 
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
@@ -345,23 +273,14 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.151
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.11
-```
-
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-
-```bash
-46.105.174.39
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
@@ -375,7 +294,6 @@ Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre héb
 ### Cluster 012
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
-
 
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
@@ -394,7 +312,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.153
 ```
@@ -405,20 +322,11 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 46.105.204.12
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-
-```bash
-46.105.174.40
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 51.68.11.219
 ```
-
 
 ### Cluster 013
 
@@ -441,37 +349,25 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.83
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.13
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-
-```bash
-46.105.174.41
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 51.68.11.223
 ```
 
-
 ### Cluster 014
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
-
 
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
@@ -490,23 +386,14 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.169
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.14
-```
-
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-
-```bash
-46.105.174.42
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
@@ -516,11 +403,9 @@ Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre héb
 51.68.11.227
 ```
 
-
 ### Cluster 015
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
-
 
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
@@ -539,37 +424,25 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.171
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.15
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-
-```bash
-46.105.174.43
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 51.68.11.231
 ```
 
-
 ### Cluster 017
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
-
 
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
@@ -588,37 +461,25 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.173
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.17
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-
-```bash
-46.105.174.44
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 51.68.11.239
 ```
 
-
 ### Cluster 020
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
-
 
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
@@ -638,13 +499,11 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.176
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
 
 ```bash
 46.105.204.20
@@ -652,16 +511,13 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
 
-
 ```bash
 91.134.248.253
 ```
 
-
 ### Cluster 021
 
 Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
-
 
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
@@ -681,20 +537,17 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy**  est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.177
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020)est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.21
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 91.134.248.245

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
@@ -3,10 +3,10 @@ title: 'Liste des adresses IP des clusters et hebergements web'
 slug: liste-des-adresses-ip-des-clusters-et-hebergements-web
 section: "Configuration de l'hébergement"
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Dernière mise à jour le 14/04/2023**
+**Dernière mise à jour le 03/05/2023**
 
 Retrouvez dans ce guide toutes les adresses IP des hébergements web OVHcloud. Cela vous permettra par exemple de trouver quelle adresse IP renseigner dans vos zones DNS, en fonction de :
 
@@ -285,11 +285,9 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
 
-
 ```bash
 51.68.11.215
 ```
-
 
 ### Cluster 012
 
@@ -397,7 +395,6 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 51.68.11.227
@@ -575,20 +572,17 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.186
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.23
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 91.134.248.235
@@ -616,13 +610,11 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 213.186.33.187
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
 
 ```bash
 46.105.204.24
@@ -630,11 +622,9 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
 
-
 ```bash
 91.134.248.230
 ```
-
 
 ### Cluster 026
 
@@ -658,20 +648,17 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 188.165.51.93
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.26
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 91.134.248.211
@@ -699,20 +686,17 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 145.239.51.129
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.27
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 54.37.121.239
@@ -740,20 +724,17 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 51.255.119.116
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.28
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 91.134.248.249
@@ -781,20 +762,17 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
  51.255.215.242 
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.29
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 91.134.248.192
@@ -822,20 +800,17 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 54.36.13.47
 ```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.30
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 51.178.146.199
@@ -863,13 +838,11 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.31
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 141.94.87.67
@@ -883,8 +856,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-Si le *CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
+Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 178.32.120.166
@@ -892,13 +864,11 @@ Si le *CDN Legacy** est activé sur votre hébergement, vous devez utiliser cett
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.51
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 51.161.94.36

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
@@ -3,12 +3,12 @@ title: 'Liste des adresses IP des clusters et hebergements web'
 slug: liste-des-adresses-ip-des-clusters-et-hebergements-web
 section: "Configuration de l'hébergement"
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Dernière mise à jour le 07/01/2021**
+**Dernière mise à jour le 14/04/2023**
 
-Vous trouverez dans ce guide toutes les adresses IP des hébergements web OVHcloud. Cela vous permettra par exemple de trouver quelle adresse IP renseigner dans vos zones DNS, en fonction de :
+Retrouvez dans ce guide toutes les adresses IP des hébergements web OVHcloud. Cela vous permettra par exemple de trouver quelle adresse IP renseigner dans vos zones DNS, en fonction de :
 
 - votre cluster
 - vos options (CDN, SSL payant, SSL gratuit...)
@@ -1050,3 +1050,10 @@ Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre héb
 ```bash
 51.161.94.36
 ```
+## Aller plus loin
+
+Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr-ca/directory/).
+
+Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr-ca/support-levels/).
+
+Échangez avec notre communauté d'utilisateurs sur <https://community.ovh.com>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
@@ -62,12 +62,6 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 46.105.204.2
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-46.105.174.33
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
 
 ```bash
@@ -103,12 +97,6 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 
 ```bash
 46.105.204.3
-```
-
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-46.105.174.34
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
@@ -148,12 +136,6 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 46.105.204.5
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-46.105.174.35
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
 
 ```bash
@@ -189,12 +171,6 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 
 ```bash
 46.105.204.6
-```
-
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-46.105.174.36
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
@@ -234,12 +210,6 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 46.105.204.7
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-46.105.174.37
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
 
 ```bash
@@ -275,12 +245,6 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 
 ```bash
 46.105.204.10
-```
-
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-46.105.174.38
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
@@ -320,12 +284,6 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 46.105.204.11
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-46.105.174.39
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
 
 ```bash
@@ -361,12 +319,6 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 
 ```bash
 46.105.204.12
-```
-
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-46.105.174.40
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
@@ -406,12 +358,6 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 46.105.204.13
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-46.105.174.41
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
 
 ```bash
@@ -447,12 +393,6 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 
 ```bash
 46.105.204.14
-```
-
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-46.105.174.42
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
@@ -492,12 +432,6 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 46.105.204.15
 ```
 
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-46.105.174.43
-```
-
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
 
 ```bash
@@ -533,12 +467,6 @@ Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, v
 
 ```bash
 46.105.204.17
-```
-
-Si le **Certificat SSL GlobalSign (payant)** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-46.105.174.44
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
@@ -3,10 +3,10 @@ title: 'Liste des adresses IP des clusters et hebergements web'
 slug: liste-des-adresses-ip-des-clusters-et-hebergements-web
 section: "Configuration de l'hébergement"
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Dernière mise à jour le 14/04/2023**
+**Dernière mise à jour le 03/05/2023**
 
 ## Objectif
 
@@ -839,13 +839,11 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
-
 ```bash
 46.105.204.31
 ```
 
 Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre hébergement (gateway), vous devez utiliser cette adresse IP :
-
 
 ```bash
 141.94.87.67
@@ -859,7 +857,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-Si le *CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 178.32.120.166

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
@@ -877,6 +877,12 @@ Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre héb
 
 ## Aller plus loin
 
+[Mettre en place un multisite sur votre hébergement Web](/pages/web/hosting/multisites_configure_multisite)
+
+[Activer le HTTPS avec votre certificat SSL sur votre hébergement Web](/pages/web/hosting/ssl-activate-https-website)
+
+[Optimiser les performances de votre site Web](/pages/web/hosting/optimise_your_website_performance)
+
 Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/).
 
 Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr/support-levels/).

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
@@ -3,16 +3,16 @@ title: 'Liste des adresses IP des clusters et hebergements web'
 slug: liste-des-adresses-ip-des-clusters-et-hebergements-web
 section: "Configuration de l'hébergement"
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Dernière mise à jour le 07/01/2021**
+**Dernière mise à jour le 14/04/2023**
 
 ## Objectif
 
-Vous trouverez dans ce guide toutes les adresses IP des hébergements web OVHcloud. Cela vous permettra par exemple de trouver quelle adresse IP renseigner dans vos zones DNS, en fonction de :
+Retrouvez dans ce guide toutes les adresses IP des hébergements web OVHcloud. Cela vous permettra par exemple de trouver quelle adresse IP renseigner dans vos zones DNS, en fonction de :
 
-- votre cluster
+- votre cluster/votre hébergement
 - vos options (CDN, SSL payant, SSL gratuit...)
 - le pays recherché ...
 
@@ -951,4 +951,8 @@ Si vous avez besoin de l'adresse IP de la **passerelle de sortie** de votre héb
 
 ## Aller plus loin
 
-Échangez avec notre communauté d’utilisateurs sur [https://community.ovh.com/](https://community.ovh.com/){.external}.
+Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/).
+
+Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr/support-levels/).
+
+Échangez avec notre communauté d'utilisateurs sur <https://community.ovh.com>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.it-it.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.it-it.md
@@ -3,10 +3,10 @@ title: 'Lista degli indirizzi IP di cluster e hosting Web'
 slug: lista-indirizzi-ip-di-cluster-e-hosting-web
 section: Configurazione dell’hosting
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Ultimo aggiornamento: 14/04/2023**
+**Ultimo aggiornamento: 03/05/2023**
 
 > [!primary]
 > Questa traduzione è stata generata automaticamente dal nostro partner SYSTRAN. I contenuti potrebbero presentare imprecisioni, ad esempio la nomenclatura dei pulsanti o alcuni dettagli tecnici. In caso di dubbi consigliamo di fare riferimento alla versione inglese o francese della guida. Per aiutarci a migliorare questa traduzione, utilizza il pulsante "Modifica" di questa pagina.
@@ -67,12 +67,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 46.105.204.2
 ```
 
-Se hai attivato il **Certificato SSL GlobalSign (a pagamento)** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-46.105.174.33
-```
-
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
 
 ```bash
@@ -108,12 +102,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 
 ```bash
 46.105.204.3
-```
-
-Se hai attivato il **Certificato SSL GlobalSign (a pagamento)** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-46.105.174.34
 ```
 
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
@@ -153,12 +141,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 46.105.204.5
 ```
 
-Se hai attivato il **Certificato SSL GlobalSign (a pagamento)** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-46.105.174.35
-```
-
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
 
 ```bash
@@ -194,12 +176,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 
 ```bash
 46.105.204.6
-```
-
-Se hai attivato il **Certificato SSL GlobalSign (a pagamento)** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-46.105.174.36
 ```
 
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
@@ -239,12 +215,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 46.105.204.7
 ```
 
-Se hai attivato il **Certificato SSL GlobalSign (a pagamento)** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-46.105.174.37
-```
-
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
 
 ```bash
@@ -280,12 +250,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 
 ```bash
 46.105.204.10
-```
-
-Se hai attivato il **Certificato SSL GlobalSign (a pagamento)** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-46.105.174.38
 ```
 
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
@@ -325,12 +289,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 46.105.204.11
 ```
 
-Se hai attivato il **Certificato SSL GlobalSign (a pagamento)** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-46.105.174.39
-```
-
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
 
 ```bash
@@ -366,13 +324,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 
 ```bash
 46.105.204.12
-```
-
-Se hai attivato il **Certificato SSL GlobalSign (a pagamento)** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-
-```bash
-46.105.174.40
 ```
 
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
@@ -412,12 +363,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 46.105.204.13
 ```
 
-Se hai attivato il **Certificato SSL GlobalSign (a pagamento)** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-46.105.174.41
-```
-
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
 
 ```bash
@@ -455,12 +400,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 46.105.204.14
 ```
 
-Se hai attivato il **Certificato SSL GlobalSign (a pagamento)** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-46.105.174.42
-```
-
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
 
 ```bash
@@ -494,15 +433,8 @@ Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indi
 
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
-
 ```bash
 46.105.204.15
-```
-
-Se hai attivato il **Certificato SSL GlobalSign (a pagamento)** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-46.105.174.43
 ```
 
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
@@ -542,13 +474,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 46.105.204.17
 ```
 
-Se hai attivato il **Certificato SSL GlobalSign (a pagamento)** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-
-```bash
-46.105.174.44
-```
-
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
 
 ```bash
@@ -558,7 +483,6 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 ### Cluster 020
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
-
 
 |Paese|Codice Paese|IPv4|IPv6|
 |---|---|----|---|
@@ -578,7 +502,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 
 Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
 
-
 ```bash
 213.186.33.176
 ```
@@ -591,16 +514,13 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
 
-
 ```bash
 91.134.248.253
 ```
 
-
 ### Cluster 021
 
 Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la geolocalizzazione):
-
 
 |Paese|Codice Paese|IPv4|IPv6|
 |---|---|----|---|
@@ -619,7 +539,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Belgio|BE|178.32.40.72|2001:41d0:301:10::21|
 
 Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
 
 ```bash
 213.186.33.177
@@ -709,11 +628,9 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
 
-
 ```bash
 91.134.248.230
 ```
-
 
 ### Cluster 026
 
@@ -748,7 +665,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 ```
 
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
-
 
 ```bash
 91.134.248.211
@@ -788,7 +704,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
 
-
 ```bash
 54.37.121.239
 ```
@@ -826,7 +741,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 ```
 
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
-
 
 ```bash
 91.134.248.249
@@ -965,7 +879,6 @@ Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi util
 ```
 
 Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è necessario utilizzare questo indirizzo IP:
-
 
 ```bash
 51.161.94.36

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.it-it.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.it-it.md
@@ -3,10 +3,14 @@ title: 'Lista degli indirizzi IP di cluster e hosting Web'
 slug: lista-indirizzi-ip-di-cluster-e-hosting-web
 section: Configurazione dell’hosting
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Ultimo aggiornamento: 08/01/2021**
+**Ultimo aggiornamento: 14/04/2023**
+
+> [!primary]
+> Questa traduzione è stata generata automaticamente dal nostro partner SYSTRAN. I contenuti potrebbero presentare imprecisioni, ad esempio la nomenclatura dei pulsanti o alcuni dettagli tecnici. In caso di dubbi consigliamo di fare riferimento alla versione inglese o francese della guida. Per aiutarci a migliorare questa traduzione, utilizza il pulsante "Modifica" di questa pagina.
+>
 
 ## Obiettivo
 
@@ -969,4 +973,8 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 ## Per saperne di più
 
-Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/){.external}.
+Per prestazioni specializzate (referenziamento, sviluppo, ecc...), contatta i [partner OVHcloud](https://partner.ovhcloud.com/it/directory/).
+ 
+Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre soluzioni [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
+ 
+Contatta la nostra Community di utenti all'indirizzo <https://community.ovh.com/en/>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.it-it.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.it-it.md
@@ -886,6 +886,12 @@ Se hai bisogno dell’indirizzo IP del **gateway di uscita** del tuo hosting, è
 
 ## Per saperne di più
 
+[Installare un multisito sul tuo hosting Web](/pages/web/hosting/multisites_configure_multisite) 
+
+[Attiva l'HTTPS con il tuo certificato SSL sul tuo hosting Web](/pages/web/hosting/ssl-activate-https-website)
+
+[Ottimizza le performance del tuo sito Web](/pages/web/hosting/optimise_your_website_performance)
+
 Per prestazioni specializzate (referenziamento, sviluppo, ecc...), contatta i [partner OVHcloud](https://partner.ovhcloud.com/it/directory/).
  
 Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre soluzioni [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pl-pl.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pl-pl.md
@@ -883,6 +883,12 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 ## Sprawdź również
 
+[Uruchomienie strony podpiętej w opcji MultiSite na Twoim hostingu](/pages/web/hosting/multisites_configure_multisite)
+
+[Włącz HTTPS za pomocą certyfikatu SSL na Twoim hostingu](/pages/web/hosting/ssl-activate-https-website)
+
+[Zoptymalizuj wydajność swojej strony www](/pages/web/hosting/optimise_your_website_performance)
+
 W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj się z [partnerami OVHcloud](https://partner.ovhcloud.com/pl/directory/).
  
 Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](https://www.ovhcloud.com/pl/support-levels/).

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pl-pl.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pl-pl.md
@@ -3,10 +3,14 @@ title: 'Lista adresów IP klastrów i hostingów WWW'
 slug: lista-adresow-ip-klastrow-i-hostingow-www
 section: 'Konfiguracja hostingu'
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Ostatnia aktualizacja z dnia 08-01-2021**
+**Ostatnia aktualizacja z dnia 14-04-2023**
+
+> [!primary]
+> Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera SYSTRAN. W niektórych przypadkach mogą wystąpić nieprecyzyjne sformułowania, na przykład w tłumaczeniu nazw przycisków lub szczegółów technicznych. W przypadku jakichkolwiek wątpliwości zalecamy zapoznanie się z angielską/francuską wersją przewodnika. Jeśli chcesz przyczynić się do ulepszenia tłumaczenia, kliknij przycisk „Zaproponuj zmianę” na tej stronie.
+>
 
 ## Wprowadzenie 
 
@@ -952,4 +956,8 @@ Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj po
 
 ## Sprawdź również
 
-Przyłącz się do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.
+W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj się z [partnerami OVHcloud](https://partner.ovhcloud.com/pl/directory/).
+ 
+Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](https://www.ovhcloud.com/pl/support-levels/).
+ 
+Dołącz do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pl-pl.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pl-pl.md
@@ -3,10 +3,10 @@ title: 'Lista adresów IP klastrów i hostingów WWW'
 slug: lista-adresow-ip-klastrow-i-hostingow-www
 section: 'Konfiguracja hostingu'
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Ostatnia aktualizacja z dnia 14-04-2023**
+**Ostatnia aktualizacja z dnia 03-05-2023**
 
 > [!primary]
 > Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera SYSTRAN. W niektórych przypadkach mogą wystąpić nieprecyzyjne sformułowania, na przykład w tłumaczeniu nazw przycisków lub szczegółów technicznych. W przypadku jakichkolwiek wątpliwości zalecamy zapoznanie się z angielską/francuską wersją przewodnika. Jeśli chcesz przyczynić się do ulepszenia tłumaczenia, kliknij przycisk „Zaproponuj zmianę” na tej stronie.
@@ -67,12 +67,6 @@ Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj 
 46.105.204.2
 ```
 
-Jeśli w hostingu masz aktywny **certyfikat SSL GlobalSign (płatny)**, użyj poniższego adresu IP:
-
-```bash
-46.105.174.33
-```
-
 Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj poniższego adresu IP:
 
 ```bash
@@ -108,12 +102,6 @@ Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj 
 
 ```bash
 46.105.204.3
-```
-
-Jeśli w hostingu masz aktywny **certyfikat SSL GlobalSign (płatny)**, użyj poniższego adresu IP:
-
-```bash
-46.105.174.34
 ```
 
 Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj poniższego adresu IP:
@@ -153,12 +141,6 @@ Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj 
 46.105.204.5
 ```
 
-Jeśli w hostingu masz aktywny **certyfikat SSL GlobalSign (płatny)**, użyj poniższego adresu IP:
-
-```bash
-46.105.174.35
-```
-
 Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj poniższego adresu IP:
 
 ```bash
@@ -194,12 +176,6 @@ Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj 
 
 ```bash
 46.105.204.6
-```
-
-Jeśli w hostingu masz aktywny **certyfikat SSL GlobalSign (płatny)**, użyj poniższego adresu IP:
-
-```bash
-46.105.174.36
 ```
 
 Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj poniższego adresu IP:
@@ -239,12 +215,6 @@ Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj 
 46.105.204.7
 ```
 
-Jeśli w hostingu masz aktywny **certyfikat SSL GlobalSign (płatny)**, użyj poniższego adresu IP:
-
-```bash
-46.105.174.37
-```
-
 Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj poniższego adresu IP:
 
 ```bash
@@ -280,12 +250,6 @@ Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj 
 
 ```bash
 46.105.204.10
-```
-
-Jeśli w hostingu masz aktywny **certyfikat SSL GlobalSign (płatny)**, użyj poniższego adresu IP:
-
-```bash
-46.105.174.38
 ```
 
 Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj poniższego adresu IP:
@@ -326,12 +290,6 @@ Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj 
 46.105.204.11
 ```
 
-Jeśli w hostingu masz aktywny **certyfikat SSL GlobalSign (płatny)**, użyj poniższego adresu IP:
-
-```bash
-46.105.174.39
-```
-
 Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj poniższego adresu IP:
 
 ```bash
@@ -367,12 +325,6 @@ Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj 
 
 ```bash
 46.105.204.12
-```
-
-Jeśli w hostingu masz aktywny **certyfikat SSL GlobalSign (płatny)**, użyj poniższego adresu IP:
-
-```bash
-46.105.174.40
 ```
 
 Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj poniższego adresu IP:
@@ -412,12 +364,6 @@ Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj 
 46.105.204.13
 ```
 
-Jeśli w hostingu masz aktywny **certyfikat SSL GlobalSign (płatny)**, użyj poniższego adresu IP:
-
-```bash
-46.105.174.41
-```
-
 Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj poniższego adresu IP:
 
 ```bash
@@ -453,12 +399,6 @@ Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj 
 
 ```bash
 46.105.204.14
-```
-
-Jeśli w hostingu masz aktywny **certyfikat SSL GlobalSign (płatny)**, użyj poniższego adresu IP:
-
-```bash
-46.105.174.42
 ```
 
 Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj poniższego adresu IP:
@@ -498,12 +438,6 @@ Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj 
 46.105.204.15
 ```
 
-Jeśli w hostingu masz aktywny **certyfikat SSL GlobalSign (płatny)**, użyj poniższego adresu IP:
-
-```bash
-46.105.174.43
-```
-
 Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj poniższego adresu IP:
 
 ```bash
@@ -539,12 +473,6 @@ Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj 
 
 ```bash
 46.105.204.17
-```
-
-Jeśli w hostingu masz aktywny **certyfikat SSL GlobalSign (płatny)**, użyj poniższego adresu IP:
-
-```bash
-46.105.174.44
 ```
 
 Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj poniższego adresu IP:
@@ -852,7 +780,6 @@ Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj 
 ```
 
 Jeśli potrzebujesz adresu IP **bramy wyjściowej** hostingu (gateway), użyj poniższego adresu IP:
-
 
 ```bash
 91.134.248.192

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pt-pt.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pt-pt.md
@@ -3,10 +3,10 @@ title: 'Lista dos endereços IP dos clusters e alojamentos web'
 slug: lista-dos-enderecos-ip-dos-clusters-e-alojamentos-web
 section: Configuração do alojamento
 order: 01
-updated: 2023-04-14
+updated: 2023-05-03
 ---
 
-**Última atualização: 14/04/2023**
+**Última atualização: 03/05/2023**
 
 > [!primary]
 > Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certos casos, poderão ocorrer formulações imprecisas, como por exemplo nomes de botões ou detalhes técnicos. Recomendamos que consulte a versão inglesa ou francesa do manual, caso tenha alguma dúvida. Se nos quiser ajudar a melhorar esta tradução, clique em "Contribuir" nesta página.
@@ -67,12 +67,6 @@ Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, 
 46.105.204.2
 ```
 
-Se tem o certificado **SSL GlobalSign (pago)** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-46.105.174.33
-```
-
 Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve utilizar o seguinte endereço IP:
 
 ```bash
@@ -110,12 +104,6 @@ Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, 
 46.105.204.3
 ```
 
-Se tem o certificado **SSL GlobalSign (pago)** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-46.105.174.34
-```
-
 Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve utilizar o seguinte endereço IP:
 
 ```bash
@@ -125,7 +113,6 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 ### Cluster 005
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
-
 
 |País|Código de país|IPv4|IPv6|
 |---|---|----|---|
@@ -154,12 +141,6 @@ Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, 
 46.105.204.5
 ```
 
-Se tem o certificado **SSL GlobalSign (pago)** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-46.105.174.35
-```
-
 Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve utilizar o seguinte endereço IP:
 
 ```bash
@@ -169,7 +150,6 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 ### Cluster 006
 
 De seguida indicamos os endereços IP do **cluster** para cada país (tendo em vista a geolocalização):
-
 
 |País|Código de país|IPv4|IPv6|
 |---|---|----|---|
@@ -196,12 +176,6 @@ Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, 
 
 ```bash
 46.105.204.6
-```
-
-Se tem o certificado **SSL GlobalSign (pago)** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-46.105.174.36
 ```
 
 Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve utilizar o seguinte endereço IP:
@@ -241,12 +215,6 @@ Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, 
 46.105.204.7
 ```
 
-Se tem o certificado **SSL GlobalSign (pago)** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-46.105.174.37
-```
-
 Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve utilizar o seguinte endereço IP:
 
 ```bash
@@ -282,12 +250,6 @@ Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, 
 
 ```bash
 46.105.204.10
-```
-
-Se tem o certificado **SSL GlobalSign (pago)** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-46.105.174.38
 ```
 
 Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve utilizar o seguinte endereço IP:
@@ -327,12 +289,6 @@ Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, 
 46.105.204.11
 ```
 
-Se tem o certificado **SSL GlobalSign (pago)** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-46.105.174.39
-```
-
 Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve utilizar o seguinte endereço IP:
 
 ```bash
@@ -368,12 +324,6 @@ Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, 
 
 ```bash
 46.105.204.12
-```
-
-Se tem o certificado **SSL GlobalSign (pago)** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-46.105.174.40
 ```
 
 Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve utilizar o seguinte endereço IP:
@@ -413,12 +363,6 @@ Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, 
 46.105.204.13
 ```
 
-Se tem o certificado **SSL GlobalSign (pago)** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-46.105.174.41
-```
-
 Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve utilizar o seguinte endereço IP:
 
 ```bash
@@ -454,12 +398,6 @@ Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, 
 
 ```bash
 46.105.204.14
-```
-
-Se tem o certificado **SSL GlobalSign (pago)** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-46.105.174.42
 ```
 
 Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve utilizar o seguinte endereço IP:
@@ -499,12 +437,6 @@ Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, 
 46.105.204.15
 ```
 
-Se tem o certificado **SSL GlobalSign (pago)** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-46.105.174.43
-```
-
 Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve utilizar o seguinte endereço IP:
 
 ```bash
@@ -540,12 +472,6 @@ Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, 
 
 ```bash
 46.105.204.17
-```
-
-Se tem o certificado **SSL GlobalSign (pago)** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-46.105.174.44
 ```
 
 Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve utilizar o seguinte endereço IP:

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pt-pt.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pt-pt.md
@@ -3,12 +3,16 @@ title: 'Lista dos endereços IP dos clusters e alojamentos web'
 slug: lista-dos-enderecos-ip-dos-clusters-e-alojamentos-web
 section: Configuração do alojamento
 order: 01
-updated: 2021-01-08
+updated: 2023-04-14
 ---
 
-**Última atualização: 08/01/2021**
+**Última atualização: 14/04/2023**
 
-## Sumário
+> [!primary]
+> Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certos casos, poderão ocorrer formulações imprecisas, como por exemplo nomes de botões ou detalhes técnicos. Recomendamos que consulte a versão inglesa ou francesa do manual, caso tenha alguma dúvida. Se nos quiser ajudar a melhorar esta tradução, clique em "Contribuir" nesta página.
+>
+
+## Objetivo
 
 Neste guia encontrará todos os endereços IP dos alojamentos web OVHcloud. Assim, poderá nomeadamente encontrar o endereço IP a indicar nas zonas DNS em função:
 
@@ -952,4 +956,8 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 ## Quer saber mais?
 
-Ou fale com a nossa comunidade de utilizadores: <https://community.ovh.com/en/>.
+Para serviços especializados (referenciamento, desenvolvimento, etc), contacte os [parceiros OVHcloud](https://partner.ovhcloud.com/pt/directory/).
+ 
+Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
+ 
+Fale com nossa comunidade de utilizadores: <https://community.ovh.com/en/>.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pt-pt.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pt-pt.md
@@ -882,6 +882,12 @@ Se precisa do endereço IP da **porta de saída** (gateway) do alojamento, deve 
 
 ## Quer saber mais?
 
+[Implementar um multi-site no seu alojamento Web](/pages/web/hosting/multisites_configure_multisite)
+
+[Ativar o HTTPS com o seu certificado SSL no seu alojamento Web](/pages/web/hosting/ssl-activate-https-website)
+
+[Otimizar as performances do seu website](/pages/web/hosting/optimise_your_website_performance)
+
 Para serviços especializados (referenciamento, desenvolvimento, etc), contacte os [parceiros OVHcloud](https://partner.ovhcloud.com/pt/directory/).
  
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).


### PR DESCRIPTION
Updates for all subs : 

- Deletion of paragraph about SSL GS from cluster 002 to 020
- Add 3 links in go further
- uniformization of the go furthers
- Title corrections and uniformization => ## => ### based on FRFR version
- add translation paragraph
- Delete double spaces
- correction of syntaxes mistakes => *CDN** => **CDN** for example

Need proof before merge 