### PR TITLE
AI products - S3 update - Specify to use Swift and not S3 with Control Panel

### DIFF
--- a/pages/platform/ai/gi_08_s3_compliance/guide.de-de.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.de-de.md
@@ -35,7 +35,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.en-asia.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.en-asia.md
@@ -33,7 +33,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.en-au.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.en-au.md
@@ -33,7 +33,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.en-ca.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.en-ca.md
@@ -33,7 +33,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.en-gb.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.en-gb.md
@@ -33,7 +33,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.en-ie.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.en-ie.md
@@ -33,7 +33,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.en-sg.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.en-sg.md
@@ -33,7 +33,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.en-us.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.en-us.md
@@ -33,7 +33,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.es-es.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.es-es.md
@@ -35,7 +35,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.es-us.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.es-us.md
@@ -35,7 +35,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.fr-ca.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.fr-ca.md
@@ -35,7 +35,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.fr-fr.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.fr-fr.md
@@ -35,7 +35,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.it-it.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.it-it.md
@@ -35,7 +35,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.pl-pl.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.pl-pl.md
@@ -35,7 +35,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/gi_08_s3_compliance/guide.pt-pt.md
+++ b/pages/platform/ai/gi_08_s3_compliance/guide.pt-pt.md
@@ -35,7 +35,7 @@ You have two options:
 
 > [!primary]
 >
-> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `Object Storage Operator` rights.
+> Whether you create a *new user* or use an *existing one*, don't forget to grant him at least the `AI Training Operator` and `ObjectStore Operator` rights.
 >
 
 ![S3 user roles](images/user-roles.png)

--- a/pages/platform/ai/notebook_guide_data_ui/guide.de-de.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.de-de.md
@@ -37,6 +37,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -110,6 +115,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.de-de.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.de-de.md
@@ -3,10 +3,10 @@ title: AI Notebooks - Manage and use data in a notebook via UI
 excerpt: Learn how to manage and access data from your Object Storage in your Notebook
 routes:
     canonical: '/pages/platform/ai/notebook_guide_data_ui'
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-asia.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-asia.md
@@ -1,10 +1,10 @@
 ---
 title: AI Notebooks - Manage and use data in a notebook via UI
 excerpt: Learn how to manage and access data from your Object Storage in your Notebook
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-asia.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-asia.md
@@ -35,6 +35,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -108,6 +113,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-au.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-au.md
@@ -1,10 +1,10 @@
 ---
 title: AI Notebooks - Manage and use data in a notebook via UI
 excerpt: Learn how to manage and access data from your Object Storage in your Notebook
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-au.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-au.md
@@ -35,6 +35,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -108,6 +113,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-ca.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-ca.md
@@ -1,10 +1,10 @@
 ---
 title: AI Notebooks - Manage and use data in a notebook via UI
 excerpt: Learn how to manage and access data from your Object Storage in your Notebook
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-ca.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-ca.md
@@ -35,6 +35,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -108,6 +113,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-gb.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-gb.md
@@ -1,10 +1,10 @@
 ---
 title: AI Notebooks - Manage and use data in a notebook via UI
 excerpt: Learn how to manage and access data from your Object Storage in your Notebook
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-gb.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-gb.md
@@ -35,6 +35,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -108,6 +113,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-ie.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-ie.md
@@ -35,6 +35,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -107,6 +112,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-ie.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-ie.md
@@ -1,10 +1,10 @@
 ---
 title: AI Notebooks - Manage and use data in a notebook via UI
 excerpt: Learn how to manage and access data from your Object Storage in your Notebook
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-sg.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-sg.md
@@ -1,10 +1,10 @@
 ---
 title: AI Notebooks - Manage and use data in a notebook via UI
 excerpt: Learn how to manage and access data from your Object Storage in your Notebook
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-sg.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-sg.md
@@ -35,6 +35,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -108,6 +113,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-us.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-us.md
@@ -1,10 +1,10 @@
 ---
 title: AI Notebooks - Manage and use data in a notebook via UI
 excerpt: Learn how to manage and access data from your Object Storage in your Notebook
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.en-us.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.en-us.md
@@ -35,6 +35,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -108,6 +113,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.es-es.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.es-es.md
@@ -37,6 +37,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -110,6 +115,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.es-es.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.es-es.md
@@ -3,10 +3,10 @@ title: AI Notebooks - Manage and use data in a notebook via UI
 excerpt: Learn how to manage and access data from your Object Storage in your Notebook
 routes:
     canonical: '/pages/platform/ai/notebook_guide_data_ui'
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.es-us.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.es-us.md
@@ -37,6 +37,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -110,6 +115,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.es-us.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.es-us.md
@@ -3,10 +3,10 @@ title: AI Notebooks - Manage and use data in a notebook via UI
 excerpt: Learn how to manage and access data from your Object Storage in your Notebook
 routes:
     canonical: '/pages/platform/ai/notebook_guide_data_ui'
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.fr-ca.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.fr-ca.md
@@ -37,6 +37,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -110,6 +115,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.fr-ca.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.fr-ca.md
@@ -3,10 +3,10 @@ title: "AI Notebooks - Se servir de données dans un notebook via l'espace clien
 excerpt: Découvrez comment gérer et accéder aux données de votre Object Storage depuis votre AI Notebooks
 routes:
     canonical: '/pages/platform/ai/notebook_guide_data_ui'
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.fr-fr.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.fr-fr.md
@@ -37,6 +37,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -110,6 +115,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.fr-fr.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.fr-fr.md
@@ -3,10 +3,10 @@ title: "AI Notebooks - Se servir de données dans un notebook via l'espace clien
 excerpt: Découvrez comment gérer et accéder aux données de votre Object Storage depuis votre AI Notebooks
 routes:
     canonical: '/pages/platform/ai/notebook_guide_data_ui'
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.it-it.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.it-it.md
@@ -37,6 +37,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -110,6 +115,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.it-it.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.it-it.md
@@ -3,10 +3,10 @@ title: AI Notebooks - Manage and use data in a notebook via UI
 excerpt: Learn how to manage and access data from your Object Storage in your Notebook
 routes:
     canonical: '/pages/platform/ai/notebook_guide_data_ui'
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.pl-pl.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.pl-pl.md
@@ -37,6 +37,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -110,6 +115,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.pl-pl.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.pl-pl.md
@@ -3,10 +3,10 @@ title: AI Notebooks - Manage and use data in a notebook via UI
 excerpt: Learn how to manage and access data from your Object Storage in your Notebook
 routes:
     canonical: '/pages/platform/ai/notebook_guide_data_ui'
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.pt-pt.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.pt-pt.md
@@ -37,6 +37,11 @@ Let's assume that a file named `my-dataset.zip` exists locally on your computer 
 
 ### 1- Select your solution
 
+> [!warning]
+>
+> If you choose an S3 solution, please note that they are not yet compatible with our AI products from the Control Panel. **To use S3 buckets, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**. The Control Panel allows you to use Swift containers only.
+>
+
 If you want to know more about the different storage solutions, refer to this [page](/products/storage-backup).
 
 ![image](images/ui-container-solution.png){.thumbnail}
@@ -110,6 +115,11 @@ You can choose between *2 datacenters* for the storage of your notebook: `GRA` o
 ### Attach container or a Git repository
 
 You can attach your different types of data to your notebook.
+
+> [!warning]
+>
+> As mentioned before, S3 buckets are not yet compatible with our AI products from the Control Panel. To use S3 solutions, you will need to use [ovhai](/pages/platform/ai/cli_10_howto_install_cli)**.
+>
 
 #### Access with Read-Only permissions
 

--- a/pages/platform/ai/notebook_guide_data_ui/guide.pt-pt.md
+++ b/pages/platform/ai/notebook_guide_data_ui/guide.pt-pt.md
@@ -3,10 +3,10 @@ title: AI Notebooks - Manage and use data in a notebook via UI
 excerpt: Learn how to manage and access data from your Object Storage in your Notebook
 routes:
     canonical: '/pages/platform/ai/notebook_guide_data_ui'
-updated: 2022-04-13
+updated: 2023-08-08
 ---
 
-**Last updated 13th April, 2022.**
+**Last updated 08th August, 2023.**
 
 ## Objective
 


### PR DESCRIPTION
I have added some warnings in the AI Notebooks Manage data Documentation to warn users that S3 buckets are currently not available for AI Products and then AI Notebooks if they are using the OVHcloud Control Panel. They can only use Swift containers, or they need to use the `ovhai cli` which is compatible with S3 buckets.

I also take this PR to correct the name of an indication, which was not the same as the one shown on a screenshot illustrating the operation. (2nd commit)