### PR TITLE
Add -raw to "terraform output kubeconfig"

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.de-de.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-asia.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-au.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-ca.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-gb.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-ie.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-sg.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.en-us.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.es-es.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.es-us.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.fr-ca.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.fr-fr.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.it-it.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.pl-pl.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster-through-terraform/guide.pt-pt.md
@@ -422,7 +422,7 @@ Our cluster is created, now we need to connect to it in order to check our nodes
 In order to do this, retrieve the kubeconfig file locally:
 
 ```
-$ terraform output kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
+$ terraform output -raw kubeconfig > /Users/<your-user>/.kube/my_kube_cluster.yml
 ```
 
 You can define it in your `$KUBECONFIG` environment variable or you can use it directly in the `kubectl` command with `--kubeconfig` option.


### PR DESCRIPTION
Fix the following [issue](https://github.com/ovh/terraform-provider-ovh/issues/487) opened on ovh terraform provider.

The behavior from `terraform output` changed in terraform 0.15 with this [commit](https://github.com/hashicorp/terraform/commit/3268a7eabac90d3b06adeb3599734707be4b5148). The documentation was not reflecting this update which requires to add `-raw` to received the kubeconfig.