### PR TITLE
fix: iam-policies-api: urn format

### DIFF
--- a/pages/account/customer/iam-policies-api/guide.de-de.md
+++ b/pages/account/customer/iam-policies-api/guide.de-de.md
@@ -113,7 +113,7 @@ Items in policies are defined by URNs. These URNs are defined by the following p
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identity, resource, resourceGroup|:|<p>For **identity** type: account, user, group</p><p>For **resource** type: any resourceType</p>|:|Alphanumerical value|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Policy attributes
@@ -161,7 +161,7 @@ For example, create a policy to authorise a user named "*user1*" to do some acti
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -211,7 +211,7 @@ Check it via `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -229,7 +229,7 @@ Check it via `GET /iam/policy`:
 ]
 ```
 
-The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identities
 
@@ -343,7 +343,7 @@ See all the resources linked to the OVHcloud account by calling:
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -351,7 +351,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -359,7 +359,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.de-de.md
+++ b/pages/account/customer/iam-policies-api/guide.de-de.md
@@ -4,12 +4,12 @@ slug: iam-policies-api
 excerpt: "Find out how to give specific access rights to users from an OVHcloud account"
 section: 'Fortgeschrittene Nutzung'
 order: 03
-updated: 2023-03-01
+updated: 2023-05-16
 routes:
     canonical: 'https://docs.ovh.com/gb/en/customer/iam-policies-api/'
 ---
 
-**Last updated 1st March 2023**
+**Last updated 16th May 2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.en-asia.md
+++ b/pages/account/customer/iam-policies-api/guide.en-asia.md
@@ -4,10 +4,10 @@ slug: iam-policies-api
 excerpt: "Find out how to give specific access rights to users from an OVHcloud account"
 section: 'Advanced use'
 order: 03
-updated: 2023-03-01
+updated: 2023-05-16
 ---
 
-**Last updated 1st March 2023**
+**Last updated 16th May 2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.en-asia.md
+++ b/pages/account/customer/iam-policies-api/guide.en-asia.md
@@ -111,7 +111,7 @@ Items in policies are defined by URNs. These URNs are defined by the following p
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identity, resource, resourceGroup|:|<p>For **identity** type: account, user, group</p><p>For **resource** type: any resourceType</p>|:|Alphanumerical value|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Policy attributes
@@ -159,7 +159,7 @@ For example, create a policy to authorise a user named "*user1*" to do some acti
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -209,7 +209,7 @@ Check it via `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -227,7 +227,7 @@ Check it via `GET /iam/policy`:
 ]
 ```
 
-The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identities
 
@@ -341,7 +341,7 @@ See all the resources linked to the OVHcloud account by calling:
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -349,7 +349,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -357,7 +357,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.en-au.md
+++ b/pages/account/customer/iam-policies-api/guide.en-au.md
@@ -4,10 +4,10 @@ slug: iam-policies-api
 excerpt: "Find out how to give specific access rights to users from an OVHcloud account"
 section: 'Advanced use'
 order: 03
-updated: 2023-03-01
+updated: 2023-05-16
 ---
 
-**Last updated 1st March 2023**
+**Last updated 16th May 2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.en-au.md
+++ b/pages/account/customer/iam-policies-api/guide.en-au.md
@@ -111,7 +111,7 @@ Items in policies are defined by URNs. These URNs are defined by the following p
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identity, resource, resourceGroup|:|<p>For **identity** type: account, user, group</p><p>For **resource** type: any resourceType</p>|:|Alphanumerical value|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Policy attributes
@@ -159,7 +159,7 @@ For example, create a policy to authorise a user named "*user1*" to do some acti
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -209,7 +209,7 @@ Check it via `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -227,7 +227,7 @@ Check it via `GET /iam/policy`:
 ]
 ```
 
-The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identities
 
@@ -341,7 +341,7 @@ See all the resources linked to the OVHcloud account by calling:
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -349,7 +349,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -357,7 +357,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.en-ca.md
+++ b/pages/account/customer/iam-policies-api/guide.en-ca.md
@@ -4,10 +4,10 @@ slug: iam-policies-api
 excerpt: "Find out how to give specific access rights to users from an OVHcloud account"
 section: 'Advanced use'
 order: 03
-updated: 2023-03-01
+updated: 2023-05-16
 ---
 
-**Last updated 1st March 2023**
+**Last updated 16th May 2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.en-ca.md
+++ b/pages/account/customer/iam-policies-api/guide.en-ca.md
@@ -111,7 +111,7 @@ Items in policies are defined by URNs. These URNs are defined by the following p
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identity, resource, resourceGroup|:|<p>For **identity** type: account, user, group</p><p>For **resource** type: any resourceType</p>|:|Alphanumerical value|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Policy attributes
@@ -159,7 +159,7 @@ For example, create a policy to authorise a user named "*user1*" to do some acti
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -209,7 +209,7 @@ Check it via `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -227,7 +227,7 @@ Check it via `GET /iam/policy`:
 ]
 ```
 
-The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identities
 
@@ -341,7 +341,7 @@ See all the resources linked to the OVHcloud account by calling:
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -349,7 +349,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -357,7 +357,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.en-gb.md
+++ b/pages/account/customer/iam-policies-api/guide.en-gb.md
@@ -4,10 +4,10 @@ slug: iam-policies-api
 excerpt: "Find out how to give specific access rights to users from an OVHcloud account"
 section: 'Advanced use'
 order: 03
-updated: 2023-03-01
+updated: 2023-05-16
 ---
 
-**Last updated 1st March 2023**
+**Last updated 16th May 2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.en-gb.md
+++ b/pages/account/customer/iam-policies-api/guide.en-gb.md
@@ -111,7 +111,7 @@ Items in policies are defined by URNs. These URNs are defined by the following p
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identity, resource, resourceGroup|:|<p>For **identity** type: account, user, group</p><p>For **resource** type: any resourceType</p>|:|Alphanumerical value|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Policy attributes
@@ -159,7 +159,7 @@ For example, create a policy to authorise a user named "*user1*" to do some acti
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -209,7 +209,7 @@ Check it via `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -227,7 +227,7 @@ Check it via `GET /iam/policy`:
 ]
 ```
 
-The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identities
 
@@ -341,7 +341,7 @@ See all the resources linked to the OVHcloud account by calling:
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -349,7 +349,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -357,7 +357,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.en-ie.md
+++ b/pages/account/customer/iam-policies-api/guide.en-ie.md
@@ -4,10 +4,10 @@ slug: iam-policies-api
 excerpt: "Find out how to give specific access rights to users from an OVHcloud account"
 section: 'Advanced use'
 order: 03
-updated: 2023-03-01
+updated: 2023-05-16
 ---
 
-**Last updated 1st March 2023**
+**Last updated 16th May 2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.en-ie.md
+++ b/pages/account/customer/iam-policies-api/guide.en-ie.md
@@ -111,7 +111,7 @@ Items in policies are defined by URNs. These URNs are defined by the following p
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identity, resource, resourceGroup|:|<p>For **identity** type: account, user, group</p><p>For **resource** type: any resourceType</p>|:|Alphanumerical value|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Policy attributes
@@ -159,7 +159,7 @@ For example, create a policy to authorise a user named "*user1*" to do some acti
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -209,7 +209,7 @@ Check it via `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -227,7 +227,7 @@ Check it via `GET /iam/policy`:
 ]
 ```
 
-The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identities
 
@@ -341,7 +341,7 @@ See all the resources linked to the OVHcloud account by calling:
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -349,7 +349,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -357,7 +357,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.en-sg.md
+++ b/pages/account/customer/iam-policies-api/guide.en-sg.md
@@ -4,10 +4,10 @@ slug: iam-policies-api
 excerpt: "Find out how to give specific access rights to users from an OVHcloud account"
 section: 'Advanced use'
 order: 03
-updated: 2023-03-01
+updated: 2023-05-16
 ---
 
-**Last updated 1st March 2023**
+**Last updated 16th May 2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.en-sg.md
+++ b/pages/account/customer/iam-policies-api/guide.en-sg.md
@@ -111,7 +111,7 @@ Items in policies are defined by URNs. These URNs are defined by the following p
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identity, resource, resourceGroup|:|<p>For **identity** type: account, user, group</p><p>For **resource** type: any resourceType</p>|:|Alphanumerical value|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Policy attributes
@@ -159,7 +159,7 @@ For example, create a policy to authorise a user named "*user1*" to do some acti
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -209,7 +209,7 @@ Check it via `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -227,7 +227,7 @@ Check it via `GET /iam/policy`:
 ]
 ```
 
-The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identities
 
@@ -341,7 +341,7 @@ See all the resources linked to the OVHcloud account by calling:
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -349,7 +349,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -357,7 +357,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.en-us.md
+++ b/pages/account/customer/iam-policies-api/guide.en-us.md
@@ -4,10 +4,10 @@ slug: iam-policies-api
 excerpt: "Find out how to give specific access rights to users from an OVHcloud account"
 section: 'Advanced use'
 order: 03
-updated: 2023-03-01
+updated: 2023-05-16
 ---
 
-**Last updated 1st March 2023**
+**Last updated 16th May 2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.en-us.md
+++ b/pages/account/customer/iam-policies-api/guide.en-us.md
@@ -111,7 +111,7 @@ Items in policies are defined by URNs. These URNs are defined by the following p
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identity, resource, resourceGroup|:|<p>For **identity** type: account, user, group</p><p>For **resource** type: any resourceType</p>|:|Alphanumerical value|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Policy attributes
@@ -159,7 +159,7 @@ For example, create a policy to authorise a user named "*user1*" to do some acti
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -209,7 +209,7 @@ Check it via `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -227,7 +227,7 @@ Check it via `GET /iam/policy`:
 ]
 ```
 
-The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identities
 
@@ -341,7 +341,7 @@ See all the resources linked to the OVHcloud account by calling:
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -349,7 +349,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -357,7 +357,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.es-es.md
+++ b/pages/account/customer/iam-policies-api/guide.es-es.md
@@ -4,12 +4,12 @@ slug: iam-policies-api
 excerpt: "Find out how to give specific access rights to users from an OVHcloud account"
 section: 'Uso avanzado'
 order: 03
-updated: 2023-03-01
+updated: 2023-05-16
 routes:
     canonical: 'https://docs.ovh.com/gb/en/customer/iam-policies-api/'
 ---
 
-**Last updated 1st March 2023**
+**Last updated 16th May 2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.es-es.md
+++ b/pages/account/customer/iam-policies-api/guide.es-es.md
@@ -113,7 +113,7 @@ Items in policies are defined by URNs. These URNs are defined by the following p
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identity, resource, resourceGroup|:|<p>For **identity** type: account, user, group</p><p>For **resource** type: any resourceType</p>|:|Alphanumerical value|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Policy attributes
@@ -161,7 +161,7 @@ For example, create a policy to authorise a user named "*user1*" to do some acti
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -211,7 +211,7 @@ Check it via `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -229,7 +229,7 @@ Check it via `GET /iam/policy`:
 ]
 ```
 
-The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identities
 
@@ -343,7 +343,7 @@ See all the resources linked to the OVHcloud account by calling:
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -351,7 +351,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -359,7 +359,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.es-us.md
+++ b/pages/account/customer/iam-policies-api/guide.es-us.md
@@ -4,12 +4,12 @@ slug: iam-policies-api
 excerpt: "Find out how to give specific access rights to users from an OVHcloud account"
 section: 'Uso avanzado'
 order: 03
-updated: 2023-03-01
+updated: 2023-05-16
 routes:
     canonical: 'https://docs.ovh.com/gb/en/customer/iam-policies-api/'
 ---
 
-**Last updated 1st March 2023**
+**Last updated 16th May 2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.es-us.md
+++ b/pages/account/customer/iam-policies-api/guide.es-us.md
@@ -113,7 +113,7 @@ Items in policies are defined by URNs. These URNs are defined by the following p
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identity, resource, resourceGroup|:|<p>For **identity** type: account, user, group</p><p>For **resource** type: any resourceType</p>|:|Alphanumerical value|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Policy attributes
@@ -161,7 +161,7 @@ For example, create a policy to authorise a user named "*user1*" to do some acti
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -211,7 +211,7 @@ Check it via `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -229,7 +229,7 @@ Check it via `GET /iam/policy`:
 ]
 ```
 
-The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identities
 
@@ -343,7 +343,7 @@ See all the resources linked to the OVHcloud account by calling:
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -351,7 +351,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -359,7 +359,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.fr-ca.md
+++ b/pages/account/customer/iam-policies-api/guide.fr-ca.md
@@ -4,10 +4,10 @@ slug: iam-policies-api
 excerpt: "Découvrez comment donner des droits d'accès spécifiques aux utilisateurs d'un compte OVHcloud"
 section: 'Utilisation avancée'
 order: 03
-updated: 2023-03-07
+updated: 2023-05-16
 ---
 
-**Dernière mise à jour le 07/03/2023**
+**Dernière mise à jour le 16/05/2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.fr-ca.md
+++ b/pages/account/customer/iam-policies-api/guide.fr-ca.md
@@ -111,7 +111,7 @@ Les éléments des politiques sont définis par des URNs. Ces URNs sont définie
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identité, ressource, resourceGroup|:|<p>Pour le type **identity** : account, user, group</p><p>Pour le type **resource** : tous les types de ressources</p>|:|Valeur alphanumérique|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Attributs d'une politique
@@ -159,7 +159,7 @@ Par exemple, créez une politique autorisant l'utilisateur nommé "*user1*" à f
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -209,7 +209,7 @@ Vérifiez cela avec `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -227,7 +227,7 @@ Vérifiez cela avec `GET /iam/policy`:
 ]
 ```
 
-La politique a été créée avec succès. Maintenant, "***user1***" peut **effectuer des redémarrages et créer des sauvegardes (snapshots))** sur le VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+La politique a été créée avec succès. Maintenant, "***user1***" peut **effectuer des redémarrages et créer des sauvegardes (snapshots))** sur le VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identités
 
@@ -341,7 +341,7 @@ Visualisez toutes les ressources liées au compte OVHcloud en appelant :
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -349,7 +349,7 @@ Visualisez toutes les ressources liées au compte OVHcloud en appelant :
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -357,7 +357,7 @@ Visualisez toutes les ressources liées au compte OVHcloud en appelant :
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.fr-fr.md
+++ b/pages/account/customer/iam-policies-api/guide.fr-fr.md
@@ -4,10 +4,10 @@ slug: iam-policies-api
 excerpt: "Découvrez comment donner des droits d'accès spécifiques aux utilisateurs d'un compte OVHcloud"
 section: 'Utilisation avancée'
 order: 03
-updated: 2023-03-07
+updated: 2023-05-16
 ---
 
-**Dernière mise à jour le 07/03/2023**
+**Dernière mise à jour le 16/05/2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.fr-fr.md
+++ b/pages/account/customer/iam-policies-api/guide.fr-fr.md
@@ -111,7 +111,7 @@ Les éléments des politiques sont définis par des URNs. Ces URNs sont définie
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identité, ressource, resourceGroup|:|<p>Pour le type **identity** : account, user, group</p><p>Pour le type **resource** : tous les types de ressources</p>|:|Valeur alphanumérique|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Attributs d'une politique
@@ -159,7 +159,7 @@ Par exemple, créez une politique autorisant l'utilisateur nommé "*user1*" à f
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -209,7 +209,7 @@ Vérifiez cela avec `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -227,7 +227,7 @@ Vérifiez cela avec `GET /iam/policy`:
 ]
 ```
 
-La politique a été créée avec succès. Maintenant, "***user1***" peut **effectuer des redémarrages et créer des sauvegardes (snapshots))** sur le VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+La politique a été créée avec succès. Maintenant, "***user1***" peut **effectuer des redémarrages et créer des sauvegardes (snapshots))** sur le VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identités
 
@@ -341,7 +341,7 @@ Visualisez toutes les ressources liées au compte OVHcloud en appelant :
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -349,7 +349,7 @@ Visualisez toutes les ressources liées au compte OVHcloud en appelant :
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -357,7 +357,7 @@ Visualisez toutes les ressources liées au compte OVHcloud en appelant :
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.it-it.md
+++ b/pages/account/customer/iam-policies-api/guide.it-it.md
@@ -4,12 +4,12 @@ slug: iam-policies-api
 excerpt: "Find out how to give specific access rights to users from an OVHcloud account"
 section: 'Utilizzo avanzato'
 order: 03
-updated: 2023-03-01
+updated: 2023-05-16
 routes:
     canonical: 'https://docs.ovh.com/gb/en/customer/iam-policies-api/'
 ---
 
-**Last updated 1st March 2023**
+**Last updated 16th May 2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.it-it.md
+++ b/pages/account/customer/iam-policies-api/guide.it-it.md
@@ -113,7 +113,7 @@ Items in policies are defined by URNs. These URNs are defined by the following p
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identity, resource, resourceGroup|:|<p>For **identity** type: account, user, group</p><p>For **resource** type: any resourceType</p>|:|Alphanumerical value|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Policy attributes
@@ -161,7 +161,7 @@ For example, create a policy to authorise a user named "*user1*" to do some acti
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -211,7 +211,7 @@ Check it via `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -229,7 +229,7 @@ Check it via `GET /iam/policy`:
 ]
 ```
 
-The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identities
 
@@ -343,7 +343,7 @@ See all the resources linked to the OVHcloud account by calling:
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -351,7 +351,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -359,7 +359,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.pl-pl.md
+++ b/pages/account/customer/iam-policies-api/guide.pl-pl.md
@@ -4,12 +4,12 @@ slug: iam-policies-api
 excerpt: "Find out how to give specific access rights to users from an OVHcloud account"
 section: 'Poziom zaawansowany'
 order: 03
-updated: 2023-03-01
+updated: 2023-05-16
 routes:
     canonical: 'https://docs.ovh.com/gb/en/customer/iam-policies-api/'
 ---
 
-**Last updated 1st March 2023**
+**Last updated 16th May 2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.pl-pl.md
+++ b/pages/account/customer/iam-policies-api/guide.pl-pl.md
@@ -113,7 +113,7 @@ Items in policies are defined by URNs. These URNs are defined by the following p
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identity, resource, resourceGroup|:|<p>For **identity** type: account, user, group</p><p>For **resource** type: any resourceType</p>|:|Alphanumerical value|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Policy attributes
@@ -161,7 +161,7 @@ For example, create a policy to authorise a user named "*user1*" to do some acti
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -211,7 +211,7 @@ Check it via `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -229,7 +229,7 @@ Check it via `GET /iam/policy`:
 ]
 ```
 
-The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identities
 
@@ -343,7 +343,7 @@ See all the resources linked to the OVHcloud account by calling:
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -351,7 +351,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -359,7 +359,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",

--- a/pages/account/customer/iam-policies-api/guide.pt-pt.md
+++ b/pages/account/customer/iam-policies-api/guide.pt-pt.md
@@ -4,12 +4,12 @@ slug: iam-policies-api
 excerpt: "Find out how to give specific access rights to users from an OVHcloud account"
 section: 'Utilização avançada'
 order: 03
-updated: 2023-03-01
+updated: 2023-05-16
 routes:
     canonical: 'https://docs.ovh.com/gb/en/customer/iam-policies-api/'
 ---
 
-**Last updated 1st March 2023**
+**Last updated 16th May 2023**
 
 > [!warning]
 >

--- a/pages/account/customer/iam-policies-api/guide.pt-pt.md
+++ b/pages/account/customer/iam-policies-api/guide.pt-pt.md
@@ -113,7 +113,7 @@ Items in policies are defined by URNs. These URNs are defined by the following p
 |**Possible values**|urn|:|v1|:|eu, ca, us|:|identity, resource, resourceGroup|:|<p>For **identity** type: account, user, group</p><p>For **resource** type: any resourceType</p>|:|Alphanumerical value|
 |**Account ID Example**|urn|:|v1|:|eu|:|identity|:|account|:|xx1111-ovh|
 |**User group Example**|urn|:|v1|:|eu|:|identity|:|group|:|xx1111-ovh/admin@mycompany.com|
-|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|b96ffed4-3467-4129-b8be-39a3eb3a0a93|
+|**VPS Example**|urn|:|v1|:|ca|:|resource|:|vps|:|vps-5b48d78b.vps.ovh.net|
 |**Resource Group Example**|urn|:|v1|:|us|:|resourceGroup|||:|aa0713ab-ed13-4f1a-89a5-32aa0cb936d8|
 
 #### Policy attributes
@@ -161,7 +161,7 @@ For example, create a policy to authorise a user named "*user1*" to do some acti
     },
     "resources": [
         {
-            "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+            "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
         }
     ]
 }
@@ -211,7 +211,7 @@ Check it via `GET /iam/policy`:
         ],
         "resources": [
             {
-                "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93"
+                "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net"
             }
         ],
         "permissions": {
@@ -229,7 +229,7 @@ Check it via `GET /iam/policy`:
 ]
 ```
 
-The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93***".
+The policy has been created successfully. Now, "***user1***" can **carry out reboots and create snapshots** on the VPS "***urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net***".
 
 ### Identities
 
@@ -343,7 +343,7 @@ See all the resources linked to the OVHcloud account by calling:
 [
   {
     "id": "b96ffed4-3467-4129-b8be-39a3eb3a0a93",
-    "urn": "urn:v1:eu:resource:vps:b96ffed4-3467-4129-b8be-39a3eb3a0a93",
+    "urn": "urn:v1:eu:resource:vps:vps-5b48d78b.vps.ovh.net",
     "name": "vps-5b48d78b.vps.ovh.net",
     "displayName": "vps-5b48d78b.vps.ovh.net",
     "type": "vps",
@@ -351,7 +351,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "c24ace5e-6c9c-436b-9a73-515db8df6250",
-    "urn": "urn:v1:eu:resource:emailDomain:c24ace5e-6c9c-436b-9a73-515db8df6250",
+    "urn": "urn:v1:eu:resource:emailDomain:acme.com",
     "name": "acme.com",
     "displayName": "acme.com",
     "type": "emailDomain",
@@ -359,7 +359,7 @@ See all the resources linked to the OVHcloud account by calling:
   },
   {
     "id": "8d70a49b-7a8b-4ec0-ad4b-756da802d994",
-    "urn": "urn:v1:eu:resource:cdn:8d70a49b-7a8b-4ec0-ad4b-756da802d994",
+    "urn": "urn:v1:eu:resource:cdn:cdn-46.105.198.89-12969",
     "name": "cdn-46.105.198.89-12969",
     "displayName": "cdn-46.105.198.89-12969",
     "type": "cdn",


### PR DESCRIPTION
| Question         | Answer
| ---------------- | ---
| Branch?          |  fix/iam-policies-urn-format
| Doc fix?         |  yes
| New doc?     |  no
| Breaking change? |  no
| Tickets          |  ECIAM-631
| License          |  BSD 3-Clause

## Description

Following the decision to change the resource URN format from using a random ID to using the serviceName, the documentation [How to use IAM policies using the OVHcloud API](https://help.ovhcloud.com/csm/en-gb-customer-iam-policies-api?id=kb_article_view&sysparm_article=KB0056801) has to be updated.


The following examples should be adapted :

- b96ffed4-3467-4129-b8be-39a3eb3a0a93 => vps-5b48d78b.vps.ovh.net
- c24ace5e-6c9c-436b-9a73-515db8df6250 => acme.com
- 8d70a49b-7a8b-4ec0-ad4b-756da802d994 => cdn-46.105.198.89-12969

## Related

### :book: Documentation

- https://github.com/ovh/docs/pull/4286

