### PR TITLE
Fix bad formatting in the Kafka MirrorMaker capabilities guide

### DIFF
--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.en-asia.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.en-asia.md
@@ -64,6 +64,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.

--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.en-au.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.en-au.md
@@ -64,6 +64,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.

--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.en-ca.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.en-ca.md
@@ -64,6 +64,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.

--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.en-gb.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.en-gb.md
@@ -64,6 +64,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.

--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.en-ie.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.en-ie.md
@@ -64,6 +64,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.

--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.en-sg.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.en-sg.md
@@ -64,6 +64,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.

--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.en-us.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.en-us.md
@@ -64,6 +64,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.

--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.es-es.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.es-es.md
@@ -66,6 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.

--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.es-us.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.es-us.md
@@ -66,6 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.

--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.fr-ca.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.fr-ca.md
@@ -66,6 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.

--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.fr-fr.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.fr-fr.md
@@ -66,6 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.

--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.it-it.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.it-it.md
@@ -66,6 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.

--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.pl-pl.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.pl-pl.md
@@ -66,6 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.

--- a/pages/platform/databases/mirrormaker_01_capabilities/guide.pt-pt.md
+++ b/pages/platform/databases/mirrormaker_01_capabilities/guide.pt-pt.md
@@ -66,6 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run as well as 
 
 > [!primary]
 > Be aware that you will be able to upgrade your plan but you won't be able to downgrade it afterwards.
+
 #### Nodes
 
 - **Essential**: the cluster is delivered with 1 node by default.


### PR DESCRIPTION
"Nodes" title was merged with the info panel just before it because of a missing line feed.