### PR TITLE
Mb some ai guides fixes

### DIFF
--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.de-de.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.de-de.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.de-de.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.de-de.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-asia.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-asia.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-asia.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-asia.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-au.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-au.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-au.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-au.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-ca.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-ca.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-ca.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-ca.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-gb.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-gb.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-gb.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-gb.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-ie.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-ie.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-ie.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-ie.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-sg.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-sg.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-sg.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-sg.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-us.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-us.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-us.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.en-us.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.es-es.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.es-es.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.es-es.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.es-es.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.es-us.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.es-us.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.es-us.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.es-us.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.fr-ca.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.fr-ca.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.fr-ca.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.fr-ca.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.fr-fr.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.fr-fr.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.fr-fr.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.fr-fr.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.it-it.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.it-it.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.it-it.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.it-it.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.pl-pl.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.pl-pl.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.pl-pl.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.pl-pl.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.pt-pt.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.pt-pt.md
@@ -60,7 +60,7 @@ print(secrets.token_urlsafe())
 
 The second one will be the algorithm used for the Json web token. The algorithm used will be H256.
 
-You have your two environment variables. Time to save them! Create an `.env` file inside the folder `flask_app`. Your `.env` should look like this:
+You have your two environment variables. Time to save them! Create an `.env` file inside the `flask_app` folder. Your `.env` should look like this:
 
 ```
 JWT_SECRET_KEY=your-jwebtoken-generated-before
@@ -87,7 +87,7 @@ For the chatbot deployment, we will create one object storage bucket. It will co
 To create the volume in GRA (Gravelines data centre) in read-only, go into the folder `ai-training-examples/apps/flask/conversational-rasa-chatbot/back-end/models`. After, you will just have to type:
 
 ```bash
-ovhai bucket object <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
+ovhai bucket object upload <model-output-container>@GRA 20221220-094914-yellow-foley.tar.gz
 ```
 
 The model `20221220-094914-yellow-foley.tar.gz` will be added in your container `<model-output-container>`. That's it, now you can deploy your chatbot.
@@ -114,9 +114,7 @@ docker compose -f flask-docker-compose.yml down
 
 For simplicity, we will use the ovhai CLI. With one command line, you will have your model up and running securely with TLS!
 
-If you have already trained your chatbot with **AI Training** and use the same Dockerfile, you don't have to create and push a new image because the two images are the same. In this case, skip the creation of the container and go directly to the creation of the app. 
-
-We will need to create a container in order to deploy the chatbot. Let's create a Dockerfile, build the container and push it to your personal docker account. Here is the Dockerfile:Docker
+We will need to create a container in order to deploy the chatbot. You don't have to create the Dockerfile since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile) and looks like the following:
  
 ```docker
 FROM python:3.8
@@ -135,13 +133,11 @@ EXPOSE 5005
 CMD rasa run -m trained-models --cors "*" --debug --connector socketio --credentials "crendentials.yml" --endpoints "endpoints.yml" & rasa run actions
 ```
 
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/back-end/rasa.Dockerfile).
-
-Now run the following command in this folder (`back-end`) to build and push the container:
+Now run the following command in this folder (`/apps/flask/conversational-rasa-chatbot/back-end/`) to build and push the container:
 
 ```bash
-docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot:latest
-docker push <yourdockerhubId>/rasa-chatbot:latest
+docker build .  -f rasa.Dockerfile -t <yourdockerhubId>/rasa-chatbot-backend:latest
+docker push <yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Now that your container is created, let's run our application and deploy our model!
@@ -153,7 +149,7 @@ ovhai app run --name rasa-back \
 --cpu 4 \
 --volume <model-output-container>@GRA:/workspace/trained-models:RO \
 -e JWT_SECRET=<JWT_SECRET_KEY> \
-<yourdockerhubId>/rasa-chatbot:latest
+<yourdockerhubId>/rasa-chatbot-backend:latest
 ```
 
 Explanation of each line:
@@ -177,7 +173,7 @@ Explication of the bash command running the chatbot (you can find it inside the 
 - `--endpoints "endpoints.yml"`: Specify the path of the `endpoints.yml` file.
 - `rasa run actions`: The custom actions you've made before to launch them and use them.
 
-Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.0**!
+Now, you can wait until your app is started, then go to the URL. Nothing special will happen, just a small message with **hello from Rasa 3.2.10**!
 
 For better interactions, we will now deploy the Flask frontend.
 For simplification, everything is on the cloned [GitHub repository](https://github.com/ovh/ai-training-examples/tree/main/apps/flask/conversational-rasa-chatbot).
@@ -186,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. This Dockerfile is already created and it is in the folder `front-end`. Here is what it looks like:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8
@@ -204,18 +200,18 @@ EXPOSE 5000
 CMD python3 app.py
 ```
 
-Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the folder `front-end` (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
+Let's now run the app on AI Deploy! To do so, you will need to create a Docker image. Go into the `front-end` folder (`ai-training-examples/apps/flask/conversational-rasa-chatbot/front-end`) and run:
 
 ```bash
-docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app:latest
-docker push <yourdockerhubId>/flask-app:latest
+docker build . -f flask.Dockerfile -t <yourdockerhubId>/flask-app-frontend:latest
+docker push <yourdockerhubId>/flask-app-frontend:latest
 ```
 
 - Deploy the Docker image
 
 Once built, let's run the Frontend application with the ovhai CLI. 
 
-But first, get the URL of your backend Rasa chatbot. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
+But first, get the URL of your backend Rasa chatbot app. It will be something like this: **https://259b36ff-fc61-46a5-9a25-8d9a7b9f8ff6.app.gra.ai.cloud.ovh.net/**. You can have it with the CLI by listing all of your apps and locating the one you want. 
 
 Now you can run this command:
 
@@ -225,7 +221,7 @@ ovhai app run --name flask-app \
 --default-http-port 5000 \
 -e API_URL=<RasaURL_Previously_Copied> \
 --cpu 2 \
-<yourdockerhubId>/flask-app:latest 
+<yourdockerhubId>/flask-app-frontend:latest 
 ```
 
 That's it! On the URL of this app, you can speak to your chatbot. Try to have a simple conversation! If you reload the page, you will notice that the chatbot goes back to zero. So every user is different on each machine.

--- a/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.pt-pt.md
+++ b/pages/public_cloud/ai_machine_learning/deploy_tuto_11_rasa_chatbot_flask/guide.pt-pt.md
@@ -182,7 +182,7 @@ For simplification, everything is on the cloned [GitHub repository](https://gith
 
 - Create the Dockerfile
 
-First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `/front-end/` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
+First, we will need to create the Dockerfile. As before, this Dockerfile has already been created and is located in the `front-end` folder. The file is [here](https://github.com/ovh/ai-training-examples/blob/main/apps/flask/conversational-rasa-chatbot/front-end/flask.Dockerfile) and looks like this:
 
 ```docker
 FROM python:3.8

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.de-de.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.de-de.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-asia.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-asia.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-au.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-au.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-ca.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-ca.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-gb.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-gb.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-ie.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-ie.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-sg.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-sg.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-us.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.en-us.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.es-es.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.es-es.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.es-us.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.es-us.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.fr-ca.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.fr-ca.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.fr-fr.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.fr-fr.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.it-it.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.it-it.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.pl-pl.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.pl-pl.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.pt-pt.md
+++ b/pages/public_cloud/ai_machine_learning/gi_08_s3_compliance/guide.pt-pt.md
@@ -230,7 +230,7 @@ ovhai bucket object upload my-bucket-s3@S3GRA train-first-model.py
 You are now able to list the content of your S3 bucket:
 
 ```console
-ovhai bucket object list my-bucket-s3@S3-GRA
+ovhai bucket object list my-bucket-s3@S3GRA
 ```
 
 You should see your object (here the python file).

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.de-de.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.de-de.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-asia.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-asia.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-au.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-au.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-ca.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-ca.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-gb.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-gb.md
@@ -81,7 +81,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-ie.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-ie.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-sg.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-sg.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-us.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.en-us.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.es-es.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.es-es.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.es-us.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.es-us.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.fr-ca.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.fr-ca.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.fr-fr.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.fr-fr.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.it-it.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.it-it.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.pl-pl.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.pl-pl.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.pt-pt.md
+++ b/pages/public_cloud/ai_machine_learning/notebook_tuto_10_create_chatbot/guide.pt-pt.md
@@ -80,7 +80,7 @@ Explanation of each line:
 
 Your notebook is ready, you can access it and log in. 
 
-Before training an AI model inside the notebook, you must install all the dependencies of Rasa. Open a terminal and launch this command:
+Before training an AI model inside the notebook, you must install all the dependencies of Rasa. To do this, open a terminal by clicking the menu icon > Terminal > New Terminal, and launch the following command:
 
 ```console 
 pip install rasa

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.de-de.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.de-de.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-asia.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-asia.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-au.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-au.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-ca.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-ca.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-gb.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-gb.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-ie.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-ie.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-sg.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-sg.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-us.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.en-us.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.es-es.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.es-es.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.es-us.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.es-us.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.fr-ca.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.fr-ca.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.fr-fr.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.fr-fr.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.it-it.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.it-it.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.pl-pl.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.pl-pl.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 

--- a/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.pt-pt.md
+++ b/pages/public_cloud/ai_machine_learning/training_tuto_07_train_rasa_chatbot/guide.pt-pt.md
@@ -72,10 +72,11 @@ To train the model, we will use AI Training. This tool is much more powerful. It
 
 AI Training allows you to train models directly from your own Docker images.
 
-First, you need to create a Dockerfile compliant with AI Training. You can find an example here:
+First, you need a Dockerfile compliant with AI Training. You don't have to create this file since an example of it can be found in our GitHub repository. This Dockerfile is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot) and looks like the following:
+
 
 ```docker
-FROM python:3.8
+FROM tensorflow/tensorflow:2.12.0-gpu
 
 WORKDIR /workspace
 ADD . /workspace
@@ -90,8 +91,6 @@ EXPOSE 5005
 
 CMD rasa train --force --out trained-models
 ```
-
-This file can be found in the GitHub repository, you don't have to create it. The file is [here](https://github.com/ovh/ai-training-examples/tree/main/jobs/rasa-chatbot).
 
 Secondly, you have to build the Docker image and push it inside your public repository (such as Dockerhub) or in a private directory.
 Here are the two commands to run inside the folder `rasa_bot`:
@@ -134,7 +133,7 @@ ovhai notebook run conda vscode \
 	--token <token> \
 ```
 
-Then install all the requirements by running in a terminal:
+Then install all the requirements by running in a terminal (Click the menu icon > Terminal > New Terminal):
 
 ```bash 
 pip install -r ~/ai-training-examples/jobs/rasa-chatbot/requirements_rasa.txt 


### PR DESCRIPTION
Here is a small PR to correct a few things through different guides:

- **"S3 Compliance with AI Tools"**: There was a typo in an optional command of this guide.
- **"AI Notebooks - Tutorial - Create and train a Rasa chatbot"**: I've added some explanations about opening a terminal on VS Code, since this editor is the less used among those we offer. This step could be tricky for beginners.
- **"AI Training - Tutorial - Train a Rasa chatbot inside a Docker container "**: Fix the docker base image, to make the job usable on GPUs
- **"AI Deploy - Tutorial - Deploy a Rasa chatbot with a simple Flask app "**: I have updated the guide to make it clearer.