### PR TITLE
Remove enterprise plan and add module licensing information

### DIFF
--- a/pages/platform/databases/redis_01_capabilities/guide.de-de.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.de-de.md
@@ -3,10 +3,8 @@ title: Redis - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
 routes:
     canonical: '/pages/platform/databases/redis_01_capabilities'
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -48,7 +46,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -56,7 +53,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -67,11 +63,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -123,8 +121,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.de-de.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.de-de.md
@@ -68,7 +68,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-asia.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-asia.md
@@ -66,7 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-asia.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-asia.md
@@ -1,10 +1,8 @@
 ---
 title: Redis - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -46,7 +44,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -54,7 +51,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -65,11 +61,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -121,8 +119,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-au.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-au.md
@@ -66,7 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-au.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-au.md
@@ -1,10 +1,8 @@
 ---
 title: Redis - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -46,7 +44,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -54,7 +51,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -65,11 +61,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -121,8 +119,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-ca.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-ca.md
@@ -66,7 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-ca.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-ca.md
@@ -1,10 +1,8 @@
 ---
 title: Redis - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -46,7 +44,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -54,7 +51,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -65,11 +61,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -121,8 +119,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-gb.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-gb.md
@@ -66,7 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-gb.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-gb.md
@@ -1,10 +1,8 @@
 ---
 title: Redis - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -46,7 +44,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -54,7 +51,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -65,11 +61,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -121,8 +119,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-ie.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-ie.md
@@ -66,7 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-ie.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-ie.md
@@ -1,10 +1,8 @@
 ---
 title: Redis - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -46,7 +44,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -54,7 +51,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -65,11 +61,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -121,8 +119,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-sg.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-sg.md
@@ -66,7 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-sg.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-sg.md
@@ -1,10 +1,8 @@
 ---
 title: Redis - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -46,7 +44,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -54,7 +51,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -65,11 +61,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -121,8 +119,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-us.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-us.md
@@ -66,7 +66,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.en-us.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.en-us.md
@@ -1,10 +1,8 @@
 ---
 title: Redis - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -46,7 +44,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -54,7 +51,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -65,11 +61,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -121,8 +119,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.es-es.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.es-es.md
@@ -3,10 +3,8 @@ title: Redis - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
 routes:
     canonical: '/pages/platform/databases/redis_01_capabilities'
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -48,7 +46,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -56,7 +53,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -67,11 +63,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -123,8 +121,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.es-es.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.es-es.md
@@ -68,7 +68,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.es-us.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.es-us.md
@@ -3,10 +3,8 @@ title: Redis - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
 routes:
     canonical: '/pages/platform/databases/redis_01_capabilities'
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -48,7 +46,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -56,7 +53,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -67,11 +63,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -123,8 +121,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.es-us.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.es-us.md
@@ -68,7 +68,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.fr-ca.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.fr-ca.md
@@ -68,7 +68,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.fr-ca.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.fr-ca.md
@@ -3,10 +3,8 @@ title: Redis - Capacités et limites (EN)
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
 routes:
     canonical: '/pages/platform/databases/redis_01_capabilities'
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -48,7 +46,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -56,7 +53,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -67,11 +63,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -123,8 +121,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.fr-fr.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.fr-fr.md
@@ -68,7 +68,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.fr-fr.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.fr-fr.md
@@ -3,10 +3,8 @@ title: Redis - Capacités et limites (EN)
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
 routes:
     canonical: '/pages/platform/databases/redis_01_capabilities'
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -48,7 +46,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -56,7 +53,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -67,11 +63,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -123,8 +121,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.it-it.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.it-it.md
@@ -3,10 +3,8 @@ title: Redis - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
 routes:
     canonical: '/pages/platform/databases/redis_01_capabilities'
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -48,7 +46,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -56,7 +53,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -67,11 +63,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -123,8 +121,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.it-it.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.it-it.md
@@ -68,7 +68,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.pl-pl.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.pl-pl.md
@@ -3,10 +3,8 @@ title: Redis - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
 routes:
     canonical: '/pages/platform/databases/redis_01_capabilities'
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -48,7 +46,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -56,7 +53,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -67,11 +63,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -123,8 +121,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.pl-pl.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.pl-pl.md
@@ -68,7 +68,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.pt-pt.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.pt-pt.md
@@ -3,10 +3,8 @@ title: Redis - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Redis
 routes:
     canonical: '/pages/platform/databases/redis_01_capabilities'
-updated: 2023-05-23
+updated: 2023-07-03
 ---
-
-**Last updated May 23rd, 2023**
 
 ## Objective
 
@@ -48,7 +46,6 @@ Three plans are available:
 
 - *Essential*
 - *Business*
-- *Enterprise*
 
 Here is an overview of the various plans' capabilities:
 
@@ -56,7 +53,6 @@ Here is an overview of the various plans' capabilities:
 | ------------ | -------------------------- | ---------------- |
 | *Essential*  | 1                          | No               |
 | *Business*   | 2                          | No               |
-| *Enterprise* | 3                          | No               |
 
 Your choice of plan affects the number of nodes your cluster can run, the SLA, and a few other features such as read replicas or backup retention.
 
@@ -67,11 +63,13 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 - **Essential**: the cluster can support at most one node.
 - **Business**: the cluster is delivered with 2 nodes by default.
-- **Enterprise**: the cluster is delivered with 3 nodes by default.
 
 #### License type
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
+
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+
 More information on <https://redis.com/legal/licenses/>.
 
 ### Hardware resources
@@ -123,8 +121,6 @@ You can further customise your Redis by using advanced parameters. See the [Adva
 *Essential* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 1 day.
 
 *Business* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 3 days.
-
-*Enterprise* plan clusters are automatically backed up every 12 hours during their maintenance window. Backup retention is 13 days.
 
 See the [Automated Backups guide](/pages/platform/databases/databases_05_automated_backups) for more information.
 

--- a/pages/platform/databases/redis_01_capabilities/guide.pt-pt.md
+++ b/pages/platform/databases/redis_01_capabilities/guide.pt-pt.md
@@ -68,7 +68,7 @@ Your choice of plan affects the number of nodes your cluster can run, the SLA, a
 
 Redis Community software is under the 3-Clause-BSD license, a liberal open-source license.
 
-Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model forbid OVHcloud, and any other service provider, offering these modules to third parties as a service. So **these modules are not available**.
+Redis Stack and all Redis modules created by Redis Ltd. (e.g., RediSearch, RedisJSON, RedisGraph, RedisTimeSeries, and RedisBloom) are dual-licensed under the Redis Source Available License v2 (RSALv2) and SSPL. The RSALv2 license model prohibits OVHcloud, and any other service provider, from offering these modules to third parties as a service. So **these modules are not available**.
 
 More information on <https://redis.com/legal/licenses/>.
 


### PR DESCRIPTION
We could not offer the enterprise plan for Redis because they own the trademark Redis Enterprise. I added specificities of the license model regarding popular modules.