### PR TITLE
fix: createToken not working url

### DIFF
--- a/pages/web_cloud/messaging/sms/envoyer_des_sms_avec_lapi_ovh_en_nodejs/guide.fr-fr.md
+++ b/pages/web_cloud/messaging/sms/envoyer_des_sms_avec_lapi_ovh_en_nodejs/guide.fr-fr.md
@@ -36,7 +36,7 @@ Vous devez récupérer un répertoire ./node_modules/ovh/...
 Des identifiants sont nécessaires pour consommer l’API SMS. Ces identifiants sont créés une fois pour identifier l’application qui va envoyer des SMS. La durée de vie de ces identifiants est paramétrable.
 
 Créez vos identifiants de Script (all keys at once) sur cette page :
-[https://api.ovh.com/createToken](https://eu.api.ovh.com/createToken/index.cgi?GET=/sms/&GET=/sms/*/jobs/&POST=/sms/*/jobs/) (cette url vous permet d'avoir automatiquement les bons droits pour les étapes décrites dans ce guide).
+[https://api.ovh.com/createToken](https://eu.api.ovh.com/createToken/index.cgi?GET=/sms&GET=/sms/*&GET=/sms/*/jobs&POST=/sms/*/jobs) (cette url vous permet d'avoir automatiquement les bons droits pour les étapes décrites dans ce guide).
 
 ![création des tokens](images/img_2462.jpg){.thumbnail}
 


### PR DESCRIPTION
The url to create an API token provided in this guide: https://help.ovhcloud.com/csm/fr-sms-sending-via-api-nodejs?id=kb_article_view&sysparm_article=KB0051367
Give a 403 - This call has not been granted when running the sample script.

By using the new url with the sms/* grant, the script is now working.
-> https://eu.api.ovh.com/createToken/index.cgi?GET=/sms&GET=/sms/*&GET=/sms/*/jobs&POST=/sms/*/jobs


Answer to the issue was found here: https://community.ovh.com/t/get-https-eu-api-ovh-com-1-0-sms-resulted-in-a-403-forbidden-response-message-this-call-has-not-been-granted/47569/2