### PR TITLE
EN-US Update Inconsistency in which services have manual renewal

### DIFF
--- a/pages/account_and_service_management/managing_billing_payments_and_services/faq-billing/guide.en-us.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/faq-billing/guide.en-us.md
@@ -46,7 +46,7 @@ For further information, please read this detailed guide: [Managing renewal for 
 
 ### How do I disable automatic renewal?
 
-Log in to the OVHcloud Control Panel, and click on the `Products and services`{.action} shortcut in the dashboard. Click on the three dots next to the service concerned, then select `Configure renewal`{.action}. You can then choose manual mode. This mode is not available for certain services — e.g. domain names, web hosting plans, VPS, and dedicated servers.
+Log in to the OVHcloud Control Panel, and click on the `Products and services`{.action} shortcut in the dashboard. Click on the three dots next to the service concerned, then select `Configure renewal`{.action}. You can then choose manual mode. This mode is only available for certain services — e.g. domain names, web hosting plans, VPS, and dedicated servers.
 
 To cancel a service, go to [How do I cancel a service?](#cancelservice)
 


### PR DESCRIPTION
The updated FAQ entry is in direct conflict with other entries in the same page and at least one other page.

A [few lines above](https://github.com/ovh/docs/blob/677baab4b41cbd3e7149c1e53703c93df27612ad/pages/account_and_service_management/managing_billing_payments_and_services/faq-billing/guide.en-us.md?plain=1#L28) it is stated that:
> For certain ranges (domains, web hosting plans, VPS and dedicated servers), you can choose a manual renewal method.

As well as in at least [another guide](https://github.com/ovh/docs/blob/677baab4b41cbd3e7149c1e53703c93df27612ad/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-us.md?plain=1#L30):
> You can also set certain products (domain names, Web Hosting plans, VPS, dedicated servers) to *manual* renewal (...)