### PR TITLE
Unify variable names in ipv6 guide

### DIFF
--- a/pages/platform/network-services/configuration-02-how-to-configure-ipv6/guide.en-us.md
+++ b/pages/platform/network-services/configuration-02-how-to-configure-ipv6/guide.en-us.md
@@ -45,8 +45,8 @@ Here is a short glossary of the terms used in this tutorial:
 |Glossary|Description|
 |---|---|
 |YOUR_IPV6|The IPv6 address assigned to your service.|
-|IPv6_PREFIX|The prefix of your IPv6 block (e.g. 2607:5300:60:62ac::/128 -> netmask = 128)|
-|IPv6_GATEWAY|The gateway of your IPv6 block.|
+|IPV6_PREFIX|The prefix of your IPv6 block (e.g. 2607:5300:60:62ac::/128 -> netmask = 128)|
+|IPV6_GATEWAY|The gateway of your IPv6 block.|
 
 
 ### Retrieve your network information.


### PR DESCRIPTION
Hello!

While following [your IPv6 configuration guide](https://help.ovhcloud.com/csm/en-vps-configuring-ipv6?id=kb_article_view&sysparm_article=KB0047575) I've noticed that the variable names used across the tutorial were not unified in terms of casing. The initial table uses "IPv6" and "IPV6" interchangeably:

![image](https://github.com/ovh/docs/assets/19196352/07b66c16-2c48-4cee-ac84-3b12be648899)

The later command examples use only the upper-case variants:

![image](https://github.com/ovh/docs/assets/19196352/d7087cc2-09da-44e7-ab21-cee75330a365)

I've unified them for the sake of readability and easier copy-pasting.