### PR TITLE
KevS-SK1207-Update-clusters-IPs-Legacy-CDN-deletion_Webhosting

### DIFF
--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
@@ -47,7 +47,7 @@ Um herauszufinden, auf welchem Webhosting Cluster Ihr Dienst liegt, loggen Sie s
 |Litauen|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Deutschland|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.2
@@ -78,7 +78,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Deutschland|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.3
@@ -109,7 +109,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Deutschland|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.5
@@ -140,7 +140,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Deutschland|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.6
@@ -171,7 +171,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Deutschland|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.7
@@ -202,7 +202,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Deutschland|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.10
@@ -233,7 +233,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Deutschland|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.11
@@ -264,7 +264,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Deutschland|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.12
@@ -295,7 +295,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Deutschland|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.13
@@ -326,7 +326,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Deutschland|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.14
@@ -357,7 +357,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Deutschland|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.15
@@ -388,7 +388,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Deutschland|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.17
@@ -420,7 +420,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgien|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.20
@@ -453,7 +453,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgien|BE|178.32.40.72|2001:41d0:301:10::21|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.21
@@ -485,7 +485,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgien|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.23
@@ -517,7 +517,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgien|BE|213.32.81.103|2001:41d0:301:10::24|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.24
@@ -549,7 +549,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgien|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.26
@@ -581,7 +581,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgien|BE|193.70.58.226|2001:41d0:301:10::27|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.27
@@ -613,7 +613,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgien|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.28
@@ -645,7 +645,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgien|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.29
@@ -677,7 +677,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgien|BE|213.32.107.241|2001:41d0:301:10::30|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.30
@@ -709,7 +709,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|151.80.4.219|2001:41d0:301:1::31|
 |Belgien|BE|217.182.187.17|2001:41d0:301:10::31|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.31
@@ -729,7 +729,7 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
+Wenn Sie die Option **Shared CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
@@ -1,10 +1,8 @@
 ---
 title: 'Verzeichnis von IP-Adressen für die Webhosting Cluster'
 excerpt: 'Erfahren Sie hier, welche IP-Adresse für Ihr OVHcloud Webhosting zu verwenden ist'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Letzte Aktualisierung am 03.05.2023**
 
 > [!primary]
 > Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In manchen Fällen können ungenaue Formulierungen verwendet worden sein, z.B. bei der Beschriftung von Schaltflächen oder technischen Details. Bitte ziehen Sie beim geringsten Zweifel die englische oder französische Fassung der Anleitung zu Rate. Möchten Sie mithelfen, diese Übersetzung zu verbessern? Dann nutzen Sie dazu bitte den Button «Mitmachen» auf dieser Seite.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.de-de.md
@@ -47,12 +47,6 @@ Um herauszufinden, auf welchem Webhosting Cluster Ihr Dienst liegt, loggen Sie s
 |Litauen|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Deutschland|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.69
-```
-
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
@@ -83,12 +77,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Finnland|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Litauen|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Deutschland|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.85
-```
 
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
@@ -121,12 +109,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Deutschland|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.95
-```
-
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
@@ -157,12 +139,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Finnland|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Litauen|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Deutschland|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.97
-```
 
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
@@ -195,12 +171,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Deutschland|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.105
-```
-
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
@@ -231,12 +201,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Finnland|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Litauen|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Deutschland|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.107
-```
 
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
@@ -269,12 +233,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Deutschland|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.151
-```
-
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
@@ -305,12 +263,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Finnland|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Litauen|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Deutschland|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.153
-```
 
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
@@ -343,12 +295,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Deutschland|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.83
-```
-
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
@@ -379,12 +325,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Finnland|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Litauen|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Deutschland|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.169
-```
 
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
@@ -417,12 +357,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Deutschland|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.171
-```
-
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
@@ -453,12 +387,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Finnland|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Litauen|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Deutschland|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.173
-```
 
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
@@ -491,12 +419,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|5.196.129.52|2001:41d0:301:9::20|
 |Deutschland|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgien|BE|5.196.203.200|2001:41d0:301:10::20|
-
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.176
-```
 
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
@@ -531,12 +453,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgien|BE|178.32.40.72|2001:41d0:301:10::21|
 
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.177
-```
-
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
@@ -568,12 +484,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|37.59.69.122|2001:41d0:301:9::23|
 |Deutschland|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgien|BE|137.74.229.68|2001:41d0:301:10::23|
-
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.186
-```
 
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
@@ -607,12 +517,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgien|BE|213.32.81.103|2001:41d0:301:10::24|
 
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-213.186.33.187
-```
-
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
@@ -644,12 +548,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.29.126|2001:41d0:301:9::26|
 |Deutschland|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgien|BE|178.32.43.46|2001:41d0:301:10::26|
-
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-188.165.51.93
-```
 
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
@@ -683,12 +581,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgien|BE|193.70.58.226|2001:41d0:301:10::27|
 
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-145.239.51.129
-```
-
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
@@ -720,12 +612,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|51.83.29.135|2001:41d0:301:9::28|
 |Deutschland|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgien|BE|193.70.70.144|2001:41d0:301:10::28|
-
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-51.255.119.116
-```
 
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
@@ -759,12 +645,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Deutschland|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgien|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
- 51.255.215.242 
-```
-
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
 ```bash
@@ -796,12 +676,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Litauen|LT|188.165.24.146|2001:41d0:301:9::30|
 |Deutschland|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgien|BE|213.32.107.241|2001:41d0:301:10::30|
-
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-54.36.13.47
-```
 
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 
@@ -854,12 +728,6 @@ Wenn Sie die **ausgehende IP-Adresse** des Webhostings benötigen, verwenden Sie
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-Wenn Sie die Option **CDN** für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
-
-```bash
-178.32.120.166
-```
 
 Wenn Sie die Option **Shared CDN** (veröffentlicht am 19.11.2020) für Ihr Webhosting aktiviert haben, verwenden Sie diese IP-Adresse:
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
@@ -44,7 +44,7 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.2
@@ -75,7 +75,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.3
@@ -106,7 +106,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.5
@@ -137,7 +137,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.6
@@ -168,7 +168,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.7
@@ -199,7 +199,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.10
@@ -230,7 +230,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.11
@@ -261,7 +261,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.12
@@ -292,7 +292,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.13
@@ -323,7 +323,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.14
@@ -354,7 +354,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.15
@@ -385,7 +385,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.17
@@ -417,7 +417,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.20
@@ -449,7 +449,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.21
@@ -481,7 +481,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.23
@@ -513,7 +513,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.24
@@ -545,7 +545,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.26
@@ -577,7 +577,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.27
@@ -609,7 +609,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.28
@@ -641,7 +641,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.29
@@ -673,7 +673,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.30
@@ -705,7 +705,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|151.80.4.219|2001:41d0:301:1::31|
 |Belgium|BE|217.182.187.17|2001:41d0:301:10::31|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.31
@@ -725,7 +725,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
@@ -1,10 +1,8 @@
 ---
 title: 'IP address list for Web Hosting clusters'
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Last updated 03rd May 2023**
 
 ## Objective
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-asia.md
@@ -44,12 +44,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.69
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -80,12 +74,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.85
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -118,12 +106,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.95
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -154,12 +136,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.97
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -192,12 +168,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.105
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -228,12 +198,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.107
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -266,12 +230,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.151
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -302,12 +260,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.153
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -340,12 +292,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.83
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -376,12 +322,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.169
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -414,12 +354,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.171
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -450,12 +384,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.173
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -489,12 +417,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.176
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -526,12 +448,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.30.41|2001:41d0:301:9::21|
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.177
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -565,12 +481,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.186
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -602,12 +512,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|164.132.150.73|2001:41d0:301:9::24|
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.187
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -641,12 +545,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-188.165.51.93
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -678,12 +576,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|51.255.97.18|2001:41d0:301:9::27|
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-145.239.51.129
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -717,12 +609,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-51.255.119.116
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -755,12 +641,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
- 51.255.215.242 
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -792,12 +672,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.24.146|2001:41d0:301:9::30|
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-54.36.13.47
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -850,12 +724,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-178.32.120.166
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
@@ -44,7 +44,7 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.2
@@ -75,7 +75,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.3
@@ -106,7 +106,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.5
@@ -137,7 +137,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.6
@@ -168,7 +168,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.7
@@ -199,7 +199,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.10
@@ -230,7 +230,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.11
@@ -261,7 +261,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.12
@@ -292,7 +292,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.13
@@ -323,7 +323,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.14
@@ -354,7 +354,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.15
@@ -385,7 +385,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.17
@@ -417,7 +417,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.20
@@ -449,7 +449,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.21
@@ -481,7 +481,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.23
@@ -513,7 +513,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.24
@@ -545,7 +545,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.26
@@ -577,7 +577,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.27
@@ -609,7 +609,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.28
@@ -641,7 +641,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.29
@@ -673,7 +673,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.30
@@ -705,7 +705,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|151.80.4.219|2001:41d0:301:1::31|
 |Belgium|BE|217.182.187.17|2001:41d0:301:10::31|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.31
@@ -725,7 +725,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
@@ -1,10 +1,8 @@
 ---
 title: 'IP address list for Web Hosting clusters'
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Last updated 03rd May 2023**
 
 ## Objective
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-au.md
@@ -44,12 +44,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.69
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -80,12 +74,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.85
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -118,12 +106,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.95
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -154,12 +136,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.97
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -192,12 +168,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.105
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -228,12 +198,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.107
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -266,12 +230,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.151
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -302,12 +260,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.153
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -340,12 +292,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.83
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -376,12 +322,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.169
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -414,12 +354,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.171
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -450,12 +384,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.173
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -489,12 +417,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.176
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -526,12 +448,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.30.41|2001:41d0:301:9::21|
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.177
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -565,12 +481,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.186
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -602,12 +512,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|164.132.150.73|2001:41d0:301:9::24|
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.187
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -641,12 +545,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-188.165.51.93
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -678,12 +576,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|51.255.97.18|2001:41d0:301:9::27|
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-145.239.51.129
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -717,12 +609,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-51.255.119.116
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -755,12 +641,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
- 51.255.215.242 
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -792,12 +672,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.24.146|2001:41d0:301:9::30|
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-54.36.13.47
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -850,12 +724,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-178.32.120.166
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
@@ -44,7 +44,7 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.2
@@ -75,7 +75,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.3
@@ -106,7 +106,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.5
@@ -137,7 +137,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.6
@@ -168,7 +168,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.7
@@ -199,7 +199,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.10
@@ -230,7 +230,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.11
@@ -261,7 +261,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.12
@@ -292,7 +292,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.13
@@ -323,7 +323,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.14
@@ -354,7 +354,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.15
@@ -385,7 +385,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.17
@@ -417,7 +417,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.20
@@ -449,7 +449,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.21
@@ -481,7 +481,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.23
@@ -513,7 +513,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.24
@@ -545,7 +545,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.26
@@ -577,7 +577,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.27
@@ -609,7 +609,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.28
@@ -641,7 +641,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.29
@@ -673,7 +673,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.30
@@ -705,7 +705,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|151.80.4.219|2001:41d0:301:1::31|
 |Belgium|BE|217.182.187.17|2001:41d0:301:10::31|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.31
@@ -725,7 +725,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
@@ -1,10 +1,8 @@
 ---
 title: 'IP address list for Web Hosting clusters'
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Last updated 03rd May 2023**
 
 ## Objective
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ca.md
@@ -44,12 +44,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.69
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -80,12 +74,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.85
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -118,12 +106,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.95
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -154,12 +136,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.97
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -192,12 +168,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.105
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -228,12 +198,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.107
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -266,12 +230,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.151
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -302,12 +260,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.153
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -340,12 +292,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.83
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -376,12 +322,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.169
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -414,12 +354,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.171
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -450,12 +384,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.173
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -489,12 +417,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.176
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -526,12 +448,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.30.41|2001:41d0:301:9::21|
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.177
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -565,12 +481,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.186
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -602,12 +512,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|164.132.150.73|2001:41d0:301:9::24|
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.187
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -641,12 +545,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-188.165.51.93
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -678,12 +576,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|51.255.97.18|2001:41d0:301:9::27|
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-145.239.51.129
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -717,12 +609,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-51.255.119.116
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -755,12 +641,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
- 51.255.215.242 
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -792,12 +672,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.24.146|2001:41d0:301:9::30|
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-54.36.13.47
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -850,12 +724,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-178.32.120.166
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
@@ -44,7 +44,7 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.2
@@ -75,7 +75,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.3
@@ -106,7 +106,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.5
@@ -137,7 +137,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.6
@@ -168,7 +168,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.7
@@ -199,7 +199,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.10
@@ -230,7 +230,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.11
@@ -261,7 +261,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.12
@@ -292,7 +292,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.13
@@ -323,7 +323,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.14
@@ -354,7 +354,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.15
@@ -385,7 +385,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.17
@@ -417,7 +417,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.20
@@ -449,7 +449,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.21
@@ -481,7 +481,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.23
@@ -513,7 +513,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.24
@@ -545,7 +545,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.26
@@ -577,7 +577,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.27
@@ -609,7 +609,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.28
@@ -641,7 +641,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.29
@@ -673,7 +673,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.30
@@ -705,7 +705,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|151.80.4.219|2001:41d0:301:1::31|
 |Belgium|BE|217.182.187.17|2001:41d0:301:10::31|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.31
@@ -725,7 +725,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
@@ -1,10 +1,8 @@
 ---
 title: 'IP address list for Web Hosting clusters'
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Last updated 03rd May 2023**
 
 ## Objective
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-gb.md
@@ -44,12 +44,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.69
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -80,12 +74,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.85
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -118,12 +106,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.95
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -154,12 +136,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.97
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -192,12 +168,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.105
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -228,12 +198,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.107
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -266,12 +230,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.151
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -302,12 +260,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.153
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -340,12 +292,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.83
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -376,12 +322,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.169
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -414,12 +354,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.171
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -450,12 +384,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.173
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -489,12 +417,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.176
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -526,12 +448,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.30.41|2001:41d0:301:9::21|
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.177
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -565,12 +481,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.186
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -602,12 +512,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|164.132.150.73|2001:41d0:301:9::24|
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.187
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -641,12 +545,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-188.165.51.93
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -678,12 +576,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|51.255.97.18|2001:41d0:301:9::27|
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-145.239.51.129
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -717,12 +609,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-51.255.119.116
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -755,12 +641,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
- 51.255.215.242 
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -792,12 +672,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.24.146|2001:41d0:301:9::30|
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-54.36.13.47
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -850,12 +724,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-178.32.120.166
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
@@ -44,7 +44,7 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.2
@@ -75,7 +75,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.3
@@ -106,7 +106,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.5
@@ -137,7 +137,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.6
@@ -168,7 +168,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.7
@@ -199,7 +199,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.10
@@ -230,7 +230,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.11
@@ -261,7 +261,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.12
@@ -292,7 +292,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.13
@@ -323,7 +323,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.14
@@ -354,7 +354,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.15
@@ -385,7 +385,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.17
@@ -417,7 +417,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.20
@@ -449,7 +449,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.21
@@ -481,7 +481,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.23
@@ -513,7 +513,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.24
@@ -545,7 +545,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.26
@@ -577,7 +577,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.27
@@ -609,7 +609,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.28
@@ -641,7 +641,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.29
@@ -673,7 +673,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.30
@@ -705,7 +705,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|151.80.4.219|2001:41d0:301:1::31|
 |Belgium|BE|217.182.187.17|2001:41d0:301:10::31|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.31
@@ -725,7 +725,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
@@ -1,10 +1,8 @@
 ---
 title: 'IP address list for Web Hosting clusters'
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Last updated 03rd May 2023**
 
 ## Objective
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-ie.md
@@ -44,12 +44,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.69
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -80,12 +74,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.85
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -118,12 +106,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.95
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -154,12 +136,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.97
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -192,12 +168,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.105
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -228,12 +198,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.107
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -266,12 +230,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.151
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -302,12 +260,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.153
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -340,12 +292,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.83
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -376,12 +322,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.169
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -414,12 +354,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.171
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -450,12 +384,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.173
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -489,12 +417,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.176
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -526,12 +448,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.30.41|2001:41d0:301:9::21|
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.177
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -565,12 +481,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.186
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -602,12 +512,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|164.132.150.73|2001:41d0:301:9::24|
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.187
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -641,12 +545,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-188.165.51.93
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -678,12 +576,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|51.255.97.18|2001:41d0:301:9::27|
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-145.239.51.129
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -717,12 +609,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-51.255.119.116
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -755,12 +641,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
- 51.255.215.242 
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -792,12 +672,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.24.146|2001:41d0:301:9::30|
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-54.36.13.47
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -850,12 +724,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-178.32.120.166
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
@@ -44,7 +44,7 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.2
@@ -75,7 +75,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.3
@@ -106,7 +106,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.5
@@ -137,7 +137,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.6
@@ -168,7 +168,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.7
@@ -199,7 +199,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.10
@@ -230,7 +230,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.11
@@ -261,7 +261,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.12
@@ -292,7 +292,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.13
@@ -323,7 +323,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.14
@@ -354,7 +354,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.15
@@ -385,7 +385,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.17
@@ -417,7 +417,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.20
@@ -449,7 +449,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.21
@@ -481,7 +481,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.23
@@ -513,7 +513,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.24
@@ -545,7 +545,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.26
@@ -577,7 +577,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.27
@@ -609,7 +609,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.28
@@ -641,7 +641,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.29
@@ -673,7 +673,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.30
@@ -705,7 +705,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|151.80.4.219|2001:41d0:301:1::31|
 |Belgium|BE|217.182.187.17|2001:41d0:301:10::31|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.31
@@ -725,7 +725,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
@@ -1,10 +1,8 @@
 ---
 title: 'IP address list for Web Hosting clusters'
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Last updated 03rd May 2023**
 
 ## Objective
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-sg.md
@@ -44,12 +44,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.69
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -80,12 +74,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.85
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -118,12 +106,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.95
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -154,12 +136,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.97
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -192,12 +168,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.105
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -228,12 +198,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.107
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -266,12 +230,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.151
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -302,12 +260,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.153
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -340,12 +292,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.83
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -376,12 +322,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.169
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -414,12 +354,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.171
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -450,12 +384,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.173
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -489,12 +417,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.176
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -526,12 +448,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.30.41|2001:41d0:301:9::21|
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.177
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -565,12 +481,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.186
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -602,12 +512,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|164.132.150.73|2001:41d0:301:9::24|
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.187
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -641,12 +545,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-188.165.51.93
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -678,12 +576,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|51.255.97.18|2001:41d0:301:9::27|
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-145.239.51.129
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -717,12 +609,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-51.255.119.116
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -755,12 +641,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
- 51.255.215.242 
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -792,12 +672,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.24.146|2001:41d0:301:9::30|
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-54.36.13.47
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -850,12 +724,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-178.32.120.166
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
@@ -44,7 +44,7 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.2
@@ -75,7 +75,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.3
@@ -106,7 +106,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.5
@@ -137,7 +137,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.6
@@ -168,7 +168,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.7
@@ -199,7 +199,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.10
@@ -230,7 +230,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.11
@@ -261,7 +261,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.12
@@ -292,7 +292,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.13
@@ -323,7 +323,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.14
@@ -354,7 +354,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.15
@@ -385,7 +385,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.17
@@ -417,7 +417,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.20
@@ -449,7 +449,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.21
@@ -481,7 +481,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.23
@@ -513,7 +513,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.24
@@ -545,7 +545,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.26
@@ -577,7 +577,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.27
@@ -609,7 +609,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.28
@@ -641,7 +641,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.29
@@ -673,7 +673,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.30
@@ -705,7 +705,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|151.80.4.219|2001:41d0:301:1::31|
 |Belgium|BE|217.182.187.17|2001:41d0:301:10::31|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.31
@@ -725,7 +725,7 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
+If you have activated the **Shared CDN** option on your Web Hosting, use this IP address:
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
@@ -1,10 +1,8 @@
 ---
 title: 'IP address list for Web Hosting clusters'
 excerpt: 'Find out the appropriate IP addresses to use with your OVHcloud Web Hosting plan'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Last updated 03rd May 2023**
 
 ## Objective
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.en-us.md
@@ -44,12 +44,6 @@ You can verify the cluster number of the Web Hosting on this page under **FTP se
 |Lithuania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germany|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.69
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -80,12 +74,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Lithuania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germany|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.85
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -118,12 +106,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germany|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.95
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -154,12 +136,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Lithuania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germany|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.97
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -192,12 +168,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germany|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.105
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -228,12 +198,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Lithuania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germany|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.107
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -266,12 +230,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germany|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.151
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -302,12 +260,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Lithuania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germany|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.153
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -340,12 +292,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germany|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.83
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -376,12 +322,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Lithuania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germany|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.169
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -414,12 +354,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germany|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.171
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -450,12 +384,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Finland|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Lithuania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germany|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.173
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -489,12 +417,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgium|BE|5.196.203.200|2001:41d0:301:10::20|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.176
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -526,12 +448,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.30.41|2001:41d0:301:9::21|
 |Germany|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgium|BE|178.32.40.72|2001:41d0:301:10::21|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.177
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -565,12 +481,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgium|BE|137.74.229.68|2001:41d0:301:10::23|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.186
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -602,12 +512,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|164.132.150.73|2001:41d0:301:9::24|
 |Germany|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgium|BE|213.32.81.103|2001:41d0:301:10::24|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-213.186.33.187
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -641,12 +545,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgium|BE|178.32.43.46|2001:41d0:301:10::26|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-188.165.51.93
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -678,12 +576,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|51.255.97.18|2001:41d0:301:9::27|
 |Germany|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgium|BE|193.70.58.226|2001:41d0:301:10::27|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-145.239.51.129
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -717,12 +609,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgium|BE|193.70.70.144|2001:41d0:301:10::28|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-51.255.119.116
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -755,12 +641,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Germany|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgium|BE|178.32.44.140|2001:41d0:301:10::29|
 
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
- 51.255.215.242 
-```
-
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
 ```bash
@@ -792,12 +672,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Lithuania|LT|188.165.24.146|2001:41d0:301:9::30|
 |Germany|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgium|BE|213.32.107.241|2001:41d0:301:10::30|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-54.36.13.47
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 
@@ -850,12 +724,6 @@ If you need the **outgoing IP address** of the Web Hosting cluster (gateway), us
 |Country|Country Code|IPv4|IPv6|
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-If you have activated the **CDN** option on your Web Hosting, use this IP address:
-
-```bash
-178.32.120.166
-```
 
 If you have activated the **Shared CDN** option (released on 19/11/2020) on your Web Hosting, use this IP address:
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-es.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-es.md
@@ -1,9 +1,7 @@
 ---
 title: 'Direcciones IP de los clusters y alojamientos web'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Última actualización: 03/05/2023**
 
 > [!primary]
 > Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón «Contribuir» de esta página.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-es.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-es.md
@@ -50,12 +50,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Alemania|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.69
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -86,12 +80,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Finlandia|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Lituania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Alemania|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.85
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -124,12 +112,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Alemania|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.95
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -160,12 +142,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Finlandia|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Lituania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Alemania|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.97
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -198,12 +174,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Alemania|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.105
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -234,12 +204,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Finlandia|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Lituania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Alemania|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.107
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -272,12 +236,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Alemania|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.151
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -308,12 +266,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Finlandia|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Lituania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Alemania|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.153
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -346,12 +298,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Alemania|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.83
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -382,12 +328,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Finlandia|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Lituania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Alemania|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.169
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -420,12 +360,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Alemania|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.171
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -456,12 +390,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Finlandia|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Lituania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Alemania|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.173
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -495,12 +423,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|5.135.108.219|2001:41d0:301:1::20|
 |Bélgica|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.176
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -532,12 +454,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.30.41|2001:41d0:301:9::21|
 |Alemania|DE|94.23.162.9|2001:41d0:301:1::21|
 |Bélgica|BE|178.32.40.72|2001:41d0:301:10::21|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.177
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -571,12 +487,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|87.98.242.65|2001:41d0:301:1::23|
 |Bélgica|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.186
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -608,12 +518,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|164.132.150.73|2001:41d0:301:9::24|
 |Alemania|DE|178.33.38.88|2001:41d0:301:1::24|
 |Bélgica|BE|213.32.81.103|2001:41d0:301:10::24|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.187
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -647,12 +551,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|94.23.160.29|2001:41d0:301:1::26|
 |Bélgica|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-188.165.51.93
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -684,12 +582,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|51.255.97.18|2001:41d0:301:9::27|
 |Alemania|DE|91.134.179.251|2001:41d0:301:1::27|
 |Bélgica|BE|193.70.58.226|2001:41d0:301:10::27|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-145.239.51.129
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -723,12 +615,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|54.37.173.127|2001:41d0:301:1::28|
 |Bélgica|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-51.255.119.116
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -761,12 +647,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|145.239.222.45|2001:41d0:301:1::29|
 |Bélgica|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
- 51.255.215.242 
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -798,12 +678,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.24.146|2001:41d0:301:9::30|
 |Alemania|DE|51.255.232.79|2001:41d0:301:1::30|
 |Bélgica|BE|213.32.107.241|2001:41d0:301:10::30|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-54.36.13.47
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -860,12 +734,6 @@ A continuación indicamos las direcciones IP del **cluster** para cada país (pa
 |País|Código de país|IPv4|IPv6|
 |---|---|----|---|
 |Canadá|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-178.32.120.166
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-es.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-es.md
@@ -50,7 +50,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Alemania|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.2
@@ -81,7 +81,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Alemania|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.3
@@ -112,7 +112,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Alemania|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.5
@@ -143,7 +143,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Alemania|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.6
@@ -174,7 +174,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Alemania|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.7
@@ -205,7 +205,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Alemania|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.10
@@ -236,7 +236,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Alemania|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.11
@@ -267,7 +267,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Alemania|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.12
@@ -298,7 +298,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Alemania|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.13
@@ -329,7 +329,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Alemania|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.14
@@ -360,7 +360,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Alemania|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.15
@@ -391,7 +391,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Alemania|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.17
@@ -423,7 +423,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|5.135.108.219|2001:41d0:301:1::20|
 |Bélgica|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.20
@@ -455,7 +455,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|94.23.162.9|2001:41d0:301:1::21|
 |Bélgica|BE|178.32.40.72|2001:41d0:301:10::21|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.21
@@ -487,7 +487,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|87.98.242.65|2001:41d0:301:1::23|
 |Bélgica|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.23
@@ -519,7 +519,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|178.33.38.88|2001:41d0:301:1::24|
 |Bélgica|BE|213.32.81.103|2001:41d0:301:10::24|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.24
@@ -551,7 +551,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|94.23.160.29|2001:41d0:301:1::26|
 |Bélgica|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.26
@@ -583,7 +583,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|91.134.179.251|2001:41d0:301:1::27|
 |Bélgica|BE|193.70.58.226|2001:41d0:301:10::27|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.27
@@ -615,7 +615,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|54.37.173.127|2001:41d0:301:1::28|
 |Bélgica|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.28
@@ -647,7 +647,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|145.239.222.45|2001:41d0:301:1::29|
 |Bélgica|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.29
@@ -679,7 +679,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|51.255.232.79|2001:41d0:301:1::30|
 |Bélgica|BE|213.32.107.241|2001:41d0:301:10::30|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.30
@@ -713,7 +713,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|151.80.4.219|2001:41d0:301:1::31|
 |Bélgica|BE|217.182.187.17|2001:41d0:301:10::31|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.31
@@ -735,7 +735,7 @@ A continuación indicamos las direcciones IP del **cluster** para cada país (pa
 |---|---|----|---|
 |Canadá|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-us.md
@@ -50,12 +50,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Alemania|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.69
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -86,12 +80,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Finlandia|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Lituania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Alemania|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.85
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -124,12 +112,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Alemania|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.95
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -160,12 +142,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Finlandia|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Lituania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Alemania|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.97
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -198,12 +174,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Alemania|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.105
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -234,12 +204,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Finlandia|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Lituania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Alemania|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.107
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -272,12 +236,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Alemania|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.151
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -308,12 +266,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Finlandia|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Lituania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Alemania|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.153
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -346,12 +298,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Alemania|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.83
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -382,12 +328,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Finlandia|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Lituania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Alemania|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.169
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -420,12 +360,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Alemania|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.171
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -456,12 +390,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Finlandia|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Lituania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Alemania|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.173
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -495,12 +423,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|5.135.108.219|2001:41d0:301:1::20|
 |Bélgica|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.176
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -532,12 +454,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.30.41|2001:41d0:301:9::21|
 |Alemania|DE|94.23.162.9|2001:41d0:301:1::21|
 |Bélgica|BE|178.32.40.72|2001:41d0:301:10::21|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.177
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -571,12 +487,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|87.98.242.65|2001:41d0:301:1::23|
 |Bélgica|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.186
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -608,12 +518,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|164.132.150.73|2001:41d0:301:9::24|
 |Alemania|DE|178.33.38.88|2001:41d0:301:1::24|
 |Bélgica|BE|213.32.81.103|2001:41d0:301:10::24|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-213.186.33.187
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -647,12 +551,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|94.23.160.29|2001:41d0:301:1::26|
 |Bélgica|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-188.165.51.93
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -684,12 +582,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|51.255.97.18|2001:41d0:301:9::27|
 |Alemania|DE|91.134.179.251|2001:41d0:301:1::27|
 |Bélgica|BE|193.70.58.226|2001:41d0:301:10::27|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-145.239.51.129
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -723,12 +615,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|54.37.173.127|2001:41d0:301:1::28|
 |Bélgica|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-51.255.119.116
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -761,12 +647,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|145.239.222.45|2001:41d0:301:1::29|
 |Bélgica|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
- 51.255.215.242 
-```
-
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
@@ -798,12 +678,6 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.24.146|2001:41d0:301:9::30|
 |Alemania|DE|51.255.232.79|2001:41d0:301:1::30|
 |Bélgica|BE|213.32.107.241|2001:41d0:301:10::30|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-54.36.13.47
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
@@ -858,12 +732,6 @@ A continuación indicamos las direcciones IP del **cluster** para cada país (pa
 |País|Código de país|IPv4|IPv6|
 |---|---|----|---|
 |Canadá|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-Si tiene el servicio **CDN** activado en su alojamiento, debe utilizar la siguiente dirección IP:
-
-```bash
-178.32.120.166
-```
 
 Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-us.md
@@ -1,9 +1,7 @@
 ---
 title: 'Direcciones IP de los clusters y alojamientos web'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Última actualización: 03/05/2023**
 
 > [!primary]
 > Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón «Contribuir» de esta página.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-us.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.es-us.md
@@ -50,7 +50,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Alemania|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.2
@@ -81,7 +81,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Alemania|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.3
@@ -112,7 +112,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Alemania|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.5
@@ -143,7 +143,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Alemania|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.6
@@ -174,7 +174,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Alemania|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.7
@@ -205,7 +205,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Alemania|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.10
@@ -236,7 +236,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Alemania|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.11
@@ -267,7 +267,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Alemania|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.12
@@ -298,7 +298,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Alemania|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.13
@@ -329,7 +329,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Alemania|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.14
@@ -360,7 +360,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Alemania|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.15
@@ -391,7 +391,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Lituania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Alemania|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.17
@@ -423,7 +423,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|5.135.108.219|2001:41d0:301:1::20|
 |Bélgica|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.20
@@ -455,7 +455,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|94.23.162.9|2001:41d0:301:1::21|
 |Bélgica|BE|178.32.40.72|2001:41d0:301:10::21|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.21
@@ -487,7 +487,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|87.98.242.65|2001:41d0:301:1::23|
 |Bélgica|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.23
@@ -519,7 +519,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|178.33.38.88|2001:41d0:301:1::24|
 |Bélgica|BE|213.32.81.103|2001:41d0:301:10::24|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.24
@@ -551,7 +551,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|94.23.160.29|2001:41d0:301:1::26|
 |Bélgica|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.26
@@ -583,7 +583,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|91.134.179.251|2001:41d0:301:1::27|
 |Bélgica|BE|193.70.58.226|2001:41d0:301:10::27|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.27
@@ -615,7 +615,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|54.37.173.127|2001:41d0:301:1::28|
 |Bélgica|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.28
@@ -647,7 +647,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|145.239.222.45|2001:41d0:301:1::29|
 |Bélgica|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.29
@@ -679,7 +679,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|51.255.232.79|2001:41d0:301:1::30|
 |Bélgica|BE|213.32.107.241|2001:41d0:301:10::30|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.30
@@ -711,7 +711,7 @@ A continuación se indican las direcciones IP del **cluster** para cada país (p
 |Alemania|DE|151.80.4.219|2001:41d0:301:1::31|
 |Bélgica|BE|217.182.187.17|2001:41d0:301:10::31|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.31
@@ -733,7 +733,7 @@ A continuación indicamos las direcciones IP del **cluster** para cada país (pa
 |---|---|----|---|
 |Canadá|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-Si el servicio **Shared CDN** (lanzado el 19/11/2020) está activado en su alojamiento, debe utilizar la siguiente dirección IP:
+Si el servicio **Shared CDN** está activado en su alojamiento, debe utilizar la siguiente dirección IP:
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
@@ -46,12 +46,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Allemagne|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.69
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -82,12 +76,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Finlande|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Lituanie|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Allemagne|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.85
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -120,12 +108,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Allemagne|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.95
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -156,12 +138,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Finlande|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Lituanie|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Allemagne|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.97
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -194,12 +170,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Allemagne|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.105
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -230,12 +200,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Finlande|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Lituanie|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Allemagne|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.107
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -268,12 +232,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Allemagne|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.151
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -304,12 +262,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Finlande|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Lituanie|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Allemagne|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.153
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -342,12 +294,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Allemagne|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.83
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -378,12 +324,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Finlande|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Lituanie|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Allemagne|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.169
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -416,12 +356,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Allemagne|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.171
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -452,12 +386,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Finlande|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Lituanie|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Allemagne|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.173
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -491,12 +419,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgique|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.176
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -528,12 +450,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.30.41|2001:41d0:301:9::21|
 |Allemagne|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgique|BE|178.32.40.72|2001:41d0:301:10::21|
-
-Si le **CDN Legacy**  est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.177
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020)est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -567,12 +483,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgique|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.186
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -604,12 +514,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|164.132.150.73|2001:41d0:301:9::24|
 |Allemagne|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgique|BE|213.32.81.103|2001:41d0:301:10::24|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.187
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -643,12 +547,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgique|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-188.165.51.93
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -680,12 +578,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|51.255.97.18|2001:41d0:301:9::27|
 |Allemagne|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgique|BE|193.70.58.226|2001:41d0:301:10::27|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-145.239.51.129
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -719,12 +611,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgique|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-51.255.119.116
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -757,12 +643,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgique|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
- 51.255.215.242 
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -794,12 +674,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.24.146|2001:41d0:301:9::30|
 |Allemagne|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgique|BE|213.32.107.241|2001:41d0:301:10::30|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-54.36.13.47
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -852,12 +726,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-178.32.120.166
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
@@ -1,9 +1,9 @@
 ---
 title: 'Liste des adresses IP des clusters et hebergements web'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
 
-**Dernière mise à jour le 03/05/2023**
+## Objectif
 
 Retrouvez dans ce guide toutes les adresses IP des hébergements web OVHcloud. Cela vous permettra par exemple de trouver quelle adresse IP renseigner dans vos zones DNS, en fonction de :
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-ca.md
@@ -46,7 +46,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Allemagne|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.2
@@ -77,7 +77,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Allemagne|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.3
@@ -108,7 +108,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Allemagne|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.5
@@ -139,7 +139,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Allemagne|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.6
@@ -170,7 +170,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Allemagne|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.7
@@ -201,7 +201,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Allemagne|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.10
@@ -232,7 +232,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Allemagne|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.11
@@ -263,7 +263,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Allemagne|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.12
@@ -294,7 +294,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Allemagne|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.13
@@ -325,7 +325,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Allemagne|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.14
@@ -356,7 +356,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Allemagne|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.15
@@ -387,7 +387,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Allemagne|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.17
@@ -419,7 +419,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgique|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.20
@@ -451,7 +451,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgique|BE|178.32.40.72|2001:41d0:301:10::21|
 
-Si le **Shared CDN** (sorti le 19/11/2020)est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN**est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.21
@@ -483,7 +483,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgique|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.23
@@ -515,7 +515,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgique|BE|213.32.81.103|2001:41d0:301:10::24|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.24
@@ -547,7 +547,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgique|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.26
@@ -579,7 +579,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgique|BE|193.70.58.226|2001:41d0:301:10::27|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.27
@@ -611,7 +611,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgique|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.28
@@ -643,7 +643,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgique|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.29
@@ -675,7 +675,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgique|BE|213.32.107.241|2001:41d0:301:10::30|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.30
@@ -707,7 +707,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|151.80.4.219|2001:41d0:301:1::31|
 |Belgique|BE|217.182.187.17|2001:41d0:301:10::31|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.31
@@ -727,7 +727,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
@@ -46,12 +46,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Allemagne|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.69
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -82,12 +76,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Finlande|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Lituanie|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Allemagne|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.85
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -120,12 +108,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Allemagne|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.95
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -156,12 +138,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Finlande|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Lituanie|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Allemagne|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.97
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -194,12 +170,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Allemagne|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.105
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -230,12 +200,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Finlande|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Lituanie|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Allemagne|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.107
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -268,12 +232,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Allemagne|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.151
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -304,12 +262,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Finlande|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Lituanie|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Allemagne|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.153
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -342,12 +294,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Allemagne|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.83
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -378,12 +324,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Finlande|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Lituanie|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Allemagne|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.169
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -416,12 +356,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Allemagne|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.171
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -452,12 +386,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Finlande|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Lituanie|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Allemagne|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.173
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -491,12 +419,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgique|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.176
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -529,13 +451,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgique|BE|178.32.40.72|2001:41d0:301:10::21|
 
-Si le **CDN Legacy**  est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.177
-```
-
-Si le **Shared CDN** (sorti le 19/11/2020)est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.21
@@ -566,12 +482,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|37.59.69.122|2001:41d0:301:9::23|
 |Allemagne|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgique|BE|137.74.229.68|2001:41d0:301:10::23|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.186
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -605,12 +515,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgique|BE|213.32.81.103|2001:41d0:301:10::24|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-213.186.33.187
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -642,12 +546,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.29.126|2001:41d0:301:9::26|
 |Allemagne|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgique|BE|178.32.43.46|2001:41d0:301:10::26|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-188.165.51.93
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -681,12 +579,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgique|BE|193.70.58.226|2001:41d0:301:10::27|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-145.239.51.129
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -718,12 +610,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|51.83.29.135|2001:41d0:301:9::28|
 |Allemagne|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgique|BE|193.70.70.144|2001:41d0:301:10::28|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-51.255.119.116
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -757,12 +643,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgique|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
- 51.255.215.242 
-```
-
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
@@ -794,12 +674,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.24.146|2001:41d0:301:9::30|
 |Allemagne|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgique|BE|213.32.107.241|2001:41d0:301:10::30|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-54.36.13.47
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
@@ -852,12 +726,6 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Pays|Code Pays|IPv4|IPv6|
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-Si le **CDN Legacy** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
-
-```bash
-178.32.120.166
-```
 
 Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
@@ -1,9 +1,7 @@
 ---
 title: 'Liste des adresses IP des clusters et hebergements web'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Dernière mise à jour le 03/05/2023**
 
 ## Objectif
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.fr-fr.md
@@ -46,7 +46,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Allemagne|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.2
@@ -77,7 +77,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Allemagne|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.3
@@ -108,7 +108,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Allemagne|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.5
@@ -139,7 +139,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Allemagne|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.6
@@ -170,7 +170,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Allemagne|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.7
@@ -201,7 +201,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Allemagne|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.10
@@ -232,7 +232,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Allemagne|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.11
@@ -263,7 +263,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Allemagne|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.12
@@ -294,7 +294,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Allemagne|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.13
@@ -325,7 +325,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Allemagne|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.14
@@ -356,7 +356,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Allemagne|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.15
@@ -387,7 +387,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Lituanie|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Allemagne|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.17
@@ -419,7 +419,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgique|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.20
@@ -451,7 +451,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgique|BE|178.32.40.72|2001:41d0:301:10::21|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.21
@@ -483,7 +483,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgique|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.23
@@ -515,7 +515,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgique|BE|213.32.81.103|2001:41d0:301:10::24|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.24
@@ -547,7 +547,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgique|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.26
@@ -579,7 +579,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgique|BE|193.70.58.226|2001:41d0:301:10::27|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.27
@@ -611,7 +611,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgique|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.28
@@ -643,7 +643,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgique|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.29
@@ -675,7 +675,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgique|BE|213.32.107.241|2001:41d0:301:10::30|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.30
@@ -707,7 +707,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |Allemagne|DE|151.80.4.219|2001:41d0:301:1::31|
 |Belgique|BE|217.182.187.17|2001:41d0:301:10::31|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.31
@@ -727,7 +727,7 @@ Retrouvez les adresses IP du **cluster** par pays (pour la géolocalisation) :
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-Si le **Shared CDN** (sorti le 19/11/2020) est activé sur votre hébergement, vous devez utiliser cette adresse IP :
+Si le **Shared CDN** est activé sur votre hébergement, vous devez utiliser cette adresse IP :
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.it-it.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.it-it.md
@@ -50,7 +50,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germania|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.2
@@ -81,7 +81,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germania|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.3
@@ -112,7 +112,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germania|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.5
@@ -143,7 +143,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germania|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.6
@@ -174,7 +174,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germania|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.7
@@ -205,7 +205,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germania|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.10
@@ -236,7 +236,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germania|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.11
@@ -267,7 +267,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germania|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.12
@@ -298,7 +298,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germania|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.13
@@ -329,7 +329,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germania|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.14
@@ -360,7 +360,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germania|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.15
@@ -391,7 +391,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germania|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.17
@@ -423,7 +423,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgio|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.20
@@ -455,7 +455,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgio|BE|178.32.40.72|2001:41d0:301:10::21|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.21
@@ -487,7 +487,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgio|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.23
@@ -519,7 +519,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgio|BE|213.32.81.103|2001:41d0:301:10::24|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.24
@@ -551,7 +551,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgio|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.26
@@ -583,7 +583,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgio|BE|193.70.58.226|2001:41d0:301:10::27|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.27
@@ -615,7 +615,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgio|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.28
@@ -647,7 +647,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgio|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.29
@@ -679,7 +679,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgio|BE|213.32.107.241|2001:41d0:301:10::30|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.30
@@ -713,7 +713,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|151.80.4.219|2001:41d0:301:1::31|
 |Belgio|BE|217.182.187.17|2001:41d0:301:10::31|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.31
@@ -735,7 +735,7 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
+Se il **Shared CDN** è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.it-it.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.it-it.md
@@ -1,9 +1,7 @@
 ---
 title: 'Lista degli indirizzi IP di cluster e hosting Web'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Ultimo aggiornamento: 03/05/2023**
 
 > [!primary]
 > Questa traduzione è stata generata automaticamente dal nostro partner SYSTRAN. I contenuti potrebbero presentare imprecisioni, ad esempio la nomenclatura dei pulsanti o alcuni dettagli tecnici. In caso di dubbi consigliamo di fare riferimento alla versione inglese o francese della guida. Per aiutarci a migliorare questa traduzione, utilizza il pulsante "Modifica" di questa pagina.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.it-it.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.it-it.md
@@ -50,12 +50,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Germania|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.69
-```
-
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
@@ -86,12 +80,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Finlandia|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Lituania|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Germania|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.85
-```
 
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
@@ -124,12 +112,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Germania|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.95
-```
-
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
@@ -160,12 +142,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Finlandia|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Lituania|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Germania|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.97
-```
 
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
@@ -198,12 +174,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Germania|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.105
-```
-
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
@@ -234,12 +204,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Finlandia|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Lituania|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Germania|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.107
-```
 
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
@@ -272,12 +236,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Germania|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.151
-```
-
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
@@ -308,12 +266,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Finlandia|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Lituania|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Germania|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.153
-```
 
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
@@ -346,12 +298,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Germania|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.83
-```
-
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
@@ -382,12 +328,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Finlandia|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Lituania|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Germania|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.169
-```
 
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
@@ -420,12 +360,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Germania|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.171
-```
-
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
@@ -456,12 +390,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Finlandia|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Lituania|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Germania|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.173
-```
 
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
@@ -495,12 +423,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgio|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.176
-```
-
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
@@ -532,12 +454,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.30.41|2001:41d0:301:9::21|
 |Germania|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgio|BE|178.32.40.72|2001:41d0:301:10::21|
-
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.177
-```
 
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
@@ -571,12 +487,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgio|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.186
-```
-
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
@@ -608,12 +518,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|164.132.150.73|2001:41d0:301:9::24|
 |Germania|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgio|BE|213.32.81.103|2001:41d0:301:10::24|
-
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-213.186.33.187
-```
 
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
@@ -647,12 +551,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgio|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-188.165.51.93
-```
-
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
@@ -684,12 +582,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|51.255.97.18|2001:41d0:301:9::27|
 |Germania|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgio|BE|193.70.58.226|2001:41d0:301:10::27|
-
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-145.239.51.129
-```
 
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
@@ -723,12 +615,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgio|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-51.255.119.116
-```
-
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
@@ -761,12 +647,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Germania|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgio|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
- 51.255.215.242 
-```
-
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
 ```bash
@@ -798,12 +678,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Lituania|LT|188.165.24.146|2001:41d0:301:9::30|
 |Germania|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgio|BE|213.32.107.241|2001:41d0:301:10::30|
-
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-54.36.13.47
-```
 
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 
@@ -860,12 +734,6 @@ Qui di seguito trovi gli indirizzi IP del **cluster** per ciascun Paese (per la 
 |Paese|Codice Paese|IPv4|IPv6|
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-Se hai attivato la **CDN** sul tuo hosting, è necessario utilizzare questo indirizzo IP: 
-
-```bash
-178.32.120.166
-```
 
 Se il **Shared CDN** (uscito il 19/11/2020) è attivo sul tuo hosting, devi utilizzare questo indirizzo IP:
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pl-pl.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pl-pl.md
@@ -1,9 +1,7 @@
 ---
 title: 'Lista adresów IP klastrów i hostingów WWW'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Ostatnia aktualizacja z dnia 03-05-2023**
 
 > [!primary]
 > Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera SYSTRAN. W niektórych przypadkach mogą wystąpić nieprecyzyjne sformułowania, na przykład w tłumaczeniu nazw przycisków lub szczegółów technicznych. W przypadku jakichkolwiek wątpliwości zalecamy zapoznanie się z angielską/francuską wersją przewodnika. Jeśli chcesz przyczynić się do ulepszenia tłumaczenia, kliknij przycisk „Zaproponuj zmianę” na tej stronie.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pl-pl.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pl-pl.md
@@ -50,12 +50,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Niemcy|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.69
-```
-
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
@@ -86,12 +80,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Finlandia|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Litwa|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Niemcy|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.85
-```
 
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
@@ -124,12 +112,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Niemcy|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.95
-```
-
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
@@ -160,12 +142,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Finlandia|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Litwa|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Niemcy|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.97
-```
 
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
@@ -198,12 +174,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Niemcy|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.105
-```
-
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
@@ -234,12 +204,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Finlandia|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Litwa|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Niemcy|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.107
-```
 
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
@@ -273,12 +237,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Niemcy|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.151
-```
-
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
@@ -309,12 +267,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Finlandia|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Litwa|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Niemcy|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.153
-```
 
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
@@ -347,12 +299,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Niemcy|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.83
-```
-
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
@@ -383,12 +329,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Finlandia|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Litwa|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Niemcy|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.169
-```
 
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
@@ -421,12 +361,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Niemcy|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.171
-```
-
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
@@ -457,12 +391,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Finlandia|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Litwa|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Niemcy|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.173
-```
 
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
@@ -496,12 +424,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgia|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.176
-```
-
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
@@ -533,12 +455,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.30.41|2001:41d0:301:9::21|
 |Niemcy|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgia|BE|178.32.40.72|2001:41d0:301:10::21|
-
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.177
-```
 
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
@@ -572,12 +488,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgia|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.186
-```
-
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
@@ -609,12 +519,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|164.132.150.73|2001:41d0:301:9::24|
 |Niemcy|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgia|BE|213.32.81.103|2001:41d0:301:10::24|
-
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-213.186.33.187
-```
 
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
@@ -648,12 +552,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgia|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-188.165.51.93
-```
-
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
@@ -685,12 +583,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|51.255.97.18|2001:41d0:301:9::27|
 |Niemcy|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgia|BE|193.70.58.226|2001:41d0:301:10::27|
-
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-145.239.51.129
-```
 
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
@@ -724,12 +616,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgia|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-51.255.119.116
-```
-
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
@@ -762,12 +648,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgia|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
- 51.255.215.242 
-```
-
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
@@ -799,12 +679,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.24.146|2001:41d0:301:9::30|
 |Niemcy|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgia|BE|213.32.107.241|2001:41d0:301:10::30|
-
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-54.36.13.47
-```
 
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
@@ -857,12 +731,6 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Kraj|Kod kraju|IPv4|IPv6|
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-Jeśli w hostingu masz aktywną opcję **CDN**, użyj poniższego adresu IP:
-
-```bash
-178.32.120.166 
-```
 
 Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
 

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pl-pl.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pl-pl.md
@@ -50,7 +50,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Niemcy|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.2
@@ -81,7 +81,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Niemcy|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.3
@@ -112,7 +112,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Niemcy|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.5
@@ -143,7 +143,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Niemcy|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.6
@@ -174,7 +174,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Niemcy|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.7
@@ -205,7 +205,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Niemcy|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.10
@@ -237,7 +237,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Niemcy|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.11
@@ -268,7 +268,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Niemcy|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.12
@@ -299,7 +299,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Niemcy|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.13
@@ -330,7 +330,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Niemcy|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.14
@@ -361,7 +361,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Niemcy|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.15
@@ -392,7 +392,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Litwa|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Niemcy|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.17
@@ -424,7 +424,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|5.135.108.219|2001:41d0:301:1::20|
 |Belgia|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.20
@@ -456,7 +456,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|94.23.162.9|2001:41d0:301:1::21|
 |Belgia|BE|178.32.40.72|2001:41d0:301:10::21|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.21
@@ -488,7 +488,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|87.98.242.65|2001:41d0:301:1::23|
 |Belgia|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.23
@@ -520,7 +520,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|178.33.38.88|2001:41d0:301:1::24|
 |Belgia|BE|213.32.81.103|2001:41d0:301:10::24|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.24
@@ -552,7 +552,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|94.23.160.29|2001:41d0:301:1::26|
 |Belgia|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.26
@@ -584,7 +584,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|91.134.179.251|2001:41d0:301:1::27|
 |Belgia|BE|193.70.58.226|2001:41d0:301:10::27|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.27
@@ -616,7 +616,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|54.37.173.127|2001:41d0:301:1::28|
 |Belgia|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.28
@@ -648,7 +648,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|145.239.222.45|2001:41d0:301:1::29|
 |Belgia|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.29
@@ -680,7 +680,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|51.255.232.79|2001:41d0:301:1::30|
 |Belgia|BE|213.32.107.241|2001:41d0:301:10::30|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.30
@@ -712,7 +712,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |Niemcy|DE|151.80.4.219|2001:41d0:301:1::31|
 |Belgia|BE|217.182.187.17|2001:41d0:301:10::31|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.31
@@ -732,7 +732,7 @@ Tutaj znajdziesz adresy IP **klastra** według kraju (w przypadku geolokalizacji
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-Jeśli **Shared CDN** (wydany 19/11/2020) jest aktywny na Twoim hostingu, użyj tego adresu IP:
+Jeśli **Shared CDN** jest aktywny na Twoim hostingu, użyj tego adresu IP:
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pt-pt.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pt-pt.md
@@ -50,7 +50,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Alemanha|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.2
@@ -81,7 +81,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Alemanha|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.3
@@ -112,7 +112,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Alemanha|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.5
@@ -143,7 +143,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Alemanha|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.6
@@ -174,7 +174,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Alemanha|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.7
@@ -205,7 +205,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Alemanha|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.10
@@ -236,7 +236,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Alemanha|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.11
@@ -267,7 +267,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Alemanha|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.12
@@ -298,7 +298,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Alemanha|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.13
@@ -329,7 +329,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Alemanha|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.14
@@ -360,7 +360,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Alemanha|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.15
@@ -391,7 +391,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Alemanha|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.17
@@ -423,7 +423,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|5.135.108.219|2001:41d0:301:1::20|
 |Bélgica|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.20
@@ -455,7 +455,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|94.23.162.9|2001:41d0:301:1::21|
 |Bélgica|BE|178.32.40.72|2001:41d0:301:10::21|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.21
@@ -487,7 +487,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|87.98.242.65|2001:41d0:301:1::23|
 |Bélgica|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.23
@@ -519,7 +519,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|178.33.38.88|2001:41d0:301:1::24|
 |Bélgica|BE|213.32.81.103|2001:41d0:301:10::24|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.24
@@ -551,7 +551,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|94.23.160.29|2001:41d0:301:1::26|
 |Bélgica|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.26
@@ -583,7 +583,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|91.134.179.251|2001:41d0:301:1::27|
 |Bélgica|BE|193.70.58.226|2001:41d0:301:10::27|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.27
@@ -615,7 +615,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|54.37.173.127|2001:41d0:301:1::28|
 |Bélgica|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.28
@@ -647,7 +647,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|145.239.222.45|2001:41d0:301:1::29|
 |Bélgica|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.29
@@ -679,7 +679,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|51.255.232.79|2001:41d0:301:1::30|
 |Bélgica|BE|213.32.107.241|2001:41d0:301:10::30|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.30
@@ -711,7 +711,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|151.80.4.219|2001:41d0:301:1::31|
 |Bélgica|BE|217.182.187.17|2001:41d0:301:10::31|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.31
@@ -731,7 +731,7 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
 
-Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
+Se o **Shared CDN** estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
 46.105.204.51

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pt-pt.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pt-pt.md
@@ -1,9 +1,7 @@
 ---
 title: 'Lista dos endereços IP dos clusters e alojamentos web'
-updated: 2023-05-03
+updated: 2023-08-22
 ---
-
-**Última atualização: 03/05/2023**
 
 > [!primary]
 > Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certos casos, poderão ocorrer formulações imprecisas, como por exemplo nomes de botões ou detalhes técnicos. Recomendamos que consulte a versão inglesa ou francesa do manual, caso tenha alguma dúvida. Se nos quiser ajudar a melhorar esta tradução, clique em "Contribuir" nesta página.

--- a/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pt-pt.md
+++ b/pages/web/hosting/clusters_and_shared_hosting_IP/guide.pt-pt.md
@@ -50,12 +50,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.2|2001:41d0:1:1b00:188:165:31:2|
 |Alemanha|DE|87.98.247.2|2001:41d0:1:1b00:87:98:247:2|
 
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.69
-```
-
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
@@ -86,12 +80,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Finlândia|FI|188.165.143.4|2001:41d0:1:1b00:188:165:143:4|
 |Lituânia|LT|188.165.31.4|2001:41d0:1:1b00:188:165:31:4|
 |Alemanha|DE|87.98.247.4|2001:41d0:1:1b00:87:98:247:4|
-
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.85
-```
 
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
@@ -124,12 +112,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.16|2001:41d0:1:1b00:188.165.31.16|
 |Alemanha|DE|87.98.247.16|2001:41d0:1:1b00:87:98:247:16|
 
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.95
-```
-
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
@@ -160,12 +142,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Finlândia|FI|188.165.143.17|2001:41d0:1:1b00:188:165:143:17|
 |Lituânia|LT|188.165.31.17|2001:41d0:1:1b00:188:165:31:17|
 |Alemanha|DE|87.98.247.17|2001:41d0:1:1b00:87:98:247:17|
-
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.97
-```
 
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
@@ -198,12 +174,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.18|2001:41d0:1:1b00:188:165:31:18|
 |Alemanha|DE|87.98.247.18|2001:41d0:1:1b00:87:98:247:18|
 
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.105
-```
-
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
@@ -234,12 +204,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Finlândia|FI|188.165.143.19|2001:41d0:1:1b00:188:165:143:19|
 |Lituânia|LT|188.165.31.19|2001:41d0:1:1b00:188:165:31:19|
 |Alemanha|DE|87.98.247.19|2001:41d0:1:1b00:87:98:247:19|
-
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.107
-```
 
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
@@ -272,12 +236,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.40|2001:41d0:1:1b00:188:165:31:40|
 |Alemanha|DE|87.98.247.40|2001:41d0:1:1b00:87:98:247:40|
 
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.151
-```
-
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
@@ -308,12 +266,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Finlândia|FI|188.165.143.48|2001:41d0:1:1b00:188:165:143:48|
 |Lituânia|LT|188.165.31.48|2001:41d0:1:1b00:188:165:31:48|
 |Alemanha|DE|87.98.247.48|2001:41d0:1:1b00:87:98:247:48|
-
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.153
-```
 
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
@@ -346,12 +298,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.24|2001:41d0:1:1b00:188:165:31:24|
 |Alemanha|DE|87.98.247.24|2001:41d0:1:1b00:87:98:247:24|
 
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.83
-```
-
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
@@ -382,12 +328,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Finlândia|FI|188.165.143.87|2001:41d0:1:1b00:188:165:143:87|
 |Lituânia|LT|188.165.31.87|2001:41d0:1:1b00:188:165:31:87|
 |Alemanha|DE|87.98.247.87|2001:41d0:1:1b00:87:98:247:87|
-
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.169
-```
 
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
@@ -420,12 +360,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.31.3|2001:41d0:1:1b00:188:165:31:3|
 |Alemanha|DE|87.98.247.3|2001:41d0:1:1b00:87:98:247:3|
 
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.171
-```
-
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
@@ -456,12 +390,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Finlândia|FI|188.165.143.50|2001:41d0:1:1b00:188:165:143:50|
 |Lituânia|LT|188.165.31.50|2001:41d0:1:1b00:188:165:31:50|
 |Alemanha|DE|87.98.247.50|2001:41d0:1:1b00:87:98:247:50|
-
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.173
-```
 
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
@@ -495,12 +423,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|5.135.108.219|2001:41d0:301:1::20|
 |Bélgica|BE|5.196.203.200|2001:41d0:301:10::20|
 
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.176
-```
-
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
@@ -532,12 +454,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.30.41|2001:41d0:301:9::21|
 |Alemanha|DE|94.23.162.9|2001:41d0:301:1::21|
 |Bélgica|BE|178.32.40.72|2001:41d0:301:10::21|
-
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.177
-```
 
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
@@ -571,12 +487,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|87.98.242.65|2001:41d0:301:1::23|
 |Bélgica|BE|137.74.229.68|2001:41d0:301:10::23|
 
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.186
-```
-
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
@@ -608,12 +518,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|164.132.150.73|2001:41d0:301:9::24|
 |Alemanha|DE|178.33.38.88|2001:41d0:301:1::24|
 |Bélgica|BE|213.32.81.103|2001:41d0:301:10::24|
-
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-213.186.33.187
-```
 
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
@@ -647,12 +551,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|94.23.160.29|2001:41d0:301:1::26|
 |Bélgica|BE|178.32.43.46|2001:41d0:301:10::26|
 
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-188.165.51.93
-```
-
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
@@ -684,12 +582,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|51.255.97.18|2001:41d0:301:9::27|
 |Alemanha|DE|91.134.179.251|2001:41d0:301:1::27|
 |Bélgica|BE|193.70.58.226|2001:41d0:301:10::27|
-
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-145.239.51.129
-```
 
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
@@ -723,12 +615,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|54.37.173.127|2001:41d0:301:1::28|
 |Bélgica|BE|193.70.70.144|2001:41d0:301:10::28|
 
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-51.255.119.116
-```
-
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
@@ -761,12 +647,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Alemanha|DE|145.239.222.45|2001:41d0:301:1::29|
 |Bélgica|BE|178.32.44.140|2001:41d0:301:10::29|
 
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
- 51.255.215.242 
-```
-
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
 ```bash
@@ -798,12 +678,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |Lituânia|LT|188.165.24.146|2001:41d0:301:9::30|
 |Alemanha|DE|51.255.232.79|2001:41d0:301:1::30|
 |Bélgica|BE|213.32.107.241|2001:41d0:301:10::30|
-
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-54.36.13.47
-```
 
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 
@@ -856,12 +730,6 @@ De seguida indicamos os endereços IP do **cluster** para cada país (tendo em v
 |País|Código de país|IPv4|IPv6|
 |---|---|----|---|
 |Canada|CA|51.161.122.78|2607:5300:202:0:0::51|
-
-Se tem o serviço **CDN** ativado no seu alojamento, deve utilizar o seguinte endereço IP:
-
-```bash
-178.32.120.166
-```
 
 Se o **Shared CDN** (lançado em 19/11/2020) estiver ativado no seu alojamento, deve utilizar este endereço IP:
 


### PR DESCRIPTION
Updates for all subs: 

- Deletion of CDN legacy IPs => they aren't used anymore
- Deletion of the "release" date of Shared CDN (useless since CDN legacy is no longer used)
- Date of "last update"