### PR TITLE
[ai notebooks] - new image generation documentation + links fix

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -827,6 +827,7 @@
                 + [AI Notebooks - Tutorial - Train YOLOv7 for sign language recognition](platform/ai/notebook_tuto_11_yolov7)
                 + [AI Notebooks - Tutorial - Brain tumor segmentation using U-Net](platform/ai/notebook_tuto_12_image-segmentation-unet-tumors)
                 + [AI Notebooks - Tutorial - Fine-tuning LLaMA 2](platform/ai/notebook_tuto_13_fine_tune_llama_v2)
+                + [AI Notebooks - Tutorial - Create and train an image generation model](platform/ai/notebook_tuto_14_image_generation_dcgan)
         + [AI Training](public-cloud-ai-and-machine-learning-ai-training)
             + [Guides](public-cloud-ai-and-machine-learning-ai-training-guides)
                 + [AI Training - Features, Capabilities and Limitations](platform/ai/training_guide_01_capabilities)

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.de-de.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.de-de.md
@@ -144,7 +144,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-asia.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-asia.md
@@ -142,7 +142,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-au.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-au.md
@@ -142,7 +142,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-ca.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-ca.md
@@ -142,7 +142,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-gb.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-gb.md
@@ -142,7 +142,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-ie.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-ie.md
@@ -142,7 +142,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-sg.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-sg.md
@@ -142,7 +142,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-us.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.en-us.md
@@ -142,7 +142,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.es-es.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.es-es.md
@@ -144,7 +144,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.es-us.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.es-us.md
@@ -144,7 +144,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.fr-ca.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.fr-ca.md
@@ -144,7 +144,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.fr-fr.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.fr-fr.md
@@ -144,7 +144,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.it-it.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.it-it.md
@@ -144,7 +144,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.pl-pl.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.pl-pl.md
@@ -144,7 +144,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.pt-pt.md
+++ b/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification/guide.pt-pt.md
@@ -144,7 +144,7 @@ You can then reach your notebook’s URL once the notebook is running.
 
 Once the repository has been cloned, find your notebook by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-classification` > `tensorflow` > `notebook-resnet-transfer-learning-image-classification.ipynb`.
 
-A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/notebook-resnet-transfer-learning-image-classification.ipynb).
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb).
 
 ## Go further
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.de-de.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.de-de.md
@@ -104,9 +104,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-asia.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-asia.md
@@ -102,9 +102,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-au.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-au.md
@@ -102,9 +102,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-ca.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-ca.md
@@ -102,9 +102,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-gb.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-gb.md
@@ -102,9 +102,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-ie.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-ie.md
@@ -102,9 +102,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-sg.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-sg.md
@@ -102,9 +102,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-us.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.en-us.md
@@ -102,9 +102,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.es-es.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.es-es.md
@@ -104,9 +104,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.es-us.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.es-us.md
@@ -104,9 +104,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.fr-ca.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.fr-ca.md
@@ -104,9 +104,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr-ca/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.fr-fr.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.fr-fr.md
@@ -104,9 +104,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.it-it.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.it-it.md
@@ -104,9 +104,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.pl-pl.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.pl-pl.md
@@ -104,9 +104,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.pt-pt.md
+++ b/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors/guide.pt-pt.md
@@ -104,9 +104,9 @@ A preview of this notebook can be found on GitHub [here](https://github.com/ovh/
 
 There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
 
-- [Use Transfer Learning with ResNet50 for image classification](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-classification/tensorflow/resnet50/notebook-resnet-transfer-learning-image-classification.ipynb)
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
 
-- [Train YOLOv7 for American Sign Language recognition](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/object-detection/miniconda/yolov7/notebook_object_detection_yolov7_asl.ipynb)
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.de-de.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.de-de.md
@@ -1,0 +1,109 @@
+---
+title: AI Notebooks - Tutorial - Create and train an image generation model
+excerpt: Get started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-asia.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-asia.md
@@ -1,0 +1,109 @@
+---
+title: AI Notebooks - Tutorial - Create and train an image generation model
+excerpt: Get started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-au.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-au.md
@@ -1,0 +1,109 @@
+---
+title: AI Notebooks - Tutorial - Create and train an image generation model
+excerpt: Get started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-ca.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-ca.md
@@ -1,0 +1,109 @@
+---
+title: AI Notebooks - Tutorial - Create and train an image generation model
+excerpt: Get started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-gb.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-gb.md
@@ -80,7 +80,8 @@ To launch your notebook, run the following command:
 ovhai notebook run conda jupyterlab \
 		--name <notebook-name> \
 		--framework-version <conda-version> \
-  	    --gpu <nb-gpus>
+		--gpu <nb-gpus>
+
 ```
 
 You can then reach your notebook’s URL once the notebook is running.

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-gb.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-gb.md
@@ -1,10 +1,8 @@
 ---
 title: AI Notebooks - Tutorial - Create and train an image generation model
-excerpt: Getting Started with Generative Adversarial Networks (GANs) to generate synthetic images
-updated: 2023-08-03
+excerpt: Get started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-04
 ---
-
-**Last updated 08th August, 2023.**
 
 ## Objective
 
@@ -16,7 +14,7 @@ The purpose of this tutorial is to show you how it is possible to build and trai
 
 At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
 
-![image](images/dcgan_training_animation.gif){.thumbnail}
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
 
 > [!primary]
 >

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-gb.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-gb.md
@@ -1,0 +1,110 @@
+---
+title: AI Notebooks - Tutorial - Create and train an image generation model
+excerpt: Getting Started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-03
+---
+
+**Last updated 08th August, 2023.**
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![image](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+  	    --gpu <nb-gpus>
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-ie.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-ie.md
@@ -1,0 +1,109 @@
+---
+title: AI Notebooks - Tutorial - Create and train an image generation model
+excerpt: Get started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-sg.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-sg.md
@@ -1,0 +1,109 @@
+---
+title: AI Notebooks - Tutorial - Create and train an image generation model
+excerpt: Get started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-us.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.en-us.md
@@ -1,0 +1,109 @@
+---
+title: AI Notebooks - Tutorial - Create and train an image generation model
+excerpt: Get started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.es-es.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.es-es.md
@@ -1,0 +1,109 @@
+---
+title: AI Notebooks - Tutorial - Create and train an image generation model
+excerpt: Get started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.es-us.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.es-us.md
@@ -1,0 +1,109 @@
+---
+title: AI Notebooks - Tutorial - Create and train an image generation model
+excerpt: Get started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/es/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.fr-ca.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.fr-ca.md
@@ -1,0 +1,109 @@
+---
+title: "AI Notebooks - Tutoriel - Créer et entraîner un modèle de génération d'images (EN)"
+excerpt: Découvrez le fonctionnement des GANs et comment générer vos propres images synthétiques
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/fr-ca/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr-ca/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.fr-fr.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.fr-fr.md
@@ -1,0 +1,109 @@
+---
+title: "AI Notebooks - Tutoriel - Créer et entraîner un modèle de génération d'images (EN)"
+excerpt: Découvrez le fonctionnement des GANs et comment générer vos propres images synthétiques
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/fr/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.it-it.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.it-it.md
@@ -1,0 +1,109 @@
+---
+title: AI Notebooks - Tutorial - Create and train an image generation model
+excerpt: Get started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.pl-pl.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.pl-pl.md
@@ -1,0 +1,109 @@
+---
+title: AI Notebooks - Tutorial - Create and train an image generation model
+excerpt: Get started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.pt-pt.md
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/guide.pt-pt.md
@@ -1,0 +1,109 @@
+---
+title: AI Notebooks - Tutorial - Create and train an image generation model
+excerpt: Get started with Generative Adversarial Networks (GANs) to generate synthetic images
+updated: 2023-08-04
+---
+
+## Objective
+
+Over the past few years, the field of **computer vision** has experienced a significant growth. It encompasses a wide range of methods for acquiring, processing, analyzing and understanding digital images. 
+
+Among these methods, one is called **image generation**. 
+
+The purpose of this tutorial is to show you how it is possible to build and train an image generation model with **OVHcloud AI Notebooks**. We will use a popular convolutional GAN named **DCGAN**.
+
+At the end of this tutorial, you will have learnt the concepts of generative models, model evaluation, and how to generate your own images by training a DCGAN on your dataset.
+
+![DCGAN training animation](images/dcgan_training_animation.gif){.thumbnail}
+
+> [!primary]
+>
+> We will train the DCGAN on the *[Chest X-Ray dataset](https://www.kaggle.com/datasets/paultimothymooney/chest-xray-pneumonia)*. We will show you how you can easily download the dataset in the notebook tutorial.
+>
+
+## Requirements
+
+- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- An AI Notebooks project created inside a [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
+- A user for AI Notebooks
+- A [Kaggle](https://www.kaggle.com/) account to download the dataset
+
+## Instructions
+
+You can launch the notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt) or via the ovhai [CLI](/pages/platform/ai/cli_11_howto_run_notebook_cli).
+
+### Launching a Jupyter notebook with "Conda" via UI (Control Panel)
+
+To launch your notebook from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt), refer to the following steps.
+
+#### Code editor
+
+Choose the `Jupyterlab` code editor.
+
+#### Framework
+
+In this tutorial, the `conda` framework is used.
+
+#### Resources
+
+Using GPUs is recommended because manipulating images is a training intensive task.
+
+> [!primary]
+>
+> Here, using `1 GPU` is sufficient.
+>
+
+### Launching a Jupyter notebook with "conda" via CLI
+
+*If you do not use our CLI yet, follow [this guide](/pages/platform/ai/cli_10_howto_install_cli) to install it.*
+
+If you want to launch your notebook with the OVHcloud AI CLI, choose the `jupyterlab` editor and the `conda` framework.
+
+To access the different versions of `conda` available, run the following command:
+
+```console
+ovhai capabilities framework get conda -o yaml
+```
+
+> [!primary]
+>
+> If you do not specify a version, your notebook starts with the default version of `conda`.
+>
+
+You will also need to choose the number of GPUs to use in your notebook using `<nb-gpus>`.
+
+To launch your notebook, run the following command: 
+
+```console
+ovhai notebook run conda jupyterlab \
+		--name <notebook-name> \
+		--framework-version <conda-version> \
+		--gpu <nb-gpus>
+
+```
+
+You can then reach your notebook’s URL once the notebook is running.
+
+### Accessing the notebooks
+
+Once our [AI examples repository](https://github.com/ovh/ai-training-examples/) has been cloned in your environment, find the fine-tuning notebook tutorial by following this path: `ai-training-examples` > `notebooks` > `computer-vision` > `image-generation` > `miniconda` > `dcgan-image-generation` > `notebook_chest_image_generation_dcgan.ipynb`.
+
+A preview of this notebook can be found on GitHub [here](https://github.com/ovh/ai-training-examples/blob/main/notebooks/computer-vision/image-generation/miniconda/dcgan-image-generation/notebook_chest_image_generation_dcgan.ipynb).
+
+## Go further
+
+There are many other tasks that exist in the computer vision field. Check our other tutorials to learn how to:
+
+- [Perform Brain tumor segmentation using U-Net](/pages/platform/ai/notebook_tuto_12_image-segmentation-unet-tumors) 
+
+- [Use Transfer Learning with ResNet50 for image classification](/pages/platform/ai/notebook_tuto_07_transfer_learning_resnet50_image_classification)
+
+- [Train YOLOv7 for American Sign Language recognition](/pages/platform/ai/notebook_tuto_11_yolov7)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+## Feedback
+
+Please send us your questions, feedback and suggestions to improve the service:
+
+- On the OVHcloud [Discord server](https://discord.com/invite/vXVurFfwe9)

--- a/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/meta.yaml
+++ b/pages/platform/ai/notebook_tuto_14_image-generation-dcgan/meta.yaml
@@ -1,0 +1,2 @@
+id: 8b1c3020-28d0-4f35-90c8-ff318e43f15f
+full_slug: public-cloud-ai-notebooks-tuto-image-generation-dcgan


### PR DESCRIPTION
New Pull request to add a new tutorial about image generation using GANs. 

I have: 
- Created `.gb` version
- Modified `index.md` file 
- modified `meta.yaml` file
- Corrected a few errors in other documentations (links referring to notebooks.ipynb instead of documentations)

Here are the proposed info for **French version** : 

- title:  AI Notebooks - Tutoriel - Créer et entraîner un modèle de génération d'images

- excerpt: Découvrez le fonctionnement des GANs et générer vos propres images synthétiques
