### PR TITLE
Upgrade Kubernetes guide

### DIFF
--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.de-de.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.de-de.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.de-de.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/de/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/de/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/de/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-asia.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-asia.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/asia/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/asia/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/asia/en/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-asia.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-au.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-au.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/en-au/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/en-au/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/au/en/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-au.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-ca.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/en-ca/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/en-ca/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/ca/en/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-gb.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/en-gb/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/en-gb/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/gb/en/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-ie.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-ie.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/en-ie/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/en-ie/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/ie/en/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-ie.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-sg.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-sg.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/en-sg/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/en-sg/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/sg/en/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-sg.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.en-us.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/en/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/en/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/us/en/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.es-es.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.es-es.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/es-es/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/es-es/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/es/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.es-es.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.es-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.es-us.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/es/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/es/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/us/es/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.es-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.fr-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.fr-ca.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/fr-ca/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/fr-ca/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/ca/fr/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.fr-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.fr-fr.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.fr-fr.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/fr/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/fr/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/fr/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.fr-fr.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.it-it.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.it-it.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.it-it.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/it/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/it/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/it/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.pl-pl.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.pl-pl.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/pl/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/pl/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/pl/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.pl-pl.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.pt-pt.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2023-09-07
+updated: 2023-09-08
 ---
 
 ## Objective
@@ -41,7 +41,7 @@ kubectl create namespace logging
 
 ### Configuration
 
-Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
+Once the namespace is created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
@@ -55,14 +55,13 @@ We create a *ldp-token* secret with only one key named *ldp-token* as the value 
 
 #### Helm Values
 
-The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used by the Helm installation in order to change the configuration of Fluent Bit before its deployment.
 
-The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+The default values in the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
 
-For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+For brievety sake, we will just detail the part where we change the default values. Make sure to check the default values in the whole file to adadpt it to your Kubernetes configuration.
 
-
-Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
+Look for the *env:* configuration in the file and add the following values to use your secret as an environment variable.
 
 ```yaml
 env:
@@ -73,7 +72,7 @@ env:
              key: ldp-token
 ```
 
-We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
+We now need to add several filters in order to add the token and format logs records for the GELF output of Fluent Bit.
 
 
 ```yaml
@@ -110,14 +109,13 @@ We now need to add several filter in order to add the token, format logs records
         Add log "none"
 ```
 
-- The first filter parse the incoming messages and add all metadata information (pod, container, images)
-- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
-- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
-- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
-- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+- The first filter parses the incoming messages and add all metadata information (pod, container, images).
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier.
+- The third filter ensures all kubernetes metadata are flattened on the first level of the record so that they could be used as fields.
+- The fourth filter copies the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some softwares might have their log messages in another field than *log*. This will prevent these log messages from being lost.
 
-Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
-
+Now we can provide the output configuration that will send logs to Logs Data Platform in GELF format.
 
 ```yaml
     [OUTPUT]
@@ -131,12 +129,11 @@ Now we can provide the output configuration that will sent logs to Logs Data Pla
         Gelf_Short_Message_Key log
 ```
 
-In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
-
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
 ### Launch Fluent Bit
 
-You must first add teh Helm repository with the following command:
+You must first add the Helm repository with the following command:
 
 ```bash
 helm repo add fluent https://fluent.github.io/helm-charts
@@ -148,14 +145,15 @@ Then use the following helm command to deploy Fluent Bit on your platform:
 helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
-**values.yaml** is the file that contains the modifid configuration.
+**values.yaml** is the file that contains the modified configuration.
+
 Verify that the pods are running correctly with the command:
 
 ```bash
 kubectl get pods --namespace logging
 ```
 
-You can now fly to the stream interface to witness your beautifully structured logs
+You can now fly to the stream interface to witness your beautifully structured logs.
 
 ![kube_graylog](images/kube_graylog.png){.thumbnail}
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.pt-pt.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/guide.pt-pt.md
@@ -1,14 +1,14 @@
 ---
 title: Pushing logs from a Kubernetes cluster to Logs Data Platform using Fluent Bit
 excerpt: All the logs of your pods in one place
-updated: 2022-11-15
+updated: 2023-09-07
 ---
 
 ## Objective
 
 In this tutorial, you will learn how to collect logs from pods in a Kubernetes cluster and send them to Logs Data Platform.
 
-[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](http://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](http://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/pt/public-cloud/kubernetes/){.external}.
+[Kubernetes](https://kubernetes.io/){.external} is the de facto standard to manage containerized applications on cloud platforms. It is open source, has a large ecosystem, and has a ever growing community. Kubernetes is great but once your containers go live in the cloud, you still want to monitor their behavior. The more containers you have, the more difficult it can be to navigate through the logs and have a clear picture of what's happening. How can you centralize all your Kubernetes pods logs in one place and analyze them easily ? By using Logs Data Platform with the help of Fluent Bit. [Fluent Bit](https://fluentbit.io/) is a fast and lightweight log processor and forwarder. It is open source, cloud oriented and a part of the [Fluentd](https://fluentd.org/){.external} ecosystem. This tutorial will help you to configure it for Logs Data Platform, you can of course apply it to our [fully managed Kubernetes offer](https://www.ovhcloud.com/pt/public-cloud/kubernetes/){.external}.
 
 ## Requirements
 
@@ -21,284 +21,137 @@ Note that in order to complete this tutorial, you should have at least:
 
 ## Preparation
 
-Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](http://fluentbit.io/). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information.
+Before we dive into this tutorial, it is important to understand how we will deploy Fluent Bit. The configuration of Fluent Bit will be similar as the one you can find in the [official documentation](https://docs.fluentbit.io/manual/installation/kubernetes). Fluent Bit will be deployed as a *DaemonSet* in every node of the kubernetes cluster through an [Helm installation](https://helm.sh). Helm is a package manager for Kubernetes which can simplify the deployment of applications on Kubernetes. Fluent Bit will read, parse and ship every log of every pods of your cluster by default. It will also enrich each log with precious metadata like pod name and id, container name and ids, labels and annotations. As stated in the Fluent Bit documentation, a built-in Kubernetes filter will use Kubernetes API to gather some of these information. This configuration has been tested with kubernetes 1.28 and Fluent Bit image 2.1.8
 
 ## Instructions
 
 We will configure Fluent Bit with these steps:
 
-- Create the namespace, service account and the access rights of the Fluent Bit deployment.
-- Define the Fluent Bit configuration.
-- Launch the DaemonSet of Fluent Bit.
+- Create the logging namespace where the Fluent Bit deployment will live.
+- Define the Helm values which will be used in the Fluent Bit configuration
+- Install the DaemonSet with Helm to launch Fluent Bit
 
-### Installation
+### Namespace
 
-The Fluent Bit installation part is strictly identical to the documentation. Run the following commands to create the namespace, the service account and the role of this account
+Run the following commands to create the namespace of Fluent Bit
 
-```shell-session
+```bash
 kubectl create namespace logging
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-service-account.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role.yaml
-kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
 ### Configuration
 
-Once the account created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token and upload the *ConfigMap* of Fluent Bit.
+Once the namespace created, we can proceed to the next steps: define a secret for the *X-OVH-TOKEN* value of your stream token.
 
 #### Token Secret creation
 
 there is several methods to create a secret in Kubernetes, for brevity sake, we will use the one-liner version of secret creation.
 
-```shell-session
+```bash
 kubectl --namespace logging create secret generic ldp-token --from-literal=ldp-token=<your-token-value>
 ```
 
-We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *ldp-token* value with the value of your token.
+We create a *ldp-token* secret with only one key named *ldp-token* as the value of our token. Replace the *your-token-value* value with the value of your token.
 
-#### ConfigMap File
+#### Helm Values
 
-Even if it is undocumented, Fluent Bit supports [GELF](https://docs.graylog.org/){.external} as a standard output with udp, tcp and TLS protocols out of the box. We will modify the proposed file of the documentation to parse and convert Fluent Bit logs to GELF. The input is using the [CRI parser](https://docs.fluentbit.io/manual/installation/kubernetes#container-runtime-interface-cri-parser) to properly format logs:
+The Helm installation is documented here: [https://docs.fluentbit.io/manual/installation/](https://docs.fluentbit.io/manual/installation/kubernetes). We will customize the values used byu the Helm installation in order to change the configuration of Fluent Bit before its deployment.
+
+The default values if the configuration file of the Helm package are located here: [https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml).
+
+For brievety sake, we will just detail the part where we change the default values. Be sure to check the default values in thewhle file to adadpt it to your Kubernetes configuration.
+
+
+Look for the *env:* configuration in the file and add the following values to use your secret as a environment variable.
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit
-data:
-  # Configuration files: server, input, filters and output
-  # ======================================================
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush         1
-        Log_Level     info
-        Daemon        off
-        Parsers_File  parsers.conf
-        HTTP_Server   On
-        HTTP_Listen   0.0.0.0
-        HTTP_Port     2020
+env:
+   - name: FLUENT_LDP_TOKEN
+     valueFrom:
+         secretKeyRef:
+             name: ldp-token
+             key: ldp-token
+```
 
-    @INCLUDE input-kubernetes.conf
-    @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-ldp.conf
+We now need to add several filter in order to add the token, format logs records for teh GELF output of Fluent Bit.
 
-  input-kubernetes.conf: |
-    # CRI Parser
-    [PARSER]
-        # http://rubular.com/r/tjUt3Awgg4
-        Name cri
-        Format regex
-        Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
-    [INPUT]
-        Name tail
-        Path /var/log/containers/*.log
-        Parser cri
-        Tag kube.*
-        Mem_Buf_Limit 5MB
-        Skip_Long_Lines On
 
-  filter-kubernetes.conf: |
+```yaml
+  filters: |
     [FILTER]
-        Name                kubernetes
-        Match               kube.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_CA_File        /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        Kube_Token_File     /var/run/secrets/kubernetes.io/serviceaccount/token
-        Kube_Tag_Prefix     kube.var.log.containers.
-        Merge_Log           Off
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
+        Name kubernetes
+        Match kube.*
+        Merge_Log On
+        Keep_Log Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
     [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
-    [FILTER]
-        Name                record_modifier
-        Match               *
-        Record     fluent-bit-host ${HOSTNAME}
-    [FILTER]
-        Name                nest
-        Match               *
-        Wildcard            pod_name
+        Name record_modifier
+        Match *
+        Record X-OVH-TOKEN ${FLUENT_LDP_TOKEN}
+
+      [FILTER]
+        Name nest
+        Match *
+        Wildcard pod_name
         Operation lift
         Nested_under kubernetes
-        Add_prefix   kubernetes_
-    [FILTER]
-        Name                modify
-        Match               *
-        Copy     kubernetes_pod_name host
-    [FILTER]
-        Name                modify
-        Match               *
-        Rename     log short_message
+        Add_prefix kubernetes_
 
-  output-ldp.conf: |
+    [FILTER]
+        Name modify
+        Match *
+        Copy kubernetes_pod_name host
+
+    [FILTER]
+        Name modify
+        Match *
+        Add log "none"
+```
+
+- The first filter parse the incoming messages and add all metadata information (pod, container, images)
+- The second filter adds the **X-OVH-TOKEN** by using the environment variable we configured earlier
+- The third filter ensure all kubernetes metadata are flatten on the first level of the record so that they could be used as fields.
+- The fourth filter copy the name of the pod in the key **host** so that this value is properly set. You are free to use any other metadata value that will suit your needs here.
+- The final filter ensures there is always a value for the field log. This field will be used as the *short_message* key for the GELF output and thus cannot be empty. Some software might have their log message in another field than *log*. This will prevent these log messages to be lost.
+
+Now we can provide the output configuration that will sent logs to Logs Data Platform in GELF format.
+
+
+```yaml
     [OUTPUT]
-        Name            gelf
-        Match           *
-        Host            ${FLUENT_LDP_HOST}
-        Port            ${FLUENT_LDP_PORT}
-        Mode            tls
-        tls             On
-        Compress        False
-
-  parsers.conf: |
-    [PARSER]
-        Name   apache
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache2
-        Format regex
-        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   apache_error
-        Format regex
-        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](/pt/logs-data-platform/logs-data-platform-kubernetes-fluent-bit/?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
-
-    [PARSER]
-        Name   nginx
-        Format regex
-        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name   json
-        Format json
-        Time_Key time
-        Time_Format %d/%b/%Y:%H:%M:%S %z
-
-    [PARSER]
-        Name        docker
-        Format      json
-        Time_Key    time
-        Time_Format %Y-%m-%dT%H:%M:%S.%L
-        Time_Keep   On
-
-    [PARSER]
-        Name        syslog
-        Format      regex
-        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key    time
-        Time_Format %b %d %H:%M:%S
+        Name gelf
+        Match kube.*
+        Host graX.logs.ovh.com
+        Port 12202
+        Mode tls
+        tls On
+        Compress False
+        Gelf_Short_Message_Key log
 ```
 
-The differences with the proposed file in the documentation are in the filter configuration file and the output configuration file:
+In this [GELF output configuration](https://docs.fluentbit.io/manual/pipeline/outputs/gelf) configuration we use the address **graX.logs.ovh.com**. Please change it to the actual address of your Logs Data Platform account. The port used is the one for GELF and *tls* is activated. Note that *Gelf_Short_Message_Key* is put to **log**, because that's where the main kubernetes log field is.
 
-- We use a **record_modifier** filter to add the *X-OVH-TOKEN* at each log, the value of the token will be taken from an environment variable.
-- We use a **record_modifier** extract the container name handling this log as new key *fluent-bit-host*.
-- We use the **nest** modifier to flatten the Fluent Bit log message at the filter stage
-- We use a **modify** filter to copy the pod name which generated the log to the name of the source
-- We finally use a **modify** filter to rename the log field to the standard  *short_message* value
-
-If you need more information on what you can do with the filters, don't hesitate to navigate to the [Fluent Bit filter documentation](http://fluentbit.io/){.external}. With the Fluent Bit filters, you can specify which pods should be logged and what data must be included or discarded.
-
-The second modified file is the *output-ldp.conf* file. Here we configure the *Gelf output* with environment variables and activate the TLS.
-The final part of the file is some parsers that you can use to create structured logs from well known log formats.
-
-To upload the configuration file use the following command
-
-```shell-session
-kubectl create -f fluent-bit-configmap.yaml
-```
 
 ### Launch Fluent Bit
 
-Now that Fluent Bit accounts and configuration file are setup, we can now launch our DaemonSet. Create a *fluent-bit-ds.yaml* file with the following content to configure the DaemonSet.
+You must first add teh Helm repository with the following command:
 
-```yaml hl_lines="103 113"
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: logging
-  labels:
-    k8s-app: fluent-bit-logging
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit-logging
-  template:
-    metadata:
-      labels:
-        k8s-app: fluent-bit-logging
-        version: v1
-        kubernetes.io/cluster-service: "true"
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "2020"
-        prometheus.io/path: /api/v1/metrics/prometheus
-    spec:
-      containers:
-      - name: fluent-bit
-        image: fluent/fluent-bit:1.5.0
-        imagePullPolicy: Always
-        ports:
-          - containerPort: 2020
-        env:
-        - name: FLUENT_LDP_HOST
-          value: "gra2.logs.ovh.com"
-        - name: FLUENT_LDP_PORT
-          value: "12202"
-        - name: FLUENT_LDP_TOKEN
-          valueFrom:
-              secretKeyRef:
-                  name: ldp-token
-                  key: ldp-token
-        volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"
+```bash
+helm repo add fluent https://fluent.github.io/helm-charts
 ```
 
-In this file you must specify the address of your cluster (here **gra2.logs.ovh.com** for example) and the port of the GELF TLS input (here **12202**). You will find these information at the **Home** page of your Logs Data Platform manager.
+Then use the following helm command to deploy Fluent Bit on your platform:
 
-Upload this file with the following command:
-```shell-session
-kubectl create -f fluent-bit-ds.yaml
+```bash
+helm upgrade --install --namespace logging  -f values.yaml fluent-bit fluent/fluent-bit
 ```
 
+**values.yaml** is the file that contains the modifid configuration.
 Verify that the pods are running correctly with the command:
-```shell-session
+
+```bash
 kubectl get pods --namespace logging
 ```
 


### PR DESCRIPTION
The Kubernetes logging guide is outdated and not working properly anymore. We reviewed and changed the guide according to the documentation of the software we use (Fluent Bit). 