### PR TITLE
Object Storage - S3 website HTTPS - Minor fix for FR versions

### DIFF
--- a/pages/cloud/storage/object_storage/s3_website_https/guide.fr-ca.md
+++ b/pages/cloud/storage/object_storage/s3_website_https/guide.fr-ca.md
@@ -121,7 +121,7 @@ Ajouter 2 frontends :
     - datacenter : la région où se trouve votre bucket
     - ferme de serveurs par défaut : la ferme de serveurs créée au préalable
     - certificate: le certificat que vous avez créé
-    - paramètres avancés > HTTP Header : Hôte `<default_website_url>` sous la forme `<bucket>.s3-website.<region>.io.cloud.ovh.net`
+    - paramètres avancés > HTTP Header : Host `<default_website_url>` sous la forme `<bucket>.s3-website.<region>.io.cloud.ovh.net`
 
 ![configuration du frontend](images/front-2.PNG){.thumbnail}
 

--- a/pages/cloud/storage/object_storage/s3_website_https/guide.fr-fr.md
+++ b/pages/cloud/storage/object_storage/s3_website_https/guide.fr-fr.md
@@ -121,7 +121,7 @@ Ajouter 2 frontends :
     - datacenter : la région où se trouve votre bucket
     - ferme de serveurs par défaut : la ferme de serveurs créée au préalable
     - certificate: le certificat que vous avez créé
-    - paramètres avancés > HTTP Header : Hôte `<default_website_url>` sous la forme `<bucket>.s3-website.<region>.io.cloud.ovh.net`
+    - paramètres avancés > HTTP Header : Host `<default_website_url>` sous la forme `<bucket>.s3-website.<region>.io.cloud.ovh.net`
 
 ![configuration du frontend](images/front-2.PNG){.thumbnail}
 


### PR DESCRIPTION
undo translation of Host to Hôte in FR guide (Host should not be translated because it is the name of the standard http header)