### PR TITLE
NAS-HA - FAQ - Reverting to last updated state

### DIFF
--- a/pages/cloud/storage/file_storage/nas_faq/guide.de-de.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.de-de.md
@@ -1,145 +1,196 @@
 ---
 title: Häufig gestellte Fragen zu HA-NAS
-slug: nas/faq
-excerpt: Sie haben eine Frage zu HA-NAS? Hier sind die am häufigsten gestellten Fragen und Antworten
-section: HA-NAS
-order: 02
-updated: 2021-09-09
+excerpt: Sie haben eine Frage zu HA-NAS? Erfahren Sie hier Antworten auf die am häufigsten gestellten Fragen
+updated: 2023-06-07
 ---
 
 > [!primary]
 > Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In manchen Fällen können ungenaue Formulierungen verwendet worden sein, z.B. bei der Beschriftung von Schaltflächen oder technischen Details. Bitte ziehen Sie im Zweifelsfall die englische oder französische Fassung der Anleitung zu Rate. Möchten Sie mithelfen, diese Übersetzung zu verbessern? Dann nutzen Sie dazu bitte den Button "Beitragen" auf dieser Seite.
 >
 
-**Stand 09.09.2021**
+## Ziel
 
-## Das Produkt
+**Sie finden hier die häufigsten Fragen zum HA-NAS von OVHcloud.**
 
-### Kann der HA-NAS über eine Konfigurationsschnittstelle verwaltet werden?
+## Allgemeine Fragen
 
-Ja, die Konfiguration erfolgt über Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) im Bereich `Bare Metal Cloud`{.action}, dann `NAS und CDN`{.action}.
+### Was ist die HA-NAS Lösung von OVHcloud?
 
-### Ist es möglich, die Gesamtkapazität meines HA-NAS zu erhöhen?
+HA-NAS ist ein vollständig gemanagter und gemeinsam genutzter Dateispeicherdienst, der auf der Open-Source-Technologie OpenZFS basiert.
 
-Nach der Bestellung ist es nicht mehr möglich, die Kapazität eines HA-NAS zu erhöhen. Um die Speicherkapazität zu erhöhen, müssen Ihre Daten auf einen anderen HA-NAS mit größerer Kapazität migriert werden.
+### Was kann ich mit HA-NAS tun?
+
+HA-NAS erlaubt die Zentralisierung der Daten verschiedener Workloads von Linux und Windows für zahlreiche Szenarien, zum Beispiel:
+
+- Geteilter und ausgelagerter Speicher für IT-Anwendungen (VM, DB, etc.)
+- Verwaltung von Webinhalten 
+- Filesharing im Netzwerk
+
+### Kann das HA-NAS über eine Verwaltungsoberfläche genutzt werden?
+
+Ja, das ist in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) im Bereich `Bare Metal Cloud`{.action} und dann `NAS und CDN`{.action} möglich.
+
+## Verfügbarkeit
+
+### Welches SLA wird mit HA-NAS bereitgestellt?
+
+HA-NAS wird mit einer Verfügbarkeitsrate von 99,99% geliefert.
+
+## Netzwerk und Sicherheit
+
+### Welche Dateiübertragungsprotokolle werden derzeit auf der HA-NAS unterstützt?
+
+HA-NAS unterstützt den Transfer von Dateien über NFS (NFSv3) und CIFS (SMB).
+
+### Aus welchen OVHcloud Diensten kann ich Daten übertragen?
+
+HA-NAS ist ein Dienst, der Daten aus allen bestehenden OVHcloud Diensten empfangen kann: Bare Metal Cloud (VPS, Dedicated Server, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud.
+
+### Wie werden HA-NAS-Zugänge verwaltet?
+
+Die Zugriffskontrollliste (ACL) ist über Ihr OVHcloud Kundencenter konfigurierbar. Geben Sie einfach die IP-Adresse des Dienstes ein, für den Sie den Zugriff auf das HA-NAS erlauben möchten.
+
+### Ist HA-NAS mit anderen Servern außerhalb von OVHcloud kompatibel?
+
+Nein, der Zugriff auf Ihr HA-NAS ist nur über das OVHcloud Netzwerk möglich.
+
+### Ist HA-NAS für die Nutzung mit vRack geeignet?
+
+Derzeit kann ein HA-NAS nicht in das private Netzwerk vRack integriert werden. Die Verwendung von HA-NAS mit vRack ist jedoch insofern kompatibel, als der Zugriff über die öffentliche IP-Adresse des mit dem vRack verbundenen Servers erfolgen kann.
+
+## Kapazitäten und Leistung
 
 ### Welche Speicherkapazitäten sind verfügbar?
 
-Unser Angebot umfasst die folgenden Speicherkapazitäten:
+Die Mindestgröße eines Dienstes beträgt 3 TB und die Höchstgröße 144 TB.<br>
+Wir bieten folgende Speicherkapazitäten auf Basis von 3 TB Disks:
 
-- 3 To
-- 6 To
-- 9 To
-- 18 To
-- 36 To
+- 3 TB
+- 6 TB
+- 9 TB
+- 18 TB
+- 36 TB
 
-Die angebotenen Speicherkapazitäten sind die verfügbaren Kapazitäten.
+Wir bieten folgende Speicherkapazitäten auf Basis von 12 TB Disks:
 
-### Stehen die Ressourcen meines HA-NAS mir dediziert zur Verfügung?
+- 12 TB
+- 24 TB
+- 36 TB
+- 72 TB
+- 144 TB
 
-Die Festplatten in Ihrem HA-NAS sind ausschliesslich Ihnen dediziert. Die anderen Maschinenressourcen sind mit den anderen Nutzern geteilt (RAM, CPU, Bandbreite).
+Bei den angebotenen Speicherkapazitäten handelt es sich um die nutzbaren Kapazitäten.
 
-**Sonderfall:** Wenn Sie das 36 To Angebot bestellen, stehen Ihnen alle Ressourcen des Host-Servers (RAM, CPU, Bandbreite) zur Verfügung.
+### Sind die Ressourcen meines HA-NAS dediziert?
 
-### Für welchen Zeitraum kann ich einen HA-NAS abonnieren?
+Die Disks in Ihrem HA-NAS sind ausschliesslich für Ihre Nutzung dediziert. Die weiteren Hardware-Ressourcen werden mit anderen Nutzern geteilt (RAM, CPU, Bandbreite).
 
-Die angebotenen Vertragslaufzeiten sind 1, 3, 6 und 12 Monate. Am Ende jeder Vertragslaufzeit wird Ihr Abonnement automatisch verlängert, wenn keine Kündigung eingegangen ist. Sie können das Abonnement jederzeit über Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} kündigen.
+**Sonderfall:** Wenn Sie das 144 TB Angebot bestellen, stehen Ihnen alle Ressourcen des Host-Servers (RAM, CPU, Bandbreite) zur Verfügung.
 
-## Verwendung des Produkts
+### Wie viele HA-NAS Dienstleistungen kann ich über meine Kundenkennung erstellen?
+
+Es gibt keine Begrenzung der Anzahl der Dienstleistungen pro Kunden-Account.
+
+### Wie viele Partitionen können maximal pro Dienstleistung erstellt werden?
+
+Es können so viele Partitionen erstellt werden, wie Sie möchten. Die Mindestgröße beträgt 10 GB und die Maximalgröße wird von der Gesamtgröße des Dienstes bestimmt.
+
+### Ist die Transfer- und Verfügbarkeitsrate garantiert?
+
+- Transfer: Die Bandbreite des Dienstes wird geteilt. Transferraten können von OVHcloud nicht garantiert werden.
+- Verfügbarkeit: Die Service-Verfügbarkeit ist garantiert und unterliegt einer Service-Level-Vereinbarung (SLA). Die Details finden Sie unter unseren spezifischen Nutzungsbedingungen.
+
+## Nutzung des Dienstes
 
 ### Kann ein HA-NAS an mehrere Server gleichzeitig angeschlossen werden?
 
-Ja. Ihr HA-NAS kann gleichzeitig mit mehreren OVHcloud Dienstleistungen interagieren.
+Ja. Ihr HA-NAS kann gleichzeitig mit mehreren OVHcloud-Diensten interagieren.
 
 ### Kann ich ein Betriebssystem auf einem HA-NAS installieren?
 
-Nein, es ist nicht möglich, ein Betriebssystem auf den HA-NAS-Lösungen zu installieren.
+Nein, es ist nicht möglich, ein Betriebssystem auf den HA-NAS Diensten zu installieren.
 
-### Welche Protokolle sind mit HA-NAS kompatibel?
+### Ist der zugewiesene Speicherplatz partitionierbar?
 
-Der HA-NAS kann über die Protokolle CIFS (Samba) oder NFS auf einen Windows- oder Linux-Server gemountet werden.
-
-### Kann ich den zugewiesenen Storage partitionieren?
-
-Ja. Je nachdem, wie Sie den Storage verwenden, können Sie eine oder mehrere Partitionen erstellen. Die mögliche Anzahl an Partitionen ist nicht begrenzt.
-
-## Produktkompatibilität
-
-### Ist der HA-NAS mit anderen Servern außerhalb von OVHcloud kompatibel?
-
-Nein, der Zugriff auf Ihren HA-NAS ist nur über das OVHcloud Netzwerk möglich.
-
-### Über welche Dienstleistungen ist der HA-NAS erreichbar?
-
-Der HA-NAS ist über alle OVHcloud Produkte erreichbar, die über eine Distribution verfügen: Dedicated Server (OVHcloud, So you Start, Kimsufi), Hosted Private Cloud, Public Cloud und VPS.
-
-### Wie verwalte ich den Zugriff auf den HA-NAS?
-
-Sie können die Access Control List (ACL) über Ihr OVHcloud Kundencenter konfigurieren. Geben Sie einfach die IP-Adresse der Dienstleistung ein, für die Sie den Zugriff auf den HA-NAS erlauben möchten.
-
-### Ist HA-NAS mit vRack kompatibel?
-
-Derzeit kann der HA-NAS nicht in das private vRack-Netzwerk integriert werden. HA-NAS und vRack können jedoch trotzdem zusammen verwendet werden, indem der Zugriff über die öffentliche Schnittstelle des mit vRack verbundenen Servers erfolgt.
-
-## Durchsatz des NAS
-
-### Sind die Übertragungs- und Verfügbarkeitsraten garantiert?
-
-- Übertragung: Die Bandbreite des HA-NAS wird geteilt. Die Übertragungsrate kann von OVHcloud nicht garantiert werden.
-- Verfügbarkeit: Die Dienstverfügbarkeit ist garantiert und unterliegt einem Service Level Agreement (SLA). Einzelheiten entnehmen Sie bitte unseren Besonderen Nutzungsbedingungen.
+Ja, es ist notwendig, eine oder mehrere Partitionen zu erstellen, je nach Ihrer Verwendung. Die Erstellung von Partitionen ist nicht begrenzt.
 
 ## Snapshots
 
 ### Was sind Snapshots?
 
-Snapshots sind Momentaufnahmen Ihrer Festplatte und der darauf gespeicherten Daten zu einem bestimmten Zeitpunkt. Sie können die Snapshots über Ihr Kundencenter verwalten und konfigurieren.
+Ein Snapshot ist ein Image (Abbild) des Zustandes Ihrer Disk und der dort gespeicherten Daten zu einem bestimmten Zeitpunkt. Snapshots bieten so eine erste Backup-Ebene. Konfiguration und Verwaltung von Snapshots sind über Ihr OVHcloud Kundencenter möglich.
 
-Die Snapshot-Funktion ist standardmäßig aktiviert, wenn Sie Ihre Partition erstellen. Die Frequenz ist auf "stündlich" voreingestellt.
+Standardmäßig ist die Snapshot-Funktion aktiviert, wenn Sie Ihre Partition erstellen. Die Frequenz ist auf "stündlich" voreingestellt.
 
-### Wie oft werden Snapshots erstellt?
+### Welche Backup-Policy ist mit HA-NAS verbunden?
 
-Sie können die Snapshot-Frequenz in Ihrem Kundencenter einstellen und haben folgende Auswahlmöglichkeiten:  
+Die Benutzer sind für die Verwaltung ihrer Backups (Tools und Zeitplanung) innerhalb und außerhalb des Dienstes sowie für ihre Business Continuity und Planung von Disaster Recovery verantwortlich. Aus Gründen der Sicherheit und Resilienz der Infrastruktur kann OVHcloud jedoch Snapshots des Dienstes auf einem Remote-Server durchführen, ohne jedoch dazu verpflichtet zu sein.
 
-- stündlich (standardmäßig)
-- alle 6 Stunden
-- täglich
-- alle zwei Tage
-- alle drei Tage
-- wöchentlich
+Wenn OVHcloud eine Sicherung auf einem Remote-Server verfügbar hat, können wir im Fall eines Ausfalls oder Angriffs die Daten der letzten verfügbaren Sicherung wiederherstellen. Bitte beachten Sie, dass diese Aktion nur auf Anfrage durchgeführt wird und als optionale Dienstleistung in Rechnung gestellt wird.
 
-Sie können auch jederzeit manuelle Snapshots erstellen, zeitlich unbegrenzt speichern oder löschen. Diese Funktion ist über Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} oder über die [API](https://ca.api.ovh.com/){.external} verfügbar:
+### Wie oft werden Snapshots erstellt? <a name="frequency"></a>
 
-> [!api]
+Die Snapshot-Frequenz kann über Ihr OVHcloud Kundencenter verwaltet werden. Sie können die Frequenz aus den folgenden Optionen auswählen:
+
+- Stündlich (Standardeinstellung)
+- Alle 6 Stunden
+- Täglich
+- Alle zwei Tage
+- Alle drei Tage
+- Wöchentlich
+
+Sie können auch jederzeit manuelle Snapshots erstellen, zeitlich unbegrenzt speichern oder löschen. Diese Funktion ist in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) oder über folgenden [API-Aufruf](https://api.ovh.com/) verfügbar:
+
+>[!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Lesen Sie unsere Anleitung zu den [ersten Schritten mit der OVHcloud API](/pages/account/api/first-steps), um sich mit der Verwendung der OVHcloud API vertraut zu machen.
 >
 
 ### Wie funktioniert das Snapshot-Management-System?
 
-Sie können entsprechend der angebotenen Frequenzen automatische Snapshots konfigurieren. Unabhängig von der eingestellten Frequenz wird der zuletzt erstellte Snapshot immer den vorherigen überschreiben. Sie können Snapshots bei Bedarf auch manuell erstellen und löschen.
+Sie können automatische Snapshots zu den verschiedenen verfügbaren Frequenzen aktivieren. Unabhängig von der eingestellten Frequenz wird der zuletzt ausgeführte Snapshot immer den vorherigen ersetzen und überschreiben. Sie können Snapshots auch bei Bedarf erstellen und löschen.
 
-### Kann ich einen Snapshot löschen?
+### Kann ein Snapshot gelöscht werden?
 
-Es können nur Snapshots gelöscht werden, die manuell erstellt wurden (siehe vorherige Frage "Wie oft werden Snapshots erstellt"). Snapshots mit festgelegter Frequenz werden automatisch gelöscht, ohne dass ein Löschen von Hand möglich ist.
+Es können nur manuell erstellte Snapshots gelöscht werden (vgl. Abschnitt "[Wie oft werden Snapshots erstellt?](#frequency))".<br>
+Festfrequenz-Snapshots werden automatisch gelöscht und können nicht manuell gelöscht werden.
 
-### Wieviel Storage verbraucht ein Snapshot auf einem HA-NAS?
+### Sind Snapshots in der Kapazität eines Dienstes enthalten?
 
-Der von einem Snapshot belegte Storage variiert in Abhängigkeit der Aktionen, die in der Zeit zwischen zwei Snapshots durchgeführt werden.
+Ihnen wird zusätzlicher Speicherplatz auf dem gleichen physischen Speichermedium zugewiesen, um die Speicherung Ihrer Snapshots sicherzustellen. Dieser Speicherplatz entspricht mindestens 15 % des Hauptvolumens. Wenn Sie diesen Wert überschreiten, werden die Snapshots auf Ihrem primären Speicherplatz gespeichert. Der zusätzliche Speicherplatz kann nur für die Ablage Ihrer Snapshots verwendet werden.
 
-Ab dem Moment, in dem Sie den Snapshot auslösen, werden alle Aktionen, die auf der betroffenen Partition ausgeführt werden, in diesem Snapshot gespeichert und vergrößern dadurch die Datei.
+Für einen Dienst mit 3 TB sind zum Beispiel 450 GB für Snapshots reserviert.
 
 ### Wie viele Snapshots kann ich maximal erstellen?
 
-- Automatische Snapshots: ein Snapshot je Partition
-- Manuelle Snapshots: zehn Snapshots je Partition
+- Für automatische Snapshots: ein Snapshot pro Partition
+- Für manuelle Snapshots: zehn pro Partition
+
+### Wo werden die Snapshots gespeichert?
+
+Die Snapshots werden auf dem gleichen Niveau gespeichert wie Ihr Dienst. Die Snapshots werden auf zwei separate Server in zwei verschiedenen Racks repliziert. OVHcloud führt zusätzlich einen täglichen Snapshot an einem entfernten Standort durch.
 
 ### Wo kann ich meine Snapshots einsehen?
 
-In der betreffenden Partition: im versteckten Verzeichnis mit dem Namen `.zfs` → Verzeichnis `snapshots`. Die Dateien stehen als "read only" zur Verfügung.
+In der betreffenden Partition finden Sie ein verstecktes Verzeichnis mit dem Namen `.zfs`, das ein Verzeichnis `snapshot` beinhaltet. Die Dateien sind als "read only" verfügbar.
 
-### Erstellt OVHcloud auch Backups meiner Daten?
+### Wie viele Snapshot-Richtlinien kann ich pro Volume erstellen?
 
-Ja, ein internes Backup wird täglich durchgeführt. Diese erstellt einen weiteren Snapshot. Dieses Backup kann vom Kunden nicht deaktiviert werden.
+Sie können eine Richtlinie (Policy) erstellen.
+
+## Preise
+
+### Welche Art von Abrechnung wird auf den Dienst angewendet?
+
+HA-NAS ist ein Dienst, der monatlich nach Volumen abgerechnet wird (in Schritten von 3 bis 144 TB).
+
+### Für wie lange kann ich einen HA-NAS abonnieren?
+
+Die angebotenen Nutzungsperioden sind 1, 12, 24 und 36 Monate. Am Ende Ihrer Vertragslaufzeit wird Ihr Abonnement automatisch verlängert, wenn keine [Kündigungsanfrage gestellt wurde](/pages/account/billing/how_to_cancel_services). Sie können das Abonnement jederzeit über Ihr OVHcloud Kundencenter kündigen.
 
 ## Weiterführende Informationen
 

--- a/pages/cloud/storage/file_storage/nas_faq/guide.en-asia.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.en-asia.md
@@ -1,33 +1,79 @@
 ---
 title: HA-NAS - Frequently Asked Questions
-slug: nas/faq
 excerpt: Do you have questions about HA-NAS? Here are the most frequently asked questions
-section: HA-NAS
-order: 02
-updated: 2021-09-09
+updated: 2023-06-07
 ---
 
-**Last updated 9th September 2021**
+## Objective
 
-## The product
+**Here are the most frequently asked questions about the OVHcloud HA-NAS solution.**
+
+## General questions
+
+### What is the OVHcloud HA-NAS solution?
+
+HA-NAS is a fully managed, shared file storage service, based on OpenZFS open-source technology.
+
+### What can I do with HA-NAS?
+
+HA-NAS enables data to be centralised across different Linux workloads, as well as Windows for multiple scenarios:
+
+- shared and external storage for IT applications (VM, DB, etc.)
+- web content management 
+- file sharing on the network, etc.
 
 ### Can I manage my HA-NAS via a configuration panel?
 
-Yes, you can manage it from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) by going to the `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} section.
+Yes, you can access it from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) by going to the `Bare Metal Cloud`{.action} section, then `NAS and CDN`{.action}.
 
-### Can I increase the total storage capacity of my HA-NAS?
+## Availability
 
-Once you have ordered a HA-NAS, you cannot increase its storage capacity. To increase your storage capacity, you will need to migrate your data onto a second HA-NAS with a higher storage capacity.
+### Which SLA comes with HA-NAS?
+
+HA-NAS comes with a 99.99% availability rate.
+
+## IP and Security
+
+### What file transfer protocols are currently supported on the HA-NAS solution?
+
+HA-NAS supports file transfer through NFS (NFSv3) and CIFS (SMB).
+
+### Which OVHcloud services can I push data from?
+
+HA-NAS is a service that can receive data from all existing OVHcloud services: Bare Metal Cloud (VPS, OVHcloud Dedicated Servers, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, etc.
+
+### How do I manage access to a HA-NAS solution?
+
+You can configure the access control list (ACL) in your OVHcloud Control Panel. Simply enter the IP address of the service for which you want to authorise access to the HA-NAS.
+
+### Is the HA-NAS service compatible with other servers outside of OVHcloud?
+
+No. You can only access your HA-NAS from the OVHcloud network.
+
+### Is HA-NAS eligible for the vRack solution?
+
+Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP path of the server connected to vRack.
+
+## Capacity and performance
 
 ### What storage capacity options are available?
 
-We offer the following options for storage capacity:
+The minimum size of a service is 3 TB, and the maximum size is 144 TB.<br>
+We offer the following storage capacities based on 3 TB disks:
 
-- 3 To
-- 6 To
-- 9 To
-- 18 To
-- 36 To
+- 3 TB
+- 6 TB
+- 9 TB
+- 18 TB
+- 36 TB
+
+We offer the following storage capacities on a 12 TB disk base:
+
+- 12 TB
+- 24 TB
+- 36 TB
+- 72 TB
+- 144 TB
 
 The storage capacities offered are the usable capacities.
 
@@ -35,79 +81,70 @@ The storage capacities offered are the usable capacities.
 
 The disks of your HA-NAS are dedicated to your services. The machine’s other resources are shared (RAM, CPU, bandwidth).
 
-**Special case:** If you sign up to the 36 To solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
+**Special case:** If you sign up to the 144 TB solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
 
-### How long can I subscribe to an HA-NAS solution?
+### How many HA-NAS services can I create from my customer account?
 
-The subscription periods offered are 1 month, 3 months, 6 months and 12 months. At the end of your subscription period, your subscription is renewed automatically unless you submit a cancellation request. You can do this at any time during your subscription period, via your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia).
+There is no limit to the number of services per customer account.
+
+### What is the maximum number of partitions per service?
+
+You can create as many partitions as you want. The minimum size is 10 GB and the maximum size is defined by the maximum size of the service.
+
+### Are the transfer and availability rates guaranteed?
+
+- Transfer: the service’s bandwidth is shared. Transfer rates cannot be guaranteed by OVHcloud.
+- Availability: service availability is guaranteed, and is the subject of a service level agreement. You can view the details in our Terms of Use.
 
 ## Using the product
 
 ### Can HA-NAS be connected to several servers at once?
 
-Yes. You can make your HA-NAS interact simultaneously with several OVHcloud services.
+Yes. You can have your NAS interacted simultaneously with several OVHcloud services.
 
 ### Can I install an operating system on a HA-NAS?
 
 No, you cannot install operating systems on HA-NAS solutions.
 
-### Which protocols are compatible with the HA-NAS solution?
-
-HA-NAS can be mounted on a Windows or Linux server via CIFS (Samba) or NFS protocols.
-
 ### Can the allocated space be partitioned?
 
 Yes, you will need to create one or several partitions, depending on how you will use it. There are no limits to creating partitions.
-
-## Product compatibility
-
-### Is HA-NAS compatible with other services outside of OVHcloud?
-
-No, you can only access your HA-NAS from the OVHcloud network.
-
-### Which service(s) can I use to access HA-NAS?
-
-The service is accessible from all OVHcloud products that have an operating system or distribution: dedicated servers (OVHcloud, So you Start, Kimsufi), Hosted Private Cloud, Public Cloud and VPS.
-
-### How do I manage access to a HA-NAS solution?
-
-The access control list (ACL) can be configured from your OVHcloud Control Panel. Simply enter the IP address of the service for which you would like to authorise access to the HA-NAS.
-
-### Is HA-NAS eligible for the vRack solution?
-
-Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP route of the server connected to vRack.
-
-## Bandwidth
-
-### Are the transfer and availability rates guaranteed?
-
-- Transfer: the service’s bandwidth is shared. The transfer rate cannot be guaranteed by OVHcloud.
-- Availability: service availability is guaranteed, and is the subject of a service level agreement.  The details can be accessed in our Special Conditions of Use.
 
 ## Snapshots
 
 ### What are snapshots?
 
-Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. You can configure and manage snapshots from your Control Panel.
+Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. They offer you the first level of backup. You can configure and manage snapshots from your OVHcloud Control Panel.
 
 By default, the snapshot feature is enabled when you create your partition, and the frequency is set at “once every hour” by default.
 
-### How frequently are snapshots taken?
+### Which backup policy is associated with HA-NAS?
 
-You can set the frequency of snapshots from your Control Panel. You can choose the frequency from the following options:
+Users are responsible for managing their backups (tools and policies) inside and outside the service, as well as their business continuity and disaster recovery plans. However, for reasons of infrastructure security and resilience, OVHcloud can take snapshots of the service on a remote server, without any obligation.
 
-- once every hour (default);
-- once every 6 hours;
-- once every day;
-- once every 2 days;
-- once every 3 days;
-- once every week.
+In the event of an outage or attack, if OVHcloud has taken a snapshot on a remote server, we can then restore the data from the last available snapshot. Please note, however, that this is done on request and is an optional service that will be billed.
 
-You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) or via the [API](https://ca.api.ovh.com/):
+### How often are snapshots taken? <a name="frequency"></a>
+
+You can manage the frequency of snapshots from your OVHcloud Control Panel. You can choose the frequency from the following options:
+
+- every hour (default)
+- once every 6 hours
+- once every day
+- once every 2 days
+- once every 3 days
+- once every week
+
+You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) or via the following [API](https://api.ovh.com/) call:
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Please refer to our [Getting started with OVHcloud APIs](/pages/account/api/first-steps) guide to get familiar with using OVHcloud APIs.
+>
 
 ### How does the snapshot management system work?
 
@@ -115,26 +152,41 @@ You can configure automatic snapshots, and a selection of frequencies are availa
 
 ### Can I delete a snapshot?
 
-Only snapshots that are created “on demand” can be deleted (see previous question “How frequently are snapshots taken?”). Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
+Only snapshots created “on demand” can be deleted (see previous question [How often are snapshots taken?](#frequency)).<br>
+Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
 
-### How much storage space do snapshots use on a HA-NAS solution?
+### Are snapshots included in the capacity of a service?
 
-The storage capacity used by a snapshot can vary depending on the actions taken in the time period between two snapshots.
+You are allocated additional space on the same physical media to ensure that your snapshots are stored. This space corresponds to at least 15% of the primary volume. In case you exceed this limit, the snapshots will be stored on your main storage space. You cannot use the additional space for anything other than storing your snapshots.
 
-From the moment you take the snapshot, all actions made on the partition concerned are stored in this snapshot, and they will increase the file size.
+For example, for a 3 TB service, an additional 450 GB is reserved for snapshots.
 
 ### What is the maximum number of snapshots I can create?
 
 - For automatic snapshots: one per partition
 - For manual snapshots: ten per partition
 
+### Where are snapshots stored?
+
+Snapshots are stored at the same level as your service. Snapshots are replicated on two separate servers in two different racks. In addition, OVHcloud takes a daily snapshot at a remote site.
+
 ### Where can I retrieve my snapshots?
 
-In the partition concerned: a hidden directory called `.zfs` → directory `snapshots` . Files are available in read-only mode.
+In the partition concerned, you will find a hidden directory called `.zfs`, which contains a `snapshots` directory. The files are available in read only.
 
-### Does OVHcloud also create backups of my data?
+### How many snapshot policies can I create per volume?
 
-Yes, OVHcloud creates internal daily backups. It also generates a snapshot. This backup cannot be disabled by the customer.
+1
+
+## Billing
+
+### What type of pricing is linked to the service?
+
+HA-NAS is a service billed monthly by volume (from 3 to 144 TB in stages).
+
+### How long can I subscribe to a HA-NAS solution?
+
+The subscription periods offered are 1 month, 12 months, 24 months and 36 months. At the end of your subscription period, your subscription will be renewed automatically unless you submit a [cancellation request](/pages/account/billing/how_to_cancel_services). You can do this for the entire duration of your subscription, via the OVHcloud Control Panel.
 
 ## Go further
 

--- a/pages/cloud/storage/file_storage/nas_faq/guide.en-au.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.en-au.md
@@ -1,33 +1,79 @@
 ---
 title: HA-NAS - Frequently Asked Questions
-slug: nas/faq
 excerpt: Do you have questions about HA-NAS? Here are the most frequently asked questions
-section: HA-NAS
-order: 02
-updated: 2021-09-09
+updated: 2023-06-07
 ---
 
-**Last updated 9th September 2021**
+## Objective
 
-## The product
+**Here are the most frequently asked questions about the OVHcloud HA-NAS solution.**
+
+## General questions
+
+### What is the OVHcloud HA-NAS solution?
+
+HA-NAS is a fully managed, shared file storage service, based on OpenZFS open-source technology.
+
+### What can I do with HA-NAS?
+
+HA-NAS enables data to be centralised across different Linux workloads, as well as Windows for multiple scenarios:
+
+- shared and external storage for IT applications (VM, DB, etc.)
+- web content management 
+- file sharing on the network, etc.
 
 ### Can I manage my HA-NAS via a configuration panel?
 
-Yes, you can manage it from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) by going to the `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} section.
+Yes, you can access it from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) by going to the `Bare Metal Cloud`{.action} section, then `NAS and CDN`{.action}.
 
-### Can I increase the total storage capacity of my HA-NAS?
+## Availability
 
-Once you have ordered a HA-NAS, you cannot increase its storage capacity. To increase your storage capacity, you will need to migrate your data onto a second HA-NAS with a higher storage capacity.
+### Which SLA comes with HA-NAS?
+
+HA-NAS comes with a 99.99% availability rate.
+
+## IP and Security
+
+### What file transfer protocols are currently supported on the HA-NAS solution?
+
+HA-NAS supports file transfer through NFS (NFSv3) and CIFS (SMB).
+
+### Which OVHcloud services can I push data from?
+
+HA-NAS is a service that can receive data from all existing OVHcloud services: Bare Metal Cloud (VPS, OVHcloud Dedicated Servers, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, etc.
+
+### How do I manage access to a HA-NAS solution?
+
+You can configure the access control list (ACL) in your OVHcloud Control Panel. Simply enter the IP address of the service for which you want to authorise access to the HA-NAS.
+
+### Is the HA-NAS service compatible with other servers outside of OVHcloud?
+
+No. You can only access your HA-NAS from the OVHcloud network.
+
+### Is HA-NAS eligible for the vRack solution?
+
+Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP path of the server connected to vRack.
+
+## Capacity and performance
 
 ### What storage capacity options are available?
 
-We offer the following options for storage capacity:
+The minimum size of a service is 3 TB, and the maximum size is 144 TB.<br>
+We offer the following storage capacities based on 3 TB disks:
 
-- 3 To
-- 6 To
-- 9 To
-- 18 To
-- 36 To
+- 3 TB
+- 6 TB
+- 9 TB
+- 18 TB
+- 36 TB
+
+We offer the following storage capacities on a 12 TB disk base:
+
+- 12 TB
+- 24 TB
+- 36 TB
+- 72 TB
+- 144 TB
 
 The storage capacities offered are the usable capacities.
 
@@ -35,79 +81,70 @@ The storage capacities offered are the usable capacities.
 
 The disks of your HA-NAS are dedicated to your services. The machine’s other resources are shared (RAM, CPU, bandwidth).
 
-**Special case:** If you sign up to the 36 To solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
+**Special case:** If you sign up to the 144 TB solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
 
-### How long can I subscribe to an HA-NAS solution?
+### How many HA-NAS services can I create from my customer account?
 
-The subscription periods offered are 1 month, 3 months, 6 months and 12 months. At the end of your subscription period, your subscription is renewed automatically unless you submit a cancellation request. You can do this at any time during your subscription period, via your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au).
+There is no limit to the number of services per customer account.
+
+### What is the maximum number of partitions per service?
+
+You can create as many partitions as you want. The minimum size is 10 GB and the maximum size is defined by the maximum size of the service.
+
+### Are the transfer and availability rates guaranteed?
+
+- Transfer: the service’s bandwidth is shared. Transfer rates cannot be guaranteed by OVHcloud.
+- Availability: service availability is guaranteed, and is the subject of a service level agreement. You can view the details in our Terms of Use.
 
 ## Using the product
 
 ### Can HA-NAS be connected to several servers at once?
 
-Yes. You can make your HA-NAS interact simultaneously with several OVHcloud services.
+Yes. You can have your NAS interacted simultaneously with several OVHcloud services.
 
 ### Can I install an operating system on a HA-NAS?
 
 No, you cannot install operating systems on HA-NAS solutions.
 
-### Which protocols are compatible with the HA-NAS solution?
-
-HA-NAS can be mounted on a Windows or Linux server via CIFS (Samba) or NFS protocols.
-
 ### Can the allocated space be partitioned?
 
 Yes, you will need to create one or several partitions, depending on how you will use it. There are no limits to creating partitions.
-
-## Product compatibility
-
-### Is HA-NAS compatible with other services outside of OVHcloud?
-
-No, you can only access your HA-NAS from the OVHcloud network.
-
-### Which service(s) can I use to access HA-NAS?
-
-The service is accessible from all OVHcloud products that have an operating system or distribution: dedicated servers (OVHcloud, So you Start, Kimsufi), Hosted Private Cloud, Public Cloud and VPS.
-
-### How do I manage access to a HA-NAS solution?
-
-The access control list (ACL) can be configured from your OVHcloud Control Panel. Simply enter the IP address of the service for which you would like to authorise access to the HA-NAS.
-
-### Is HA-NAS eligible for the vRack solution?
-
-Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP route of the server connected to vRack.
-
-## Bandwidth
-
-### Are the transfer and availability rates guaranteed?
-
-- Transfer: the service’s bandwidth is shared. The transfer rate cannot be guaranteed by OVHcloud.
-- Availability: service availability is guaranteed, and is the subject of a service level agreement.  The details can be accessed in our Special Conditions of Use.
 
 ## Snapshots
 
 ### What are snapshots?
 
-Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. You can configure and manage snapshots from your Control Panel.
+Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. They offer you the first level of backup. You can configure and manage snapshots from your OVHcloud Control Panel.
 
 By default, the snapshot feature is enabled when you create your partition, and the frequency is set at “once every hour” by default.
 
-### How frequently are snapshots taken?
+### Which backup policy is associated with HA-NAS?
 
-You can set the frequency of snapshots from your Control Panel. You can choose the frequency from the following options:
+Users are responsible for managing their backups (tools and policies) inside and outside the service, as well as their business continuity and disaster recovery plans. However, for reasons of infrastructure security and resilience, OVHcloud can take snapshots of the service on a remote server, without any obligation.
 
-- once every hour (default);
-- once every 6 hours;
-- once every day;
-- once every 2 days;
-- once every 3 days;
-- once every week.
+In the event of an outage or attack, if OVHcloud has taken a snapshot on a remote server, we can then restore the data from the last available snapshot. Please note, however, that this is done on request and is an optional service that will be billed.
 
-You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) or via the [API](https://ca.api.ovh.com/):
+### How often are snapshots taken? <a name="frequency"></a>
+
+You can manage the frequency of snapshots from your OVHcloud Control Panel. You can choose the frequency from the following options:
+
+- every hour (default)
+- once every 6 hours
+- once every day
+- once every 2 days
+- once every 3 days
+- once every week
+
+You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) or via the following [API](https://api.ovh.com/) call:
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Please refer to our [Getting started with OVHcloud APIs](/pages/account/api/first-steps) guide to get familiar with using OVHcloud APIs.
+>
 
 ### How does the snapshot management system work?
 
@@ -115,26 +152,41 @@ You can configure automatic snapshots, and a selection of frequencies are availa
 
 ### Can I delete a snapshot?
 
-Only snapshots that are created “on demand” can be deleted (see previous question “How frequently are snapshots taken?”). Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
+Only snapshots created “on demand” can be deleted (see previous question [How often are snapshots taken?](#frequency)).<br>
+Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
 
-### How much storage space do snapshots use on a HA-NAS solution?
+### Are snapshots included in the capacity of a service?
 
-The storage capacity used by a snapshot can vary depending on the actions taken in the time period between two snapshots.
+You are allocated additional space on the same physical media to ensure that your snapshots are stored. This space corresponds to at least 15% of the primary volume. In case you exceed this limit, the snapshots will be stored on your main storage space. You cannot use the additional space for anything other than storing your snapshots.
 
-From the moment you take the snapshot, all actions made on the partition concerned are stored in this snapshot, and they will increase the file size.
+For example, for a 3 TB service, an additional 450 GB is reserved for snapshots.
 
 ### What is the maximum number of snapshots I can create?
 
 - For automatic snapshots: one per partition
 - For manual snapshots: ten per partition
 
+### Where are snapshots stored?
+
+Snapshots are stored at the same level as your service. Snapshots are replicated on two separate servers in two different racks. In addition, OVHcloud takes a daily snapshot at a remote site.
+
 ### Where can I retrieve my snapshots?
 
-In the partition concerned: a hidden directory called `.zfs` → directory `snapshots` . Files are available in read-only mode.
+In the partition concerned, you will find a hidden directory called `.zfs`, which contains a `snapshots` directory. The files are available in read only.
 
-### Does OVHcloud also create backups of my data?
+### How many snapshot policies can I create per volume?
 
-Yes, OVHcloud creates internal daily backups. It also generates a snapshot. This backup cannot be disabled by the customer.
+1
+
+## Billing
+
+### What type of pricing is linked to the service?
+
+HA-NAS is a service billed monthly by volume (from 3 to 144 TB in stages).
+
+### How long can I subscribe to a HA-NAS solution?
+
+The subscription periods offered are 1 month, 12 months, 24 months and 36 months. At the end of your subscription period, your subscription will be renewed automatically unless you submit a [cancellation request](/pages/account/billing/how_to_cancel_services). You can do this for the entire duration of your subscription, via the OVHcloud Control Panel.
 
 ## Go further
 

--- a/pages/cloud/storage/file_storage/nas_faq/guide.en-ca.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.en-ca.md
@@ -1,33 +1,79 @@
 ---
 title: HA-NAS - Frequently Asked Questions
-slug: nas/faq
 excerpt: Do you have questions about HA-NAS? Here are the most frequently asked questions
-section: HA-NAS
-order: 02
-updated: 2021-09-09
+updated: 2023-06-07
 ---
 
-**Last updated 9th September 2021**
+## Objective
 
-## The product
+**Here are the most frequently asked questions about the OVHcloud HA-NAS solution.**
+
+## General questions
+
+### What is the OVHcloud HA-NAS solution?
+
+HA-NAS is a fully managed, shared file storage service, based on OpenZFS open-source technology.
+
+### What can I do with HA-NAS?
+
+HA-NAS enables data to be centralised across different Linux workloads, as well as Windows for multiple scenarios:
+
+- shared and external storage for IT applications (VM, DB, etc.)
+- web content management 
+- file sharing on the network, etc.
 
 ### Can I manage my HA-NAS via a configuration panel?
 
-Yes, you can manage it from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) by going to the `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} section.
+Yes, you can access it from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) by going to the `Bare Metal Cloud`{.action} section, then `NAS and CDN`{.action}.
 
-### Can I increase the total storage capacity of my HA-NAS?
+## Availability
 
-Once you have ordered a HA-NAS, you cannot increase its storage capacity. To increase your storage capacity, you will need to migrate your data onto a second HA-NAS with a higher storage capacity.
+### Which SLA comes with HA-NAS?
+
+HA-NAS comes with a 99.99% availability rate.
+
+## IP and Security
+
+### What file transfer protocols are currently supported on the HA-NAS solution?
+
+HA-NAS supports file transfer through NFS (NFSv3) and CIFS (SMB).
+
+### Which OVHcloud services can I push data from?
+
+HA-NAS is a service that can receive data from all existing OVHcloud services: Bare Metal Cloud (VPS, OVHcloud Dedicated Servers, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, etc.
+
+### How do I manage access to a HA-NAS solution?
+
+You can configure the access control list (ACL) in your OVHcloud Control Panel. Simply enter the IP address of the service for which you want to authorise access to the HA-NAS.
+
+### Is the HA-NAS service compatible with other servers outside of OVHcloud?
+
+No. You can only access your HA-NAS from the OVHcloud network.
+
+### Is HA-NAS eligible for the vRack solution?
+
+Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP path of the server connected to vRack.
+
+## Capacity and performance
 
 ### What storage capacity options are available?
 
-We offer the following options for storage capacity:
+The minimum size of a service is 3 TB, and the maximum size is 144 TB.<br>
+We offer the following storage capacities based on 3 TB disks:
 
-- 3 To
-- 6 To
-- 9 To
-- 18 To
-- 36 To
+- 3 TB
+- 6 TB
+- 9 TB
+- 18 TB
+- 36 TB
+
+We offer the following storage capacities on a 12 TB disk base:
+
+- 12 TB
+- 24 TB
+- 36 TB
+- 72 TB
+- 144 TB
 
 The storage capacities offered are the usable capacities.
 
@@ -35,79 +81,70 @@ The storage capacities offered are the usable capacities.
 
 The disks of your HA-NAS are dedicated to your services. The machine’s other resources are shared (RAM, CPU, bandwidth).
 
-**Special case:** If you sign up to the 36 To solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
+**Special case:** If you sign up to the 144 TB solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
 
-### How long can I subscribe to an HA-NAS solution?
+### How many HA-NAS services can I create from my customer account?
 
-The subscription periods offered are 1 month, 3 months, 6 months and 12 months. At the end of your subscription period, your subscription is renewed automatically unless you submit a cancellation request. You can do this at any time during your subscription period, via your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca).
+There is no limit to the number of services per customer account.
+
+### What is the maximum number of partitions per service?
+
+You can create as many partitions as you want. The minimum size is 10 GB and the maximum size is defined by the maximum size of the service.
+
+### Are the transfer and availability rates guaranteed?
+
+- Transfer: the service’s bandwidth is shared. Transfer rates cannot be guaranteed by OVHcloud.
+- Availability: service availability is guaranteed, and is the subject of a service level agreement. You can view the details in our Terms of Use.
 
 ## Using the product
 
 ### Can HA-NAS be connected to several servers at once?
 
-Yes. You can make your HA-NAS interact simultaneously with several OVHcloud services.
+Yes. You can have your NAS interacted simultaneously with several OVHcloud services.
 
 ### Can I install an operating system on a HA-NAS?
 
 No, you cannot install operating systems on HA-NAS solutions.
 
-### Which protocols are compatible with the HA-NAS solution?
-
-HA-NAS can be mounted on a Windows or Linux server via CIFS (Samba) or NFS protocols.
-
 ### Can the allocated space be partitioned?
 
 Yes, you will need to create one or several partitions, depending on how you will use it. There are no limits to creating partitions.
-
-## Product compatibility
-
-### Is HA-NAS compatible with other services outside of OVHcloud?
-
-No, you can only access your HA-NAS from the OVHcloud network.
-
-### Which service(s) can I use to access HA-NAS?
-
-The service is accessible from all OVHcloud products that have an operating system or distribution: dedicated servers (OVHcloud, So you Start, Kimsufi), Hosted Private Cloud, Public Cloud and VPS.
-
-### How do I manage access to a HA-NAS solution?
-
-The access control list (ACL) can be configured from your OVHcloud Control Panel. Simply enter the IP address of the service for which you would like to authorise access to the HA-NAS.
-
-### Is HA-NAS eligible for the vRack solution?
-
-Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP route of the server connected to vRack.
-
-## Bandwidth
-
-### Are the transfer and availability rates guaranteed?
-
-- Transfer: the service’s bandwidth is shared. The transfer rate cannot be guaranteed by OVHcloud.
-- Availability: service availability is guaranteed, and is the subject of a service level agreement.  The details can be accessed in our Special Conditions of Use.
 
 ## Snapshots
 
 ### What are snapshots?
 
-Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. You can configure and manage snapshots from your Control Panel.
+Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. They offer you the first level of backup. You can configure and manage snapshots from your OVHcloud Control Panel.
 
 By default, the snapshot feature is enabled when you create your partition, and the frequency is set at “once every hour” by default.
 
-### How frequently are snapshots taken?
+### Which backup policy is associated with HA-NAS?
 
-You can set the frequency of snapshots from your Control Panel. You can choose the frequency from the following options:
+Users are responsible for managing their backups (tools and policies) inside and outside the service, as well as their business continuity and disaster recovery plans. However, for reasons of infrastructure security and resilience, OVHcloud can take snapshots of the service on a remote server, without any obligation.
 
-- once every hour (default);
-- once every 6 hours;
-- once every day;
-- once every 2 days;
-- once every 3 days;
-- once every week.
+In the event of an outage or attack, if OVHcloud has taken a snapshot on a remote server, we can then restore the data from the last available snapshot. Please note, however, that this is done on request and is an optional service that will be billed.
 
-You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) or via the [API](https://ca.api.ovh.com/):
+### How often are snapshots taken? <a name="frequency"></a>
+
+You can manage the frequency of snapshots from your OVHcloud Control Panel. You can choose the frequency from the following options:
+
+- every hour (default)
+- once every 6 hours
+- once every day
+- once every 2 days
+- once every 3 days
+- once every week
+
+You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) or via the following [API](https://api.ovh.com/) call:
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Please refer to our [Getting started with OVHcloud APIs](/pages/account/api/first-steps) guide to get familiar with using OVHcloud APIs.
+>
 
 ### How does the snapshot management system work?
 
@@ -115,26 +152,41 @@ You can configure automatic snapshots, and a selection of frequencies are availa
 
 ### Can I delete a snapshot?
 
-Only snapshots that are created “on demand” can be deleted (see previous question “How frequently are snapshots taken?”). Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
+Only snapshots created “on demand” can be deleted (see previous question [How often are snapshots taken?](#frequency)).<br>
+Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
 
-### How much storage space do snapshots use on a HA-NAS solution?
+### Are snapshots included in the capacity of a service?
 
-The storage capacity used by a snapshot can vary depending on the actions taken in the time period between two snapshots.
+You are allocated additional space on the same physical media to ensure that your snapshots are stored. This space corresponds to at least 15% of the primary volume. In case you exceed this limit, the snapshots will be stored on your main storage space. You cannot use the additional space for anything other than storing your snapshots.
 
-From the moment you take the snapshot, all actions made on the partition concerned are stored in this snapshot, and they will increase the file size.
+For example, for a 3 TB service, an additional 450 GB is reserved for snapshots.
 
 ### What is the maximum number of snapshots I can create?
 
 - For automatic snapshots: one per partition
 - For manual snapshots: ten per partition
 
+### Where are snapshots stored?
+
+Snapshots are stored at the same level as your service. Snapshots are replicated on two separate servers in two different racks. In addition, OVHcloud takes a daily snapshot at a remote site.
+
 ### Where can I retrieve my snapshots?
 
-In the partition concerned: a hidden directory called `.zfs` → directory `snapshots` . Files are available in read-only mode.
+In the partition concerned, you will find a hidden directory called `.zfs`, which contains a `snapshots` directory. The files are available in read only.
 
-### Does OVHcloud also create backups of my data?
+### How many snapshot policies can I create per volume?
 
-Yes, OVHcloud creates internal daily backups. It also generates a snapshot. This backup cannot be disabled by the customer.
+1
+
+## Billing
+
+### What type of pricing is linked to the service?
+
+HA-NAS is a service billed monthly by volume (from 3 to 144 TB in stages).
+
+### How long can I subscribe to a HA-NAS solution?
+
+The subscription periods offered are 1 month, 12 months, 24 months and 36 months. At the end of your subscription period, your subscription will be renewed automatically unless you submit a [cancellation request](/pages/account/billing/how_to_cancel_services). You can do this for the entire duration of your subscription, via the OVHcloud Control Panel.
 
 ## Go further
 

--- a/pages/cloud/storage/file_storage/nas_faq/guide.en-gb.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.en-gb.md
@@ -1,33 +1,79 @@
 ---
 title: HA-NAS - Frequently Asked Questions
-slug: nas/faq
 excerpt: Do you have questions about HA-NAS? Here are the most frequently asked questions
-section: HA-NAS
-order: 02
-updated: 2021-09-09
+updated: 2023-06-07
 ---
 
-**Last updated 9th September 2021**
+## Objective
 
-## The product
+**Here are the most frequently asked questions about the OVHcloud HA-NAS solution.**
+
+## General questions
+
+### What is the OVHcloud HA-NAS solution?
+
+HA-NAS is a fully managed, shared file storage service, based on OpenZFS open-source technology.
+
+### What can I do with HA-NAS?
+
+HA-NAS enables data to be centralised across different Linux workloads, as well as Windows for multiple scenarios:
+
+- shared and external storage for IT applications (VM, DB, etc.)
+- web content management 
+- file sharing on the network, etc.
 
 ### Can I manage my HA-NAS via a configuration panel?
 
-Yes, you can manage it from your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) by going to the `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} section.
+Yes, you can access it from your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) by going to the `Bare Metal Cloud`{.action} section, then `NAS and CDN`{.action}.
 
-### Can I increase the total storage capacity of my HA-NAS?
+## Availability
 
-Once you have ordered a HA-NAS, you cannot increase its storage capacity. To increase your storage capacity, you will need to migrate your data onto a second HA-NAS with a higher storage capacity.
+### Which SLA comes with HA-NAS?
+
+HA-NAS comes with a 99.99% availability rate.
+
+## IP and Security
+
+### What file transfer protocols are currently supported on the HA-NAS solution?
+
+HA-NAS supports file transfer through NFS (NFSv3) and CIFS (SMB).
+
+### Which OVHcloud services can I push data from?
+
+HA-NAS is a service that can receive data from all existing OVHcloud services: Bare Metal Cloud (VPS, OVHcloud Dedicated Servers, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, etc.
+
+### How do I manage access to a HA-NAS solution?
+
+You can configure the access control list (ACL) in your OVHcloud Control Panel. Simply enter the IP address of the service for which you want to authorise access to the HA-NAS.
+
+### Is the HA-NAS service compatible with other servers outside of OVHcloud?
+
+No. You can only access your HA-NAS from the OVHcloud network.
+
+### Is HA-NAS eligible for the vRack solution?
+
+Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP path of the server connected to vRack.
+
+## Capacity and performance
 
 ### What storage capacity options are available?
 
-We offer the following options for storage capacity:
+The minimum size of a service is 3 TB, and the maximum size is 144 TB.<br>
+We offer the following storage capacities based on 3 TB disks:
 
-- 3 To
-- 6 To
-- 9 To
-- 18 To
-- 36 To
+- 3 TB
+- 6 TB
+- 9 TB
+- 18 TB
+- 36 TB
+
+We offer the following storage capacities on a 12 TB disk base:
+
+- 12 TB
+- 24 TB
+- 36 TB
+- 72 TB
+- 144 TB
 
 The storage capacities offered are the usable capacities.
 
@@ -35,79 +81,70 @@ The storage capacities offered are the usable capacities.
 
 The disks of your HA-NAS are dedicated to your services. The machine’s other resources are shared (RAM, CPU, bandwidth).
 
-**Special case:** If you sign up to the 36 To solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
+**Special case:** If you sign up to the 144 TB solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
 
-### How long can I subscribe to an HA-NAS solution?
+### How many HA-NAS services can I create from my customer account?
 
-The subscription periods offered are 1 month, 3 months, 6 months and 12 months. At the end of your subscription period, your subscription is renewed automatically unless you submit a cancellation request. You can do this at any time during your subscription period, via your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB).
+There is no limit to the number of services per customer account.
+
+### What is the maximum number of partitions per service?
+
+You can create as many partitions as you want. The minimum size is 10 GB and the maximum size is defined by the maximum size of the service.
+
+### Are the transfer and availability rates guaranteed?
+
+- Transfer: the service’s bandwidth is shared. Transfer rates cannot be guaranteed by OVHcloud.
+- Availability: service availability is guaranteed, and is the subject of a service level agreement. You can view the details in our Terms of Use.
 
 ## Using the product
 
 ### Can HA-NAS be connected to several servers at once?
 
-Yes. You can make your HA-NAS interact simultaneously with several OVHcloud services.
+Yes. You can have your NAS interacted simultaneously with several OVHcloud services.
 
 ### Can I install an operating system on a HA-NAS?
 
 No, you cannot install operating systems on HA-NAS solutions.
 
-### Which protocols are compatible with the HA-NAS solution?
-
-HA-NAS can be mounted on a Windows or Linux server via CIFS (Samba) or NFS protocols.
-
 ### Can the allocated space be partitioned?
 
 Yes, you will need to create one or several partitions, depending on how you will use it. There are no limits to creating partitions.
-
-## Product compatibility
-
-### Is HA-NAS compatible with other services outside of OVHcloud?
-
-No, you can only access your HA-NAS from the OVHcloud network.
-
-### Which service(s) can I use to access HA-NAS?
-
-The service is accessible from all OVHcloud products that have an operating system or distribution: dedicated servers (OVHcloud, So you Start, Kimsufi), Hosted Private Cloud, Public Cloud and VPS.
-
-### How do I manage access to a HA-NAS solution?
-
-The access control list (ACL) can be configured from your OVHcloud Control Panel. Simply enter the IP address of the service for which you would like to authorise access to the HA-NAS.
-
-### Is HA-NAS eligible for the vRack solution?
-
-Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP route of the server connected to vRack.
-
-## Bandwidth
-
-### Are the transfer and availability rates guaranteed?
-
-- Transfer: the service’s bandwidth is shared. The transfer rate cannot be guaranteed by OVHcloud.
-- Availability: service availability is guaranteed, and is the subject of a service level agreement.  The details can be accessed in our Special Conditions of Use.
 
 ## Snapshots
 
 ### What are snapshots?
 
-Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. You can configure and manage snapshots from your Control Panel.
+Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. They offer you the first level of backup. You can configure and manage snapshots from your OVHcloud Control Panel.
 
 By default, the snapshot feature is enabled when you create your partition, and the frequency is set at “once every hour” by default.
 
-### How frequently are snapshots taken?
+### Which backup policy is associated with HA-NAS?
 
-You can set the frequency of snapshots from your Control Panel. You can choose the frequency from the following options:
+Users are responsible for managing their backups (tools and policies) inside and outside the service, as well as their business continuity and disaster recovery plans. However, for reasons of infrastructure security and resilience, OVHcloud can take snapshots of the service on a remote server, without any obligation.
 
-- once every hour (default);
-- once every 6 hours;
-- once every day;
-- once every 2 days;
-- once every 3 days;
-- once every week.
+In the event of an outage or attack, if OVHcloud has taken a snapshot on a remote server, we can then restore the data from the last available snapshot. Please note, however, that this is done on request and is an optional service that will be billed.
 
-You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) or via the [API](https://api.ovh.com/):
+### How often are snapshots taken? <a name="frequency"></a>
+
+You can manage the frequency of snapshots from your OVHcloud Control Panel. You can choose the frequency from the following options:
+
+- every hour (default)
+- once every 6 hours
+- once every day
+- once every 2 days
+- once every 3 days
+- once every week
+
+You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) or via the following [API](https://api.ovh.com/) call:
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Please refer to our [Getting started with OVHcloud APIs](/pages/account/api/first-steps) guide to get familiar with using OVHcloud APIs.
+>
 
 ### How does the snapshot management system work?
 
@@ -115,26 +152,41 @@ You can configure automatic snapshots, and a selection of frequencies are availa
 
 ### Can I delete a snapshot?
 
-Only snapshots that are created “on demand” can be deleted (see previous question “How frequently are snapshots taken?”). Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
+Only snapshots created “on demand” can be deleted (see previous question [How often are snapshots taken?](#frequency)).<br>
+Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
 
-### How much storage space do snapshots use on a HA-NAS solution?
+### Are snapshots included in the capacity of a service?
 
-The storage capacity used by a snapshot can vary depending on the actions taken in the time period between two snapshots.
+You are allocated additional space on the same physical media to ensure that your snapshots are stored. This space corresponds to at least 15% of the primary volume. In case you exceed this limit, the snapshots will be stored on your main storage space. You cannot use the additional space for anything other than storing your snapshots.
 
-From the moment you take the snapshot, all actions made on the partition concerned are stored in this snapshot, and they will increase the file size.
+For example, for a 3 TB service, an additional 450 GB is reserved for snapshots.
 
 ### What is the maximum number of snapshots I can create?
 
 - For automatic snapshots: one per partition
 - For manual snapshots: ten per partition
 
+### Where are snapshots stored?
+
+Snapshots are stored at the same level as your service. Snapshots are replicated on two separate servers in two different racks. In addition, OVHcloud takes a daily snapshot at a remote site.
+
 ### Where can I retrieve my snapshots?
 
-In the partition concerned: a hidden directory called `.zfs` → directory `snapshots` . Files are available in read-only mode.
+In the partition concerned, you will find a hidden directory called `.zfs`, which contains a `snapshots` directory. The files are available in read only.
 
-### Does OVHcloud also create backups of my data?
+### How many snapshot policies can I create per volume?
 
-Yes, OVHcloud creates internal daily backups. It also generates a snapshot. This backup cannot be disabled by the customer.
+1
+
+## Billing
+
+### What type of pricing is linked to the service?
+
+HA-NAS is a service billed monthly by volume (from 3 to 144 TB in stages).
+
+### How long can I subscribe to a HA-NAS solution?
+
+The subscription periods offered are 1 month, 12 months, 24 months and 36 months. At the end of your subscription period, your subscription will be renewed automatically unless you submit a [cancellation request](/pages/account/billing/how_to_cancel_services). You can do this for the entire duration of your subscription, via the OVHcloud Control Panel.
 
 ## Go further
 

--- a/pages/cloud/storage/file_storage/nas_faq/guide.en-ie.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.en-ie.md
@@ -1,33 +1,79 @@
 ---
 title: HA-NAS - Frequently Asked Questions
-slug: nas/faq
 excerpt: Do you have questions about HA-NAS? Here are the most frequently asked questions
-section: HA-NAS
-order: 02
-updated: 2021-09-09
+updated: 2023-06-07
 ---
 
-**Last updated 9th September 2021**
+## Objective
 
-## The product
+**Here are the most frequently asked questions about the OVHcloud HA-NAS solution.**
+
+## General questions
+
+### What is the OVHcloud HA-NAS solution?
+
+HA-NAS is a fully managed, shared file storage service, based on OpenZFS open-source technology.
+
+### What can I do with HA-NAS?
+
+HA-NAS enables data to be centralised across different Linux workloads, as well as Windows for multiple scenarios:
+
+- shared and external storage for IT applications (VM, DB, etc.)
+- web content management 
+- file sharing on the network, etc.
 
 ### Can I manage my HA-NAS via a configuration panel?
 
-Yes, you can manage it from your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) by going to the `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} section.
+Yes, you can access it from your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) by going to the `Bare Metal Cloud`{.action} section, then `NAS and CDN`{.action}.
 
-### Can I increase the total storage capacity of my HA-NAS?
+## Availability
 
-Once you have ordered a HA-NAS, you cannot increase its storage capacity. To increase your storage capacity, you will need to migrate your data onto a second HA-NAS with a higher storage capacity.
+### Which SLA comes with HA-NAS?
+
+HA-NAS comes with a 99.99% availability rate.
+
+## IP and Security
+
+### What file transfer protocols are currently supported on the HA-NAS solution?
+
+HA-NAS supports file transfer through NFS (NFSv3) and CIFS (SMB).
+
+### Which OVHcloud services can I push data from?
+
+HA-NAS is a service that can receive data from all existing OVHcloud services: Bare Metal Cloud (VPS, OVHcloud Dedicated Servers, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, etc.
+
+### How do I manage access to a HA-NAS solution?
+
+You can configure the access control list (ACL) in your OVHcloud Control Panel. Simply enter the IP address of the service for which you want to authorise access to the HA-NAS.
+
+### Is the HA-NAS service compatible with other servers outside of OVHcloud?
+
+No. You can only access your HA-NAS from the OVHcloud network.
+
+### Is HA-NAS eligible for the vRack solution?
+
+Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP path of the server connected to vRack.
+
+## Capacity and performance
 
 ### What storage capacity options are available?
 
-We offer the following options for storage capacity:
+The minimum size of a service is 3 TB, and the maximum size is 144 TB.<br>
+We offer the following storage capacities based on 3 TB disks:
 
-- 3 To
-- 6 To
-- 9 To
-- 18 To
-- 36 To
+- 3 TB
+- 6 TB
+- 9 TB
+- 18 TB
+- 36 TB
+
+We offer the following storage capacities on a 12 TB disk base:
+
+- 12 TB
+- 24 TB
+- 36 TB
+- 72 TB
+- 144 TB
 
 The storage capacities offered are the usable capacities.
 
@@ -35,79 +81,70 @@ The storage capacities offered are the usable capacities.
 
 The disks of your HA-NAS are dedicated to your services. The machine’s other resources are shared (RAM, CPU, bandwidth).
 
-**Special case:** If you sign up to the 36 To solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
+**Special case:** If you sign up to the 144 TB solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
 
-### How long can I subscribe to an HA-NAS solution?
+### How many HA-NAS services can I create from my customer account?
 
-The subscription periods offered are 1 month, 3 months, 6 months and 12 months. At the end of your subscription period, your subscription is renewed automatically unless you submit a cancellation request. You can do this at any time during your subscription period, via your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie).
+There is no limit to the number of services per customer account.
+
+### What is the maximum number of partitions per service?
+
+You can create as many partitions as you want. The minimum size is 10 GB and the maximum size is defined by the maximum size of the service.
+
+### Are the transfer and availability rates guaranteed?
+
+- Transfer: the service’s bandwidth is shared. Transfer rates cannot be guaranteed by OVHcloud.
+- Availability: service availability is guaranteed, and is the subject of a service level agreement. You can view the details in our Terms of Use.
 
 ## Using the product
 
 ### Can HA-NAS be connected to several servers at once?
 
-Yes. You can make your HA-NAS interact simultaneously with several OVHcloud services.
+Yes. You can have your NAS interacted simultaneously with several OVHcloud services.
 
 ### Can I install an operating system on a HA-NAS?
 
 No, you cannot install operating systems on HA-NAS solutions.
 
-### Which protocols are compatible with the HA-NAS solution?
-
-HA-NAS can be mounted on a Windows or Linux server via CIFS (Samba) or NFS protocols.
-
 ### Can the allocated space be partitioned?
 
 Yes, you will need to create one or several partitions, depending on how you will use it. There are no limits to creating partitions.
-
-## Product compatibility
-
-### Is HA-NAS compatible with other services outside of OVHcloud?
-
-No, you can only access your HA-NAS from the OVHcloud network.
-
-### Which service(s) can I use to access HA-NAS?
-
-The service is accessible from all OVHcloud products that have an operating system or distribution: dedicated servers (OVHcloud, So you Start, Kimsufi), Hosted Private Cloud, Public Cloud and VPS.
-
-### How do I manage access to a HA-NAS solution?
-
-The access control list (ACL) can be configured from your OVHcloud Control Panel. Simply enter the IP address of the service for which you would like to authorise access to the HA-NAS.
-
-### Is HA-NAS eligible for the vRack solution?
-
-Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP route of the server connected to vRack.
-
-## Bandwidth
-
-### Are the transfer and availability rates guaranteed?
-
-- Transfer: the service’s bandwidth is shared. The transfer rate cannot be guaranteed by OVHcloud.
-- Availability: service availability is guaranteed, and is the subject of a service level agreement.  The details can be accessed in our Special Conditions of Use.
 
 ## Snapshots
 
 ### What are snapshots?
 
-Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. You can configure and manage snapshots from your Control Panel.
+Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. They offer you the first level of backup. You can configure and manage snapshots from your OVHcloud Control Panel.
 
 By default, the snapshot feature is enabled when you create your partition, and the frequency is set at “once every hour” by default.
 
-### How frequently are snapshots taken?
+### Which backup policy is associated with HA-NAS?
 
-You can set the frequency of snapshots from your Control Panel. You can choose the frequency from the following options:
+Users are responsible for managing their backups (tools and policies) inside and outside the service, as well as their business continuity and disaster recovery plans. However, for reasons of infrastructure security and resilience, OVHcloud can take snapshots of the service on a remote server, without any obligation.
 
-- once every hour (default);
-- once every 6 hours;
-- once every day;
-- once every 2 days;
-- once every 3 days;
-- once every week.
+In the event of an outage or attack, if OVHcloud has taken a snapshot on a remote server, we can then restore the data from the last available snapshot. Please note, however, that this is done on request and is an optional service that will be billed.
 
-You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) or via the [API](https://api.ovh.com/):
+### How often are snapshots taken? <a name="frequency"></a>
+
+You can manage the frequency of snapshots from your OVHcloud Control Panel. You can choose the frequency from the following options:
+
+- every hour (default)
+- once every 6 hours
+- once every day
+- once every 2 days
+- once every 3 days
+- once every week
+
+You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) or via the following [API](https://api.ovh.com/) call:
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Please refer to our [Getting started with OVHcloud APIs](/pages/account/api/first-steps) guide to get familiar with using OVHcloud APIs.
+>
 
 ### How does the snapshot management system work?
 
@@ -115,26 +152,41 @@ You can configure automatic snapshots, and a selection of frequencies are availa
 
 ### Can I delete a snapshot?
 
-Only snapshots that are created “on demand” can be deleted (see previous question “How frequently are snapshots taken?”). Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
+Only snapshots created “on demand” can be deleted (see previous question [How often are snapshots taken?](#frequency)).<br>
+Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
 
-### How much storage space do snapshots use on a HA-NAS solution?
+### Are snapshots included in the capacity of a service?
 
-The storage capacity used by a snapshot can vary depending on the actions taken in the time period between two snapshots.
+You are allocated additional space on the same physical media to ensure that your snapshots are stored. This space corresponds to at least 15% of the primary volume. In case you exceed this limit, the snapshots will be stored on your main storage space. You cannot use the additional space for anything other than storing your snapshots.
 
-From the moment you take the snapshot, all actions made on the partition concerned are stored in this snapshot, and they will increase the file size.
+For example, for a 3 TB service, an additional 450 GB is reserved for snapshots.
 
 ### What is the maximum number of snapshots I can create?
 
 - For automatic snapshots: one per partition
 - For manual snapshots: ten per partition
 
+### Where are snapshots stored?
+
+Snapshots are stored at the same level as your service. Snapshots are replicated on two separate servers in two different racks. In addition, OVHcloud takes a daily snapshot at a remote site.
+
 ### Where can I retrieve my snapshots?
 
-In the partition concerned: a hidden directory called `.zfs` → directory `snapshots` . Files are available in read-only mode.
+In the partition concerned, you will find a hidden directory called `.zfs`, which contains a `snapshots` directory. The files are available in read only.
 
-### Does OVHcloud also create backups of my data?
+### How many snapshot policies can I create per volume?
 
-Yes, OVHcloud creates internal daily backups. It also generates a snapshot. This backup cannot be disabled by the customer.
+1
+
+## Billing
+
+### What type of pricing is linked to the service?
+
+HA-NAS is a service billed monthly by volume (from 3 to 144 TB in stages).
+
+### How long can I subscribe to a HA-NAS solution?
+
+The subscription periods offered are 1 month, 12 months, 24 months and 36 months. At the end of your subscription period, your subscription will be renewed automatically unless you submit a [cancellation request](/pages/account/billing/how_to_cancel_services). You can do this for the entire duration of your subscription, via the OVHcloud Control Panel.
 
 ## Go further
 

--- a/pages/cloud/storage/file_storage/nas_faq/guide.en-sg.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.en-sg.md
@@ -1,33 +1,79 @@
 ---
 title: HA-NAS - Frequently Asked Questions
-slug: nas/faq
 excerpt: Do you have questions about HA-NAS? Here are the most frequently asked questions
-section: HA-NAS
-order: 02
-updated: 2021-09-09
+updated: 2023-06-07
 ---
 
-**Last updated 9th September 2021**
+## Objective
 
-## The product
+**Here are the most frequently asked questions about the OVHcloud HA-NAS solution.**
+
+## General questions
+
+### What is the OVHcloud HA-NAS solution?
+
+HA-NAS is a fully managed, shared file storage service, based on OpenZFS open-source technology.
+
+### What can I do with HA-NAS?
+
+HA-NAS enables data to be centralised across different Linux workloads, as well as Windows for multiple scenarios:
+
+- shared and external storage for IT applications (VM, DB, etc.)
+- web content management 
+- file sharing on the network, etc.
 
 ### Can I manage my HA-NAS via a configuration panel?
 
-Yes, you can manage it from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) by going to the `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} section.
+Yes, you can access it from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) by going to the `Bare Metal Cloud`{.action} section, then `NAS and CDN`{.action}.
 
-### Can I increase the total storage capacity of my HA-NAS?
+## Availability
 
-Once you have ordered a HA-NAS, you cannot increase its storage capacity. To increase your storage capacity, you will need to migrate your data onto a second HA-NAS with a higher storage capacity.
+### Which SLA comes with HA-NAS?
+
+HA-NAS comes with a 99.99% availability rate.
+
+## IP and Security
+
+### What file transfer protocols are currently supported on the HA-NAS solution?
+
+HA-NAS supports file transfer through NFS (NFSv3) and CIFS (SMB).
+
+### Which OVHcloud services can I push data from?
+
+HA-NAS is a service that can receive data from all existing OVHcloud services: Bare Metal Cloud (VPS, OVHcloud Dedicated Servers, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, etc.
+
+### How do I manage access to a HA-NAS solution?
+
+You can configure the access control list (ACL) in your OVHcloud Control Panel. Simply enter the IP address of the service for which you want to authorise access to the HA-NAS.
+
+### Is the HA-NAS service compatible with other servers outside of OVHcloud?
+
+No. You can only access your HA-NAS from the OVHcloud network.
+
+### Is HA-NAS eligible for the vRack solution?
+
+Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP path of the server connected to vRack.
+
+## Capacity and performance
 
 ### What storage capacity options are available?
 
-We offer the following options for storage capacity:
+The minimum size of a service is 3 TB, and the maximum size is 144 TB.<br>
+We offer the following storage capacities based on 3 TB disks:
 
-- 3 To
-- 6 To
-- 9 To
-- 18 To
-- 36 To
+- 3 TB
+- 6 TB
+- 9 TB
+- 18 TB
+- 36 TB
+
+We offer the following storage capacities on a 12 TB disk base:
+
+- 12 TB
+- 24 TB
+- 36 TB
+- 72 TB
+- 144 TB
 
 The storage capacities offered are the usable capacities.
 
@@ -35,79 +81,70 @@ The storage capacities offered are the usable capacities.
 
 The disks of your HA-NAS are dedicated to your services. The machine’s other resources are shared (RAM, CPU, bandwidth).
 
-**Special case:** If you sign up to the 36 To solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
+**Special case:** If you sign up to the 144 TB solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
 
-### How long can I subscribe to an HA-NAS solution?
+### How many HA-NAS services can I create from my customer account?
 
-The subscription periods offered are 1 month, 3 months, 6 months and 12 months. At the end of your subscription period, your subscription is renewed automatically unless you submit a cancellation request. You can do this at any time during your subscription period, via your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg).
+There is no limit to the number of services per customer account.
+
+### What is the maximum number of partitions per service?
+
+You can create as many partitions as you want. The minimum size is 10 GB and the maximum size is defined by the maximum size of the service.
+
+### Are the transfer and availability rates guaranteed?
+
+- Transfer: the service’s bandwidth is shared. Transfer rates cannot be guaranteed by OVHcloud.
+- Availability: service availability is guaranteed, and is the subject of a service level agreement. You can view the details in our Terms of Use.
 
 ## Using the product
 
 ### Can HA-NAS be connected to several servers at once?
 
-Yes. You can make your HA-NAS interact simultaneously with several OVHcloud services.
+Yes. You can have your NAS interacted simultaneously with several OVHcloud services.
 
 ### Can I install an operating system on a HA-NAS?
 
 No, you cannot install operating systems on HA-NAS solutions.
 
-### Which protocols are compatible with the HA-NAS solution?
-
-HA-NAS can be mounted on a Windows or Linux server via CIFS (Samba) or NFS protocols.
-
 ### Can the allocated space be partitioned?
 
 Yes, you will need to create one or several partitions, depending on how you will use it. There are no limits to creating partitions.
-
-## Product compatibility
-
-### Is HA-NAS compatible with other services outside of OVHcloud?
-
-No, you can only access your HA-NAS from the OVHcloud network.
-
-### Which service(s) can I use to access HA-NAS?
-
-The service is accessible from all OVHcloud products that have an operating system or distribution: dedicated servers (OVHcloud, So you Start, Kimsufi), Hosted Private Cloud, Public Cloud and VPS.
-
-### How do I manage access to a HA-NAS solution?
-
-The access control list (ACL) can be configured from your OVHcloud Control Panel. Simply enter the IP address of the service for which you would like to authorise access to the HA-NAS.
-
-### Is HA-NAS eligible for the vRack solution?
-
-Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP route of the server connected to vRack.
-
-## Bandwidth
-
-### Are the transfer and availability rates guaranteed?
-
-- Transfer: the service’s bandwidth is shared. The transfer rate cannot be guaranteed by OVHcloud.
-- Availability: service availability is guaranteed, and is the subject of a service level agreement.  The details can be accessed in our Special Conditions of Use.
 
 ## Snapshots
 
 ### What are snapshots?
 
-Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. You can configure and manage snapshots from your Control Panel.
+Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. They offer you the first level of backup. You can configure and manage snapshots from your OVHcloud Control Panel.
 
 By default, the snapshot feature is enabled when you create your partition, and the frequency is set at “once every hour” by default.
 
-### How frequently are snapshots taken?
+### Which backup policy is associated with HA-NAS?
 
-You can set the frequency of snapshots from your Control Panel. You can choose the frequency from the following options:
+Users are responsible for managing their backups (tools and policies) inside and outside the service, as well as their business continuity and disaster recovery plans. However, for reasons of infrastructure security and resilience, OVHcloud can take snapshots of the service on a remote server, without any obligation.
 
-- once every hour (default);
-- once every 6 hours;
-- once every day;
-- once every 2 days;
-- once every 3 days;
-- once every week.
+In the event of an outage or attack, if OVHcloud has taken a snapshot on a remote server, we can then restore the data from the last available snapshot. Please note, however, that this is done on request and is an optional service that will be billed.
 
-You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) or via the [API](https://ca.api.ovh.com/):
+### How often are snapshots taken? <a name="frequency"></a>
+
+You can manage the frequency of snapshots from your OVHcloud Control Panel. You can choose the frequency from the following options:
+
+- every hour (default)
+- once every 6 hours
+- once every day
+- once every 2 days
+- once every 3 days
+- once every week
+
+You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) or via the following [API](https://api.ovh.com/) call:
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Please refer to our [Getting started with OVHcloud APIs](/pages/account/api/first-steps) guide to get familiar with using OVHcloud APIs.
+>
 
 ### How does the snapshot management system work?
 
@@ -115,26 +152,41 @@ You can configure automatic snapshots, and a selection of frequencies are availa
 
 ### Can I delete a snapshot?
 
-Only snapshots that are created “on demand” can be deleted (see previous question “How frequently are snapshots taken?”). Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
+Only snapshots created “on demand” can be deleted (see previous question [How often are snapshots taken?](#frequency)).<br>
+Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
 
-### How much storage space do snapshots use on a HA-NAS solution?
+### Are snapshots included in the capacity of a service?
 
-The storage capacity used by a snapshot can vary depending on the actions taken in the time period between two snapshots.
+You are allocated additional space on the same physical media to ensure that your snapshots are stored. This space corresponds to at least 15% of the primary volume. In case you exceed this limit, the snapshots will be stored on your main storage space. You cannot use the additional space for anything other than storing your snapshots.
 
-From the moment you take the snapshot, all actions made on the partition concerned are stored in this snapshot, and they will increase the file size.
+For example, for a 3 TB service, an additional 450 GB is reserved for snapshots.
 
 ### What is the maximum number of snapshots I can create?
 
 - For automatic snapshots: one per partition
 - For manual snapshots: ten per partition
 
+### Where are snapshots stored?
+
+Snapshots are stored at the same level as your service. Snapshots are replicated on two separate servers in two different racks. In addition, OVHcloud takes a daily snapshot at a remote site.
+
 ### Where can I retrieve my snapshots?
 
-In the partition concerned: a hidden directory called `.zfs` → directory `snapshots` . Files are available in read-only mode.
+In the partition concerned, you will find a hidden directory called `.zfs`, which contains a `snapshots` directory. The files are available in read only.
 
-### Does OVHcloud also create backups of my data?
+### How many snapshot policies can I create per volume?
 
-Yes, OVHcloud creates internal daily backups. It also generates a snapshot. This backup cannot be disabled by the customer.
+1
+
+## Billing
+
+### What type of pricing is linked to the service?
+
+HA-NAS is a service billed monthly by volume (from 3 to 144 TB in stages).
+
+### How long can I subscribe to a HA-NAS solution?
+
+The subscription periods offered are 1 month, 12 months, 24 months and 36 months. At the end of your subscription period, your subscription will be renewed automatically unless you submit a [cancellation request](/pages/account/billing/how_to_cancel_services). You can do this for the entire duration of your subscription, via the OVHcloud Control Panel.
 
 ## Go further
 

--- a/pages/cloud/storage/file_storage/nas_faq/guide.en-us.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.en-us.md
@@ -1,33 +1,79 @@
 ---
 title: HA-NAS - Frequently Asked Questions
-slug: nas/faq
 excerpt: Do you have questions about HA-NAS? Here are the most frequently asked questions
-section: HA-NAS
-order: 02
-updated: 2021-09-09
+updated: 2023-06-07
 ---
 
-**Last updated 9th September 2021**
+## Objective
 
-## The product
+**Here are the most frequently asked questions about the OVHcloud HA-NAS solution.**
+
+## General questions
+
+### What is the OVHcloud HA-NAS solution?
+
+HA-NAS is a fully managed, shared file storage service, based on OpenZFS open-source technology.
+
+### What can I do with HA-NAS?
+
+HA-NAS enables data to be centralised across different Linux workloads, as well as Windows for multiple scenarios:
+
+- shared and external storage for IT applications (VM, DB, etc.)
+- web content management 
+- file sharing on the network, etc.
 
 ### Can I manage my HA-NAS via a configuration panel?
 
-Yes, you can manage it from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) by going to the `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} section.
+Yes, you can access it from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) by going to the `Bare Metal Cloud`{.action} section, then `NAS and CDN`{.action}.
 
-### Can I increase the total storage capacity of my HA-NAS?
+## Availability
 
-Once you have ordered a HA-NAS, you cannot increase its storage capacity. To increase your storage capacity, you will need to migrate your data onto a second HA-NAS with a higher storage capacity.
+### Which SLA comes with HA-NAS?
+
+HA-NAS comes with a 99.99% availability rate.
+
+## IP and Security
+
+### What file transfer protocols are currently supported on the HA-NAS solution?
+
+HA-NAS supports file transfer through NFS (NFSv3) and CIFS (SMB).
+
+### Which OVHcloud services can I push data from?
+
+HA-NAS is a service that can receive data from all existing OVHcloud services: Bare Metal Cloud (VPS, OVHcloud Dedicated Servers, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, etc.
+
+### How do I manage access to a HA-NAS solution?
+
+You can configure the access control list (ACL) in your OVHcloud Control Panel. Simply enter the IP address of the service for which you want to authorise access to the HA-NAS.
+
+### Is the HA-NAS service compatible with other servers outside of OVHcloud?
+
+No. You can only access your HA-NAS from the OVHcloud network.
+
+### Is HA-NAS eligible for the vRack solution?
+
+Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP path of the server connected to vRack.
+
+## Capacity and performance
 
 ### What storage capacity options are available?
 
-We offer the following options for storage capacity:
+The minimum size of a service is 3 TB, and the maximum size is 144 TB.<br>
+We offer the following storage capacities based on 3 TB disks:
 
-- 3 To
-- 6 To
-- 9 To
-- 18 To
-- 36 To
+- 3 TB
+- 6 TB
+- 9 TB
+- 18 TB
+- 36 TB
+
+We offer the following storage capacities on a 12 TB disk base:
+
+- 12 TB
+- 24 TB
+- 36 TB
+- 72 TB
+- 144 TB
 
 The storage capacities offered are the usable capacities.
 
@@ -35,79 +81,70 @@ The storage capacities offered are the usable capacities.
 
 The disks of your HA-NAS are dedicated to your services. The machine’s other resources are shared (RAM, CPU, bandwidth).
 
-**Special case:** If you sign up to the 36 To solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
+**Special case:** If you sign up to the 144 TB solution, all of the host server’s resources are dedicated to you (RAM, CPU, bandwidth).
 
-### How long can I subscribe to an HA-NAS solution?
+### How many HA-NAS services can I create from my customer account?
 
-The subscription periods offered are 1 month, 3 months, 6 months and 12 months. At the end of your subscription period, your subscription is renewed automatically unless you submit a cancellation request. You can do this at any time during your subscription period, via your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we).
+There is no limit to the number of services per customer account.
+
+### What is the maximum number of partitions per service?
+
+You can create as many partitions as you want. The minimum size is 10 GB and the maximum size is defined by the maximum size of the service.
+
+### Are the transfer and availability rates guaranteed?
+
+- Transfer: the service’s bandwidth is shared. Transfer rates cannot be guaranteed by OVHcloud.
+- Availability: service availability is guaranteed, and is the subject of a service level agreement. You can view the details in our Terms of Use.
 
 ## Using the product
 
 ### Can HA-NAS be connected to several servers at once?
 
-Yes. You can make your HA-NAS interact simultaneously with several OVHcloud services.
+Yes. You can have your NAS interacted simultaneously with several OVHcloud services.
 
 ### Can I install an operating system on a HA-NAS?
 
 No, you cannot install operating systems on HA-NAS solutions.
 
-### Which protocols are compatible with the HA-NAS solution?
-
-HA-NAS can be mounted on a Windows or Linux server via CIFS (Samba) or NFS protocols.
-
 ### Can the allocated space be partitioned?
 
 Yes, you will need to create one or several partitions, depending on how you will use it. There are no limits to creating partitions.
-
-## Product compatibility
-
-### Is HA-NAS compatible with other services outside of OVHcloud?
-
-No, you can only access your HA-NAS from the OVHcloud network.
-
-### Which service(s) can I use to access HA-NAS?
-
-The service is accessible from all OVHcloud products that have an operating system or distribution: dedicated servers (OVHcloud, So you Start, Kimsufi), Hosted Private Cloud, Public Cloud and VPS.
-
-### How do I manage access to a HA-NAS solution?
-
-The access control list (ACL) can be configured from your OVHcloud Control Panel. Simply enter the IP address of the service for which you would like to authorise access to the HA-NAS.
-
-### Is HA-NAS eligible for the vRack solution?
-
-Currently, HA-NAS cannot be integrated into the vRack private network. However, HA-NAS and vRack are not incompatible if you go via the public IP route of the server connected to vRack.
-
-## Bandwidth
-
-### Are the transfer and availability rates guaranteed?
-
-- Transfer: the service’s bandwidth is shared. The transfer rate cannot be guaranteed by OVHcloud.
-- Availability: service availability is guaranteed, and is the subject of a service level agreement.  The details can be accessed in our Special Conditions of Use.
 
 ## Snapshots
 
 ### What are snapshots?
 
-Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. You can configure and manage snapshots from your Control Panel.
+Snapshots are instantaneous images of your disk’s state and the data stored on it at that particular point in time. They offer you the first level of backup. You can configure and manage snapshots from your OVHcloud Control Panel.
 
 By default, the snapshot feature is enabled when you create your partition, and the frequency is set at “once every hour” by default.
 
-### How frequently are snapshots taken?
+### Which backup policy is associated with HA-NAS?
 
-You can set the frequency of snapshots from your Control Panel. You can choose the frequency from the following options:
+Users are responsible for managing their backups (tools and policies) inside and outside the service, as well as their business continuity and disaster recovery plans. However, for reasons of infrastructure security and resilience, OVHcloud can take snapshots of the service on a remote server, without any obligation.
 
-- once every hour (default);
-- once every 6 hours;
-- once every day;
-- once every 2 days;
-- once every 3 days;
-- once every week.
+In the event of an outage or attack, if OVHcloud has taken a snapshot on a remote server, we can then restore the data from the last available snapshot. Please note, however, that this is done on request and is an optional service that will be billed.
 
-You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) or via the [API](https://ca.api.ovh.com/):
+### How often are snapshots taken? <a name="frequency"></a>
+
+You can manage the frequency of snapshots from your OVHcloud Control Panel. You can choose the frequency from the following options:
+
+- every hour (default)
+- once every 6 hours
+- once every day
+- once every 2 days
+- once every 3 days
+- once every week
+
+You can also create manual snapshots at any time, save them without any time limit, or delete them. This feature is available in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) or via the following [API](https://api.ovh.com/) call:
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Please refer to our [Getting started with OVHcloud APIs](/pages/account/api/first-steps) guide to get familiar with using OVHcloud APIs.
+>
 
 ### How does the snapshot management system work?
 
@@ -115,26 +152,41 @@ You can configure automatic snapshots, and a selection of frequencies are availa
 
 ### Can I delete a snapshot?
 
-Only snapshots that are created “on demand” can be deleted (see previous question “How frequently are snapshots taken?”). Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
+Only snapshots created “on demand” can be deleted (see previous question [How often are snapshots taken?](#frequency)).<br>
+Snapshots with a set frequency are automatically deleted, and cannot be deleted manually.
 
-### How much storage space do snapshots use on a HA-NAS solution?
+### Are snapshots included in the capacity of a service?
 
-The storage capacity used by a snapshot can vary depending on the actions taken in the time period between two snapshots.
+You are allocated additional space on the same physical media to ensure that your snapshots are stored. This space corresponds to at least 15% of the primary volume. In case you exceed this limit, the snapshots will be stored on your main storage space. You cannot use the additional space for anything other than storing your snapshots.
 
-From the moment you take the snapshot, all actions made on the partition concerned are stored in this snapshot, and they will increase the file size.
+For example, for a 3 TB service, an additional 450 GB is reserved for snapshots.
 
 ### What is the maximum number of snapshots I can create?
 
 - For automatic snapshots: one per partition
 - For manual snapshots: ten per partition
 
+### Where are snapshots stored?
+
+Snapshots are stored at the same level as your service. Snapshots are replicated on two separate servers in two different racks. In addition, OVHcloud takes a daily snapshot at a remote site.
+
 ### Where can I retrieve my snapshots?
 
-In the partition concerned: a hidden directory called `.zfs` → directory `snapshots` . Files are available in read-only mode.
+In the partition concerned, you will find a hidden directory called `.zfs`, which contains a `snapshots` directory. The files are available in read only.
 
-### Does OVHcloud also create backups of my data?
+### How many snapshot policies can I create per volume?
 
-Yes, OVHcloud creates internal daily backups. It also generates a snapshot. This backup cannot be disabled by the customer.
+1
+
+## Billing
+
+### What type of pricing is linked to the service?
+
+HA-NAS is a service billed monthly by volume (from 3 to 144 TB in stages).
+
+### How long can I subscribe to a HA-NAS solution?
+
+The subscription periods offered are 1 month, 12 months, 24 months and 36 months. At the end of your subscription period, your subscription will be renewed automatically unless you submit a [cancellation request](/pages/account/billing/how_to_cancel_services). You can do this for the entire duration of your subscription, via the OVHcloud Control Panel.
 
 ## Go further
 

--- a/pages/cloud/storage/file_storage/nas_faq/guide.es-es.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.es-es.md
@@ -1,37 +1,83 @@
 ---
-title: Preguntas frecuentes sobre los NAS
-slug: nas/faq
-excerpt: ¿Tiene alguna duda sobre los NAS? A continuación le ofrecemos la respuesta a las preguntas más frecuentes.
-section: NAS-HA
-order: 02
-updated: 2021-09-09
+title: Preguntas frecuentes sobre los NAS-HA
+excerpt: ¿Tiene alguna duda sobre los NAS-HA? A continuación le ofrecemos la respuesta a las preguntas más frecuentes.
+updated: 2023-06-07
 ---
 
 > [!primary]
 > Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón «Contribuir» de esta página.
 >
 
-**Última actualización: 22/07/2021**
+## Objetivo
 
-## Características del producto
+**Estas son las preguntas más frecuentes sobre la solución NAS-HA de OVHcloud.**
+
+## Preguntas generales
+
+### ¿Qué es la solución NAS-HA de OVHcloud?
+
+NAS-HA es un servicio de almacenamiento de archivos compartido y totalmente administrado, basado en la tecnología open source OpenZFS.
+
+### ¿Qué puedo hacer con NAS-HA?
+
+NAS-HA permite centralizar los datos de diferentes cargas de trabajo Linux pero también Windows para múltiples escenarios:
+
+- almacenamiento compartido y externalizado para aplicaciones IT (MV, DB...)
+- gestión de contenidos web
+- compartir archivos en la red, etc.
 
 ### ¿Se puede gestionar el NAS-HA desde un panel de administración?
 
-Sí. Puede acceder al panel desde el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)en la sección `Bare Metal Cloud`{.action} y, seguidamente, en la sección `NAS y CDN`{.action}.
+Sí, puede acceder a este espacio desde el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es), en la sección "`Bare Metal Cloud`{.action}" y, seguidamente, en la sección `NAS y CDN`{.action}.
 
-### ¿Es posible aumentar la capacidad total de un NAS?
+## Disponibilidad
 
-No es posible aumentar la capacidad de un NAS-HA una vez contratado. Si desea aumentar la capacidad de almacenamiento, deberá migrar los datos a un segundo NAS de mayor capacidad.
+### ¿Qué SLA incluye NAS-HA?
+
+NAS-HA se suministra con un índice de disponibilidad del 99,99%.
+
+## Red y seguridad
+
+### ¿Qué protocolos de transferencia de archivos soportan actualmente la solución NAS-HA?
+
+NAS-HA soporta la transferencia de archivos a través de NFS (NFSv3) y CIFS (SMB).
+
+### ¿Desde qué servicios de OVHcloud puedo crear datos?
+
+NAS-HA es un servicio que puede recibir datos de todos los servicios existentes de OVHcloud: Bare Metal Cloud (VPS, servidores dedicados OVHcloud, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, etc.
+
+### ¿Cómo se gestionan los accesos al NAS-HA?
+
+La lista de control de acceso (ACL) puede configurarse desde el área de cliente de OVHcloud. Solo tiene que introducir la dirección IP del servicio al que quiere autorizar el acceso al NAS-HA.
+
+### ¿El servicio NAS-HA es compatible con otros servidores fuera de OVHcloud?
+
+No, solo es posible acceder a los NAS-HA desde la red de OVHcloud.
+
+### ¿NAS-HA es compatible con el vRack?
+
+Actualmente los NAS-HA no pueden añadirse a las redes privadas de un vRack. Sin embargo, el uso del NAS-HA y del vRack no son incompatibles pasando por la ruta IP pública del servidor conectado al vRack.
+
+## Capacidades y rendimiento
 
 ### ¿Cuáles son las capacidades de almacenamiento disponibles?
 
-Ofrecemos las siguientes capacidades de almacenamiento:
+El tamaño mínimo de un servicio es de 3 TB y el tamaño máximo es de 144 TB.<br>
+Ofrecemos las siguientes capacidades de almacenamiento en una base de discos de 3 TB:
 
-- 3 To
-- 6 To
-- 9 To
-- 18 To
-- 36 To
+- 3 TB
+- 6 TB
+- 9 TB
+- 18 TB
+- 36 TB
+
+Ofrecemos las siguientes capacidades de almacenamiento en una base de discos de 12 TB:
+
+- 12 TB
+- 24 TB
+- 36 TB
+- 72 TB
+- 144 TB
 
 Las capacidades de almacenamiento que se ofrecen son las que se pueden utilizar.
 
@@ -39,79 +85,69 @@ Las capacidades de almacenamiento que se ofrecen son las que se pueden utilizar.
 
 Los discos de los NAS-HA son dedicados. Los demás recursos de la máquina son compartidos (RAM, procesador y ancho de banda), con una excepción:
 
-**Caso particular:** si se suscribe a la oferta de 36 To, todos los recursos del servidor host son dedicados (RAM, CPU, ancho de banda).
+**Caso particular:** si se suscribe a la oferta 144 TB, todos los recursos del servidor host son dedicados (RAM, CPU, ancho de banda).
 
-### ¿Por qué duración puedo contratar un NAS-HA?
+### ¿Cuántos servicios NAS-HA puedo crear desde mi cuenta de cliente?
 
-Los períodos ofrecidos son de 1, 3, 6 y 12 meses. Al finalizar el período contratado, la suscripción se renueva por prórroga tácita si no se ha solicitado la baja del servicio con anterioridad. La baja puede realizarse en cualquier momento desde el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es).
+No hay límite de número de servicios por cuenta de cliente.
+
+### ¿Cuántas particiones máximas por servicio?
+
+Es posible crear tantas particiones como desee. El tamaño mínimo es de 10 GB y el tamaño máximo se define por el tamaño máximo del servicio.
+
+### ¿La tasa de transferencia y el porcentaje de disponibilidad están garantizados?
+
+- Transferencia: El ancho de banda del servicio es compartido, OVHcloud no puede garantizar la tasa de transferencia.
+- Disponibilidad: La disponibilidad del servicio está garantizada y sujeta a un acuerdo de nivel de servicio (SLA). Puede consultar los detalles en nuestras condiciones específicas de uso.
 
 ## Uso del producto
 
 ### ¿El NAS-HA puede conectarse a varios servidores a la vez?
 
-Sí. Es posible hacer interactuar el NAS con varios servicios de OVHcloud simultáneamente.
+Sí. Es posible interactuar el NAS con varios servicios de OVHcloud simultáneamente.
 
 ### ¿Se puede instalar un sistema operativo en un NAS-HA?
 
 No, no es posible instalar un SO en los NAS-HA.
 
-### ¿Cuáles son los protocolos compatibles con los NAS-HA?
-
-Los NAS-HA pueden montarse en un servidor Windows o Linux mediante los protocolos CIFS (Samba) o NFS.
-
-### ¿El espacio asignado es particionable?
+### ¿El espacio destinado es particionable?
 
 Sí, es necesario crear una o más particiones, según su uso. No hay límite en el número de particiones.
-
-## Compatibilidad del producto
-
-### ¿Los NAS-HA son compatibles con servidores externos a OVHcloud?
-
-No, solo es posible acceder a los NAS-HA desde la red de OVHcloud.
-
-### ¿Desde qué servicios se puede acceder a un NAS-HA?
-
-Es posible acceder al servicio desde todos los productos de OVHcloud que tengan sistema operativo: servidores dedicados (OVHcloud, So you Start y Kimsufi), Hosted Private Cloud, Public Cloud y VPS.
-
-### ¿Cómo se gestionan los accesos al NAS-HA?
-
-La lista de control de acceso (ACL) puede configurarse desde el área de cliente de OVHcloud. Solo tiene que introducir la dirección IP del servicio al que quiere autorizar el acceso.
-
-### ¿Los NAS-HA son compatibles con el vRack?
-
-Actualmente los NAS-HA no pueden añadirse a las redes privadas de un vRack. No obstante, el uso del NAS-HA y el vRack no son incompatibles pasando por la ruta IP pública del servidor conectado al vRack.
-
-## Tasa de transferencia
-
-### ¿La tasa de transferencia y el porcentaje de disponibilidad están garantizados?
-
-- Transferencia: El ancho de banda del servicio es compartido, por lo que OVHcloud no puede garantizar una tasa de transferencia.
-- Disponibilidad: La disponibilidad del servicio está garantizada y sujeta a un acuerdo de nivel de servicio (SLA). Los detalles pueden consultarse en las condiciones particulares del servicio.
 
 ## Snapshots
 
 ### ¿Qué es un snapshot?
 
-Un snapshot es una imagen instantánea del estado del disco y de los datos almacenados en él en un momento determinado. Los snapshots pueden configurarse y administrarse desde el área de cliente.
+Un snapshot es una imagen instantánea del estado del disco y de los datos almacenados en él en un momento determinado. permiten ofrecer un primer nivel de backup. Es posible configurar y gestionar los snapshots desde el área de cliente de OVHcloud.
 
-Por defecto, la función snapshot está activada al crear la partición, y la frecuencia está configurada en «cada hora».
+Por defecto, la función snapshot se activa al crear la partición. La frecuencia se preestablece en "cada hora".
 
-### ¿Con qué frecuencia se realizan los snapshots?
+### ¿Qué política de backup está asociada a NAS-HA?
 
-La frecuencia de los snapshots puede configurarse desde el área de cliente. Puede elegir la frecuencia entre las siguientes opciones:
+Los usuarios son responsables de la gestión de sus copias de seguridad (herramientas y reglas) dentro y fuera del servicio, así como de sus planes de continuidad del negocio y de recuperación ante desastres. Sin embargo, por motivos de seguridad y resiliencia de la infraestructura, OVHcloud puede realizar snapshots del servicio en un servidor remoto, aunque sin obligación de hacerlo.
+
+Si OVHcloud ha realizado un snapshot en un servidor remoto, puede restaurar los datos del último snapshot disponible en caso de avería o ataque. Tenga en cuenta que esta operación se realiza bajo demanda y constituye un servicio opcional facturado.
+
+### ¿Con qué frecuencia se realizan los snapshots? <a name="frequency"></a>
+
+La frecuencia de los snapshots puede configurarse desde el área de cliente de OVHcloud. Puede elegir la frecuencia entre las siguientes opciones:
 
 - cada hora (por defecto)
-- cada seis horas
+- cada 6 horas
 - cada día
 - cada dos días
 - cada tres días
 - semanal
 
-Además, en cualquier momento puede crear snapshots manuales, que podrá conservar sin limitación de tiempo o eliminar cuando desee. Esta funcionalidad está disponible en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) o la [API de OVHcloud](https://api.ovh.com/):
+Además, en cualquier momento puede crear snapshots manuales, que podrá conservar sin limitación de tiempo o eliminar cuando desee. Esta funcionalidad está disponible en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) o a través de la siguiente llamada a la [API](https://api.ovh.com/):
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Consulte nuestra guía [Primeros pasos con las API de OVHcloud](/pages/account/api/first-steps) para familiarizarse con el uso de las API de OVHcloud.
 >
 
 ### ¿Cómo funciona el sistema de gestión de los snapshots?
@@ -120,27 +156,43 @@ Puede configurar snapshots automáticos con una de las frecuencias disponibles. 
 
 ### ¿Es posible eliminar un snapshot?
 
-Solo se pueden eliminar los snapshots creados «a demanda» (ver la pregunta «¿Con qué frecuencia se realizan los snapshots?»). Los snapshots con una frecuencia establecida se eliminan automáticamente, y no es posible eliminarlos manualmente.
+Solo se pueden eliminar los snapshots creados "bajo demanda" (véase la pregunta anterior ["¿Con qué frecuencia se realizan los snapshots?](#frequency)".<br>
+Los snapshots con una frecuencia establecida se eliminan automáticamente, y no es posible eliminarlos manualmente.
 
-### ¿Cuánto espacio ocupan los snapshots en un NAS-HA?
+### ¿Los snapshots están incluidos en la capacidad de un servicio?
 
-El espacio que ocupa un snapshot varía en función de las acciones realizadas en el intervalo de tiempo que separa dos snapshots.
+Para garantizar el almacenamiento de sus snapshots, OVHcloud dispone de un espacio adicional con el mismo soporte físico. Este espacio corresponde al menos al 15% del volumen principal. En caso de superarlo, los snapshots se almacenarán en su espacio de almacenamiento principal. El espacio adicional no puede utilizarse para otro uso que el almacenamiento de sus snapshots.
 
-Desde la realización del snapshot, todas las acciones llevadas a cabo en la partición correspondiente se almacenarán en dicho snapshot y aumentarán el tamaño del archivo.
+Por ejemplo, para un servicio de 3 TB, se reservan 450 GB adicionales para los snapshots.
 
 ### ¿Cuántos snapshots se pueden realizar?
 
 - Snapshots automáticos: uno por partición.
-- Snapshots manuales: diez por partición.
+- Para los snapshots manuales: diez por partición
+
+### ¿Con qué frecuencia se realizan los snapshots?
+
+Los snapshots se almacenan al mismo nivel que el servicio. Los snapshots se replican en dos servidores distintos en dos racks diferentes. Además, OVHcloud realiza un snapshot diario en un sitio remoto.
 
 ### ¿Dónde se pueden encontrar los snapshots?
 
-En la partición correspondiente, en un directorio oculto llamado **.zfs**. En su interior se encuentra la carpeta **snapshots** que contiene los snapshots. Los archivos están disponibles en modo *read-only*.
+En la partición correspondiente, encontrará un directorio oculto llamado `.zfs` que contiene un directorio de `snapshots`. Los archivos están disponibles en solo lectura.
 
-### ¿OVHcloud también realiza copias de seguridad de los datos?
+### ¿Cuántas políticas de snapshots puedo crear por volumen?
 
-Sí, diariamente se realiza un backup interno, que genera un snapshot más. El cliente no puede desactivar este backup.
+1
+
+## Precios
+
+### ¿Qué tipo de tarificación está asociado al servicio?
+
+NAS-HA es un servicio facturado mensualmente al volumen (de 3 a 144 TB por tramos).
+
+### ¿Por qué duración puedo contratar un NAS-HA?
+
+Los períodos ofrecidos son de 1, 3, 6 y 12 meses. Al finalizar el período contratado, la suscripción se renueva tácitamente si no se ha solicitado ninguna [rescisión](/pages/account/billing/how_to_cancel_services). Puede contratarla desde el área de cliente de OVHcloud durante toda su vigencia.
 
 ## Más información
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.
+

--- a/pages/cloud/storage/file_storage/nas_faq/guide.es-us.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.es-us.md
@@ -1,37 +1,83 @@
 ---
-title: Preguntas frecuentes sobre los NAS
-slug: nas/faq
-excerpt: ¿Tiene alguna duda sobre los NAS? A continuación le ofrecemos la respuesta a las preguntas más frecuentes.
-section: NAS-HA
-order: 02
-updated: 2021-09-09
+title: Preguntas frecuentes sobre los NAS-HA
+excerpt: ¿Tiene alguna duda sobre los NAS-HA? A continuación le ofrecemos la respuesta a las preguntas más frecuentes.
+updated: 2023-06-07
 ---
 
 > [!primary]
 > Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón «Contribuir» de esta página.
 >
 
-**Última actualización: 22/07/2021**
+## Objetivo
 
-## Características del producto
+**Estas son las preguntas más frecuentes sobre la solución NAS-HA de OVHcloud.**
+
+## Preguntas generales
+
+### ¿Qué es la solución NAS-HA de OVHcloud?
+
+NAS-HA es un servicio de almacenamiento de archivos compartido y totalmente administrado, basado en la tecnología open source OpenZFS.
+
+### ¿Qué puedo hacer con NAS-HA?
+
+NAS-HA permite centralizar los datos de diferentes cargas de trabajo Linux pero también Windows para múltiples escenarios:
+
+- almacenamiento compartido y externalizado para aplicaciones IT (MV, DB...)
+- gestión de contenidos web
+- compartir archivos en la red, etc.
 
 ### ¿Se puede gestionar el NAS-HA desde un panel de administración?
 
-Sí. Puede acceder al panel desde el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)en la sección `Bare Metal Cloud`{.action} y, seguidamente, en la sección `NAS y CDN`{.action}.
+Sí, puede acceder a este espacio desde el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws), en la sección "`Bare Metal Cloud`{.action}" y, seguidamente, en la sección `NAS y CDN`{.action}.
 
-### ¿Es posible aumentar la capacidad total de un NAS?
+## Disponibilidad
 
-No es posible aumentar la capacidad de un NAS-HA una vez contratado. Si desea aumentar la capacidad de almacenamiento, deberá migrar los datos a un segundo NAS de mayor capacidad.
+### ¿Qué SLA incluye NAS-HA?
+
+NAS-HA se suministra con un índice de disponibilidad del 99,99%.
+
+## Red y seguridad
+
+### ¿Qué protocolos de transferencia de archivos soportan actualmente la solución NAS-HA?
+
+NAS-HA soporta la transferencia de archivos a través de NFS (NFSv3) y CIFS (SMB).
+
+### ¿Desde qué servicios de OVHcloud puedo crear datos?
+
+NAS-HA es un servicio que puede recibir datos de todos los servicios existentes de OVHcloud: Bare Metal Cloud (VPS, servidores dedicados OVHcloud, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, etc.
+
+### ¿Cómo se gestionan los accesos al NAS-HA?
+
+La lista de control de acceso (ACL) puede configurarse desde el área de cliente de OVHcloud. Solo tiene que introducir la dirección IP del servicio al que quiere autorizar el acceso al NAS-HA.
+
+### ¿El servicio NAS-HA es compatible con otros servidores fuera de OVHcloud?
+
+No, solo es posible acceder a los NAS-HA desde la red de OVHcloud.
+
+### ¿NAS-HA es compatible con el vRack?
+
+Actualmente los NAS-HA no pueden añadirse a las redes privadas de un vRack. Sin embargo, el uso del NAS-HA y del vRack no son incompatibles pasando por la ruta IP pública del servidor conectado al vRack.
+
+## Capacidades y rendimiento
 
 ### ¿Cuáles son las capacidades de almacenamiento disponibles?
 
-Ofrecemos las siguientes capacidades de almacenamiento:
+El tamaño mínimo de un servicio es de 3 TB y el tamaño máximo es de 144 TB.<br>
+Ofrecemos las siguientes capacidades de almacenamiento en una base de discos de 3 TB:
 
-- 3 To
-- 6 To
-- 9 To
-- 18 To
-- 36 To
+- 3 TB
+- 6 TB
+- 9 TB
+- 18 TB
+- 36 TB
+
+Ofrecemos las siguientes capacidades de almacenamiento en una base de discos de 12 TB:
+
+- 12 TB
+- 24 TB
+- 36 TB
+- 72 TB
+- 144 TB
 
 Las capacidades de almacenamiento que se ofrecen son las que se pueden utilizar.
 
@@ -39,79 +85,69 @@ Las capacidades de almacenamiento que se ofrecen son las que se pueden utilizar.
 
 Los discos de los NAS-HA son dedicados. Los demás recursos de la máquina son compartidos (RAM, procesador y ancho de banda), con una excepción:
 
-**Caso particular:** si se suscribe a la oferta de 36 To, todos los recursos del servidor host son dedicados (RAM, CPU, ancho de banda).
+**Caso particular:** si se suscribe a la oferta 144 TB, todos los recursos del servidor host son dedicados (RAM, CPU, ancho de banda).
 
-### ¿Por qué duración puedo contratar un NAS-HA?
+### ¿Cuántos servicios NAS-HA puedo crear desde mi cuenta de cliente?
 
-Los períodos ofrecidos son de 1, 3, 6 y 12 meses. Al finalizar el período contratado, la suscripción se renueva por prórroga tácita si no se ha solicitado la baja del servicio con anterioridad. La baja puede realizarse en cualquier momento desde el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+No hay límite de número de servicios por cuenta de cliente.
+
+### ¿Cuántas particiones máximas por servicio?
+
+Es posible crear tantas particiones como desee. El tamaño mínimo es de 10 GB y el tamaño máximo se define por el tamaño máximo del servicio.
+
+### ¿La tasa de transferencia y el porcentaje de disponibilidad están garantizados?
+
+- Transferencia: El ancho de banda del servicio es compartido, OVHcloud no puede garantizar la tasa de transferencia.
+- Disponibilidad: La disponibilidad del servicio está garantizada y sujeta a un acuerdo de nivel de servicio (SLA). Puede consultar los detalles en nuestras condiciones específicas de uso.
 
 ## Uso del producto
 
 ### ¿El NAS-HA puede conectarse a varios servidores a la vez?
 
-Sí. Es posible hacer interactuar el NAS con varios servicios de OVHcloud simultáneamente.
+Sí. Es posible interactuar el NAS con varios servicios de OVHcloud simultáneamente.
 
 ### ¿Se puede instalar un sistema operativo en un NAS-HA?
 
 No, no es posible instalar un SO en los NAS-HA.
 
-### ¿Cuáles son los protocolos compatibles con los NAS-HA?
-
-Los NAS-HA pueden montarse en un servidor Windows o Linux mediante los protocolos CIFS (Samba) o NFS.
-
-### ¿El espacio asignado es particionable?
+### ¿El espacio destinado es particionable?
 
 Sí, es necesario crear una o más particiones, según su uso. No hay límite en el número de particiones.
-
-## Compatibilidad del producto
-
-### ¿Los NAS-HA son compatibles con servidores externos a OVHcloud?
-
-No, solo es posible acceder a los NAS-HA desde la red de OVHcloud.
-
-### ¿Desde qué servicios se puede acceder a un NAS-HA?
-
-Es posible acceder al servicio desde todos los productos de OVHcloud que tengan sistema operativo: servidores dedicados (OVHcloud, So you Start y Kimsufi), Hosted Private Cloud, Public Cloud y VPS.
-
-### ¿Cómo se gestionan los accesos al NAS-HA?
-
-La lista de control de acceso (ACL) puede configurarse desde el área de cliente de OVHcloud. Solo tiene que introducir la dirección IP del servicio al que quiere autorizar el acceso.
-
-### ¿Los NAS-HA son compatibles con el vRack?
-
-Actualmente los NAS-HA no pueden añadirse a las redes privadas de un vRack. No obstante, el uso del NAS-HA y el vRack no son incompatibles pasando por la ruta IP pública del servidor conectado al vRack.
-
-## Tasa de transferencia
-
-### ¿La tasa de transferencia y el porcentaje de disponibilidad están garantizados?
-
-- Transferencia: El ancho de banda del servicio es compartido, por lo que OVHcloud no puede garantizar una tasa de transferencia.
-- Disponibilidad: La disponibilidad del servicio está garantizada y sujeta a un acuerdo de nivel de servicio (SLA). Los detalles pueden consultarse en las condiciones particulares del servicio.
 
 ## Snapshots
 
 ### ¿Qué es un snapshot?
 
-Un snapshot es una imagen instantánea del estado del disco y de los datos almacenados en él en un momento determinado. Los snapshots pueden configurarse y administrarse desde el área de cliente.
+Un snapshot es una imagen instantánea del estado del disco y de los datos almacenados en él en un momento determinado. permiten ofrecer un primer nivel de backup. Es posible configurar y gestionar los snapshots desde el área de cliente de OVHcloud.
 
-Por defecto, la función snapshot está activada al crear la partición, y la frecuencia está configurada en «cada hora».
+Por defecto, la función snapshot se activa al crear la partición. La frecuencia se preestablece en "cada hora".
 
-### ¿Con qué frecuencia se realizan los snapshots?
+### ¿Qué política de backup está asociada a NAS-HA?
 
-La frecuencia de los snapshots puede configurarse desde el área de cliente. Puede elegir la frecuencia entre las siguientes opciones:
+Los usuarios son responsables de la gestión de sus copias de seguridad (herramientas y reglas) dentro y fuera del servicio, así como de sus planes de continuidad del negocio y de recuperación ante desastres. Sin embargo, por motivos de seguridad y resiliencia de la infraestructura, OVHcloud puede realizar snapshots del servicio en un servidor remoto, aunque sin obligación de hacerlo.
+
+Si OVHcloud ha realizado un snapshot en un servidor remoto, puede restaurar los datos del último snapshot disponible en caso de avería o ataque. Tenga en cuenta que esta operación se realiza bajo demanda y constituye un servicio opcional facturado.
+
+### ¿Con qué frecuencia se realizan los snapshots? <a name="frequency"></a>
+
+La frecuencia de los snapshots puede configurarse desde el área de cliente de OVHcloud. Puede elegir la frecuencia entre las siguientes opciones:
 
 - cada hora (por defecto)
-- cada seis horas
+- cada 6 horas
 - cada día
 - cada dos días
 - cada tres días
 - semanal
 
-Además, en cualquier momento puede crear snapshots manuales, que podrá conservar sin limitación de tiempo o eliminar cuando desee. Esta funcionalidad está disponible en el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) o la [API de OVHcloud](https://ca.api.ovh.com/):
+Además, en cualquier momento puede crear snapshots manuales, que podrá conservar sin limitación de tiempo o eliminar cuando desee. Esta funcionalidad está disponible en el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) o a través de la siguiente llamada a la [API](https://api.ovh.com/):
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Consulte nuestra guía [Primeros pasos con las API de OVHcloud](/pages/account/api/first-steps) para familiarizarse con el uso de las API de OVHcloud.
 >
 
 ### ¿Cómo funciona el sistema de gestión de los snapshots?
@@ -120,26 +156,41 @@ Puede configurar snapshots automáticos con una de las frecuencias disponibles. 
 
 ### ¿Es posible eliminar un snapshot?
 
-Solo se pueden eliminar los snapshots creados «a demanda» (ver la pregunta «¿Con qué frecuencia se realizan los snapshots?»). Los snapshots con una frecuencia establecida se eliminan automáticamente, y no es posible eliminarlos manualmente.
+Solo se pueden eliminar los snapshots creados "bajo demanda" (véase la pregunta anterior ["¿Con qué frecuencia se realizan los snapshots?](#frequency)".<br>
+Los snapshots con una frecuencia establecida se eliminan automáticamente, y no es posible eliminarlos manualmente.
 
-### ¿Cuánto espacio ocupan los snapshots en un NAS-HA?
+### ¿Los snapshots están incluidos en la capacidad de un servicio?
 
-El espacio que ocupa un snapshot varía en función de las acciones realizadas en el intervalo de tiempo que separa dos snapshots.
+Para garantizar el almacenamiento de sus snapshots, OVHcloud dispone de un espacio adicional con el mismo soporte físico. Este espacio corresponde al menos al 15% del volumen principal. En caso de superarlo, los snapshots se almacenarán en su espacio de almacenamiento principal. El espacio adicional no puede utilizarse para otro uso que el almacenamiento de sus snapshots.
 
-Desde la realización del snapshot, todas las acciones llevadas a cabo en la partición correspondiente se almacenarán en dicho snapshot y aumentarán el tamaño del archivo.
+Por ejemplo, para un servicio de 3 TB, se reservan 450 GB adicionales para los snapshots.
 
 ### ¿Cuántos snapshots se pueden realizar?
 
 - Snapshots automáticos: uno por partición.
-- Snapshots manuales: diez por partición.
+- Para los snapshots manuales: diez por partición
+
+### ¿Con qué frecuencia se realizan los snapshots?
+
+Los snapshots se almacenan al mismo nivel que el servicio. Los snapshots se replican en dos servidores distintos en dos racks diferentes. Además, OVHcloud realiza un snapshot diario en un sitio remoto.
 
 ### ¿Dónde se pueden encontrar los snapshots?
 
-En la partición correspondiente, en un directorio oculto llamado **.zfs**. En su interior se encuentra la carpeta **snapshots** que contiene los snapshots. Los archivos están disponibles en modo *read-only*.
+En la partición correspondiente, encontrará un directorio oculto llamado `.zfs` que contiene un directorio de `snapshots`. Los archivos están disponibles en solo lectura.
 
-### ¿OVHcloud también realiza copias de seguridad de los datos?
+### ¿Cuántas políticas de snapshots puedo crear por volumen?
 
-Sí, diariamente se realiza un backup interno, que genera un snapshot más. El cliente no puede desactivar este backup.
+1
+
+## Precios
+
+### ¿Qué tipo de tarificación está asociado al servicio?
+
+NAS-HA es un servicio facturado mensualmente al volumen (de 3 a 144 TB por tramos).
+
+### ¿Por qué duración puedo contratar un NAS-HA?
+
+Los períodos ofrecidos son de 1, 3, 6 y 12 meses. Al finalizar el período contratado, la suscripción se renueva tácitamente si no se ha solicitado ninguna [rescisión](/pages/account/billing/how_to_cancel_services). Puede contratarla desde el área de cliente de OVHcloud durante toda su vigencia.
 
 ## Más información
 

--- a/pages/cloud/storage/file_storage/nas_faq/guide.fr-ca.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.fr-ca.md
@@ -1,33 +1,79 @@
 ---
-title: Les questions fréquentes concernant le NAS
-slug: nas/faq
-excerpt: Une question sur le NAS ? Voici les questions les plus fréquemment posées.
-section: NAS-HA
-order: 02
-updated: 2021-09-09
+title: Les questions fréquentes concernant le service NAS-HA
+excerpt: Une question sur le NAS-HA ? Voici les questions les plus fréquemment posées.
+updated: 2023-06-07
 ---
 
-**Dernière mise à jour le 09/09/2021**
+## Objectif
 
-## L'offre
+**Voici les questions les plus fréquemment posées concernant l'offre NAS-HA OVHcloud.**
+
+## Questions générales
+
+### Qu’est-ce que la solution NAS-HA OVHcloud ?
+
+NAS-HA est un service de stockage fichier partagé et entièrement managé, basé sur la technologie open-source OpenZFS.
+
+### Que puis-je faire avec NAS-HA ?
+
+NAS-HA permet de centraliser les données de différentes charges de travail Linux mais aussi Windows pour de nombreux scénarios :
+
+- stockage partagé et externalisé pour des applications IT (VM, DB…) ;
+- gestion de contenus web ; 
+- partage de fichiers sur le réseau, etc.
 
 ### Peut-on gérer le NAS-HA via un espace de configuration ?
 
 Oui, cet espace est accessible depuis votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc), rubrique `Bare Metal Cloud`{.action} puis `NAS et CDN`{.action}.
 
-### Est-il possible d'augmenter la capacité totale de mon NAS ?
+## Disponibilité
 
-Il n'est pas possible d'augmenter la capacité d'un NAS-HA une fois celui-ci commandé. Pour augmenter votre capacité de stockage, vous devrez migrer vos données sur un second NAS de plus grande capacité.
+### Quel SLA est fourni avec NAS-HA ?
+
+NAS-HA est fourni avec un taux de disponibilité de 99,99%.
+
+## Réseau et sécurité
+
+### Quels protocoles de transfert de fichiers sont actuellement supportés sur la solution NAS-HA ?
+
+NAS-HA supporte le transfert de fichiers via NFS (NFSv3) et CIFS (SMB).
+
+### Depuis quels services OVHcloud puis-je pousser des données ?
+
+NAS-HA est un service qui peut recevoir des données depuis l’ensemble des services existants OVHcloud : Bare Metal Cloud (VPS, Serveurs Dédiés OVHcloud, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, service ADSL/FTTH, etc.
+
+### Comment gère-t-on les accès au NAS-HA ?
+
+La liste des contrôles d'accès (ACL) est configurable depuis votre espace client OVHcloud. Il vous suffit simplement de saisir l'adresse IP du service pour lequel vous souhaitez autoriser l'accès au NAS-HA.
+
+### Le service NAS-HA est-il compatible avec d’autres serveurs en dehors d’OVHcloud ?
+
+Non, il n’est possible d’accéder à votre NAS-HA que depuis le réseau OVHcloud.
+
+### NAS-HA est-il éligible à l’offre vRack ?
+
+Actuellement, le NAS-HA ne peut pas être intégré dans le réseau privé du vRack. Cependant, l’utilisation du NAS-HA et du vRack ne sont pas incompatibles en passant par le chemin IP public du serveur connecté au vRack.
+
+## Capacités et performances
 
 ### Quelles sont les capacités de stockage disponibles ?
 
-Nous proposons les capacités de stockage suivantes :
+La taille minimum d’un service est de 3 To et la taille maximum est de 144 To.<br>
+Nous proposons les capacités de stockage suivantes sur une base de disques de 3 To :
 
-- 3 To;
-- 6 To;
-- 9 To;
-- 18 To;
-- 36 To;
+- 3 To ;
+- 6 To ;
+- 9 To ;
+- 18 To ;
+- 36 To ;
+
+Nous proposons les capacités de stockage suivantes sur une base de disques de 12 To :
+
+- 12 To ;
+- 24 To ;
+- 36 To ;
+- 72 To ;
+- 144 To ;
 
 Les capacités de stockage proposées sont les capacités utilisables.
 
@@ -35,11 +81,20 @@ Les capacités de stockage proposées sont les capacités utilisables.
 
 Les disques de votre NAS-HA vous sont dédiés. Les autres ressources de la machine sont partagées (RAM, CPU, Bande Passante).
 
-**Cas particulier :** si vous souscrivez à l'offre 36 To, l'ensemble des ressources du serveur hôte vous sont dédiées (RAM, CPU, Bande Passante).
+**Cas particulier :** si vous souscrivez à l'offre 144 To, l'ensemble des ressources du serveur hôte vous sont dédiées (RAM, CPU, Bande Passante).
 
-### Pour quelle durée puis-je souscrire à un NAS-HA ?
+### Combien de services NAS-HA puis-je créer depuis mon compte client ?
 
-Les périodes proposées sont de 1, 3, 6 et 12 mois. À la fin de votre période d'engagement, votre abonnement est reconduit tacitement si aucune demande de résiliation n'a été formulée. Celle-ci peut être effectuée durant toute la durée de votre abonnement via votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+Il n’y a pas de limite de nombre de services par compte client.
+
+### Quel est le nombre de partitions maximum par service ?
+
+Il est possible de créer autant de partitions que vous souhaitez. La taille minimum est de 10 Go et la taille maximum est définie par la taille maximum du service.
+
+### Le taux de transfert et de disponibilité est-il garanti ?
+
+- Transfert : la bande passante du service est mutualisée. Les taux de transfert ne peuvent être garantis par OVHcloud.
+- Disponibilité : la disponibilité du service est garantie et sujette à un accord de niveau de service. Les détails sont consultables dans nos conditions spécifiques d’utilisation.
 
 ## Usage du produit
 
@@ -51,50 +106,27 @@ Oui. Il est possible de faire interagir simultanément votre NAS avec plusieurs 
 
 Non, il n'est pas possible d'installer un OS sur les offres NAS-HA.
 
-### Quels sont les protocoles compatibles avec l'offre NAS-HA ?
-
-Le NAS-HA peut être monté sur un serveur Windows ou Linux via les protocoles CIFS (Samba) ou NFS.
-
 ### L'espace alloué est-il partitionnable ?
 
 Oui, il est nécessaire de créer une ou plusieurs partitions selon votre utilisation. La création de partition n'est pas limitée.
-
-## Compatibilité du produit
-
-### Le NAS-HA est-il compatible avec d'autres serveurs en dehors d'OVHcloud ?
-
-Non, il n’est possible d'accéder à votre NAS-HA que depuis le réseau OVHcloud.
-
-### Par quel(s) service(s) le NAS-HA est-il accessible ?
-
-Le service est accessible depuis l'ensemble des produits OVHcloud disposant d'une distribution : les serveurs dédiés (OVHcloud, So you Start, Kimsufi), le Hosted Private Cloud, le Public Cloud et le VPS.
-
-### Comment gère-t-on les accès au NAS-HA ?
-
-La liste des contrôles d'accès (ACL) est configurable depuis votre espace client OVHcloud. Il vous suffit simplement de saisir l'adresse IP du service auquel vous souhaitez autoriser l'accès au NAS-HA.
-
-### Le NAS-HA est-il éligible à l'offre vRack ?
-
-Actuellement, le NAS-HA ne peut pas être intégré dans le réseau privé du vRack. Cependant, l'utilisation du NAS-HA et du vRack ne sont pas incompatibles en passant par le chemin IP public du serveur connecté au vRack.
-
-## Débits
-
-### Le taux de transfert et de disponibilité est-il garanti ?
-
-- Transfert : la bande passante du service est mutualisée. Les taux de transfert ne peuvent être garantis par OVHcloud.
-- Disponibilité : la disponibilité du service est garantie et sujette à un accord de niveau de service. Les détails sont consultables dans nos conditions spécifiques d'utilisation.
 
 ## Snapshots
 
 ### Que sont les snapshots ?
 
-Les snapshots sont des images instantanées de l’état de votre disque et des données qui y sont stockées à un instant donné. La configuration et la gestion des snapshots sont réalisables depuis votre espace client OVHcloud.
+Les snapshots sont des images instantanées de l’état de votre disque et des données qui y sont stockées à un instant donné. Ils permettent de proposer un premier niveau de sauvegarde. La configuration et la gestion des snapshots sont réalisables depuis votre espace client OVHcloud.
 
 Par défaut, la fonction snapshot est activée lors de la création de votre partition, la fréquence est préréglée sur « toutes les heures ».
 
-### Quelle est la fréquence des snapshots ?
+### Quelle politique de sauvegarde est associée à NAS-HA ?
 
-La fréquence des snapshots est administrable depuis votre espace client OVHcmpid. Vous pouvez choisir la fréquence parmi les options suivantes :
+Les utilisateurs sont responsables de la gestion de leurs sauvegardes (outils et règles) à l'intérieur ainsi qu'à l'extérieur du service, ainsi que de leurs plans de continuité d'activité et de reprise d'activité. Cependant, pour des raisons de sécurité et de résilience de l’infrastructure, OVHcloud peut effectuer des snapshots du service sur un serveur distant, sans obligation toutefois.
+
+En cas de panne ou d’attaque, si OVHcloud a effectuée un snapshot sur un serveur distant, nous pouvons ainsi restaurer les données du dernier snapshot disponible. Veuillez toutefois noter que cette action s’effectue sur demande et constitue un service optionnel facturé.
+
+### Quelle est la fréquence des snapshots ? <a name="frequency"></a>
+
+La fréquence des snapshots est administrable depuis votre espace client OVHcloud. Vous pouvez choisir la fréquence parmi les options suivantes :
 
 - toutes les heures (par défaut) ;
 - toutes les 6 heures ;
@@ -103,11 +135,15 @@ La fréquence des snapshots est administrable depuis votre espace client OVHcmpi
 - tous les trois jours ;
 - hebdomadaire.
 
-Vous pouvez aussi, à tout moment, créer des snapshots manuels, les conserver sans limitation de durée ou les supprimer. Cette fonctionnalité est disponible au sein de votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc) ou via l'[API](https://ca.api.ovh.com/):
+Vous pouvez aussi, à tout moment, créer des snapshots manuels, les conserver sans limitation de durée ou les supprimer. Cette fonctionnalité est disponible au sein de votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc) ou via l'appel [API](https://api.ovh.com/) suivant :
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Consultez notre guide « [Premiers pas avec les API OVHcloud](/pages/account/api/first-steps) » pour vous familiariser avec l'utilisation des API OVHcloud.
 >
 
 ### Comment fonctionne le système de gestion des snapshots ?
@@ -116,26 +152,41 @@ Vous pouvez configurer des snapshots automatiques, à différentes fréquences d
 
 ### Peut-on supprimer un snapshot ?
 
-Seuls les snapshots créés « à la demande » peuvent être supprimés (voir la question précédente « Quelle est la fréquence des snapshots ? »). Les snapshots à fréquence fixe sont automatiquement supprimés, sans possibilité de les supprimer manuellement.
+Seuls les snapshots créés « à la demande » peuvent être supprimés (voir la question précédente « [Quelle est la fréquence des snapshots ?](#frequency) »).<br>
+Les snapshots à fréquence fixe sont automatiquement supprimés, sans possibilité de les supprimer manuellement.
 
-### Quel est l'espace occupé par les snapshots sur un NAS-HA ?
+### Les snapshots sont-ils compris dans la capacité d’un service ?
 
-La capacité utilisée par un snapshot est variable en fonction des actions effectuées dans le laps de temps séparant deux snapshots.
+Un espace additionnel sur le même support physique vous est alloué pour assurer le stockage de vos snapshots. Cet espace correspond à au moins 15 % du volume principal. Dans le cas où vous le dépasseriez, les snapshots seront stockés sur votre espace de stockage principal. L'espace additionnel ne peut pas être utilisé pour un autre usage que le stockage de vos snapshots.
 
-À partir du moment où vous déclenchez le snapshot, toutes les actions effectuées sur la partition concernée seront stockées dans ce snapshot et augmenteront la taille du fichier.
+Par exemple, pour un service de 3 To, 450 Go additionnels sont réservés pour les snapshots.
 
 ### Combien de snapshots puis-je réaliser au maximum ?
 
 - Pour les snapshots automatiques : un par partition
-- Pour les snapshots manuels : dix par partitions
+- Pour les snapshots manuels : dix par partition
+
+### Où sont stockés les snapshots ?
+
+Les snapshots sont stockés au même niveau que votre service. Les snapshots sont ainsi répliqués sur deux serveurs distincts dans deux racks différents. En complément, OVHcloud effectue un snapshot quotidien sur un site distant.
 
 ### Où puis-je récupérer mes snapshots ?
 
-Dans la partition concernée : répertoire caché appelé `.zfs` → répertoire `snapshots`. Fichiers disponibles en read only.
+Dans la partition concernée, vous trouverez un répertoire caché appelé `.zfs` qui contient un répertoire `snapshots`. Les fichiers sont disponibles en read only.
 
-### OVHcloud réalise-t-il également des sauvegardes de mes données ?
+### Combien de politiques de snapshots puis-je créer par volume ?
 
-Oui, une sauvegarde interne est réalisée quotidiennement. Celle-ci génère un snapshot de plus. Cette sauvegarde n'est pas désactivable par le client.
+1
+
+## Tarification
+
+### Quel type de tarification est lié au service ?
+
+NAS-HA est un service facturé mensuellement au volume (de 3 à 144 To par paliers).
+
+### Pour quelle durée puis-je souscrire à un NAS-HA ?
+
+Les périodes proposées sont de 1, 12, 24 et 36 mois. À la fin de votre période d’engagement, votre abonnement est reconduit tacitement si aucune [demande de résiliation](/pages/account/billing/how_to_cancel_services) n’a été formulée. Celle-ci peut être effectuée pendant toute la durée de votre abonnement via votre espace client OVHcloud.
 
 ## Aller plus loin
 

--- a/pages/cloud/storage/file_storage/nas_faq/guide.fr-fr.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.fr-fr.md
@@ -1,33 +1,79 @@
 ---
-title: Les questions fréquentes concernant le NAS
-slug: nas/faq
-excerpt: Une question sur le NAS ? Voici les questions les plus fréquemment posées.
-section: NAS-HA
-order: 02
-updated: 2021-09-09
+title: Les questions fréquentes concernant le service NAS-HA
+excerpt: Une question sur le NAS-HA ? Voici les questions les plus fréquemment posées.
+updated: 2023-06-07
 ---
 
-**Dernière mise à jour le 09/09/2021**
+## Objectif
 
-## L'offre
+**Voici les questions les plus fréquemment posées concernant l'offre NAS-HA OVHcloud.**
+
+## Questions générales
+
+### Qu’est-ce que la solution NAS-HA OVHcloud ?
+
+NAS-HA est un service de stockage fichier partagé et entièrement managé, basé sur la technologie open-source OpenZFS.
+
+### Que puis-je faire avec NAS-HA ?
+
+NAS-HA permet de centraliser les données de différentes charges de travail Linux mais aussi Windows pour de nombreux scénarios :
+
+- stockage partagé et externalisé pour des applications IT (VM, DB…) ;
+- gestion de contenus web ; 
+- partage de fichiers sur le réseau, etc.
 
 ### Peut-on gérer le NAS-HA via un espace de configuration ?
 
 Oui, cet espace est accessible depuis votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr), rubrique `Bare Metal Cloud`{.action} puis `NAS et CDN`{.action}.
 
-### Est-il possible d'augmenter la capacité totale de mon NAS ?
+## Disponibilité
 
-Il n'est pas possible d'augmenter la capacité d'un NAS-HA une fois celui-ci commandé. Pour augmenter votre capacité de stockage, vous devrez migrer vos données sur un second NAS de plus grande capacité.
+### Quel SLA est fourni avec NAS-HA ?
+
+NAS-HA est fourni avec un taux de disponibilité de 99,99%.
+
+## Réseau et sécurité
+
+### Quels protocoles de transfert de fichiers sont actuellement supportés sur la solution NAS-HA ?
+
+NAS-HA supporte le transfert de fichiers via NFS (NFSv3) et CIFS (SMB).
+
+### Depuis quels services OVHcloud puis-je pousser des données ?
+
+NAS-HA est un service qui peut recevoir des données depuis l’ensemble des services existants OVHcloud : Bare Metal Cloud (VPS, Serveurs Dédiés OVHcloud, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, service ADSL/FTTH, etc.
+
+### Comment gère-t-on les accès au NAS-HA ?
+
+La liste des contrôles d'accès (ACL) est configurable depuis votre espace client OVHcloud. Il vous suffit simplement de saisir l'adresse IP du service pour lequel vous souhaitez autoriser l'accès au NAS-HA.
+
+### Le service NAS-HA est-il compatible avec d’autres serveurs en dehors d’OVHcloud ?
+
+Non, il n’est possible d’accéder à votre NAS-HA que depuis le réseau OVHcloud.
+
+### NAS-HA est-il éligible à l’offre vRack ?
+
+Actuellement, le NAS-HA ne peut pas être intégré dans le réseau privé du vRack. Cependant, l’utilisation du NAS-HA et du vRack ne sont pas incompatibles en passant par le chemin IP public du serveur connecté au vRack.
+
+## Capacités et performances
 
 ### Quelles sont les capacités de stockage disponibles ?
 
-Nous proposons les capacités de stockage suivantes :
+La taille minimum d’un service est de 3 To et la taille maximum est de 144 To.<br>
+Nous proposons les capacités de stockage suivantes sur une base de disques de 3 To :
 
-- 3 To;
-- 6 To;
-- 9 To;
-- 18 To;
-- 36 To;
+- 3 To ;
+- 6 To ;
+- 9 To ;
+- 18 To ;
+- 36 To ;
+
+Nous proposons les capacités de stockage suivantes sur une base de disques de 12 To :
+
+- 12 To ;
+- 24 To ;
+- 36 To ;
+- 72 To ;
+- 144 To ;
 
 Les capacités de stockage proposées sont les capacités utilisables.
 
@@ -35,11 +81,20 @@ Les capacités de stockage proposées sont les capacités utilisables.
 
 Les disques de votre NAS-HA vous sont dédiés. Les autres ressources de la machine sont partagées (RAM, CPU, Bande Passante).
 
-**Cas particulier :** si vous souscrivez à l'offre 36 To, l'ensemble des ressources du serveur hôte vous sont dédiées (RAM, CPU, Bande Passante).
+**Cas particulier :** si vous souscrivez à l'offre 144 To, l'ensemble des ressources du serveur hôte vous sont dédiées (RAM, CPU, Bande Passante).
 
-### Pour quelle durée puis-je souscrire à un NAS-HA ?
+### Combien de services NAS-HA puis-je créer depuis mon compte client ?
 
-Les périodes proposées sont de 1, 3, 6 et 12 mois. À la fin de votre période d'engagement, votre abonnement est reconduit tacitement si aucune demande de résiliation n'a été formulée. Celle-ci peut être effectuée durant toute la durée de votre abonnement via votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+Il n’y a pas de limite de nombre de services par compte client.
+
+### Quel est le nombre de partitions maximum par service ?
+
+Il est possible de créer autant de partitions que vous souhaitez. La taille minimum est de 10 Go et la taille maximum est définie par la taille maximum du service.
+
+### Le taux de transfert et de disponibilité est-il garanti ?
+
+- Transfert : la bande passante du service est mutualisée. Les taux de transfert ne peuvent être garantis par OVHcloud.
+- Disponibilité : la disponibilité du service est garantie et sujette à un accord de niveau de service. Les détails sont consultables dans nos conditions spécifiques d’utilisation.
 
 ## Usage du produit
 
@@ -51,50 +106,27 @@ Oui. Il est possible de faire interagir simultanément votre NAS avec plusieurs 
 
 Non, il n'est pas possible d'installer un OS sur les offres NAS-HA.
 
-### Quels sont les protocoles compatibles avec l'offre NAS-HA ?
-
-Le NAS-HA peut être monté sur un serveur Windows ou Linux via les protocoles CIFS (Samba) ou NFS.
-
 ### L'espace alloué est-il partitionnable ?
 
 Oui, il est nécessaire de créer une ou plusieurs partitions selon votre utilisation. La création de partition n'est pas limitée.
-
-## Compatibilité du produit
-
-### Le NAS-HA est-il compatible avec d'autres serveurs en dehors d'OVHcloud ?
-
-Non, il n’est possible d'accéder à votre NAS-HA que depuis le réseau OVHcloud.
-
-### Par quel(s) service(s) le NAS-HA est-il accessible ?
-
-Le service est accessible depuis l'ensemble des produits OVHcloud disposant d'une distribution : les serveurs dédiés (OVHcloud, So you Start, Kimsufi), le Hosted Private Cloud, le Public Cloud et le VPS.
-
-### Comment gère-t-on les accès au NAS-HA ?
-
-La liste des contrôles d'accès (ACL) est configurable depuis votre espace client OVHcloud. Il vous suffit simplement de saisir l'adresse IP du service auquel vous souhaitez autoriser l'accès au NAS-HA.
-
-### Le NAS-HA est-il éligible à l'offre vRack ?
-
-Actuellement, le NAS-HA ne peut pas être intégré dans le réseau privé du vRack. Cependant, l'utilisation du NAS-HA et du vRack ne sont pas incompatibles en passant par le chemin IP public du serveur connecté au vRack.
-
-## Débits
-
-### Le taux de transfert et de disponibilité est-il garanti ?
-
-- Transfert : la bande passante du service est mutualisée. Les taux de transfert ne peuvent être garantis par OVHcloud.
-- Disponibilité : la disponibilité du service est garantie et sujette à un accord de niveau de service. Les détails sont consultables dans nos conditions spécifiques d'utilisation.
 
 ## Snapshots
 
 ### Que sont les snapshots ?
 
-Les snapshots sont des images instantanées de l’état de votre disque et des données qui y sont stockées à un instant donné. La configuration et la gestion des snapshots sont réalisables depuis votre espace client OVHcloud.
+Les snapshots sont des images instantanées de l’état de votre disque et des données qui y sont stockées à un instant donné. Ils permettent de proposer un premier niveau de sauvegarde. La configuration et la gestion des snapshots sont réalisables depuis votre espace client OVHcloud.
 
 Par défaut, la fonction snapshot est activée lors de la création de votre partition, la fréquence est préréglée sur « toutes les heures ».
 
-### Quelle est la fréquence des snapshots ?
+### Quelle politique de sauvegarde est associée à NAS-HA ?
 
-La fréquence des snapshots est administrable depuis votre espace client OVHcmpid. Vous pouvez choisir la fréquence parmi les options suivantes :
+Les utilisateurs sont responsables de la gestion de leurs sauvegardes (outils et règles) à l'intérieur ainsi qu'à l'extérieur du service, ainsi que de leurs plans de continuité d'activité et de reprise d'activité. Cependant, pour des raisons de sécurité et de résilience de l’infrastructure, OVHcloud peut effectuer des snapshots du service sur un serveur distant, sans obligation toutefois.
+
+En cas de panne ou d’attaque, si OVHcloud a effectuée un snapshot sur un serveur distant, nous pouvons ainsi restaurer les données du dernier snapshot disponible. Veuillez toutefois noter que cette action s’effectue sur demande et constitue un service optionnel facturé.
+
+### Quelle est la fréquence des snapshots ? <a name="frequency"></a>
+
+La fréquence des snapshots est administrable depuis votre espace client OVHcloud. Vous pouvez choisir la fréquence parmi les options suivantes :
 
 - toutes les heures (par défaut) ;
 - toutes les 6 heures ;
@@ -103,11 +135,15 @@ La fréquence des snapshots est administrable depuis votre espace client OVHcmpi
 - tous les trois jours ;
 - hebdomadaire.
 
-Vous pouvez aussi, à tout moment, créer des snapshots manuels, les conserver sans limitation de durée ou les supprimer. Cette fonctionnalité est disponible au sein de votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) ou via l'[API](https://api.ovh.com/):
+Vous pouvez aussi, à tout moment, créer des snapshots manuels, les conserver sans limitation de durée ou les supprimer. Cette fonctionnalité est disponible au sein de votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) ou via l'appel [API](https://api.ovh.com/) suivant :
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Consultez notre guide « [Premiers pas avec les API OVHcloud](/pages/account/api/first-steps) » pour vous familiariser avec l'utilisation des API OVHcloud.
 >
 
 ### Comment fonctionne le système de gestion des snapshots ?
@@ -116,26 +152,41 @@ Vous pouvez configurer des snapshots automatiques, à différentes fréquences d
 
 ### Peut-on supprimer un snapshot ?
 
-Seuls les snapshots créés « à la demande » peuvent être supprimés (voir la question précédente « Quelle est la fréquence des snapshots ? »). Les snapshots à fréquence fixe sont automatiquement supprimés, sans possibilité de les supprimer manuellement.
+Seuls les snapshots créés « à la demande » peuvent être supprimés (voir la question précédente « [Quelle est la fréquence des snapshots ?](#frequency) »).<br>
+Les snapshots à fréquence fixe sont automatiquement supprimés, sans possibilité de les supprimer manuellement.
 
-### Quel est l'espace occupé par les snapshots sur un NAS-HA ?
+### Les snapshots sont-ils compris dans la capacité d’un service ?
 
-La capacité utilisée par un snapshot est variable en fonction des actions effectuées dans le laps de temps séparant deux snapshots.
+Un espace additionnel sur le même support physique vous est alloué pour assurer le stockage de vos snapshots. Cet espace correspond à au moins 15 % du volume principal. Dans le cas où vous le dépasseriez, les snapshots seront stockés sur votre espace de stockage principal. L'espace additionnel ne peut pas être utilisé pour un autre usage que le stockage de vos snapshots.
 
-À partir du moment où vous déclenchez le snapshot, toutes les actions effectuées sur la partition concernée seront stockées dans ce snapshot et augmenteront la taille du fichier.
+Par exemple, pour un service de 3 To, 450 Go additionnels sont réservés pour les snapshots.
 
 ### Combien de snapshots puis-je réaliser au maximum ?
 
 - Pour les snapshots automatiques : un par partition
-- Pour les snapshots manuels : dix par partitions
+- Pour les snapshots manuels : dix par partition
+
+### Où sont stockés les snapshots ?
+
+Les snapshots sont stockés au même niveau que votre service. Les snapshots sont ainsi répliqués sur deux serveurs distincts dans deux racks différents. En complément, OVHcloud effectue un snapshot quotidien sur un site distant.
 
 ### Où puis-je récupérer mes snapshots ?
 
-Dans la partition concernée : répertoire caché appelé `.zfs` → répertoire `snapshots`. Fichiers disponibles en read only.
+Dans la partition concernée, vous trouverez un répertoire caché appelé `.zfs` qui contient un répertoire `snapshots`. Les fichiers sont disponibles en read only.
 
-### OVHcloud réalise-t-il également des sauvegardes de mes données ?
+### Combien de politiques de snapshots puis-je créer par volume ?
 
-Oui, une sauvegarde interne est réalisée quotidiennement. Celle-ci génère un snapshot de plus. Cette sauvegarde n'est pas désactivable par le client.
+1
+
+## Tarification
+
+### Quel type de tarification est lié au service ?
+
+NAS-HA est un service facturé mensuellement au volume (de 3 à 144 To par paliers).
+
+### Pour quelle durée puis-je souscrire à un NAS-HA ?
+
+Les périodes proposées sont de 1, 12, 24 et 36 mois. À la fin de votre période d’engagement, votre abonnement est reconduit tacitement si aucune [demande de résiliation](/pages/account/billing/how_to_cancel_services) n’a été formulée. Celle-ci peut être effectuée pendant toute la durée de votre abonnement via votre espace client OVHcloud.
 
 ## Aller plus loin
 

--- a/pages/cloud/storage/file_storage/nas_faq/guide.it-it.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.it-it.md
@@ -1,37 +1,83 @@
 ---
-title: Domande frequenti sul NAS
-slug: nas/faq
-excerpt: Hai una domanda sul NAS? Ecco le risposte alle domande più frequenti
-section: NAS-HA
-order: 02
-updated: 2021-09-09
+title: Domande frequenti sul NAS-HA
+excerpt: Hai una domanda sul NAS-HA? Ecco le risposte alle domande più frequenti
+updated: 2023-06-07
 ---
 
 > [!primary]
 > Questa traduzione è stata generata automaticamente dal nostro partner SYSTRAN. I contenuti potrebbero presentare imprecisioni, ad esempio la nomenclatura dei pulsanti o alcuni dettagli tecnici. In caso di dubbi consigliamo di fare riferimento alla versione inglese o francese della guida. Per aiutarci a migliorare questa traduzione, utilizza il pulsante "Contribuisci" di questa pagina.
 >
 
-**Ultimo aggiornamento: 09/09/2021**
+## Obiettivo
 
-## Caratteristiche del prodotto
+**Ecco le domande più frequenti sull'offerta NAS-HA OVHcloud.**
+
+## Domande generali
+
+### Cos'è la soluzione NAS-HA OVHcloud?
+
+NAS-HA è un servizio di archiviazione file condiviso e totalmente gestito, basato sulla tecnologia open-source OpenZFS.
+
+### Cosa posso fare con NAS-HA?
+
+NAS-HA permette di centralizzare i dati di diversi carichi di lavoro Linux e Windows per diversi scenari:
+
+- storage condiviso ed esternalizzato per applicazioni IT (VM, DB...)
+- gestione dei contenuti web; 
+- condivisione di file sulla rete, ecc...
 
 ### È possibile gestire il NAS-HA tramite un’interfaccia di amministrazione?
 
 Sì, questo spazio è accessibile dal tuo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it), sezione `Bare Metal Cloud`{.action}, poi `NAS e CDN`{.action}.
 
-### È possibile aumentare la capacità totale del NAS?
+## Disponibilità
 
-No, una volta effettuato l’ordine non è possibile aumentare la capacità del NAS-HA. Per disporre di uno spazio di storage maggiore, è necessario migrare i dati su un secondo NAS con capacità superiore.
+### Qual è lo SLA fornito con NAS-HA?
+
+NAS-HA è fornito con un tasso di disponibilità del 99,99%.
+
+## Rete e Sicurezza
+
+### Quali protocolli di trasferimento di file sono supportati sul NAS-HA?
+
+NAS-HA supporta il trasferimento di file tramite NFS (NFSv3) e CIFS (SMB).
+
+### Da quali servizi OVHcloud è possibile caricare dati?
+
+NAS-HA è un servizio che può ricevere dati da tutti i servizi esistenti OVHcloud: Bare Metal Cloud (VPS, server dedicati OVHcloud, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, ecc...
+
+### Come gestire gli accessi al NAS-HA?
+
+La lista dei controlli degli accessi (ACL) è configurabile dallo Spazio Cliente OVHcloud. Inserisci semplicemente l'indirizzo IP del servizio per il quale vuoi autorizzare l'accesso al NAS-HA.
+
+### Il servizio NAS-HA è compatibile con altri server al di fuori di OVHcloud?
+
+No, è possibile accedere al NAS-HA solo dalla rete OVHcloud.
+
+### NAS-HA è ammissibile all'offerta vRack?
+
+Al momento il NAS-HA non può essere integrato nella rete privata vRack. Tuttavia, l'utilizzo del NAS-HA e della vRack non è incompatibile tramite il percorso IP pubblico del server connesso alla vRack.
+
+## Capacità e performance
 
 ### Quali sono le capacità di storage disponibili?
 
-Offriamo queste capacità di storage:
+La dimensione minima di un servizio è di 3 TB e la dimensione massima è di 144 TB.<br>
+OVHcloud ti offre queste capacità di storage su un database da 3 TB:
 
-- 3 To
-- 6 To
-- 9 To
-- 18 To
-- 36 To
+- 3 TB
+- 6 TB
+- 9 TB
+- 18 TB
+- 36 TB
+
+OVHcloud ti offre queste capacità di storage su un database da 12 TB:
+
+- 12 TB
+- 24 TB
+- 36 TB
+- 72 TB
+- 144 TB
 
 La capacità di storage offerta è la capacità utilizzabile.
 
@@ -39,66 +85,52 @@ La capacità di storage offerta è la capacità utilizzabile.
 
 I dischi del tuo NAS-HA ti sono dedicati. Le altre risorse della macchina sono condivise (RAM, CPU, banda passante).
 
-**Caso particolare:** se sottoscrivi l'offerta da 36 TB, tutte le risorse del server host sono dedicate (RAM, CPU, banda passante).
+**Caso particolare:** se sottoscrivi l'offerta da 144 TB, tutte le risorse del server host sono dedicate (RAM, CPU, banda passante).
 
-### Qual è la durata di sottoscrizione di un NAS-HA?
+### Quanti servizi NAS-HA posso creare dal mio account cliente?
 
-I periodi proposti sono di 1, 3, 6 e 12 mesi. Se non ne viene richiesta la rescissione prima della data di scadenza, il contratto si rinnova automaticamente. Il servizio può essere disattivato in qualsiasi momento tramite lo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}.
+Non ci sono limiti al numero di servizi per account cliente.
+
+### Qual è il numero massimo di partizioni per servizio?
+
+È possibile creare tutte le partizioni che vuoi. La dimensione minima è di 10 GB e la dimensione massima è definita dalla dimensione massima del servizio.
+
+### La velocità di trasferimento e il livello di disponibilità sono garantiti?
+
+- Trasferimento: la banda passante del servizio è condivisa. La velocità di trasferimento non può essere garantita da OVHcloud.
+- Disponibilità: la disponibilità del servizio è garantita e regolata da un accordo di livello di servizio. I dettagli sono consultabili nelle nostre specifiche condizioni di utilizzo.
 
 ## Utilizzo del prodotto
 
 ### È possibile connettere il NAS-HA a più server contemporaneamente?
 
-Sì, il NAS può comunicare simultaneamente con diversi servizi OVHcloud.
+Sì È possibile far interagire contemporaneamente il tuo NAS con diversi servizi OVHcloud.
 
 ### È possibile installare un sistema operativo su un NAS-HA?
 
 No, sui servizi NAS-HA non è possibile installare un OS.
 
-### Quali sono i protocolli compatibili con il servizio NAS-HA?
-
-Il NAS-HA può essere montato su un server Windows o Linux tramite i protocolli CIFS (Samba) o NFS.
-
-### È possibile effettuare partizioni dello spazio assegnato?
+### Lo spazio assegnato è partizionabile?
 
 Sì, è necessario creare una o più partizioni in base al tuo utilizzo. La creazione delle partizioni è illimitata.
-
-## Compatibilità del prodotto
-
-### Il NAS-HA è compatibile con server esterni a OVHcloud?
-
-No, il NAS-HA è accessibile solo dalla rete OVHcloud.
-
-### Con quali servizi è possibile utilizzare il NAS-HA?
-
-Il servizio può essere utilizzato con tutte le soluzioni OVHcloud che dispongono di una distribuzione: server dedicati (OVHcloud, So you Start, Kimsufi), Hosted Private Cloud, Public Cloud e VPS.
-
-### Come gestire gli accessi al NAS-HA?
-
-La lista del controllo degli accessi (ACL) è configurabile dallo Spazio Cliente OVHcloud. È sufficiente inserire l’indirizzo IP del servizio che vuoi autorizzare ad accedere al NAS-HA.
-
-### Il NAS-HA è compatibile con la tecnologia vRack?
-
-Al momento il NAS-HA non può essere integrato nella rete privata vRack. Tuttavia l’utilizzo di NAS-HA e vRack è possibile tramite l’IP pubblico del server connesso alla vRack.
-
-## Velocità di trasferimento
-
-### La velocità di trasferimento e il livello di disponibilità sono garantiti?
-
-- Trasferimento: la banda passante del servizio è condivisa e la velocità di trasferimento non può essere garantita. 
-- Disponibilità: la disponibilità del servizio è garantita e regolata da un accordo di livello di servizio. Tutti i dettagli sono disponibili nelle Condizioni Particolari di utilizzo.
 
 ## Snapshot
 
 ### Cosa sono gli Snapshot?
 
-Gli Snapshot sono immagini dello stato del disco e dei dati presenti nella sua partizione in un istante specifico. La configurazione e la gestione di queste istantanee sono possibili dallo Spazio Cliente OVHcloud.
+Gli Snapshot sono immagini dello stato del disco e dei dati presenti nella sua partizione in un istante specifico. Che permettono di offrire un primo livello di backup. La configurazione e la gestione degli Snapshot sono disponibili nello Spazio Cliente OVHcloud.
 
-La funzione Snapshot è attiva di default al momento della creazione della partizione e la sua frequenza predefinita è impostata su “ogni ora”.
+La funzione Snapshot è attiva di default durante la creazione della partizione e la sua frequenza è preimpostata su "ogni ora".
 
-### Qual è la frequenza degli Snapshot?
+### Qual è la politica di backup associata al NAS-HA?
 
-La frequenza degli Snapshot è configurabile dallo Spazio Cliente OVHcloud. Le opzioni disponibili sono:
+Gli utenti sono responsabili della gestione dei loro backup (strumenti e regole) all'interno e all'esterno del servizio, così come dei loro piani di continuità operativa e di ripresa delle attività. Per ragioni di sicurezza e resilienza dell'infrastruttura, OVHcloud può effettuare Snapshot del servizio su un server remoto, senza alcun obbligo.
+
+In caso di malfunzionamenti o attacchi, se OVHcloud ha effettuato uno Snapshot su un server remoto, è possibile ripristinare i dati dell'ultimo Snapshot disponibile. Ti ricordiamo tuttavia che questa operazione viene eseguita su richiesta e costituisce un servizio opzionale fatturato.
+
+### Qual è la frequenza degli Snapshot? <a name="frequency"></a>
+
+La frequenza degli Snapshot è gestibile dallo Spazio Cliente OVHcloud. Le opzioni disponibili sono:
 
 - ogni ora (di default)
 - ogni 6 ore
@@ -107,11 +139,15 @@ La frequenza degli Snapshot è configurabile dallo Spazio Cliente OVHcloud. Le o
 - ogni 3 giorni
 - settimanale
 
-In qualsiasi momento è inoltre possibile creare Snapshot manuali, conservarli senza limite di durata o eliminarli. Questa funzionalità è disponibile nello [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external} o via [API](https://api.ovh.com/){.external}:
+In qualsiasi momento è inoltre possibile creare Snapshot manuali, conservarli senza limite di durata o eliminarli. Questa funzionalità è disponibile nello [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) o tramite [API](https://api.ovh.com/):
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Consulta la nostra guida Iniziare a [utilizzare le API OVHcloud](/pages/account/api/first-steps) per familiarizzare con l'utilizzo delle API OVHcloud.
 >
 
 ### Come funziona il sistema di gestione degli Snapshot?
@@ -120,26 +156,41 @@ In qualsiasi momento è inoltre possibile creare Snapshot manuali, conservarli s
 
 ### È possibile eliminare uno Snapshot?
 
-Solo gli Snapshot creati “on demand” possono essere eliminati (vedi domanda “Qual è la frequenza degli Snapshot?”). Gli Snapshot con frequenza fissa vengono eliminati automaticamente e non prevedono la possibilità di eseguire l’operazione manualmente.
+Solo gli Snapshot creati "on demand" possono essere eliminati (vedi domanda precedente "[Qual è la frequenza degli snapshot?](#frequency)").<br>
+Gli Snapshot con frequenza fissa vengono eliminati automaticamente e non prevedono la possibilità di eseguire l’operazione manualmente.
 
-### Qual è lo spazio occupato dagli Snapshot su un NAS-HA?
+### Gli Snapshot sono inclusi nella capacità di un servizio?
 
-La capacità utilizzata da uno Snapshot varia in base alle operazioni effettuate nell’intervallo di tempo che separa le due istantanee.
+Per assicurare lo storage dei tuoi Snapshot, hai a disposizione uno spazio aggiuntivo sullo stesso supporto fisico. Questo spazio corrisponde ad almeno il 15 % del volume principale. In caso di superamento del limite, gli Snapshot saranno salvati sul tuo spazio di archiviazione principale. Lo spazio aggiuntivo non può essere utilizzato per scopi diversi dallo storage dei tuoi Snapshot.
 
-A partire dal momento in cui lo Snapshot viene avviato, tutte le azioni eseguite sulla partizione vengono salvate nell’istantanea e aumentano la dimensione del file.
+Ad esempio, per un servizio da 3 TB, 450 GB aggiuntivi sono riservati agli Snapshot.
 
 ### Qual è il numero massimo di Snapshot eseguibili?
 
 - Snapshot automatici: uno per partizione
 - Snapshot manuali: dieci per partizione
 
+### Dove sono salvati gli Snapshot?
+
+Gli Snapshot sono salvati allo stesso livello del tuo servizio. Gli Snapshot vengono replicati su due server distinti in due rack diversi. OVHcloud esegue uno Snapshot giornaliero su un sito remoto.
+
 ### Dove è possibile recuperare gli Snapshot?
 
-Nella partizione interessata: directory nascosta `.zfs` → cartella `snapshot`. I file sono disponibili in modalità *read only*.
+Nella partizione interessata, troverai una directory nascosta chiamata `.zfs` che contiene una directory `snapshot`. I file sono disponibili in read only.
 
-### OVHcloud esegue un backup dei dati?
+### Quante politiche di Snapshot puoi creare per volume?
 
-Sì, OVHcloud provvede a effettuare un backup interno giornaliero, che genera uno Snapshot aggiuntivo.  Questo backup non può essere disattivato dal cliente.
+1
+
+## Tariffe
+
+### Che tipo di tariffazione è associata al servizio?
+
+NAS-HA è un servizio fatturato mensilmente al volume (da 3 a 144 TB per incrementi).
+
+### Qual è la durata di sottoscrizione di un NAS-HA?
+
+I periodi proposti sono di 1, 12, 24 e 36 mesi. Alla fine del periodo contrattuale sottoscritto, l'abbonamento viene rinnovato automaticamente se non è stata presentata alcuna [richiesta di rescissione](/pages/account/billing/how_to_cancel_services). e può essere effettuata per tutta la durata dell'abbonamento tramite lo Spazio Cliente OVHcloud.
 
 ## Per saperne di più
 

--- a/pages/cloud/storage/file_storage/nas_faq/guide.pl-pl.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.pl-pl.md
@@ -1,145 +1,196 @@
 ---
-title: Najczęściej zadawane pytania dotyczące technologii NAS
-slug: nas/faq
-excerpt: Masz pytania dotyczące NAS? Oto odpowiedzi na najczęściej zadawane pytania.
-section: NAS-HA
-order: 02
-updated: 2021-09-09
+title: Najczęściej zadawane pytania dotyczące technologii NAS-HA
+excerpt: Masz pytania dotyczące NAS-HA? Oto odpowiedzi na najczęściej zadawane pytania.
+updated: 2023-06-07
 ---
 
 > [!primary]
 > Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera SYSTRAN. W niektórych przypadkach mogą wystąpić nieprecyzyjne sformułowania, na przykład w tłumaczeniu nazw przycisków lub szczegółów technicznych. W przypadku jakichkolwiek wątpliwości zalecamy zapoznanie się z angielską/francuską wersją przewodnika. Jeśli chcesz przyczynić się do ulepszenia tłumaczenia, kliknij przycisk "Zgłóś propozycję modyfikacji" na tej stronie.
 >
 
-**Ostatnia aktualizacja dnia 09-09-2021**
+## Wprowadzenie
 
-## Oferta
+**Oto najczęściej zadawane pytania dotyczące oferty NAS-HA OVHcloud.**
 
-### Czy można zarządzać NAS-HA przez Panel klienta?
+## Pytania ogólne
 
-Tak, opcje zarządzania usługą są dostępne w Twoim [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}, w rubryce `Bare Metal Cloud`{.action}, następnie `NAS i CDN`{.action}.
+### Czym jest rozwiązanie NAS-HA OVHcloud?
 
-### Czy jest możliwość zwiększenia miejsca na usłudze NAS?
+NAS-HA to usługa przechowywania plików współdzielonych i w pełni zarządzanych, oparta na technologii open-source OpenZFS.
 
-Po zakupie nie ma możliwości zwiększenia pojemności NAS. W celu zwiększenia przestrzeni dyskowej należy przenieść dane na drugi NAS o większym rozmiarze.
+### Co mogę zrobić z usługą NAS-HA?
 
-### Jakie są dostępne pojemności przestrzeni dyskowej?
+NAS-HA pozwala na scentralizowanie danych z różnych obciążeń związanych z Linuxem oraz Windows w wielu scenariuszach:
 
-Oferujemy następujące przestrzenie dyskowe:
+- współdzielona i zewnętrzna przestrzeń dyskowa dla aplikacji IT (VM, DB...);
+- zarządzanie treściami www; 
+- udostępnianie plików w sieci itp.
 
-- 3 To
-- 6 To
-- 9 To
-- 18 To
-- 36 To
+### Czy można zarządzać usługą NAS-HA za pomocą przestrzeni konfiguracyjnej?
+
+Tak, ta przestrzeń jest dostępna w [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl), w rubryce `Bare Metal Cloud`{.action}, następnie `NAS i CDN`{.action}.
+
+## Dostępność
+
+### Jaki SLA jest dostarczany z usługą NAS-HA?
+
+NAS-HA jest dostarczana z dostępnością na poziomie 99,99%.
+
+## Sieć i bezpieczeństwo
+
+### Jakie protokoły do przesyłania plików są aktualnie obsługiwane w rozwiązaniu NAS-HA?
+
+NAS-HA obsługuje przesyłanie plików przez NFS (NFSv3) i CIFS (SMB).
+
+### Z jakich usług mogę hostować dane?
+
+NAS-HA to usługa, która może otrzymywać dane z wszystkich istniejących usług OVHcloud: Bare Metal Cloud (VPS, Serwery dedykowane OVHcloud, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, itp.
+
+### Jak zarządzać dostępami do NAS HA?
+
+Lista kontroli dostępu (ACL) jest konfigurowana w Panelu klienta OVHcloud. Wystarczy wpisać adres IP usługi, dla której chcesz zezwolić na dostęp do NAS-HA.
+
+### Czy usługa NAS-HA jest kompatybilna z innymi serwerami poza infrastrukturą OVHcloud?
+
+Nie, dostęp do usługi NAS-HA jest możliwy tylko z poziomu sieci OVHcloud.
+
+### Czy NAS-HA kwalifikuje się do oferty vRack?
+
+Obecnie NAS-HA nie może być zintegrowany z prywatną siecią vRack. Jednakże korzystanie z NAS-HA i z sieci vRack nie jest niezgodne z prawem, przechodząc przez publiczną ścieżkę IP serwera podłączonego do sieci vRack.
+
+## Wydajność i wydajność
+
+### Jakie są dostępne możliwości przechowywania danych?
+
+Minimalny rozmiar usługi to 3 TB, a maksymalny rozmiar to 144 TB.<br>
+Proponujemy następującą przestrzeń dyskową na bazie dysków 3 TB:
+
+- 3 TB
+- 6 TB
+- 9 TB
+- 18 TB
+- 36 TB
+
+Proponujemy następującą przestrzeń dyskową na bazie dysków 12 TB:
+
+- 12 TB
+- 24 TB
+- 36 TB
+- 72 TB
+- 144 TB
 
 Proponowana zdolność magazynowania to zdolność do wykorzystania.
 
-### Czy usługa NAS-HA jest w pełni dedykowana?
+### Czy moje zasoby NAS-HA są dedykowane?
 
 Dyski NAS-HA są dedykowane. Pozostałe zasoby maszyny są współdzielone (RAM, CPU, Przepustowość).
 
-**Szczególne przypadki:** jeśli zamówiłeś ofertę 36 To, wszystkie zasoby serwera hosta są dedykowane (RAM, CPU, Przepustowość).
+**Szczególne przypadki:** jeśli zamówiłeś ofertę 144 TB, wszystkie zasoby serwera hosta są dedykowane (RAM, CPU, Przepustowość).
 
-### Na jaki okres mogę wykupić NAS-HA?
+### Ile usług NAS-HA mogę utworzyć z konta klienta?
 
-Oferowane okresy to: 1, 3, 6 i 12 miesięcy. W przypadku braku złożenia wniosku o rozwiązanie umowy, po zakończeniu okresu rozliczeniowego subskrypcja jest przedłużana automatycznie. Wniosek można złożyć przez [Panel klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external} w trakcie całego okresu obowiązywania umowy.
+Nie ma limitu liczby usług na konto klienta.
 
-## Użytkowanie produktu
+### Jaka jest maksymalna liczba partycji na usługę?
+
+Możesz utworzyć wybraną liczbę partycji. Minimalny rozmiar to 10 GB, a maksymalny rozmiar usługi jest określony przez maksymalny rozmiar usługi.
+
+### Czy poziom transferu i dostępności jest gwarantowany?
+
+- Transfer: przepustowość usługi jest współdzielona. Współczynniki transferu nie mogą być gwarantowane przez OVHcloud.
+- Dostępność: dostępność usługi jest gwarantowana i podlega umowie o gwarantowanym poziomie usługi. Szczegóły znajdziesz w szczegółowych warunkach korzystania z usługi.
+
+## Wykorzystanie produktu
 
 ### Czy NAS-HA może być podłączony do kilku serwerów jednocześnie?
 
-Tak, NAS może współpracować jednocześnie z wieloma usługami OVHcloud.
+Tak. Usługa NAS może współdziałać z wieloma usługami OVHcloud.
 
-### Czy na NAS-HA można zainstalować system operacyjny?
+### Czy można zainstalować system operacyjny na NAS-HA?
 
-Nie, na NAS-HA nie ma możliwości zainstalowania systemu operacyjnego.
+Nie, nie można zainstalować systemu operacyjnego w ofercie NAS-HA.
 
-### Jakie protokoły są zgodne z NAS-HA?
+### Czy przydzielona przestrzeń jest podzielona na kategorie?
 
-NAS-HA może być zainstalowany na serwerze Windows lub Linux z protokołem CIFS (Samba) lub NFS.
-
-### Czy przestrzeń dyskową można dzielić na partycje?
-
-Tak, konieczne jest utworzenie jednej lub kilku partycji. Nie ma ograniczeń w liczbie tworzonych partycji.
-
-## Kompatybilność
-
-### Czy NAS-HA jest kompatybilny z serwerami innymi niż OVHcloud?
-
-Nie, dostęp do NAS-HA możliwy jest wyłącznie poprzez sieć OVHcloud.
-
-### Dla jakich usług jest dostępne rozwiązanie NAS-HA?
-
-Dostępny jest we wszystkich przystosowanych do tego produktach OVHcloud: serwerach dedykowanych (OVHcloud, So you Start, Kimsufi), Hosted Private Cloud, Public Cloud i VPS.
-
-### Jak zarządzać dostępem do NAS-HA?
-
-Listę kontroli dostępu (ACL) można konfigurować z poziomu Panelu klienta OVHcloud. Wystarczy wprowadzić adres IP usługi, której chcesz zezwolić na dostęp do NAS-HA.
-
-### Czy NAS-HA jest dostępne dla oferty vRack?
-
-Obecnie nie można zintegrować NAS-HA z siecią prywatną vRack. Jednakże można pogodzić korzystanie z NAS-Ha i vRack przez publiczny adres IP serwera połączonego z vRack.
-
-## Prędkość przesyłu
-
-### Czy prędkość przesyłu danych i dostępność są gwarantowane?
-
-- Przesyłanie danych: pasmo przesyłowe dla usługi jest współdzielone. OVHcloud nie może więc zagwarantować prędkości przesyłu danych.
-- Dostępność: dostępność usługi jest gwarantowana i podlega umowie o gwarantowanym poziomie usług. Szczegóły dostępne są w szczegółowych warunkach korzystania z usługi.
+Tak, konieczne jest utworzenie jednej lub kilku partycji w zależności od korzystania z usługi. Tworzenie partycji nie jest ograniczone.
 
 ## Snapshoty
 
-### Co to jest snapshot?
+### Czym są snapshoty?
 
-Snapshot (inaczej migawka) to rodzaj zrzutu danych przechowywanych na dysku w danym momencie. Konfiguracja i zarządzanie snapshotami są dostępne z poziomu Panelu klienta.
+Snapshoty to obrazy stanu dysku oraz danych przechowywanych w danej chwili. Umożliwiają zaproponowanie pierwszego poziomu kopii zapasowych. Możesz skonfigurować snapshoty i zarządzać nimi w Panelu klienta.
 
-Snapshot jest aktywowany domyślnie w chwili tworzenia partycji, a domyśla częstotliwość jego wykonywania to “co godzinę”.
+Domyślnie funkcja snapshot jest aktywowana podczas tworzenia partycji. Częstotliwość jest ustawiana na "co godzinę".
 
-### Jak często tworzyć snapshoty?
+### Jaka polityka tworzenia kopii zapasowych jest związana z usługą NAS-HA?
 
-Częstotliwością tworzenia snapshotów można zarządzać z poziomu Panelu klienta. Możesz wybrać jeden z poniższych odstępów czasowych:
+Użytkownicy są odpowiedzialni za zarządzanie kopiami zapasowymi (narzędzia i reguły) wewnątrz i na zewnątrz usługi oraz za planowanie ciągłości działania i przywrócenia działania. Jednak ze względów bezpieczeństwa i odporności infrastruktury OVHcloud może wykonywać snapshoty usługi na zdalnym serwerze, bez konieczności wykonywania żadnych zobowiązań.
+
+W przypadku awarii lub ataku, jeśli OVHcloud wykonał snapshot na zdalnym serwerze, możemy przywrócić dane z ostatniego dostępnego snapshota. Pamiętaj, że operacja ta jest realizowana na zamówienie i stanowi usługę opcjonalną fakturowaną.
+
+### Jak często są wykonywane snapshoty? <a name="frequency"></a>
+
+Częstotliwość kopii zapasowych (snapshot) można zarządzać w Panelu klienta OVHcloud. Możesz wybrać częstotliwość z następujących opcji:
 
 - co godzinę (domyślnie);
 - co 6 godzin;
-- codziennie;
+- każdego dnia;
 - co dwa dni;
 - co trzy dni;
-- raz w tygodniu.
+- tygodniowo.
 
-W każdej chwili  możesz również tworzyć snapshoty ręcznie, przechowywać je bezterminowo lub usuwać. Te funkcje są dostępne w Twoim [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external} lub przez [API](https://api.ovh.com/){.external}:
+W każdej chwili możesz również tworzyć ręczne snapshoty, przechowywać je bez ograniczeń czasowych lub je usuwać. Funkcja ta jest dostępna w Panelu [klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) lub za pośrednictwem [następującego wywołania API](https://api.ovh.com/):
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Zapoznaj się z naszym przewodnikiem "[Pierwsze kroki z API OVHcloud](/pages/account/api/first-steps)", aby zapoznać się z korzystaniem z API OVHcloud.
 >
 
 ### Jak działa system zarządzania snapshotami?
 
-Istnieje możliwość automatycznego tworzenia snapshotów w określonych odstępach czasowych. Bez względu na ustawioną częstotliwość, ostatnio utworzony snapshot zawsze usuwa i zastępuje poprzedni. Możesz również tworzyć i usuwać snapshoty na żądanie.
+Możesz skonfigurować automatyczne snapshoty z różnymi dostępnymi częstotliwościami. Bez względu na skonfigurowaną częstotliwość ostatni wykonany snapshot zastąpi poprzedni snapshot. Możesz również tworzyć i usuwać snapshoty na żądanie.
 
-### Czy można usunąć snapshota?
+### Czy można usunąć snapshot?
 
-Usuwane mogą być jedynie snapshoty utworzone “na żądanie” (patrz poprzednie pytanie “Jak często należy tworzyć snapshoty?”). Snapshoty tworzone w stałych odstępach czasowych są usuwane automatycznie, bez możliwości ich ręcznego usuwania.
+Można usunąć jedynie snapshoty utworzone "na żądanie" (patrz poprzednie pytanie "[Jak często są wykonywane snapshoty?](#frequency)").<br>
+Snapshoty o stałej częstotliwości są automatycznie usuwane bez możliwości ich ręcznego usuwania.
 
-### Ile przestrzeni zajmują snapshoty na NAS-HA?
+### Czy snapshoty są zawarte w usłudze?
 
-Przestrzeń zajmowana przez utworzone snapshoty różni się w zależności od działań wykonywanych pomiędzy ich utworzeniem.
+W ramach tej samej fizyki przydzielasz dodatkową przestrzeń do przechowywania kopii zapasowych snapshot. Przestrzeń ta odpowiada co najmniej 15 % objętości głównej. W przypadku przekroczenia tej wartości snapshoty będą przechowywane na Twojej głównej przestrzeni dyskowej. Dodatkowa przestrzeń nie może być używana do innych celów niż przechowywanie kopii zapasowych snapshot.
 
-Od chwili utworzenia snapshota wszystkie działania wykonane na danej partycji będą w nim przechowywane, co wiąże się ze zwiększaniem rozmiaru pliku. Można również w każdej chwili przywrócić poprzednią wersję partycji (czyli tę, w jakiej była w chwili tworzenia snapshota).  Z technicznego punktu widzenia wszelkie zmiany i usuwanie danych powodują, że pliki snapshota zajmują coraz więcej miejsca na dysku.
+Na przykład, w przypadku usługi 3 TB, dodatkowe 450 GB jest zarezerwowane dla kopii zapasowych snapshot.
 
-### Ile snapshotów mogę maksymalnie utworzyć?
+### Ile snapshotów mogę wykonać maksymalnie?
 
-- snapshoty automatyczne: jeden na partycję
-- snapshoty ręczne: dziesięć na partycję
+- Dla automatycznych snapshotów: jeden na partycję
+- W przypadku ręcznych kopii zapasowych: dziesięć na partycję
 
-### Skąd mogę odzyskać snapshoty?
+### Gdzie są przechowywane snapshoty?
 
-Na właściwej partycji: katalog ukryty o nazwie `.zfs` → katalog `snapshots`. Pliki mają status “read only”.
+Snapshoty są przechowywane na tym samym poziomie, co Twoja usługa. Snapshoty są kopiowane na dwa różne serwery w dwóch różnych konfiguracjach. Dodatkowo OVHcloud wykonuje codzienną kopię zapasową snapshot na zdalnej witrynie.
 
-### Czy OVHcloud wykonuje również kopię zapasową moich danych?
+### Gdzie mogę pobrać moje snapshoty?
 
-Tak, wykonywana jest wewnętrzna kopia zapasowa. Generuje to o jeden snapshot więcej. Tworzenie takiej kopii zapasowej nie może zostać dezaktywowane przez klienta.
+W wybranej partycji znajdziesz ukryty katalog o nazwie `.zfs`, który zawiera katalog `snapshots`. Pliki są dostępne w trybie read only.
+
+### Jak wiele polityk snapshotów mogę tworzyć na podstawie wolumenu?
+
+1
+
+## Cennik
+
+### Jaki rodzaj opłat jest przypisany do usługi?
+
+NAS-HA to usługa płatna co miesiąc w zależności od wolumenu (od 3 do 144 TB w odstępach).
+
+### Na jaki czas mogę zamówić usługę NAS-HA?
+
+Proponowane okresy to 1, 12, 24 i 36 miesięcy. Pod koniec okresu abonamentu zostanie automatycznie odnowiony, jeśli nie zostanie złożony [wniosek o rezygnację](/pages/account/billing/how_to_cancel_services). Operacja ta może zostać przeprowadzona przez cały okres abonamentu w Panelu klienta.
 
 ## Sprawdź również
 

--- a/pages/cloud/storage/file_storage/nas_faq/guide.pt-pt.md
+++ b/pages/cloud/storage/file_storage/nas_faq/guide.pt-pt.md
@@ -1,35 +1,83 @@
 ---
-title: NAS - Perguntas Frequentes
-slug: nas/faq
-excerpt: Tem dúvidas sobre o NAS (Network Attached Storage)? Veja as repostas às perguntas mais frequentes
-section: NAS-HA
-order: 02
-updated: 2021-09-09
+title: NAS-HA - Perguntas Frequentes
+excerpt: Tem dúvidas sobre o NAS-HA? Veja as repostas às perguntas mais frequentes
+updated: 2023-06-07
 ---
 
 > [!primary]
 > Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certos casos, poderão ocorrer formulações imprecisas, como por exemplo nomes de botões ou detalhes técnicos. Recomendamos que consulte a versão inglesa ou francesa do manual, caso tenha alguma dúvida. Se nos quiser ajudar a melhorar esta tradução, clique em "Contribuir" nesta página.
 >
 
-**Ultima atualização: 09/09/2021**
+## Objetivo
 
-## Especificidades do Serviço
+**Veja as perguntas mais frequentes sobre a oferta NAS-HA da OVHcloud.**
+
+## Questões gerais
+
+### O que é a solução NAS-HA OVHcloud?
+
+NAS-HA é um serviço de armazenamento de ficheiros partilhado e inteiramente gerido, baseado na tecnologia open-source OpenZFS.
+
+### O que posso fazer com o NAS-HA?
+
+NAS-HA permite centralizar os dados de diferentes cargas de trabalho Linux, mas também Windows para vários cenários:
+
+- armazenamento partilhado e externalizado para aplicações IT (VM, DB..)
+- gestão de conteúdos web
+- partilha de ficheiros na rede, etc.
 
 ### É possível obter o NAS-HA através da área de gestão do serviço?
 
-Sim, esta ferramenta está disponível na [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}, secção `Bare Metal Cloud`{.action} e depois `NAS e CDN`{.action}.
+Sim, este espaço pode ser acedido a partir da [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt), secção `Bare Metal Cloud`{.action} e depois `NAS e CDN`{.action}.
 
-### É possível aumentar a capacidade total do meu NAS?
+## Disponibilidade
 
-Depois de registado o pedido, já não é possível aumentar a capacidade de armazenamento. Para aumentar a capacidade de armazenamento, terá que migrar os seus dados para um NAS com maior espaço de armazenamento.
+### Qual é o SLA fornecido com o NAS-HA?
+
+NAS-HA é fornecido com uma taxa de disponibilidade de 99,99%.
+
+## Rede e segurança
+
+### Que protocolos de transferência de ficheiros são atualmente suportados na solução NAS-HA?
+
+NAS-HA suporta a transferência de ficheiros através de NFS (NFSv3) e CIFS (SMB).
+
+### A partir de que serviços OVHcloud posso cultivar dados?
+
+NAS-HA é um serviço que pode receber dados de todos os serviços existentes da OVHcloud: Bare Metal Cloud (VPS, Servidores Dedicados OVHcloud, So you Start, Kimsufi), Public Cloud, Hosted Private Cloud, etc.
+
+### Como gerir os acessos ao NAS-HA?
+
+A lista dos controlos de acesso (ACL) pode ser configurada a partir da Área de Cliente OVHcloud. Basta introduzir o endereço IP do serviço para o qual deseja autorizar o acesso ao NAS-HA.
+
+### O serviço NAS-HA é compatível com outros servidores fora da OVHcloud?
+
+Não, o NAS-HA só pode ser acedido através da rede OVHcloud.
+
+### O NAS-HA é elegível para a oferta vRack?
+
+Neste momento, o NAS não pode ser integrado na rede privada vRack. No entanto, a utilização do NAS-HA e do vRack não são incompatíveis, passando pelo caminho IP público do servidor ligado ao vRack.
+
+## Capacidade e desempenho
 
 ### Quais as opções em termos de espaço de armazenamento?
 
-- 3 To
-- 6 To
-- 9 To
-- 18 To
-- 36 To
+O tamanho mínimo de um serviço é de 3 TB e o tamanho máximo é de 144 TB.<br>
+Oferecemos as seguintes capacidades de armazenamento com base em discos de 3 TB:
+
+- 3 TB
+- 6 TB
+- 9 TB
+- 18 TB
+- 36 TB
+
+Oferecemos as seguintes capacidades de armazenamento com base em discos de 12 TB:
+
+- 12 TB
+- 24 TB
+- 36 TB
+- 72 TB
+- 144 TB
 
 As capacidades de armazenamento propostas são as capacidades utilizáveis.
 
@@ -37,79 +85,69 @@ As capacidades de armazenamento propostas são as capacidades utilizáveis.
 
 Os discos do NAS-HA são dedicados. Os outros recursos (RAM, CPU, Banda Larga) são partilhados.
 
-**Caso específico:** se subscrever à oferta 36 To, o conjunto dos recursos do servidor host são-lhe dedicados (RAM, CPU, Largura de banda).
+**Caso específico:** se subscrever a oferta 144 TB, o conjunto dos recursos do servidor host são-lhe dedicados (RAM, CPU, Largura de banda).
 
-### Quais são os períodos de subscrição do NAS-HA?
+### Quantos serviços NAS-HA posso criar a partir da minha conta de cliente?
 
-O serviço pode ser contratado por 1, 3, 6 e 12 meses. Se não houver qualquer cancelamento, o serviço é renovado no final do período da subscrição. O cancelamento pode ser efetuado a qualquer momento, através da [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}.
+Não há limite de número de serviços por conta de cliente.
+
+### Qual é o número máximo de partições por serviço?
+
+É possível criar tantas partições quantas desejar. O tamanho mínimo é de 10 GB e o tamanho máximo é definido pelo tamanho máximo do serviço.
+
+### A taxa de transferência e a disponibilidade são garantidas?
+
+- Transferência: a banda larga do serviço é partilhada. As taxas de transferência não podem ser garantidas pela OVHcloud.
+- Disponibilidade: a disponibilidade do serviço é garantida e está abrangida por garantias SLA (Service Level Agreement). Os detalhes podem ser consultados nas nossas condições específicas de utilização.
 
 ## Utilização do serviço
 
 ### O NAS pode ser ligado a vários servidores ao mesmo tempo?
 
-Sim. O NAS pode ser configurado para interagir em simultâneo com vários serviços OVHcloud.
+Sim. É possível fazer interagir simultaneamente o seu NAS com vários serviços da OVHcloud.
 
 ### Podemos instalar um sistema operativo num NAS?
 
 Não, não é possível instalar um sistema operativo num NAS-HA.
 
-### Quais são os protocolos compatíveis com a oferta NAS-HA?
-
-O NAS-HA pode ser montado num servidor Windows ou Linux através dos protocolos CIFS (Samba) ou NFS.
-
-### O espaço de armazenamento pode ser compartimentado?
+### O espaço atribuído é particionável?
 
 Sim, para tal basta criar as partições adequadas ao tipo de utilização. A criação de partições é ilimitada.
-
-## Compatibilidade do produto
-
-### O NAS-HA é compatível com servidores de outros operadores?
-
-Não, só é possível aceder ao NAS-HA através da rede OVHcloud.
-
-### O NAS é compatível com que serviços?
-
-O NAS está acessível a todos os produtos OVHcloud com um sistema operativo: servidores dedicados (OVHcloud, So you Start, Kimsufi), Hosted Private Cloud, Public Cloud e VPS.
-
-### Como gerir os acessos ao NAS-HA?
-
-A lista dos controlos de acesso (Access Control List / ACL) pode ser configurada através da Área de Cliente Para tal, basta introduzir o endereço IP do serviço ao qual será dada a autorização de acesso ao NAS-HA.
-
-### O NAS é compatível com a oferta vRack?
-
-Neste momento, o NAS não pode ser integrado na rede privada vRack. No entanto, as soluções NAS e vRack não são incompatíveis, se optar pelo roteamento IP do servidor ligado ao VRack.
-
-## Taxa de transferência
-
-### A taxa de transferência e a disponibilidade são garantidas?
-
-- Transferência: a banda larga do serviço é partilhada. Por isso, a OVHcloud não podem garantir as taxas de transferência.
-- Disponibilidade: a disponibilidade do serviço é garantida e está abrangida por garantias SLA (Service Level Agreement). A informação pode ser consultada nas condições particulares do serviço.
 
 ## Snapshots
 
 ### O que são Snapshots?
 
-Snapshots são imagens instantâneas do disco e dos dados existentes num determinado momento. A configuração e a gestão das Snapshots são efetuadas a partir da Área de Cliente.
+Snapshots são imagens instantâneas do disco e dos dados existentes num determinado momento. Eles permitem propor um primeiro nível de backup. A configuração e a gestão das snapshots podem ser realizadas a partir da Área de Cliente OVHcloud.
 
-A função Snapshot é ativada automaticamente após a criação duma partição. A frequência das Snapshots está predefinida para ser executada de hora em hora.
+Por predefinição, a função snapshot é ativada aquando da criação da sua partição, a frequência é pré-regulada para "todas as horas".
 
-### Qual é a frequência das Snapshots?
+### Qual é a política de backup associada ao NAS-HA?
 
-A frequência das Snapshots está predefinida para ser executada de hora em hora, mas pode ser redefinida a partir da Área de Cliente. A frequência das Snapshots pode ser definida de acordo com as seguintes opções:
+Os utilizadores são responsáveis pela gestão dos seus backups (ferramentas e regras) dentro e fora do serviço, bem como pelos seus planos de continuidade de atividade e de retoma de atividade. No entanto, por razões de segurança e resiliência da infraestrutura, a OVHcloud pode efetuar snapshots do serviço num servidor distante, sem qualquer obrigação.
 
-- de hora em hora (predefinido);
+Em caso de avaria ou de ataque, se a OVHcloud tiver efetuado uma snapshot num servidor remoto, poderemos restaurar os dados da última snapshot disponível. No entanto, note que esta ação é realizada a pedido e constitui um serviço opcional faturado.
+
+### Qual é a frequência das snapshots? <a name="frequency"></a>
+
+A frequência das snapshots pode ser administrada a partir da Área de Cliente OVHcloud. A frequência das Snapshots pode ser definida de acordo com as seguintes opções:
+
+- todas as horas (predefinido);
 - de 6 em 6 horas;
 - diária;
 - de 2 em 2 dias;
 - de 3 em 3 dias;
 - semanal.
 
-Também pode criar Snapshots manuais a qualquer momento. Esta funcionalidade pode ser acedida através da [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external} ou através da[API](https://api.ovh.com/){.external}:
+Também pode criar Snapshots manuais a qualquer momento. Esta funcionalidade está disponível no seio do seu [Espaço Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) ou através da [API](https://api.ovh.com/) seguinte:
 
 > [!api]
 >
-> @api {GET} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+> @api {POST} /dedicated/nasha/{serviceName}/partition/{partitionName}/customSnapshot
+>
+
+> [!primary]
+> Consulte o nosso guia "[Primeiros passos com as API OVHcloud](/pages/account/api/first-steps)" para se familiarizar com a utilização das API OVHcloud.
 >
 
 ### Como funciona a gestão das Snapshots?
@@ -118,26 +156,41 @@ Pode configurar snapshots automáticas, de acordo com as opções disponíveis. 
 
 ### Posso eliminar uma Snapshot?
 
-As Snapshots criadas manualmente podem ser eliminadas manualmente (ver questão precedente, «Qual a frequência das Snapshots?»). As Snapshots com frequência automática são eliminadas automaticamente; não podem ser eliminadas manualmente.
+Apenas as snapshots criadas "a pedido" podem ser eliminadas (ver a pergunta anterior "[Qual a frequência das snapshots?](#frequency)").<br>
+As Snapshots com frequência automática são eliminadas automaticamente; não podem ser eliminadas manualmente.
 
-### Quanto espaço ocupam as Snapshots na NAS?
+### As snapshots estão incluídas na capacidade de um serviço?
 
-O espaço usado por uma Snapshot varia em função das ações efetuadas durante o período de tempo compreendido ente cada Snapshot.
+Um espaço adicional no mesmo suporte físico é-lhe atribuído para assegurar o armazenamento das suas snapshots. Este espaço corresponde a pelo menos 15 % do volume principal. Caso o ultrapasse, as snapshots serão armazenadas no seu espaço de armazenamento principal. O espaço adicional não pode ser utilizado para outra utilização que não o armazenamento das suas snapshots.
 
-Quando efetua a Snaphot, todas as ações realizadas na partição serão guardadas nesta snapshot e irão aumentar a dimensão do ficheiro.
+Por exemplo, para um serviço de 3 TB, são reservados 450 GB adicionais para as snapshots.
 
 ### Quantas Snapshots podem ser realizadas? Existe algum limite?
 
 - Uma por partição, para as Snapshots automáticas.
-- Dez por partição, para as Snapshots manuais.
+- Para as snapshots manuais: dez por partição
+
+### Onde estão armazenadas as snapshots?
+
+As snapshots são armazenadas ao mesmo nível que o seu serviço. As snapshots são replicadas em dois servidores diferentes em dois racks diferentes. Além disso, a OVHcloud efetua uma snapshot diária num site remoto.
 
 ### Como aceder às Snapshots?
 
-Na partição em causa: pasta oculta chamada `.zfs` → pasta `snapshots`. Ficheiros disponíveis apenas em modo de leitura
+Na partição em causa, poderá encontrar um diretório oculto chamado `.zfs` que contém um diretório `snapshots`. Os ficheiros estão disponíveis apenas em modo de leitura.
 
-### A OVHcloud também realiza backups dos meus dados?
+### Quantas políticas de snapshots posso criar por volume?
 
-Sim, o nosso sistema efetua um backup diário interno, que gera mais uma snapshot. Este backup não pode ser desativado pelo cliente
+1
+
+## Preços
+
+### Que tipo de preços está associado ao serviço?
+
+NAS-HA é um serviço faturado mensalmente ao volume (de 3 a 144 TB por patamares).
+
+### Quais são os períodos de subscrição do NAS-HA?
+
+O serviço pode ser contratado por 1, 12, 24 e 36 meses. No final do período de compromisso, a sua subscrição será renovada tacitamente se não tiver sido formulado qualquer [pedido de cancelamento](/pages/account/billing/how_to_cancel_services). Esta pode ser efetuada durante toda a duração da subscrição através da Área de Cliente OVHcloud.
 
 ## Quer saber mais?
 


### PR DESCRIPTION
The NAS-HA FAQ had been updated back in August 2022: https://github.com/ovh/docs/pull/3386
Somehow, when renaming the /storage/ folders in October 2022 (https://github.com/ovh/docs/pull/3582/), this guide had been reverted to its previous version.

This PR reintroduces the right version for this guide. Translations had already been validated.
Links have been updated, deprecated keys have been withdrawn from the header.
Date is updated.