### PR TITLE
fix typo in commpte client

### DIFF
--- a/pages/account/api/authenticate-api-with-service-account/guide.fr-ca.md
+++ b/pages/account/api/authenticate-api-with-service-account/guide.fr-ca.md
@@ -29,7 +29,7 @@ Oauth2 permet aussi de développer des applications tierces se connectant aux AP
 
 ## Prérequis
 
-- Un [commpte client OVHcloud](/pages/account/customer/ovhcloud-account-creation).
+- Un [compte client OVHcloud](/pages/account/customer/ovhcloud-account-creation).
 - Savoir configurer des [politiques d'accès via API](/pages/account/customer/iam-policies-api).
 - Savoir utiliser les [APIs de OVHcloud](/pages/account/api/first-steps).
 - Avoir créé un [compte de service via API](/pages/account/policies/manage-service-account).

--- a/pages/account/api/authenticate-api-with-service-account/guide.fr-fr.md
+++ b/pages/account/api/authenticate-api-with-service-account/guide.fr-fr.md
@@ -29,7 +29,7 @@ Oauth2 permet aussi de développer des applications tierces se connectant aux AP
 
 ## Prérequis
 
-- Un [commpte client OVHcloud](/pages/account/customer/ovhcloud-account-creation).
+- Un [compte client OVHcloud](/pages/account/customer/ovhcloud-account-creation).
 - Savoir configurer des [politiques d'accès via API](/pages/account/customer/iam-policies-api).
 - Savoir utiliser les [APIs de OVHcloud](/pages/account/api/first-steps).
 - Avoir créé un [compte de service via API](/pages/account/policies/manage-service-account).

--- a/pages/platform/public-cloud/authenticate-api-openstack-with-service-account/guide.fr-ca.md
+++ b/pages/platform/public-cloud/authenticate-api-openstack-with-service-account/guide.fr-ca.md
@@ -23,7 +23,7 @@ Cela vous permet :
 
 ## Prérequis
 
-- Un [commpte client OVHcloud](/pages/account/customer/ovhcloud-account-creation).
+- Un [compte client OVHcloud](/pages/account/customer/ovhcloud-account-creation).
 - Savoir configurer des [politiques d'accès via API](/pages/account/customer/iam-policies-api).
 - Vous savez [utiliser l'API OpenStack](/pages/platform/public-cloud/starting_with_nova).
 - Avoir créé un [compte de service via API](/pages/account/policies/manage-service-account).

--- a/pages/platform/public-cloud/authenticate-api-openstack-with-service-account/guide.fr-fr.md
+++ b/pages/platform/public-cloud/authenticate-api-openstack-with-service-account/guide.fr-fr.md
@@ -23,7 +23,7 @@ Cela vous permet :
 
 ## Prérequis
 
-- Un [commpte client OVHcloud](/pages/account/customer/ovhcloud-account-creation).
+- Un [compte client OVHcloud](/pages/account/customer/ovhcloud-account-creation).
 - Savoir configurer des [politiques d'accès via API](/pages/account/customer/iam-policies-api).
 - Vous savez [utiliser l'API OpenStack](/pages/platform/public-cloud/starting_with_nova).
 - Avoir créé un [compte de service via API](/pages/account/policies/manage-service-account).


### PR DESCRIPTION
While browsing https://help.ovhcloud.com/csm/fr-api-service-account-connection?id=kb_article_view&sysparm_article=KB0059325 I noticed a typo.

This PR fixes it.