### PR TITLE
Add new PTT code

### DIFF
--- a/pages/telecom/sms/smpp-specification/guide.en-gb.md
+++ b/pages/telecom/sms/smpp-specification/guide.en-gb.md
@@ -261,6 +261,7 @@ Our service will attempt to send the `deliver_sm` to ESME for up to 7 days.
 |51  | Internal Error |
 |52  | Missing Template (e.g. US destination requires approved templates) |
 |53  | Blacklisted (a STOP response sent by the recipient to block the sender) |
+|54  | Forbidden destination |
 |100 | Invalid Destination Numbering Plan |
 |101 | Invalid Content |
 |102 | Invalid GSM7 Coding (e.g. error with packed/unpacked GSM7) |

--- a/pages/telecom/sms/smpp-specification/guide.en-gb.md
+++ b/pages/telecom/sms/smpp-specification/guide.en-gb.md
@@ -1,10 +1,10 @@
 ---
 title: SMPP Technical Specifications
 excerpt: 'Discover the technical specifications of the OVHcloud SMPP solution'
-updated: 2023-05-22
+updated: 2023-07-25
 ---
 
-**Last updated 22nd May 2023**
+**Last updated 25th July 2023**
 
 ## Objective
 

--- a/pages/telecom/sms/smpp-specification/guide.en-ie.md
+++ b/pages/telecom/sms/smpp-specification/guide.en-ie.md
@@ -261,6 +261,7 @@ Our service will attempt to send the `deliver_sm` to ESME for up to 7 days.
 |51  | Internal Error |
 |52  | Missing Template (e.g. US destination requires approved templates) |
 |53  | Blacklisted (a STOP response sent by the recipient to block the sender) |
+|54  | Forbidden destination |
 |100 | Invalid Destination Numbering Plan |
 |101 | Invalid Content |
 |102 | Invalid GSM7 Coding (e.g. error with packed/unpacked GSM7) |

--- a/pages/telecom/sms/smpp-specification/guide.en-ie.md
+++ b/pages/telecom/sms/smpp-specification/guide.en-ie.md
@@ -1,10 +1,10 @@
 ---
 title: SMPP Technical Specifications
 excerpt: 'Discover the technical specifications of the OVHcloud SMPP solution'
-updated: 2023-05-22
+updated: 2023-07-25
 ---
 
-**Last updated 22nd May 2023**
+**Last updated 25th July 2023**
 
 ## Objective
 

--- a/pages/telecom/sms/smpp-specification/guide.es-es.md
+++ b/pages/telecom/sms/smpp-specification/guide.es-es.md
@@ -3,10 +3,10 @@ title: SMPP Technical Specifications (EN)
 routes:
     canonical: '/pages/telecom/sms/smpp-specification'
 excerpt: 'Discover the technical specifications of the OVHcloud SMPP solution'
-updated: 2023-05-22
+updated: 2023-07-25
 ---
 
-**Last updated 22nd May 2023**
+**Last updated 25th July 2023**
 
 ## Objective
 

--- a/pages/telecom/sms/smpp-specification/guide.es-es.md
+++ b/pages/telecom/sms/smpp-specification/guide.es-es.md
@@ -263,6 +263,7 @@ Our service will attempt to send the `deliver_sm` to ESME for up to 7 days.
 |51  | Internal Error |
 |52  | Missing Template (e.g. US destination requires approved templates) |
 |53  | Blacklisted (a STOP response sent by the recipient to block the sender) |
+|54  | Forbidden destination |
 |100 | Invalid Destination Numbering Plan |
 |101 | Invalid Content |
 |102 | Invalid GSM7 Coding (e.g. error with packed/unpacked GSM7) |

--- a/pages/telecom/sms/smpp-specification/guide.fr-fr.md
+++ b/pages/telecom/sms/smpp-specification/guide.fr-fr.md
@@ -1,10 +1,10 @@
 ---
 title: Spécifications techniques du SMPP
 excerpt: 'Découvrez les spécifications techniques du SMPP'
-updated: 2023-05-22
+updated: 2023-07-25
 ---
 
-**Dernière mise à jour le 22/05/2023**
+**Dernière mise à jour le 25/07/2023**
 
 ## Objectif
 

--- a/pages/telecom/sms/smpp-specification/guide.fr-fr.md
+++ b/pages/telecom/sms/smpp-specification/guide.fr-fr.md
@@ -263,6 +263,7 @@ Notre service essaie d'envoyer les `deliver_sm` au ESME pendant 7 jours maximum.
 |51  | Internal Error |
 |52  | Missing Template (e.g. US destination requires approved templates) |
 |53  | Blacklisted (a STOP response sent by the recipient to block the sender) |
+|54  | Forbidden destination |
 |100 | Invalid Destination Numbering Plan |
 |101 | Invalid Content |
 |102 | Invalid GSM7 Coding (e.g. error with packed/unpacked GSM7) |

--- a/pages/telecom/sms/smpp-specification/guide.it-it.md
+++ b/pages/telecom/sms/smpp-specification/guide.it-it.md
@@ -3,10 +3,10 @@ title: SMPP Technical Specifications (EN)
 routes:
     canonical: '/pages/telecom/sms/smpp-specification'
 excerpt: 'Discover the technical specifications of the OVHcloud SMPP solution'
-updated: 2023-05-22
+updated: 2023-07-25
 ---
 
-**Last updated 22nd May 2023**
+**Last updated 25th July 2023**
 
 ## Objective
 

--- a/pages/telecom/sms/smpp-specification/guide.it-it.md
+++ b/pages/telecom/sms/smpp-specification/guide.it-it.md
@@ -263,6 +263,7 @@ Our service will attempt to send the `deliver_sm` to ESME for up to 7 days.
 |51  | Internal Error |
 |52  | Missing Template (e.g. US destination requires approved templates) |
 |53  | Blacklisted (a STOP response sent by the recipient to block the sender) |
+|54  | Forbidden destination |
 |100 | Invalid Destination Numbering Plan |
 |101 | Invalid Content |
 |102 | Invalid GSM7 Coding (e.g. error with packed/unpacked GSM7) |

--- a/pages/telecom/sms/smpp-specification/guide.pl-pl.md
+++ b/pages/telecom/sms/smpp-specification/guide.pl-pl.md
@@ -3,10 +3,10 @@ title: SMPP Technical Specifications (EN)
 routes:
     canonical: '/pages/telecom/sms/smpp-specification'
 excerpt: 'Discover the technical specifications of the OVHcloud SMPP solution'
-updated: 2023-05-22
+updated: 2023-07-25
 ---
 
-**Last updated 22nd May 2023**
+**Last updated 25th July 2023**
 
 ## Objective
 

--- a/pages/telecom/sms/smpp-specification/guide.pl-pl.md
+++ b/pages/telecom/sms/smpp-specification/guide.pl-pl.md
@@ -263,6 +263,7 @@ Our service will attempt to send the `deliver_sm` to ESME for up to 7 days.
 |51  | Internal Error |
 |52  | Missing Template (e.g. US destination requires approved templates) |
 |53  | Blacklisted (a STOP response sent by the recipient to block the sender) |
+|54  | Forbidden destination |
 |100 | Invalid Destination Numbering Plan |
 |101 | Invalid Content |
 |102 | Invalid GSM7 Coding (e.g. error with packed/unpacked GSM7) |


### PR DESCRIPTION
We updated our SMPP spec with a new PTT code signifying that we can not send an SMS to the desired destination, since it is forbidden by us.