### PR TITLE
Cleaning of naming for the product Public Cloud Load Balancer

### DIFF
--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.de-de.md
@@ -109,7 +109,7 @@ It is important to note that a resource (instance) remains fully private in this
 
 #### Load Balancer inside private networking <a name="loadbalancer"></a>
 
-OVHcloud offers the Octavia Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
+OVHcloud offers a Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
 
 The Public Cloud Load Balancer remains fully private, therefore it needs a Gateway service to access the public network and Floating IP for outbound service exposure.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-asia.md
@@ -109,7 +109,7 @@ It is important to note that a resource (instance) remains fully private in this
 
 #### Load Balancer inside private networking <a name="loadbalancer"></a>
 
-OVHcloud offers the Octavia Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
+OVHcloud offers a Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
 
 The Public Cloud Load Balancer remains fully private, therefore it needs a Gateway service to access the public network and Floating IP for outbound service exposure.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-au.md
@@ -109,7 +109,7 @@ It is important to note that a resource (instance) remains fully private in this
 
 #### Load Balancer inside private networking <a name="loadbalancer"></a>
 
-OVHcloud offers the Octavia Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
+OVHcloud offers a Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
 
 The Public Cloud Load Balancer remains fully private, therefore it needs a Gateway service to access the public network and Floating IP for outbound service exposure.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-ca.md
@@ -109,7 +109,7 @@ It is important to note that a resource (instance) remains fully private in this
 
 #### Load Balancer inside private networking <a name="loadbalancer"></a>
 
-OVHcloud offers the Octavia Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
+OVHcloud offers a Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
 
 The Public Cloud Load Balancer remains fully private, therefore it needs a Gateway service to access the public network and Floating IP for outbound service exposure.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-gb.md
@@ -109,7 +109,7 @@ It is important to note that a resource (instance) remains fully private in this
 
 #### Load Balancer inside private networking <a name="loadbalancer"></a>
 
-OVHcloud offers the Octavia Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
+OVHcloud offers a Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
 
 The Public Cloud Load Balancer remains fully private, therefore it needs a Gateway service to access the public network and Floating IP for outbound service exposure.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-ie.md
@@ -109,7 +109,7 @@ It is important to note that a resource (instance) remains fully private in this
 
 #### Load Balancer inside private networking <a name="loadbalancer"></a>
 
-OVHcloud offers the Octavia Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
+OVHcloud offers a Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
 
 The Public Cloud Load Balancer remains fully private, therefore it needs a Gateway service to access the public network and Floating IP for outbound service exposure.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-sg.md
@@ -109,7 +109,7 @@ It is important to note that a resource (instance) remains fully private in this
 
 #### Load Balancer inside private networking <a name="loadbalancer"></a>
 
-OVHcloud offers the Octavia Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
+OVHcloud offers a Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
 
 The Public Cloud Load Balancer remains fully private, therefore it needs a Gateway service to access the public network and Floating IP for outbound service exposure.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.en-us.md
@@ -109,7 +109,7 @@ It is important to note that a resource (instance) remains fully private in this
 
 #### Load Balancer inside private networking <a name="loadbalancer"></a>
 
-OVHcloud offers the Octavia Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
+OVHcloud offers a Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
 
 The Public Cloud Load Balancer remains fully private, therefore it needs a Gateway service to access the public network and Floating IP for outbound service exposure.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.es-es.md
@@ -109,7 +109,7 @@ It is important to note that a resource (instance) remains fully private in this
 
 #### Load Balancer inside private networking <a name="loadbalancer"></a>
 
-OVHcloud offers the Octavia Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
+OVHcloud offers a Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
 
 The Public Cloud Load Balancer remains fully private, therefore it needs a Gateway service to access the public network and Floating IP for outbound service exposure.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.es-us.md
@@ -109,7 +109,7 @@ It is important to note that a resource (instance) remains fully private in this
 
 #### Load Balancer inside private networking <a name="loadbalancer"></a>
 
-OVHcloud offers the Octavia Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
+OVHcloud offers a Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
 
 The Public Cloud Load Balancer remains fully private, therefore it needs a Gateway service to access the public network and Floating IP for outbound service exposure.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.fr-ca.md
@@ -109,7 +109,7 @@ Il est important de noter qu’une ressource (instance) reste totalement privée
 
 #### Load Balancer dans un réseau privé <a name="loadbalancer"></a>
 
-OVHcloud propose l'Octavia Load Balancer dans le cadre de l'écosystème Public Cloud. Il offre la plus grande flexibilité pour faire évoluer vos applications.
+OVHcloud propose un Load Balancer dans le cadre de l'écosystème Public Cloud. Il offre la plus grande flexibilité pour faire évoluer vos applications.
 
 Le Public Cloud Load Balancer reste entièrement privé, il a donc besoin d'un service Gateway pour accéder au réseau public et d'une Floating IP pour l'exposition du service sortant.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.fr-fr.md
@@ -109,7 +109,7 @@ Il est important de noter qu’une ressource (instance) reste totalement privée
 
 #### Load Balancer dans un réseau privé <a name="loadbalancer"></a>
 
-OVHcloud propose l'Octavia Load Balancer dans le cadre de l'écosystème Public Cloud. Il offre la plus grande flexibilité pour faire évoluer vos applications.
+OVHcloud propose un Load Balancer dans le cadre de l'écosystème Public Cloud. Il offre la plus grande flexibilité pour faire évoluer vos applications.
 
 Le Public Cloud Load Balancer reste entièrement privé, il a donc besoin d'un service Gateway pour accéder au réseau public et d'une Floating IP pour l'exposition du service sortant.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.it-it.md
@@ -109,7 +109,7 @@ It is important to note that a resource (instance) remains fully private in this
 
 #### Load Balancer inside private networking <a name="loadbalancer"></a>
 
-OVHcloud offers the Octavia Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
+OVHcloud offers a Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
 
 The Public Cloud Load Balancer remains fully private, therefore it needs a Gateway service to access the public network and Floating IP for outbound service exposure.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.pl-pl.md
@@ -109,7 +109,7 @@ It is important to note that a resource (instance) remains fully private in this
 
 #### Load Balancer inside private networking <a name="loadbalancer"></a>
 
-OVHcloud offers the Octavia Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
+OVHcloud offers a Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
 
 The Public Cloud Load Balancer remains fully private, therefore it needs a Gateway service to access the public network and Floating IP for outbound service exposure.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-01-public-cloud-networking-concepts/guide.pt-pt.md
@@ -109,7 +109,7 @@ It is important to note that a resource (instance) remains fully private in this
 
 #### Load Balancer inside private networking <a name="loadbalancer"></a>
 
-OVHcloud offers the Octavia Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
+OVHcloud offers a Load Balancer as part of the Public Cloud ecosystem. This provides the most flexibility for scaling your applications.
 
 The Public Cloud Load Balancer remains fully private, therefore it needs a Gateway service to access the public network and Floating IP for outbound service exposure.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.de-de.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objective
 
-Our new Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} and is fully integrated into the Public Cloud universe.
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe.
 
 **Learn how to configure an OVHcloud Load Balancer with the help of this guide.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-asia.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objective
 
-Our new Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} and is fully integrated into the Public Cloud universe.
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe.
 
 **Learn how to configure an OVHcloud Load Balancer with the help of this guide.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-au.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objective
 
-Our new Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} and is fully integrated into the Public Cloud universe.
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe.
 
 **Learn how to configure an OVHcloud Load Balancer with the help of this guide.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-ca.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objective
 
-Our new Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} and is fully integrated into the Public Cloud universe.
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe.
 
 **Learn how to configure an OVHcloud Load Balancer with the help of this guide.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-gb.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objective
 
-Our new Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} and is fully integrated into the Public Cloud universe.
+Our Public Cloud Load Balancer  is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 **Learn how to configure an OVHcloud Load Balancer with the help of this guide.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-ie.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objective
 
-Our new Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} and is fully integrated into the Public Cloud universe.
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe.
 
 **Learn how to configure an OVHcloud Load Balancer with the help of this guide.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-sg.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objective
 
-Our new Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} and is fully integrated into the Public Cloud universe.
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe.
 
 **Learn how to configure an OVHcloud Load Balancer with the help of this guide.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.en-us.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objective
 
-Our new Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} and is fully integrated into the Public Cloud universe.
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe.
 
 **Learn how to configure an OVHcloud Load Balancer with the help of this guide.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.es-es.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objective
 
-Our new Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} and is fully integrated into the Public Cloud universe.
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe.
 
 **Learn how to configure an OVHcloud Load Balancer with the help of this guide.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.es-us.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objective
 
-Our new Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} and is fully integrated into the Public Cloud universe.
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe.
 
 **Learn how to configure an OVHcloud Load Balancer with the help of this guide.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.fr-ca.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objectif
 
-Notre nouvelle solution Load Balancer as a Service (LBaaS) est basée sur le service [Openstack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} et est entièrement intégrée dans l'univers Public Cloud.
+Notre Load Balancer Public Cloud est basé sur le service [Openstack Octavia](https://wiki.openstack.org/wiki/Octavia){.external} et est entièrement intégré dans l'univers Public Cloud.
 
 **Découvrez comment débuter avec un Load Balancer sur le Public Cloud.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.fr-fr.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objectif
 
-Notre nouvelle solution Load Balancer as a Service (LBaaS) est basée sur le service [Openstack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} et est entièrement intégrée dans l'univers Public Cloud.
+Notre Load Balancer Public Cloud est basé sur le service [Openstack Octavia](https://wiki.openstack.org/wiki/Octavia){.external} et est entièrement intégré dans l'univers Public Cloud.
 
 **Découvrez comment débuter avec un Load Balancer sur le Public Cloud.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.it-it.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objective
 
-Our new Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} and is fully integrated into the Public Cloud universe.
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe.
 
 **Learn how to configure an OVHcloud Load Balancer with the help of this guide.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.pl-pl.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objective
 
-Our new Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} and is fully integrated into the Public Cloud universe.
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe.
 
 **Learn how to configure an OVHcloud Load Balancer with the help of this guide.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service/guide.pt-pt.md
@@ -6,7 +6,7 @@ updated: 2022-11-02
 
 ## Objective
 
-Our new Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://docs.openstack.org/octavia/queens/reference/introduction.html){.external} and is fully integrated into the Public Cloud universe.
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe.
 
 **Learn how to configure an OVHcloud Load Balancer with the help of this guide.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.de-de.md
@@ -23,9 +23,9 @@ As of today, other setups (including cross-universe usage with baremetal servers
 
 A beta is ongoing to provide integration with Managed Kubernetes Service. Please reach out on the [Discord community](https://discord.gg/ovhcloud) on the channel **#beta-lb-for-k8s**
 
-### I want to monitor Octavia Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
+### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023.
+Yes this feature is available since we rolled out Zed version in June 2023. You can find more information on [this page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 
@@ -39,7 +39,7 @@ No. A new type of IP has been introduced for this purpose, Floating IP. It's mor
 
 Yes, multiple listeners (frontends) and pool (backends) can be configured. There is only a limitation of a single Floating IP per Load Balancer.
 
-### What's happening if our Octavia Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
+### What's happening if our Public Cloud Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
 
 First of all, the values shown are only a rough estimate of the Load Balancer's capabilities. The price will not increase. Pricing is linked to the flavors (small, medium, large) and we cannot change the flavor at this time. This is up to customers' orchestration services. 
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-asia.md
@@ -23,9 +23,9 @@ As of today, other setups (including cross-universe usage with baremetal servers
 
 A beta is ongoing to provide integration with Managed Kubernetes Service. Please reach out on the [Discord community](https://discord.gg/ovhcloud) on the channel **#beta-lb-for-k8s**
 
-### I want to monitor Octavia Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
+### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023.
+Yes this feature is available since we rolled out Zed version in June 2023. You can find more information on [this page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 
@@ -39,7 +39,7 @@ No. A new type of IP has been introduced for this purpose, Floating IP. It's mor
 
 Yes, multiple listeners (frontends) and pool (backends) can be configured. There is only a limitation of a single Floating IP per Load Balancer.
 
-### What's happening if our Octavia Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
+### What's happening if our Public Cloud Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
 
 First of all, the values shown are only a rough estimate of the Load Balancer's capabilities. The price will not increase. Pricing is linked to the flavors (small, medium, large) and we cannot change the flavor at this time. This is up to customers' orchestration services. 
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-au.md
@@ -23,9 +23,9 @@ As of today, other setups (including cross-universe usage with baremetal servers
 
 A beta is ongoing to provide integration with Managed Kubernetes Service. Please reach out on the [Discord community](https://discord.gg/ovhcloud) on the channel **#beta-lb-for-k8s**
 
-### I want to monitor Octavia Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
+### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023.
+Yes this feature is available since we rolled out Zed version in June 2023. You can find more information on [this page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 
@@ -39,7 +39,7 @@ No. A new type of IP has been introduced for this purpose, Floating IP. It's mor
 
 Yes, multiple listeners (frontends) and pool (backends) can be configured. There is only a limitation of a single Floating IP per Load Balancer.
 
-### What's happening if our Octavia Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
+### What's happening if our Public Cloud Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
 
 First of all, the values shown are only a rough estimate of the Load Balancer's capabilities. The price will not increase. Pricing is linked to the flavors (small, medium, large) and we cannot change the flavor at this time. This is up to customers' orchestration services. 
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-ca.md
@@ -23,9 +23,9 @@ As of today, other setups (including cross-universe usage with baremetal servers
 
 A beta is ongoing to provide integration with Managed Kubernetes Service. Please reach out on the [Discord community](https://discord.gg/ovhcloud) on the channel **#beta-lb-for-k8s**
 
-### I want to monitor Octavia Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
+### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023.
+Yes this feature is available since we rolled out Zed version in June 2023. You can find more information on [this page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 
@@ -39,7 +39,7 @@ No. A new type of IP has been introduced for this purpose, Floating IP. It's mor
 
 Yes, multiple listeners (frontends) and pool (backends) can be configured. There is only a limitation of a single Floating IP per Load Balancer.
 
-### What's happening if our Octavia Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
+### What's happening if our Public Cloud Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
 
 First of all, the values shown are only a rough estimate of the Load Balancer's capabilities. The price will not increase. Pricing is linked to the flavors (small, medium, large) and we cannot change the flavor at this time. This is up to customers' orchestration services. 
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-gb.md
@@ -23,9 +23,9 @@ As of today, other setups (including cross-universe usage with baremetal servers
 
 A beta is ongoing to provide integration with Managed Kubernetes Service. Please reach out on the [Discord community](https://discord.gg/ovhcloud) on the channel **#beta-lb-for-k8s**
 
-### I want to monitor Octavia Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
+### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023.
+Yes this feature is available since we rolled out Zed version in June 2023. Check this [page](../technical-resources-02-octavia-monitoring-prometheus/guide.en-gb.md)
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 
@@ -39,7 +39,7 @@ No. A new type of IP has been introduced for this purpose, Floating IP. It's mor
 
 Yes, multiple listeners (frontends) and pool (backends) can be configured. There is only a limitation of a single Floating IP per Load Balancer.
 
-### What's happening if our Octavia Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
+### What's happening if our Public Cloud Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
 
 First of all, the values shown are only a rough estimate of the Load Balancer's capabilities. The price will not increase. Pricing is linked to the flavors (small, medium, large) and we cannot change the flavor at this time. This is up to customers' orchestration services. 
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-gb.md
@@ -25,7 +25,7 @@ A beta is ongoing to provide integration with Managed Kubernetes Service. Please
 
 ### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023. Check this [page](../technical-resources-02-octavia-monitoring-prometheus/guide.en-gb.md)
+Yes this feature is available since we rolled out Zed version in June 2023. You can find more information on [this page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-ie.md
@@ -23,9 +23,9 @@ As of today, other setups (including cross-universe usage with baremetal servers
 
 A beta is ongoing to provide integration with Managed Kubernetes Service. Please reach out on the [Discord community](https://discord.gg/ovhcloud) on the channel **#beta-lb-for-k8s**
 
-### I want to monitor Octavia Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
+### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023.
+Yes this feature is available since we rolled out Zed version in June 2023. You can find more information on [this page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 
@@ -39,7 +39,7 @@ No. A new type of IP has been introduced for this purpose, Floating IP. It's mor
 
 Yes, multiple listeners (frontends) and pool (backends) can be configured. There is only a limitation of a single Floating IP per Load Balancer.
 
-### What's happening if our Octavia Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
+### What's happening if our Public Cloud Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
 
 First of all, the values shown are only a rough estimate of the Load Balancer's capabilities. The price will not increase. Pricing is linked to the flavors (small, medium, large) and we cannot change the flavor at this time. This is up to customers' orchestration services. 
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-sg.md
@@ -23,9 +23,9 @@ As of today, other setups (including cross-universe usage with baremetal servers
 
 A beta is ongoing to provide integration with Managed Kubernetes Service. Please reach out on the [Discord community](https://discord.gg/ovhcloud) on the channel **#beta-lb-for-k8s**
 
-### I want to monitor Octavia Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
+### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023.
+Yes this feature is available since we rolled out Zed version in June 2023. You can find more information on [this page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 
@@ -39,7 +39,7 @@ No. A new type of IP has been introduced for this purpose, Floating IP. It's mor
 
 Yes, multiple listeners (frontends) and pool (backends) can be configured. There is only a limitation of a single Floating IP per Load Balancer.
 
-### What's happening if our Octavia Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
+### What's happening if our Public Cloud Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
 
 First of all, the values shown are only a rough estimate of the Load Balancer's capabilities. The price will not increase. Pricing is linked to the flavors (small, medium, large) and we cannot change the flavor at this time. This is up to customers' orchestration services. 
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.en-us.md
@@ -23,9 +23,9 @@ As of today, other setups (including cross-universe usage with baremetal servers
 
 A beta is ongoing to provide integration with Managed Kubernetes Service. Please reach out on the [Discord community](https://discord.gg/ovhcloud) on the channel **#beta-lb-for-k8s**
 
-### I want to monitor Octavia Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
+### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023.
+Yes this feature is available since we rolled out Zed version in June 2023. You can find more information on [this page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 
@@ -39,7 +39,7 @@ No. A new type of IP has been introduced for this purpose, Floating IP. It's mor
 
 Yes, multiple listeners (frontends) and pool (backends) can be configured. There is only a limitation of a single Floating IP per Load Balancer.
 
-### What's happening if our Octavia Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
+### What's happening if our Public Cloud Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
 
 First of all, the values shown are only a rough estimate of the Load Balancer's capabilities. The price will not increase. Pricing is linked to the flavors (small, medium, large) and we cannot change the flavor at this time. This is up to customers' orchestration services. 
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.es-es.md
@@ -23,9 +23,9 @@ As of today, other setups (including cross-universe usage with baremetal servers
 
 A beta is ongoing to provide integration with Managed Kubernetes Service. Please reach out on the [Discord community](https://discord.gg/ovhcloud) on the channel **#beta-lb-for-k8s**
 
-### I want to monitor Octavia Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
+### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023.
+Yes this feature is available since we rolled out Zed version in June 2023. You can find more information on [this page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 
@@ -39,7 +39,7 @@ No. A new type of IP has been introduced for this purpose, Floating IP. It's mor
 
 Yes, multiple listeners (frontends) and pool (backends) can be configured. There is only a limitation of a single Floating IP per Load Balancer.
 
-### What's happening if our Octavia Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
+### What's happening if our Public Cloud Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
 
 First of all, the values shown are only a rough estimate of the Load Balancer's capabilities. The price will not increase. Pricing is linked to the flavors (small, medium, large) and we cannot change the flavor at this time. This is up to customers' orchestration services. 
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.es-us.md
@@ -23,9 +23,9 @@ As of today, other setups (including cross-universe usage with baremetal servers
 
 A beta is ongoing to provide integration with Managed Kubernetes Service. Please reach out on the [Discord community](https://discord.gg/ovhcloud) on the channel **#beta-lb-for-k8s**
 
-### I want to monitor Octavia Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
+### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023.
+Yes this feature is available since we rolled out Zed version in June 2023. You can find more information on [this page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 
@@ -39,7 +39,7 @@ No. A new type of IP has been introduced for this purpose, Floating IP. It's mor
 
 Yes, multiple listeners (frontends) and pool (backends) can be configured. There is only a limitation of a single Floating IP per Load Balancer.
 
-### What's happening if our Octavia Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
+### What's happening if our Public Cloud Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
 
 First of all, the values shown are only a rough estimate of the Load Balancer's capabilities. The price will not increase. Pricing is linked to the flavors (small, medium, large) and we cannot change the flavor at this time. This is up to customers' orchestration services. 
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.fr-ca.md
@@ -23,9 +23,9 @@ Actuellement, ces modes ne sont pas pris en charge. Pour du load balancing publi
 
 Une version bêta est en cours pour fournir une intégration avec Managed Kubernetes Service. Merci de contacter notre [communauté Discord](https://discord.gg/ovhcloud) sur le canal **#beta-lb-for-k8s**
 
-### Je souhaite monitorer le Load Balancer Octavia. Est-il possible d’activer [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatiquement sur le Load Balancer ?
+### Je souhaite monitorer mon Load Balancer Public Cloud. Est-il possible d’activer [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatiquement sur le Load Balancer ?
 
-Oui cette fonctionnalité est disponible depuis le déploiement de la version Zed en juin 2023.
+Oui cette fonctionnalité est disponible depuis le déploiement de la version Zed en juin 2023. Retrouvez plus d'informations sur [cette page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### Comment est mise en oeuvre la redondance pour chaque type d'offre ? Les Amphoras sont-ils configurés en mode ACT/STBY ?
 
@@ -39,7 +39,7 @@ Non, un nouveau type d’adresse IP a été créé pour ce rôle, Floating IP. C
 
 Oui, plusieurs *listeners* (frontends) et *pools* (backends) peuvent être configurés. Il n'y a qu'une limitation d'une seule Floating IP par Load Balancer.
 
-### Que se passe-t-il si l'Octavia Load Balancer reçoit plus de requêtes que prévu ? Le prix va-t-il augmenter ? En serai-je informé ?
+### Que se passe-t-il si le Load Balancer Public Cloud reçoit plus de requêtes que prévu ? Le prix va-t-il augmenter ? En serai-je informé ?
 
 Tout d'abord, les valeurs indiquées ne sont qu'une estimation des capacités du Load Balancer. Le prix n'augmentera pas. La tarification est liée aux types (small, medium, large) et nous ne pouvons pas changer la flavor pour le moment. Le choix d'orchestration de ses services est à la charge du client.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.fr-fr.md
@@ -23,10 +23,9 @@ Actuellement, ces modes ne sont pas pris en charge. Pour du load balancing publi
 
 Une version bêta est en cours pour fournir une intégration avec Managed Kubernetes Service. Merci de contacter notre [communauté Discord](https://discord.gg/ovhcloud) sur le canal **#beta-lb-for-k8s**
 
+### Je souhaite monitorer mon Load Balancer Public Cloud. Est-il possible d’activer [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatiquement sur le Load Balancer ?
 
-### Je souhaite monitorer le Load Balancer Octavia. Est-il possible d’activer [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatiquement sur le Load Balancer ?
-
-Oui cette fonctionnalité est disponible depuis le déploiement de la version Zed en juin 2023.
+Oui cette fonctionnalité est disponible depuis le déploiement de la version Zed en juin 2023. Retrouvez plus d'informations sur [cette page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### Comment est mise en oeuvre la redondance pour chaque type d'offre ? Les Amphoras sont-ils configurés en mode ACT/STBY ?
 
@@ -40,7 +39,7 @@ Non, un nouveau type d’adresse IP a été créé pour ce rôle, Floating IP. C
 
 Oui, plusieurs *listeners* (frontends) et *pools* (backends) peuvent être configurés. Il n'y a qu'une limitation d'une seule Floating IP par Load Balancer.
 
-### Que se passe-t-il si l'Octavia Load Balancer reçoit plus de requêtes que prévu ? Le prix va-t-il augmenter ? En serai-je informé ?
+### Que se passe-t-il si le Load Balancer Public Cloud reçoit plus de requêtes que prévu ? Le prix va-t-il augmenter ? En serai-je informé ?
 
 Tout d'abord, les valeurs indiquées ne sont qu'une estimation des capacités du Load Balancer. Le prix n'augmentera pas. La tarification est liée aux types (small, medium, large) et nous ne pouvons pas changer la flavor pour le moment. Le choix d'orchestration de ses services est à la charge du client.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.it-it.md
@@ -23,9 +23,9 @@ As of today, other setups (including cross-universe usage with baremetal servers
 
 A beta is ongoing to provide integration with Managed Kubernetes Service. Please reach out on the [Discord community](https://discord.gg/ovhcloud) on the channel **#beta-lb-for-k8s**
 
-### I want to monitor Octavia Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
+### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023.
+Yes this feature is available since we rolled out Zed version in June 2023. You can find more information on [this page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 
@@ -39,7 +39,7 @@ No. A new type of IP has been introduced for this purpose, Floating IP. It's mor
 
 Yes, multiple listeners (frontends) and pool (backends) can be configured. There is only a limitation of a single Floating IP per Load Balancer.
 
-### What's happening if our Octavia Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
+### What's happening if our Public Cloud Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
 
 First of all, the values shown are only a rough estimate of the Load Balancer's capabilities. The price will not increase. Pricing is linked to the flavors (small, medium, large) and we cannot change the flavor at this time. This is up to customers' orchestration services. 
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.pl-pl.md
@@ -23,9 +23,9 @@ As of today, other setups (including cross-universe usage with baremetal servers
 
 A beta is ongoing to provide integration with Managed Kubernetes Service. Please reach out on the [Discord community](https://discord.gg/ovhcloud) on the channel **#beta-lb-for-k8s**
 
-### I want to monitor Octavia Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
+### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023.
+Yes this feature is available since we rolled out Zed version in June 2023. You can find more information on [this page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 
@@ -39,7 +39,7 @@ No. A new type of IP has been introduced for this purpose, Floating IP. It's mor
 
 Yes, multiple listeners (frontends) and pool (backends) can be configured. There is only a limitation of a single Floating IP per Load Balancer.
 
-### What's happening if our Octavia Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
+### What's happening if our Public Cloud Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
 
 First of all, the values shown are only a rough estimate of the Load Balancer's capabilities. The price will not increase. Pricing is linked to the flavors (small, medium, large) and we cannot change the flavor at this time. This is up to customers' orchestration services. 
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-06-faq/guide.pt-pt.md
@@ -23,9 +23,9 @@ As of today, other setups (including cross-universe usage with baremetal servers
 
 A beta is ongoing to provide integration with Managed Kubernetes Service. Please reach out on the [Discord community](https://discord.gg/ovhcloud) on the channel **#beta-lb-for-k8s**
 
-### I want to monitor Octavia Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
+### I want to monitor my Public Cloud Load Balancer. Is it possible to enable [metrics](https://docs.openstack.org/octavia/latest/user/guides/monitoring.html) automatically on Load Balancer?
 
-Yes this feature is available since we rolled out Zed version in June 2023.
+Yes this feature is available since we rolled out Zed version in June 2023. You can find more information on [this page](/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus).
 
 ### How is the redundancy implemented for each type of service plan? Are the Amphoras configured in a ACT/STBY mode?
 
@@ -39,7 +39,7 @@ No. A new type of IP has been introduced for this purpose, Floating IP. It's mor
 
 Yes, multiple listeners (frontends) and pool (backends) can be configured. There is only a limitation of a single Floating IP per Load Balancer.
 
-### What's happening if our Octavia Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
+### What's happening if our Public Cloud Load Balancer receives more requests than indicated? Will the price increase? Will I be notified?
 
 First of all, the values shown are only a rough estimate of the Load Balancer's capabilities. The price will not increase. Pricing is linked to the flavors (small, medium, large) and we cannot change the flavor at this time. This is up to customers' orchestration services. 
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.de-de.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying an Octavia Load Balancer (EN)
-excerpt: Find out how to configure the Octavia LBaaS for Public Cloud
+title: Deploying a Public Cloud Load Balancer (EN)
+excerpt: Find out how to configure the Public Cloud Load Balancer
 updated: 2024-01-10
 ---
 
@@ -69,12 +69,12 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 > 
 > If you do not provide the parameter `--flavor` during the creation, the Load Balancer will be of a small size.
 > 
 
-Use the following command to display the Octavia flavors in OpenStack:
+Use the following command to display the flavors in OpenStack:
 
 ```bash
 ❯ openstack loadbalancer flavor list
@@ -87,9 +87,9 @@ Use the following command to display the Octavia flavors in OpenStack:
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> The Octavia Load Balancer creation will take some time, mainly to create the instance and to configure the network.
+> The Load Balancer creation will take some time, mainly to create the instance and to configure the network.
 >
 > For the next configuration, you will have to wait until the `provisioning_status` becomes `ACTIVE`.
 
@@ -212,7 +212,7 @@ Backend 2
 
 ### Load Balancer with a public IP (Public → Private)
 
-We will be using the Octavia Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
+We will be using the Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
 
 We will need to create a Floating IP address on the public network (Ext-Net), and then associate it to the Load Balancer's VIP port.
 
@@ -225,7 +225,7 @@ Floating IP addresses are used in the OpenStack universe to expose resources (Ne
 You can expose two types of resources:
 
 - An instance with a private port
-- An Octavia Load Balancer Virtual IP address (VIP)
+- An Load Balancer Virtual IP address (VIP)
 
 Floating IP currently does not support IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-asia.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying an Octavia Load Balancer
-excerpt: Find out how to configure the Octavia LBaaS for Public Cloud
+title: Deploying a Public Cloud Load Balancer
+excerpt: Find out how to configure the Public Cloud Load Balancer
 updated: 2024-01-10
 ---
 
@@ -69,12 +69,12 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 > 
 > If you do not provide the parameter `--flavor` during the creation, the Load Balancer will be of a small size.
 > 
 
-Use the following command to display the Octavia flavors in OpenStack:
+Use the following command to display the flavors in OpenStack:
 
 ```bash
 ❯ openstack loadbalancer flavor list
@@ -87,9 +87,9 @@ Use the following command to display the Octavia flavors in OpenStack:
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> The Octavia Load Balancer creation will take some time, mainly to create the instance and to configure the network.
+> The Load Balancer creation will take some time, mainly to create the instance and to configure the network.
 >
 > For the next configuration, you will have to wait until the `provisioning_status` becomes `ACTIVE`.
 
@@ -212,7 +212,7 @@ Backend 2
 
 ### Load Balancer with a public IP (Public → Private)
 
-We will be using the Octavia Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
+We will be using the Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
 
 We will need to create a Floating IP address on the public network (Ext-Net), and then associate it to the Load Balancer's VIP port.
 
@@ -225,7 +225,7 @@ Floating IP addresses are used in the OpenStack universe to expose resources (Ne
 You can expose two types of resources:
 
 - An instance with a private port
-- An Octavia Load Balancer Virtual IP address (VIP)
+- An Load Balancer Virtual IP address (VIP)
 
 Floating IP currently does not support IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-au.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying an Octavia Load Balancer
-excerpt: Find out how to configure the Octavia LBaaS for Public Cloud
+title: Deploying a Public Cloud Load Balancer
+excerpt: Find out how to configure the Public Cloud Load Balancer
 updated: 2024-01-10
 ---
 
@@ -69,12 +69,12 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 > 
 > If you do not provide the parameter `--flavor` during the creation, the Load Balancer will be of a small size.
 > 
 
-Use the following command to display the Octavia flavors in OpenStack:
+Use the following command to display the flavors in OpenStack:
 
 ```bash
 ❯ openstack loadbalancer flavor list
@@ -87,9 +87,9 @@ Use the following command to display the Octavia flavors in OpenStack:
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> The Octavia Load Balancer creation will take some time, mainly to create the instance and to configure the network.
+> The Load Balancer creation will take some time, mainly to create the instance and to configure the network.
 >
 > For the next configuration, you will have to wait until the `provisioning_status` becomes `ACTIVE`.
 
@@ -212,7 +212,7 @@ Backend 2
 
 ### Load Balancer with a public IP (Public → Private)
 
-We will be using the Octavia Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
+We will be using the Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
 
 We will need to create a Floating IP address on the public network (Ext-Net), and then associate it to the Load Balancer's VIP port.
 
@@ -225,7 +225,7 @@ Floating IP addresses are used in the OpenStack universe to expose resources (Ne
 You can expose two types of resources:
 
 - An instance with a private port
-- An Octavia Load Balancer Virtual IP address (VIP)
+- An Load Balancer Virtual IP address (VIP)
 
 Floating IP currently does not support IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-ca.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying an Octavia Load Balancer
-excerpt: Find out how to configure the Octavia LBaaS for Public Cloud
+title: Deploying a Public Cloud Load Balancer
+excerpt: Find out how to configure the Public Cloud Load Balancer
 updated: 2024-01-10
 ---
 
@@ -69,12 +69,12 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 > 
 > If you do not provide the parameter `--flavor` during the creation, the Load Balancer will be of a small size.
 > 
 
-Use the following command to display the Octavia flavors in OpenStack:
+Use the following command to display the flavors in OpenStack:
 
 ```bash
 ❯ openstack loadbalancer flavor list
@@ -87,9 +87,9 @@ Use the following command to display the Octavia flavors in OpenStack:
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> The Octavia Load Balancer creation will take some time, mainly to create the instance and to configure the network.
+> The Load Balancer creation will take some time, mainly to create the instance and to configure the network.
 >
 > For the next configuration, you will have to wait until the `provisioning_status` becomes `ACTIVE`.
 
@@ -212,7 +212,7 @@ Backend 2
 
 ### Load Balancer with a public IP (Public → Private)
 
-We will be using the Octavia Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
+We will be using the Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
 
 We will need to create a Floating IP address on the public network (Ext-Net), and then associate it to the Load Balancer's VIP port.
 
@@ -225,7 +225,7 @@ Floating IP addresses are used in the OpenStack universe to expose resources (Ne
 You can expose two types of resources:
 
 - An instance with a private port
-- An Octavia Load Balancer Virtual IP address (VIP)
+- An Load Balancer Virtual IP address (VIP)
 
 Floating IP currently does not support IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-gb.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying an Octavia Load Balancer
-excerpt: Find out how to configure the Octavia LBaaS for Public Cloud
+title: Deploying a Public Cloud Load Balancer
+excerpt: Find out how to configure the Public Cloud Load Balancer
 updated: 2024-01-10
 ---
 
@@ -69,12 +69,12 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 > 
 > If you do not provide the parameter `--flavor` during the creation, the Load Balancer will be of a small size.
 > 
 
-Use the following command to display the Octavia flavors in OpenStack:
+Use the following command to display the flavors in OpenStack:
 
 ```bash
 ❯ openstack loadbalancer flavor list
@@ -87,9 +87,9 @@ Use the following command to display the Octavia flavors in OpenStack:
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> The Octavia Load Balancer creation will take some time, mainly to create the instance and to configure the network.
+> The Load Balancer creation will take some time, mainly to create the instance and to configure the network.
 >
 > For the next configuration, you will have to wait until the `provisioning_status` becomes `ACTIVE`.
 
@@ -212,7 +212,7 @@ Backend 2
 
 ### Load Balancer with a public IP (Public → Private)
 
-We will be using the Octavia Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
+We will be using the Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
 
 We will need to create a Floating IP address on the public network (Ext-Net), and then associate it to the Load Balancer's VIP port.
 
@@ -225,7 +225,7 @@ Floating IP addresses are used in the OpenStack universe to expose resources (Ne
 You can expose two types of resources:
 
 - An instance with a private port
-- An Octavia Load Balancer Virtual IP address (VIP)
+- An Load Balancer Virtual IP address (VIP)
 
 Floating IP currently does not support IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-ie.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying an Octavia Load Balancer
-excerpt: Find out how to configure the Octavia LBaaS for Public Cloud
+title: Deploying a Public Cloud Load Balancer
+excerpt: Find out how to configure the Public Cloud Load Balancer
 updated: 2024-01-10
 ---
 
@@ -69,12 +69,12 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 > 
 > If you do not provide the parameter `--flavor` during the creation, the Load Balancer will be of a small size.
 > 
 
-Use the following command to display the Octavia flavors in OpenStack:
+Use the following command to display the flavors in OpenStack:
 
 ```bash
 ❯ openstack loadbalancer flavor list
@@ -87,9 +87,9 @@ Use the following command to display the Octavia flavors in OpenStack:
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> The Octavia Load Balancer creation will take some time, mainly to create the instance and to configure the network.
+> The Load Balancer creation will take some time, mainly to create the instance and to configure the network.
 >
 > For the next configuration, you will have to wait until the `provisioning_status` becomes `ACTIVE`.
 
@@ -212,7 +212,7 @@ Backend 2
 
 ### Load Balancer with a public IP (Public → Private)
 
-We will be using the Octavia Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
+We will be using the Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
 
 We will need to create a Floating IP address on the public network (Ext-Net), and then associate it to the Load Balancer's VIP port.
 
@@ -225,7 +225,7 @@ Floating IP addresses are used in the OpenStack universe to expose resources (Ne
 You can expose two types of resources:
 
 - An instance with a private port
-- An Octavia Load Balancer Virtual IP address (VIP)
+- An Load Balancer Virtual IP address (VIP)
 
 Floating IP currently does not support IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-sg.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying an Octavia Load Balancer
-excerpt: Find out how to configure the Octavia LBaaS for Public Cloud
+title: Deploying a Public Cloud Load Balancer
+excerpt: Find out how to configure the Public Cloud Load Balancer
 updated: 2024-01-10
 ---
 
@@ -69,12 +69,12 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 > 
 > If you do not provide the parameter `--flavor` during the creation, the Load Balancer will be of a small size.
 > 
 
-Use the following command to display the Octavia flavors in OpenStack:
+Use the following command to display the flavors in OpenStack:
 
 ```bash
 ❯ openstack loadbalancer flavor list
@@ -87,9 +87,9 @@ Use the following command to display the Octavia flavors in OpenStack:
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> The Octavia Load Balancer creation will take some time, mainly to create the instance and to configure the network.
+> The Load Balancer creation will take some time, mainly to create the instance and to configure the network.
 >
 > For the next configuration, you will have to wait until the `provisioning_status` becomes `ACTIVE`.
 
@@ -212,7 +212,7 @@ Backend 2
 
 ### Load Balancer with a public IP (Public → Private)
 
-We will be using the Octavia Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
+We will be using the Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
 
 We will need to create a Floating IP address on the public network (Ext-Net), and then associate it to the Load Balancer's VIP port.
 
@@ -225,7 +225,7 @@ Floating IP addresses are used in the OpenStack universe to expose resources (Ne
 You can expose two types of resources:
 
 - An instance with a private port
-- An Octavia Load Balancer Virtual IP address (VIP)
+- An Load Balancer Virtual IP address (VIP)
 
 Floating IP currently does not support IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-us.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying an Octavia Load Balancer
-excerpt: Find out how to configure the Octavia LBaaS for Public Cloud
+title: Deploying a Public Cloud Load Balancer
+excerpt: Find out how to configure the Public Cloud Load Balancer
 updated: 2024-01-10
 ---
 
@@ -69,12 +69,12 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 > 
 > If you do not provide the parameter `--flavor` during the creation, the Load Balancer will be of a small size.
 > 
 
-Use the following command to display the Octavia flavors in OpenStack:
+Use the following command to display the flavors in OpenStack:
 
 ```bash
 ❯ openstack loadbalancer flavor list
@@ -87,9 +87,9 @@ Use the following command to display the Octavia flavors in OpenStack:
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> The Octavia Load Balancer creation will take some time, mainly to create the instance and to configure the network.
+> The Load Balancer creation will take some time, mainly to create the instance and to configure the network.
 >
 > For the next configuration, you will have to wait until the `provisioning_status` becomes `ACTIVE`.
 
@@ -212,7 +212,7 @@ Backend 2
 
 ### Load Balancer with a public IP (Public → Private)
 
-We will be using the Octavia Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
+We will be using the Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
 
 We will need to create a Floating IP address on the public network (Ext-Net), and then associate it to the Load Balancer's VIP port.
 
@@ -225,7 +225,7 @@ Floating IP addresses are used in the OpenStack universe to expose resources (Ne
 You can expose two types of resources:
 
 - An instance with a private port
-- An Octavia Load Balancer Virtual IP address (VIP)
+- An Load Balancer Virtual IP address (VIP)
 
 Floating IP currently does not support IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.es-es.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying an Octavia Load Balancer (EN)
-excerpt: Find out how to configure the Octavia LBaaS for Public Cloud
+title: Deploying a Public Cloud Load Balancer (EN)
+excerpt: Find out how to configure the Public Cloud Load Balancer
 updated: 2024-01-10
 ---
 
@@ -69,12 +69,12 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 > 
 > If you do not provide the parameter `--flavor` during the creation, the Load Balancer will be of a small size.
 > 
 
-Use the following command to display the Octavia flavors in OpenStack:
+Use the following command to display the flavors in OpenStack:
 
 ```bash
 ❯ openstack loadbalancer flavor list
@@ -87,9 +87,9 @@ Use the following command to display the Octavia flavors in OpenStack:
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> The Octavia Load Balancer creation will take some time, mainly to create the instance and to configure the network.
+> The Load Balancer creation will take some time, mainly to create the instance and to configure the network.
 >
 > For the next configuration, you will have to wait until the `provisioning_status` becomes `ACTIVE`.
 
@@ -212,7 +212,7 @@ Backend 2
 
 ### Load Balancer with a public IP (Public → Private)
 
-We will be using the Octavia Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
+We will be using the Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
 
 We will need to create a Floating IP address on the public network (Ext-Net), and then associate it to the Load Balancer's VIP port.
 
@@ -225,7 +225,7 @@ Floating IP addresses are used in the OpenStack universe to expose resources (Ne
 You can expose two types of resources:
 
 - An instance with a private port
-- An Octavia Load Balancer Virtual IP address (VIP)
+- An Load Balancer Virtual IP address (VIP)
 
 Floating IP currently does not support IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.es-us.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying an Octavia Load Balancer (EN)
-excerpt: Find out how to configure the Octavia LBaaS for Public Cloud
+title: Deploying a Public Cloud Load Balancer (EN)
+excerpt: Find out how to configure the Public Cloud Load Balancer
 updated: 2024-01-10
 ---
 
@@ -69,12 +69,12 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 > 
 > If you do not provide the parameter `--flavor` during the creation, the Load Balancer will be of a small size.
 > 
 
-Use the following command to display the Octavia flavors in OpenStack:
+Use the following command to display the flavors in OpenStack:
 
 ```bash
 ❯ openstack loadbalancer flavor list
@@ -87,9 +87,9 @@ Use the following command to display the Octavia flavors in OpenStack:
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> The Octavia Load Balancer creation will take some time, mainly to create the instance and to configure the network.
+> The Load Balancer creation will take some time, mainly to create the instance and to configure the network.
 >
 > For the next configuration, you will have to wait until the `provisioning_status` becomes `ACTIVE`.
 
@@ -212,7 +212,7 @@ Backend 2
 
 ### Load Balancer with a public IP (Public → Private)
 
-We will be using the Octavia Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
+We will be using the Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
 
 We will need to create a Floating IP address on the public network (Ext-Net), and then associate it to the Load Balancer's VIP port.
 
@@ -225,7 +225,7 @@ Floating IP addresses are used in the OpenStack universe to expose resources (Ne
 You can expose two types of resources:
 
 - An instance with a private port
-- An Octavia Load Balancer Virtual IP address (VIP)
+- An Load Balancer Virtual IP address (VIP)
 
 Floating IP currently does not support IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.fr-ca.md
@@ -1,6 +1,6 @@
 ---
-title: "Déployer un Load Balancer Octavia"
-excerpt: Découvrez comment configurer Octavia LBaaS pour Public Cloud
+title: "Déployer un Load Balancer Public Cloud"
+excerpt: Découvrez comment configurer le Load Balander pour Public Cloud
 updated: 2024-01-10
 ---
 
@@ -69,7 +69,7 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 >
 > Notez que si vous ne fournissez pas le paramètre `--flavor` pendant la création, le load balancer sera de taille *small*.
 > 
@@ -85,9 +85,9 @@ openstack loadbalancer flavor list
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> La création du Load Balancer Octavia prendra un certain temps, essentiellement le temps de création de l'instance et la configuration du réseau.
+> La création du Load Balancer prendra un certain temps, essentiellement le temps de création de l'instance et la configuration du réseau.
 >
 > Pour la configuration suivante, vous devrez attendre que le `provisioning_status` devienne `ACTIVE`.
 
@@ -206,7 +206,7 @@ Backend 2
 
 ### Load Balancer en utilisant une IP publique (Public → Privé)
 
-Nous allons utiliser le Load Balancer Octavia préalablement déployé en réseau privé et utiliser une Floating IP OpenStack.
+Nous allons utiliser le Load Balancer préalablement déployé en réseau privé et utiliser une Floating IP OpenStack.
 
 Nous devons créer une Floating IP sur le réseau public (Ext-Net) et associer cette IP au port VIP du Load Balancer.
 
@@ -219,7 +219,7 @@ Les adresses Floating IP sont utilisées dans l'univers OpenStack pour exposer d
 Vous pouvez exposer deux types de ressources :
 
 - Une instance avec un port privé
-- Avoir une adresse IP virtuelle (VIP) d’Octavia Load Balancer.
+- Avoir une adresse IP virtuelle (VIP) de Load Balancer.
 
 Actuellement, les Floating IPs ne supportent pas les IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.fr-fr.md
@@ -1,6 +1,6 @@
 ---
-title: "Déployer un Load Balancer Octavia"
-excerpt: Découvrez comment configurer Octavia LBaaS pour Public Cloud
+title: "Déployer un Load Balancer Public Cloud"
+excerpt: Découvrez comment configurer le Load Balander pour Public Cloud
 updated: 2024-01-10
 ---
 
@@ -69,7 +69,7 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 >
 > Notez que si vous ne fournissez pas le paramètre `--flavor` pendant la création, le load balancer sera de taille *small*.
 > 
@@ -85,9 +85,9 @@ openstack loadbalancer flavor list
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> La création du Load Balancer Octavia prendra un certain temps, essentiellement le temps de création de l'instance et la configuration du réseau.
+> La création du Load Balancer prendra un certain temps, essentiellement le temps de création de l'instance et la configuration du réseau.
 >
 > Pour la configuration suivante, vous devrez attendre que le `provisioning_status` devienne `ACTIVE`.
 
@@ -206,7 +206,7 @@ Backend 2
 
 ### Load Balancer en utilisant une IP publique (Public → Privé)
 
-Nous allons utiliser le Load Balancer Octavia préalablement déployé en réseau privé et utiliser une Floating IP OpenStack.
+Nous allons utiliser le Load Balancer préalablement déployé en réseau privé et utiliser une Floating IP OpenStack.
 
 Nous devons créer une Floating IP sur le réseau public (Ext-Net) et associer cette IP au port VIP du Load Balancer.
 
@@ -219,7 +219,7 @@ Les adresses Floating IP sont utilisées dans l'univers OpenStack pour exposer d
 Vous pouvez exposer deux types de ressources :
 
 - Une instance avec un port privé
-- Avoir une adresse IP virtuelle (VIP) d’Octavia Load Balancer.
+- Avoir une adresse IP virtuelle (VIP) de Load Balancer.
 
 Actuellement, les Floating IPs ne supportent pas les IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.it-it.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying an Octavia Load Balancer (EN)
-excerpt: Find out how to configure the Octavia LBaaS for Public Cloud
+title: Deploying a Public Cloud Load Balancer (EN)
+excerpt: Find out how to configure the Public Cloud Load Balancer
 updated: 2024-01-10
 ---
 
@@ -69,12 +69,12 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 > 
 > If you do not provide the parameter `--flavor` during the creation, the Load Balancer will be of a small size.
 > 
 
-Use the following command to display the Octavia flavors in OpenStack:
+Use the following command to display the flavors in OpenStack:
 
 ```bash
 ❯ openstack loadbalancer flavor list
@@ -87,9 +87,9 @@ Use the following command to display the Octavia flavors in OpenStack:
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> The Octavia Load Balancer creation will take some time, mainly to create the instance and to configure the network.
+> The Load Balancer creation will take some time, mainly to create the instance and to configure the network.
 >
 > For the next configuration, you will have to wait until the `provisioning_status` becomes `ACTIVE`.
 
@@ -212,7 +212,7 @@ Backend 2
 
 ### Load Balancer with a public IP (Public → Private)
 
-We will be using the Octavia Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
+We will be using the Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
 
 We will need to create a Floating IP address on the public network (Ext-Net), and then associate it to the Load Balancer's VIP port.
 
@@ -225,7 +225,7 @@ Floating IP addresses are used in the OpenStack universe to expose resources (Ne
 You can expose two types of resources:
 
 - An instance with a private port
-- An Octavia Load Balancer Virtual IP address (VIP)
+- An Load Balancer Virtual IP address (VIP)
 
 Floating IP currently does not support IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.pl-pl.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying an Octavia Load Balancer (EN)
-excerpt: Find out how to configure the Octavia LBaaS for Public Cloud
+title: Deploying a Public Cloud Load Balancer (EN)
+excerpt: Find out how to configure the Public Cloud Load Balancer
 updated: 2024-01-10
 ---
 
@@ -69,12 +69,12 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 > 
 > If you do not provide the parameter `--flavor` during the creation, the Load Balancer will be of a small size.
 > 
 
-Use the following command to display the Octavia flavors in OpenStack:
+Use the following command to display the flavors in OpenStack:
 
 ```bash
 ❯ openstack loadbalancer flavor list
@@ -87,9 +87,9 @@ Use the following command to display the Octavia flavors in OpenStack:
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> The Octavia Load Balancer creation will take some time, mainly to create the instance and to configure the network.
+> The Load Balancer creation will take some time, mainly to create the instance and to configure the network.
 >
 > For the next configuration, you will have to wait until the `provisioning_status` becomes `ACTIVE`.
 
@@ -212,7 +212,7 @@ Backend 2
 
 ### Load Balancer with a public IP (Public → Private)
 
-We will be using the Octavia Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
+We will be using the Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
 
 We will need to create a Floating IP address on the public network (Ext-Net), and then associate it to the Load Balancer's VIP port.
 
@@ -225,7 +225,7 @@ Floating IP addresses are used in the OpenStack universe to expose resources (Ne
 You can expose two types of resources:
 
 - An instance with a private port
-- An Octavia Load Balancer Virtual IP address (VIP)
+- An Load Balancer Virtual IP address (VIP)
 
 Floating IP currently does not support IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.pt-pt.md
@@ -1,6 +1,6 @@
 ---
-title: Deploying an Octavia Load Balancer (EN)
-excerpt: Find out how to configure the Octavia LBaaS for Public Cloud
+title: Deploying a Public Cloud Load Balancer (EN)
+excerpt: Find out how to configure the Public Cloud Load Balancer
 updated: 2024-01-10
 ---
 
@@ -69,12 +69,12 @@ openstack loadbalancer create --name loadbalancer_private_to_private --vip-subne
 +---------------------+--------------------------------------+
 ```
 
-> [!warning] **Octavia Flavors**
+> [!warning] **Load Balancer Flavors**
 > 
 > If you do not provide the parameter `--flavor` during the creation, the Load Balancer will be of a small size.
 > 
 
-Use the following command to display the Octavia flavors in OpenStack:
+Use the following command to display the flavors in OpenStack:
 
 ```bash
 ❯ openstack loadbalancer flavor list
@@ -87,9 +87,9 @@ Use the following command to display the Octavia flavors in OpenStack:
 +--------------------------------------+--------+--------------------------------------+---------+
 ```
 
-> [!warning] **Octavia status**
+> [!warning] **Status**
 >
-> The Octavia Load Balancer creation will take some time, mainly to create the instance and to configure the network.
+> The Load Balancer creation will take some time, mainly to create the instance and to configure the network.
 >
 > For the next configuration, you will have to wait until the `provisioning_status` becomes `ACTIVE`.
 
@@ -212,7 +212,7 @@ Backend 2
 
 ### Load Balancer with a public IP (Public → Private)
 
-We will be using the Octavia Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
+We will be using the Load Balancer previously deployed in a private network and use an OpenStack Floating IP.
 
 We will need to create a Floating IP address on the public network (Ext-Net), and then associate it to the Load Balancer's VIP port.
 
@@ -225,7 +225,7 @@ Floating IP addresses are used in the OpenStack universe to expose resources (Ne
 You can expose two types of resources:
 
 - An instance with a private port
-- An Octavia Load Balancer Virtual IP address (VIP)
+- An Load Balancer Virtual IP address (VIP)
 
 Floating IP currently does not support IPv6.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.de-de.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-asia.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-au.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-ca.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-gb.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-ie.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-sg.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-us.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.es-es.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.es-us.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.fr-ca.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.fr-ca.md
@@ -1,5 +1,5 @@
 ---
-title: "Mettre en place un monitoring de Octavia Load Balancer avec Prometheus (EN)"
+title: "Mettre en place un monitoring du Load Balancer Public Cloud avec Prometheus (EN)"
 excerpt: "Découvrez les différentes options disponibles pour monitorer votre Load Balancer Octavia"
 updated: 2023-12-22
 ---

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.fr-fr.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.fr-fr.md
@@ -1,5 +1,5 @@
 ---
-title: "Mettre en place un monitoring de Octavia Load Balancer avec Prometheus (EN)"
+title: "Mettre en place un monitoring du Load Balancer Public Cloud avec Prometheus (EN)"
 excerpt: "Découvrez les différentes options disponibles pour monitorer votre Load Balancer Octavia"
 updated: 2023-12-22
 ---

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.it-it.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.pl-pl.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.pt-pt.md
@@ -50,7 +50,7 @@ $ openstack loadbalancer listener stats show <listener id>
 
 ### Monitoring with Prometheus
 
-To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. The listener supports all of the features of an Octavia Load Balancer, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
+To add a Prometheus endpoint on a Public Cloud Load Balancer, create a listener with a `PROMETHEUS` special protocol. This will enable the endpoint `/metrics` on the listener. This listener type provides the same features as the "regular" listeners, such as `allowed_cidrs`, but does not support attaching pools or L7 policies. All metrics will be identified by the Octavia object ID (UUID) of the resources.
 
 > [!primary]
 >

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.de-de.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objective
 
-Our Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 After setting up your Load Balancer, you can configure it with a certificate in order to process HTTPS connections.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-asia.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objective
 
-Our Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 After setting up your Load Balancer, you can configure it with a certificate in order to process HTTPS connections.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-au.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objective
 
-Our Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 After setting up your Load Balancer, you can configure it with a certificate in order to process HTTPS connections.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-ca.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objective
 
-Our Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 After setting up your Load Balancer, you can configure it with a certificate in order to process HTTPS connections.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-gb.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objective
 
-Our Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
+Our Public Cloud Load Balancer  is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 After setting up your Load Balancer, you can configure it with a certificate in order to process HTTPS connections.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-ie.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objective
 
-Our Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 After setting up your Load Balancer, you can configure it with a certificate in order to process HTTPS connections.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-sg.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objective
 
-Our Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 After setting up your Load Balancer, you can configure it with a certificate in order to process HTTPS connections.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-us.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objective
 
-Our Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 After setting up your Load Balancer, you can configure it with a certificate in order to process HTTPS connections.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.es-es.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objective
 
-Our Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 After setting up your Load Balancer, you can configure it with a certificate in order to process HTTPS connections.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.es-us.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objective
 
-Our Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 After setting up your Load Balancer, you can configure it with a certificate in order to process HTTPS connections.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.fr-ca.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objectif
 
-Notre nouvelle solution Load Balancer as a Service (LBaaS) est basée sur le service [Openstack Octavia](https://wiki.openstack.org/wiki/Octavia){.external} et est entièrement intégrée dans l'univers Public Cloud.
+Notre Load Balancer Public Cloud est basé sur le service [Openstack Octavia](https://wiki.openstack.org/wiki/Octavia){.external} et est entièrement intégré dans l'univers Public Cloud.
 
 Une fois votre Load Balancer mis en place, vous pouvez le configurer avec un certificat afin de traiter les connexions HTTPS.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.fr-fr.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objectif
 
-Notre nouvelle solution Load Balancer as a Service (LBaaS) est basée sur le service [Openstack Octavia](https://wiki.openstack.org/wiki/Octavia){.external} et est entièrement intégrée dans l'univers Public Cloud.
+Notre Load Balancer Public Cloud est basé sur le service [Openstack Octavia](https://wiki.openstack.org/wiki/Octavia){.external} et est entièrement intégré dans l'univers Public Cloud.
 
 Une fois votre Load Balancer mis en place, vous pouvez le configurer avec un certificat afin de traiter les connexions HTTPS.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.it-it.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objective
 
-Our Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 After setting up your Load Balancer, you can configure it with a certificate in order to process HTTPS connections.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.pl-pl.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objective
 
-Our Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 After setting up your Load Balancer, you can configure it with a certificate in order to process HTTPS connections.
 

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.pt-pt.md
@@ -6,7 +6,7 @@ updated: 2023-11-06
 
 ## Objective
 
-Our Load Balancer as a Service (LBaaS) solution is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
+Our Public Cloud Load Balancer is based on [OpenStack Octavia](https://wiki.openstack.org/wiki/Octavia) and is fully integrated into the Public Cloud universe. 
 
 After setting up your Load Balancer, you can configure it with a certificate in order to process HTTPS connections.
 


### PR DESCRIPTION
The official naming of the product is "Public Cloud Load Balancer" or "Load Balancer".

Since the wording LBaaS / Octavia was used. I tried to have something consistent across multiple document. 
