### PR TITLE
Add a limitation on the deletion of a instance backup

### DIFF
--- a/pages/public_cloud/compute/save_an_instance/guide.de-de.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Backup einer Instanz erstellen
 excerpt: Erfahren Sie hier, wie Sie eine Public Cloud Instanz in Ihrem OVHcloud Kundencenter sichern
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 > [!primary]
@@ -85,6 +85,9 @@ Zeitplanungen können im Bereich `Workflow Management`{.action} Ihres Public Clo
 Die Backups Ihrer Instanzen werden im Bereich `Instance Backup`{.action} in Ihrem Public Cloud Kundencenter verwaltet.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Beachten Sie, dass Sie ein Instanz-Backup nicht löschen können, wenn eine Instanz, die aus diesem Backup erzeugt wurde, zum Zeitpunkt des Löschvorgangs ausgeführt wird.**
 
 Erfahren Sie in [dieser Anleitung](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup), wie Sie Sicherungen verwenden, um Instanzen zu klonen oder wiederherzustellen.
 

--- a/pages/public_cloud/compute/save_an_instance/guide.en-asia.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up an instance
 excerpt: Find out how to back up a Public Cloud instance in the OVHcloud Control Panel
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 ## Objective
@@ -18,6 +18,10 @@ You can create a single backup of an instance or configure a schedule in order t
 ## Instructions
 
 ### Creating a backup of an instance
+
+> [!warning]
+> This option is only available through a **Cold Snapshot** for Metal instances. During this process, the Metal instance will be switched to rescue-mode, and once the backup is performed, the instance will reboot back to normal mode.
+>
 
 Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) and open your `Public Cloud`{.action} project. Then click on `Instances`{.action} in the left-hand menu.
 
@@ -77,6 +81,9 @@ Schedules can be created and removed in the Public Cloud `Workflow Management`{.
 Your instance backups are managed in the Public Cloud `Instance Backup`{.action} section.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Note that you cannot delete an instance backup if an instance that has been spawned from this backup is running at the time of the delete action.**
 
 Find out how to use backups to clone or restore instances in [this guide](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 

--- a/pages/public_cloud/compute/save_an_instance/guide.en-au.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up an instance
 excerpt: Find out how to back up a Public Cloud instance in the OVHcloud Control Panel
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 ## Objective
@@ -18,6 +18,10 @@ You can create a single backup of an instance or configure a schedule in order t
 ## Instructions
 
 ### Creating a backup of an instance
+
+> [!warning]
+> This option is only available through a **Cold Snapshot** for Metal instances. During this process, the Metal instance will be switched to rescue-mode, and once the backup is performed, the instance will reboot back to normal mode.
+>
 
 Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) and open your `Public Cloud`{.action} project. Then click on `Instances`{.action} in the left-hand menu.
 
@@ -77,6 +81,9 @@ Schedules can be created and removed in the Public Cloud `Workflow Management`{.
 Your instance backups are managed in the Public Cloud `Instance Backup`{.action} section.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Note that you cannot delete an instance backup if an instance that has been spawned from this backup is running at the time of the delete action.**
 
 Find out how to use backups to clone or restore instances in [this guide](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 

--- a/pages/public_cloud/compute/save_an_instance/guide.en-ca.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up an instance
 excerpt: Find out how to back up a Public Cloud instance in the OVHcloud Control Panel
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 ## Objective
@@ -81,6 +81,9 @@ Schedules can be created and removed in the Public Cloud `Workflow Management`{.
 Your instance backups are managed in the Public Cloud `Instance Backup`{.action} section.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Note that you cannot delete an instance backup if an instance that has been spawned from this backup is running at the time of the delete action.**
 
 Find out how to use backups to clone or restore instances in [this guide](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 

--- a/pages/public_cloud/compute/save_an_instance/guide.en-gb.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-gb.md
@@ -82,6 +82,8 @@ Your instance backups are managed in the Public Cloud `Instance Backup`{.action}
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
 
+**Note that you cannot delete an instance backup if an instance that have been spawned from this backup is running at the time of the delete action**
+
 Find out how to use backups to clone or restore instances in [this guide](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 
 ## Go further

--- a/pages/public_cloud/compute/save_an_instance/guide.en-gb.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up an instance
 excerpt: Find out how to back up a Public Cloud instance in the OVHcloud Control Panel
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 ## Objective
@@ -82,7 +82,8 @@ Your instance backups are managed in the Public Cloud `Instance Backup`{.action}
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
 
-**Note that you cannot delete an instance backup if an instance that have been spawned from this backup is running at the time of the delete action**
+> [!warning]
+> **Note that you cannot delete an instance backup if an instance that has been spawned from this backup is running at the time of the delete action.**
 
 Find out how to use backups to clone or restore instances in [this guide](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 

--- a/pages/public_cloud/compute/save_an_instance/guide.en-ie.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up an instance
 excerpt: Find out how to back up a Public Cloud instance in the OVHcloud Control Panel
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 ## Objective
@@ -81,6 +81,9 @@ Schedules can be created and removed in the Public Cloud `Workflow Management`{.
 Your instance backups are managed in the Public Cloud `Instance Backup`{.action} section.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Note that you cannot delete an instance backup if an instance that has been spawned from this backup is running at the time of the delete action.**
 
 Find out how to use backups to clone or restore instances in [this guide](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 

--- a/pages/public_cloud/compute/save_an_instance/guide.en-sg.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up an instance
 excerpt: Find out how to back up a Public Cloud instance in the OVHcloud Control Panel
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 ## Objective
@@ -18,6 +18,10 @@ You can create a single backup of an instance or configure a schedule in order t
 ## Instructions
 
 ### Creating a backup of an instance
+
+> [!warning]
+> This option is only available through a **Cold Snapshot** for Metal instances. During this process, the Metal instance will be switched to rescue-mode, and once the backup is performed, the instance will reboot back to normal mode.
+>
 
 Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) and open your `Public Cloud`{.action} project. Then click on `Instances`{.action} in the left-hand menu.
 
@@ -77,6 +81,9 @@ Schedules can be created and removed in the Public Cloud `Workflow Management`{.
 Your instance backups are managed in the Public Cloud `Instance Backup`{.action} section.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Note that you cannot delete an instance backup if an instance that has been spawned from this backup is running at the time of the delete action.**
 
 Find out how to use backups to clone or restore instances in [this guide](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 

--- a/pages/public_cloud/compute/save_an_instance/guide.en-us.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up an instance
 excerpt: Find out how to back up a Public Cloud instance in the OVHcloud Control Panel
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 ## Objective
@@ -81,6 +81,9 @@ Schedules can be created and removed in the Public Cloud `Workflow Management`{.
 Your instance backups are managed in the Public Cloud `Instance Backup`{.action} section.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Note that you cannot delete an instance backup if an instance that has been spawned from this backup is running at the time of the delete action.**
 
 Find out how to use backups to clone or restore instances in [this guide](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 

--- a/pages/public_cloud/compute/save_an_instance/guide.es-es.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: 'Guardar una instancia'
 excerpt: 'Cómo realizar el backup de una instancia de Public Cloud desde el área de cliente de OVHcloud'
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 > [!primary]
@@ -85,6 +85,9 @@ Las planificaciones pueden crearse y eliminarse en la sección `Workflow Managem
 Las copias de seguridad de sus instancias se gestionan en la sección `Instance Backup`{.action} del área de cliente de Public Cloud.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Tenga en cuenta que no puede eliminar una copia de seguridad de instancia si una instancia que se ha generado a partir de esta copia de seguridad se está ejecutando en el momento de la acción de eliminación.**
 
 Esta guía explica cómo utilizar las copias de seguridad para clonar o restaurar instancias en [esta guía](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 

--- a/pages/public_cloud/compute/save_an_instance/guide.es-us.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: 'Guardar una instancia'
 excerpt: 'Cómo realizar el backup de una instancia de Public Cloud desde el área de cliente de OVHcloud'
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 > [!primary]
@@ -85,6 +85,9 @@ Las planificaciones pueden crearse y eliminarse en la sección `Workflow Managem
 Las copias de seguridad de sus instancias se gestionan en la sección `Instance Backup`{.action} del área de cliente de Public Cloud.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Tenga en cuenta que no puede eliminar una copia de seguridad de instancia si una instancia que se ha generado a partir de esta copia de seguridad se está ejecutando en el momento de la acción de eliminación.**
 
 Esta guía explica cómo utilizar las copias de seguridad para clonar o restaurar instancias en [esta guía](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 

--- a/pages/public_cloud/compute/save_an_instance/guide.fr-ca.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: 'Sauvegarder une instance'
 excerpt: 'Découvrez comment sauvegarder une instance Public Cloud depuis votre espace client OVHcloud'
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 ## Objectif
@@ -81,6 +81,9 @@ Les planifications peuvent être créées et supprimées dans la section `Workfl
 Les sauvegardes de vos instances sont gérées dans la section `Instance Backup`{.action} de votre espace client Public Cloud.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Notez que vous ne pouvez pas supprimer une sauvegarde d'instance si une instance qui a été générée à partir de cette sauvegarde est en cours d'exécution au moment de l'action de suppression.**
 
 Découvrez comment utiliser les sauvegardes pour cloner ou restaurer des instances dans [ce guide](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 

--- a/pages/public_cloud/compute/save_an_instance/guide.fr-fr.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: 'Sauvegarder une instance'
 excerpt: 'Découvrez comment sauvegarder une instance Public Cloud depuis votre espace client OVHcloud'
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 ## Objectif
@@ -81,6 +81,9 @@ Les planifications peuvent être créées et supprimées dans la section `Workfl
 Les sauvegardes de vos instances sont gérées dans la section `Instance Backup`{.action} de votre espace client Public Cloud.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Notez que vous ne pouvez pas supprimer une sauvegarde d'instance si une instance qui a été générée à partir de cette sauvegarde est en cours d'exécution au moment de l'action de suppression.**
 
 Découvrez comment utiliser les sauvegardes pour cloner ou restaurer des instances dans [ce guide](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 

--- a/pages/public_cloud/compute/save_an_instance/guide.it-it.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Effettuare il backup di un'istanza"
 excerpt: "Come eseguire le prime operazioni su un'istanza Public Cloud dallo Spazio Cliente OVHcloud"
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 > [!primary]
@@ -85,6 +85,9 @@ Le pianificazioni possono essere create ed eliminate nella sezione `Workflow Man
 I backup delle istanze sono gestiti nella sezione `Instance Backup`{.action} dello Spazio Cliente Public Cloud.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Si noti che non è possibile eliminare un backup dell'istanza se un'istanza creata da questo backup è in esecuzione al momento dell'azione di eliminazione.**
 
 Questa guida ti mostra come utilizzare i backup per clonare o ripristinare le istanze in [questa guida](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 

--- a/pages/public_cloud/compute/save_an_instance/guide.pl-pl.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: 'Tworzenie kopii zapasowej instancji'
 excerpt: 'Dowiedz się, jak utworzyć kopię zapasową instancji Public Cloud w Panelu klienta OVHcloud'
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 > [!primary]
@@ -85,6 +85,9 @@ Planowanie może zostać utworzone i usunięte w sekcji `Workflow Management`{.a
 Kopie zapasowe instancji są zarządzane w sekcji `Instance Backup`{.action} w Panelu klienta Public Cloud.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Nie można usunąć kopii instancji, jeśli instancja uruchomiona z tej kopii zapasowej jest uruchomiona w czasie wykonywania akcji usuwania.**
 
 Dowiedz się, jak w [tym przewodniku](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup) wykorzystać kopie zapasowe do klonowania lub przywracania instancji.
 

--- a/pages/public_cloud/compute/save_an_instance/guide.pt-pt.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: 'Guardar uma instância'
 excerpt: 'Saiba como efetuar o backup de uma instância Public Cloud a partir da Área de Cliente OVHcloud'
-updated: 2023-01-04
+updated: 2023-09-21
 ---
 
 > [!primary]
@@ -85,6 +85,9 @@ Os planos podem ser criados e eliminados na secção `Workflow Management`{.acti
 Os backups das suas instâncias são geridos na secção `Instance Backup`{.action} da sua Área de Cliente Public Cloud.
 
 ![public-cloud-instance-backup](images/createbackup10.png){.thumbnail}
+
+> [!warning]
+> **Tenha em atenção que não é possível eliminar um backup de instância se uma instância gerada a partir deste backup estiver a ser executada no momento da ação de eliminação.**
 
 Saiba como utilizar os backups para clonar ou restaurar instâncias neste [guia](/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup).
 


### PR DESCRIPTION
Related to this issue opened on public cloud roadmap repo : https://github.com/ovh/public-cloud-roadmap/issues/459

Add the fact that an instance back up cannot be deleted in some cases. 

Please propagate to other en guides + translated ones

Thanks