### PR TITLE
fix: first-steps-api: remove OAuth2 banner

### DIFF
--- a/pages/manage_and_operate/api/first-steps/guide.de-de.md
+++ b/pages/manage_and_operate/api/first-steps/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Erste Schritte mit der OVHcloud API
 excerpt: Erfahren Sie hier, wie Sie die OVHcloud API verwenden
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 > [!primary]

--- a/pages/manage_and_operate/api/first-steps/guide.de-de.md
+++ b/pages/manage_and_operate/api/first-steps/guide.de-de.md
@@ -126,11 +126,6 @@ Die Tabs `PHP` und `Python` enthalten die Elemente, die entsprechend der Anwendu
 
 #### Schlüssel für Ihre Anwendung erstellen
 
-> [!success]
->
-> Die OVHcloud API ist mit dem Protokoll Oauth2 kompatibel. Weitere Informationen finden Sie in der Anleitung zur [Verwendung von Service Accounts zur Authentifizierung über OVHcloud APIs (EN)](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
->
-
 Jede Anwendung, die mit der OVHcloud API kommunizieren möchte, muss zuerst freigegeben werden.
 
 Klicken Sie hierzu auf folgenden Link: [https://eu.api.ovh.com/createToken/](https://eu.api.ovh.com/createToken/){.external}.

--- a/pages/manage_and_operate/api/first-steps/guide.en-asia.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: 'First Steps with the OVHcloud APIs'
 excerpt: 'Learn how to use OVHcloud APIs'
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 ## Objective

--- a/pages/manage_and_operate/api/first-steps/guide.en-asia.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-asia.md
@@ -123,11 +123,6 @@ The `PHP` and `Python` tabs contain the elements to be added to your script acco
 
 #### Create your app keys
 
-> [!success]
->
-> OVHcloud APIs are now compatible with the Oauth2 protocol. Find more information in our guide on [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
->
-
 Any application that wants to communicate with the OVHcloud API must be declared in advance.
 
 To do this, click the following link: [https://ca.api.ovh.com/createToken/](https://ca.api.ovh.com/createToken/){.external}.

--- a/pages/manage_and_operate/api/first-steps/guide.en-au.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: 'First Steps with the OVHcloud APIs'
 excerpt: 'Learn how to use OVHcloud APIs'
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 ## Objective

--- a/pages/manage_and_operate/api/first-steps/guide.en-au.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-au.md
@@ -123,11 +123,6 @@ The `PHP` and `Python` tabs contain the elements to be added to your script acco
 
 #### Create your app keys
 
-> [!success]
->
-> OVHcloud APIs are now compatible with the Oauth2 protocol. Find more information in our guide on [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
->
-
 Any application that wants to communicate with the OVHcloud API must be declared in advance.
 
 To do this, click the following link: [https://ca.api.ovh.com/createToken/](https://ca.api.ovh.com/createToken/){.external}.

--- a/pages/manage_and_operate/api/first-steps/guide.en-ca.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: 'First Steps with the OVHcloud APIs'
 excerpt: 'Learn how to use OVHcloud APIs'
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 ## Objective

--- a/pages/manage_and_operate/api/first-steps/guide.en-ca.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-ca.md
@@ -123,11 +123,6 @@ The `PHP` and `Python` tabs contain the elements to be added to your script acco
 
 #### Create your app keys
 
-> [!success]
->
-> OVHcloud APIs are now compatible with the Oauth2 protocol. Find more information in our guide on [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
->
-
 Any application that wants to communicate with the OVHcloud API must be declared in advance.
 
 To do this, click the following link: [https://ca.api.ovh.com/createToken/](https://ca.api.ovh.com/createToken/){.external}.

--- a/pages/manage_and_operate/api/first-steps/guide.en-gb.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: 'First Steps with the OVHcloud APIs'
 excerpt: 'Learn how to use OVHcloud APIs'
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 ## Objective

--- a/pages/manage_and_operate/api/first-steps/guide.en-gb.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-gb.md
@@ -122,11 +122,6 @@ The `PHP` and `Python` tabs contain the elements to be added to your script acco
 
 #### Create your app keys
 
-> [!success]
->
-> OVHcloud APIs are now compatible with the Oauth2 protocol. Find more information in our guide on [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
->
-
 Any application that wants to communicate with the OVHcloud API must be declared in advance.
 
 To do this, click the following link: [https://eu.api.ovh.com/createToken/](https://eu.api.ovh.com/createToken/){.external}.

--- a/pages/manage_and_operate/api/first-steps/guide.en-ie.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: 'First Steps with the OVHcloud APIs'
 excerpt: 'Learn how to use OVHcloud APIs'
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 ## Objective

--- a/pages/manage_and_operate/api/first-steps/guide.en-ie.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-ie.md
@@ -104,11 +104,6 @@ For example, if you do not want to keep the DNS record that you added to your DN
 
 ##### **API parameters**
 
-> [!success]
->
-> OVHcloud APIs are now compatible with the Oauth2 protocol. Find more information in our guide on [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
->
-
 After you click the API you want, the **Parameters** section allows you to assign variables for its application.
  
 For example, when adding a TXT record to your DNS zone, you will optimise the following settings:

--- a/pages/manage_and_operate/api/first-steps/guide.en-sg.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: 'First Steps with the OVHcloud APIs'
 excerpt: 'Learn how to use OVHcloud APIs'
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 ## Objective

--- a/pages/manage_and_operate/api/first-steps/guide.en-sg.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-sg.md
@@ -123,11 +123,6 @@ The `PHP` and `Python` tabs contain the elements to be added to your script acco
 
 #### Create your app keys
 
-> [!success]
->
-> OVHcloud APIs are now compatible with the Oauth2 protocol. Find more information in our guide on [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
->
-
 Any application that wants to communicate with the OVHcloud API must be declared in advance.
 
 To do this, click the following link: [https://ca.api.ovh.com/createToken/](https://ca.api.ovh.com/createToken/){.external}.

--- a/pages/manage_and_operate/api/first-steps/guide.en-us.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: 'First Steps with the OVHcloud APIs'
 excerpt: 'Learn how to use OVHcloud APIs'
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 ## Objective

--- a/pages/manage_and_operate/api/first-steps/guide.en-us.md
+++ b/pages/manage_and_operate/api/first-steps/guide.en-us.md
@@ -123,11 +123,6 @@ The `PHP` and `Python` tabs contain the elements to be added to your script acco
 
 #### Create your app keys
 
-> [!success]
->
-> OVHcloud APIs are now compatible with the Oauth2 protocol. Find more information in our guide on [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
->
-
 Any application that wants to communicate with the OVHcloud API must be declared in advance.
 
 To do this, click the following link: [https://ca.api.ovh.com/createToken/](https://ca.api.ovh.com/createToken/){.external}.

--- a/pages/manage_and_operate/api/first-steps/guide.es-es.md
+++ b/pages/manage_and_operate/api/first-steps/guide.es-es.md
@@ -127,11 +127,6 @@ Las pestañas `PHP` y `Python` contienen los elementos que se añadirán al scri
 
 #### Crear las claves de su aplicación
 
-> [!success]
->
-> Las API de OVHcloud ya son compatibles con el protocolo Oauth2. Para más información, consulte la guía «[Cómo autenticarse en la API de OVHcloud con Oauth2 (EN)](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)».
->
-
 Todas las aplicaciones que quieran comunicarse con la API de OVHcloud deben notificarse con antelación.
 
 Para ello, haga clic en el siguiente enlace: [https://eu.api.ovh.com/createToken/](https://eu.api.ovh.com/createToken/){.external}.

--- a/pages/manage_and_operate/api/first-steps/guide.es-es.md
+++ b/pages/manage_and_operate/api/first-steps/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: 'Primeros pasos con las API de OVHcloud'
 excerpt: 'Cómo utilizar las API de OVHcloud'
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 > [!primary]

--- a/pages/manage_and_operate/api/first-steps/guide.es-us.md
+++ b/pages/manage_and_operate/api/first-steps/guide.es-us.md
@@ -127,11 +127,6 @@ Las pestañas `PHP` y `Python` contienen los elementos que se añadirán al scri
 
 #### Crear las claves de su aplicación
 
-> [!success]
->
-> Las API de OVHcloud ya son compatibles con el protocolo Oauth2. Para más información, consulte la guía «[Cómo autenticarse en la API de OVHcloud con Oauth2 (EN)](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)».
->
-
 Todas las aplicaciones que quieran comunicarse con la API de OVHcloud deben notificarse con antelación.
 
 Para ello, haga clic en el siguiente enlace: [https://ca.api.ovh.com/createToken/](https://ca.api.ovh.com/createToken/){.external}.

--- a/pages/manage_and_operate/api/first-steps/guide.es-us.md
+++ b/pages/manage_and_operate/api/first-steps/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: 'Primeros pasos con las API de OVHcloud'
 excerpt: 'Cómo utilizar las API de OVHcloud'
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 > [!primary]

--- a/pages/manage_and_operate/api/first-steps/guide.fr-ca.md
+++ b/pages/manage_and_operate/api/first-steps/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: 'Premiers pas avec les API OVHcloud'
 excerpt: 'Découvrez comment utiliser les API OVHcloud'
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 ## Objectif

--- a/pages/manage_and_operate/api/first-steps/guide.fr-ca.md
+++ b/pages/manage_and_operate/api/first-steps/guide.fr-ca.md
@@ -123,11 +123,6 @@ Les onglets `PHP` et `Python` contiennent les éléments à ajouter dans votre s
 
 #### Créer les clés de votre application
 
-> [!success]
->
-> Les API de OVHcloud sont désormais compatible avec le protocole Oauth2. Retrouvez plus d'informations dans le guide  « [Comment s'authentifier sur l'API OVHcloud avec Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account) ».
->
-
 Toute application souhaitant communiquer avec l'API OVHcloud doit être déclarée à l'avance.
 
 Pour ce faire, cliquez sur le lien suivant : [https://ca.api.ovh.com/createToken/](https://ca.api.ovh.com/createToken/){.external}.

--- a/pages/manage_and_operate/api/first-steps/guide.fr-fr.md
+++ b/pages/manage_and_operate/api/first-steps/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: 'Premiers pas avec les API OVHcloud'
 excerpt: 'Découvrez comment utiliser les API OVHcloud'
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 ## Objectif

--- a/pages/manage_and_operate/api/first-steps/guide.fr-fr.md
+++ b/pages/manage_and_operate/api/first-steps/guide.fr-fr.md
@@ -123,11 +123,6 @@ Les onglets `PHP` et `Python` contiennent les éléments à ajouter dans votre s
 
 #### Créer les clés de votre application
 
-> [!success]
->
-> Les API de OVHcloud sont désormais compatible avec le protocole Oauth2. Retrouvez plus d'informations dans le guide  « [Comment s'authentifier sur l'API OVHcloud avec Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account) ».
->
-
 Toute application souhaitant communiquer avec l'API OVHcloud doit être déclarée à l'avance.
 
 Pour ce faire, cliquez sur le lien suivant : [https://eu.api.ovh.com/createToken/](https://eu.api.ovh.com/createToken/){.external}.

--- a/pages/manage_and_operate/api/first-steps/guide.it-it.md
+++ b/pages/manage_and_operate/api/first-steps/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Iniziare a utilizzare le API OVHcloud
 excerpt: Come utilizzare le API OVHcloud
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 > [!primary]

--- a/pages/manage_and_operate/api/first-steps/guide.it-it.md
+++ b/pages/manage_and_operate/api/first-steps/guide.it-it.md
@@ -127,11 +127,6 @@ Le schede `PHP` e `Python` contengono gli elementi da aggiungere al tuo script i
 
 #### Crea le chiavi della tua applicazione
 
-> [!success]
->
-> Le API di OVHcloud sono compatibili con il protocollo Oauth2. Per maggiori informazioni consulta la guida "[Come autenticarsi sull’API OVHcloud con Oauth2 (EN)](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)".
->
-
 Qualsiasi applicazione che desideri comunicare con l'API OVHcloud deve essere dichiarata in anticipo.
 
 Clicca su questo link: [https://eu.api.ovh.com/createToken/](https://eu.api.ovh.com/createToken/){.external}.

--- a/pages/manage_and_operate/api/first-steps/guide.pl-pl.md
+++ b/pages/manage_and_operate/api/first-steps/guide.pl-pl.md
@@ -127,11 +127,6 @@ Zakładki `PHP` i `Python` zawierają elementy, które należy dodać do skryptu
 
 #### Utwórz klucze aplikacji
 
-> [!success]
->
-> Interfejsy API OVHcloud są teraz kompatybilne z protokołem Oauth2. Więcej informacji znajdziesz w przewodniku "[Jak uwierzytelnić się za pomocą API OVHcloud Oauth2 (EN)](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)".
->
-
 Każda aplikacja, która chce komunikować się z API OVHcloud, musi zostać zgłoszona z wyprzedzeniem.
 
 W tym celu kliknij link: [https://eu.api.ovh.com/createToken/](https://eu.api.ovh.com/createToken/){.external}.

--- a/pages/manage_and_operate/api/first-steps/guide.pl-pl.md
+++ b/pages/manage_and_operate/api/first-steps/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: 'Pierwsze kroki z API OVHcloud'
 excerpt: 'Dowiedz się, jak korzystać z API OVHcloud'
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 > [!primary]

--- a/pages/manage_and_operate/api/first-steps/guide.pt-pt.md
+++ b/pages/manage_and_operate/api/first-steps/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: 'Primeiros passos com as API OVHcloud'
 excerpt: 'Saiba como utilizar as API da OVHcloud'
-updated: 2023-08-24
+updated: 2023-09-08
 ---
 
 > [!primary]

--- a/pages/manage_and_operate/api/first-steps/guide.pt-pt.md
+++ b/pages/manage_and_operate/api/first-steps/guide.pt-pt.md
@@ -127,11 +127,6 @@ Os separadores `PHP` e `Python` contêm os elementos que devem ser adicionados n
 
 #### Criar as chaves da sua aplicação
 
-> [!success]
->
-> As API da OVHcloud são agora compatíveis com o protocolo Oauth2. Encontre mais informações no guia [Como se autenticar na API OVHcloud com Oauth2 (EN)](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
->
-
 Qualquer aplicação que pretenda comunicar com a API da OVHcloud deve ser declarada previamente.
 
 Para isso, clique na seguinte ligação: [https://eu.api.ovh.com/createToken/](https://eu.api.ovh.com/createToken/){.external}.


### PR DESCRIPTION
All API wrappers introduced in this guide are not ready for OAuth2, so let's remove this banner as it will be confusing for customers.