### PR TITLE
KevS-SK1465-Update-starting-with-WebCloudDatabases

### DIFF
--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.de-de.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: 'Konfigurieren Ihres Datenbankservers'
 excerpt: 'Erfahren Sie hier, wie Sie Ihren Datenbankserver konfigurieren und optimieren können'
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 > [!primary]
@@ -206,16 +206,6 @@ show variables like "version";
 >
 
 ### Logs und Messwerte
-
-#### Statistiken zur Ausführungsdauer der Anfragen
-
-So können Sie die Ausführungsdauer auf Ihrem Datenbankserver während der letzten 24 Stunden visualisieren.
-
-Loggen Sie sich in Ihrem OVHcloud Kundencenter ein Klicken Sie auf `Web Cloud`{.action} und dann auf `Web Cloud Databases`{.action}. Wählen Sie den Namen Ihres Datenbankservers aus.
-
-Gehen Sie hierzu zum Tab `Messwerte` Ihres Datenbankservers. Sie finden hier die **Statistiken zur Ausführungsdauer der Anfragen**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Zugang zu Slow-Query-Logs
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-asia.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 ## Objective
@@ -203,16 +203,6 @@ show variables like "version";
 >
 
 ### Logs and metrics
-
-#### Query runtime statistics
-
-This allows you to view the query execution time on your database server in the last 24 hours.
-
-In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia), go to the `Web Cloud` section, and then click `Web Cloud Databases`{.action}. Select the name of your Web Cloud Databases server.
-
-Go to the `Metrics` tab for your database server. You will find the graph **Query Execution Time Statistics**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Access to Slow Query logs
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-au.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 ## Objective
@@ -203,16 +203,6 @@ show variables like "version";
 >
 
 ### Logs and metrics
-
-#### Query runtime statistics
-
-This allows you to view the query execution time on your database server in the last 24 hours.
-
-In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au), go to the `Web Cloud` section, and then click `Web Cloud Databases`{.action}. Select the name of your Web Cloud Databases server.
-
-Go to the `Metrics` tab for your database server. You will find the graph **Query Execution Time Statistics**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Access to Slow Query logs
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-ca.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 ## Objective
@@ -203,16 +203,6 @@ show variables like "version";
 >
 
 ### Logs and metrics
-
-#### Query runtime statistics
-
-This allows you to view the query execution time on your database server in the last 24 hours.
-
-In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca), go to the `Web Cloud` section, and then click `Web Cloud Databases`{.action}. Select the name of your Web Cloud Databases server.
-
-Go to the `Metrics` tab for your database server. You will find the graph **Query Execution Time Statistics**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Access to Slow Query logs
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-gb.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 ## Objective
@@ -203,16 +203,6 @@ show variables like "version";
 >
 
 ### Logs and metrics
-
-#### Query runtime statistics
-
-This allows you to view the query execution time on your database server in the last 24 hours.
-
-In your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), go to the `Web Cloud` section, and then click `Web Cloud Databases`{.action}. Select the name of your Web Cloud Databases server.
-
-Go to the `Metrics` tab for your database server. You will find the graph **Query Execution Time Statistics**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Access to Slow Query logs
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-ie.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 ## Objective
@@ -203,16 +203,6 @@ show variables like "version";
 >
 
 ### Logs and metrics
-
-#### Query runtime statistics
-
-This allows you to view the query execution time on your database server in the last 24 hours.
-
-In your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), go to the `Web Cloud` section, and then click `Web Cloud Databases`{.action}. Select the name of your Web Cloud Databases server.
-
-Go to the `Metrics` tab for your database server. You will find the graph **Query Execution Time Statistics**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Access to Slow Query logs
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-sg.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 ## Objective
@@ -203,16 +203,6 @@ show variables like "version";
 >
 
 ### Logs and metrics
-
-#### Query runtime statistics
-
-This allows you to view the query execution time on your database server in the last 24 hours.
-
-In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg), go to the `Web Cloud` section, and then click `Web Cloud Databases`{.action}. Select the name of your Web Cloud Databases server.
-
-Go to the `Metrics` tab for your database server. You will find the graph **Query Execution Time Statistics**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Access to Slow Query logs
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-us.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 ## Objective
@@ -203,16 +203,6 @@ show variables like "version";
 >
 
 ### Logs and metrics
-
-#### Query runtime statistics
-
-This allows you to view the query execution time on your database server in the last 24 hours.
-
-In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we), go to the `Web Cloud` section, and then click `Web Cloud Databases`{.action}. Select the name of your Web Cloud Databases server.
-
-Go to the `Metrics` tab for your database server. You will find the graph **Query Execution Time Statistics**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Access to Slow Query logs
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-es.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configurar el servidor de bases de datos'
 excerpt: 'Cómo configurar y optimizar el servidor de bases de datos'
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 > [!primary]
@@ -206,16 +206,6 @@ show variables like "version";
 > 
 
 ### Logs y Métricas
-
-#### Estadísticas del tiempo de ejecución de las consultas
-
-Para visualizar el tiempo de ejecución de las consultas en el servidor de bases de datos en las últimas 24 horas.
-
-Acceda a su área de cliente (sección IP) Haga clic en la pestaña `Web Cloud` y seleccione `Web Cloud Databases`{.action}. Seleccione el nombre del servidor de bases de datos.
-
-Acceda a la pestaña `Métricas` de su servidor de bases de datos. Puede consultar la gráfica **"Estadísticas del tiempo de ejecución de las consultas"**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Acceso a los logs "Slow Query"
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-us.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configurar el servidor de bases de datos'
 excerpt: 'Cómo configurar y optimizar el servidor de bases de datos'
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 > [!primary]
@@ -206,16 +206,6 @@ show variables like "version";
 > 
 
 ### Logs y Métricas
-
-#### Estadísticas del tiempo de ejecución de las consultas
-
-Para visualizar el tiempo de ejecución de las consultas en el servidor de bases de datos en las últimas 24 horas.
-
-Acceda a su área de cliente (sección IP) Haga clic en la pestaña `Web Cloud` y seleccione `Web Cloud Databases`{.action}. Seleccione el nombre del servidor de bases de datos.
-
-Acceda a la pestaña `Métricas` de su servidor de bases de datos. Puede consultar la gráfica **"Estadísticas del tiempo de ejecución de las consultas"**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Acceso a los logs "Slow Query"
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-ca.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configurer votre serveur de bases de données'
 excerpt: 'Découvrez comment configurer et optimiser votre serveur de base de données'
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 ## Objectif
@@ -202,16 +202,6 @@ show variables like "version";
 > 
 
 ### Logs et Métriques
-
-#### Connaitre le temps d'exécution des requêtes
-
-Cela vous permet de visualiser le temps d'exécution des requêtes sur votre serveur de bases de données dans les dernières 24 heures.
-
-Rendez-vous dans votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc). Cliquez sur l'onglet `Web Cloud`, puis sur `Web Cloud Databases`{.action}. Sélectionnez le nom de votre serveur de bases de données.
-
-Dirigez-vous dans l'onglet `Métriques` de votre serveur de bases de données. Vous trouverez le graphique **« Statistiques du temps d'exécution des requêtes »**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Accès aux logs « Slow Query »
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-ca.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-ca.md
@@ -203,23 +203,9 @@ show variables like "version";
 
 ### Logs et Métriques
 
-#### Accès aux logs « Slow Query »
+#### Accès aux logs
 
-> **Définition des « slow query log »**
-> 
-> Ce sont les requêtes qui prennent plus de temps à s'exécuter. La valeur est définie à 1 seconde sur nos serveurs de bases de données dans la variable **« long_query_time »**.
-
-Ces logs, appellés **« slow-query.log »**, peuvent être récupérés à la racine de l'espace SFTP de votre serveur de bases de données.
-
-Rendez-vous dans votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc). Cliquez sur l'onglet `Web Cloud`, puis sur `Web Cloud Databases`{.action}. Sélectionnez le nom de votre serveur de bases de données.
-
-Dans l'onglet `informations générales`, vous trouverez la section **« SFTP »** dans le cadre **« Informations de connexion »**
-
-![Web Cloud Databases](images/sftp-login.png){.thumbnail}
-
-Pour vous y connecter en **SFTP**, vous pouvez le faire via le logiciel Filezilla en vous aidant du guide: [« Utilisation du logiciel FileZilla avec votre hébergement »](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide).
-
-Si ce fichier est vide, c'est que vous n'avez aucune requête lente.
+Pour accéder aux logs de votre solution Web Cloud Databases, consultez notre guide « [Web Cloud Databases - Comment récupérer les logs ?](/pages/web_cloud/web_cloud_databases/retrieve-logs) ».
 
 #### Suivre la RAM consommée
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-fr.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-fr.md
@@ -203,23 +203,9 @@ show variables like "version";
 
 ### Logs et Métriques
 
-#### Accès aux logs « Slow Query »
+#### Accès aux logs
 
-> **Définition des « slow query log »**
-> 
-> Ce sont les requêtes qui prennent plus de temps à s'exécuter. La valeur est définie à 1 seconde sur nos serveurs de bases de données dans la variable **« long_query_time »**.
-
-Ces logs, appellés **« slow-query.log »**, peuvent être récupérés à la racine de l'espace SFTP de votre serveur de bases de données.
-
-Rendez-vous dans votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr). Cliquez sur l'onglet `Web Cloud`, puis sur `Web Cloud Databases`{.action}. Sélectionnez le nom de votre serveur de bases de données.
-
-Dans l'onglet `informations générales`, vous trouverez la section **« SFTP »** dans le cadre **« Informations de connexion »**
-
-![Web Cloud Databases](images/sftp-login.png){.thumbnail}
-
-Pour vous y connecter en **SFTP**, vous pouvez le faire via le logiciel Filezilla en vous aidant du guide: [« Utilisation du logiciel FileZilla avec votre hébergement »](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide).
-
-Si ce fichier est vide, c'est que vous n'avez aucune requête lente.
+Pour accéder aux logs de votre solution Web Cloud Databases, consultez notre guide « [Web Cloud Databases - Comment récupérer les logs ?](/pages/web_cloud/web_cloud_databases/retrieve-logs) ».
 
 #### Suivre la RAM consommée
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-fr.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Configurer votre serveur de bases de données"
 excerpt: "Découvrez comment configurer et optimiser votre serveur de base de données"
-updated: 2023-04-20
+updated: 2024-03-13
 ---
 
 ## Objectif
@@ -202,16 +202,6 @@ show variables like "version";
 > 
 
 ### Logs et Métriques
-
-#### Connaitre le temps d'exécution des requêtes
-
-Cela vous permet de visualiser le temps d'exécution des requêtes sur votre serveur de bases de données dans les dernières 24 heures.
-
-Rendez-vous dans votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr). Cliquez sur l'onglet `Web Cloud`, puis sur `Web Cloud Databases`{.action}. Sélectionnez le nom de votre serveur de bases de données.
-
-Dirigez-vous dans l'onglet `Métriques` de votre serveur de bases de données. Vous trouverez le graphique **« Statistiques du temps d'exécution des requêtes »**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Accès aux logs « Slow Query »
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Configura il tuo database server 
 excerpt: Come configurare e ottimizzare il tuo database server
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 > [!primary]
@@ -206,16 +206,6 @@ show variables like "version";
 > 
 
 ### Log e Metriche
-
-#### Conoscere il tempo di esecuzione delle richieste
-
-In questo modo è possibile visualizzare il tempo di esecuzione delle richieste sul tuo database server nelle ultime 24 ore.
-
-Accedi allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it). Clicca sulla scheda `Web Cloud` e poi su `Web Cloud Databases`{.action}. Seleziona il nome del tuo database server.
-
-Clicca sulla scheda `Metriche` del tuo database server. Il grafico **"Statistiche dei tempi di esecuzione delle richieste"**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Accesso ai log "Slow Query"
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pl-pl.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: 'Konfiguracja serwera baz danych'
 excerpt: 'Dowiedz się, jak skonfigurować i zoptymalizować serwer bazy danych'
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 > [!primary]
@@ -205,16 +205,6 @@ show variables like "version";
 > 
 
 ### Logi i metryki
-
-#### Statystyki czasu wykonywania zapytań
-
-Dzięki temu możesz wyświetlić czas wykonywania zapytań na serwerze baz danych w ciągu ostatnich 24 godzin.
-
-Przejdź do Panelu [klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl). Kliknij kartę `Web Cloud`, a następnie `Web Cloud Databases`{.action}. Wybierz nazwę serwera baz danych.
-
-Przejdź do karty `Metryki` serwera baz danych. Wykres **"Statystyki czasu wykonywania zapytań"**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Dostęp do logów "Slow Query"
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pt-pt.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configurar o servidor de bases de dados'
 excerpt: 'Descubra como configurar e otimizar o servidor de bases de dados'
-updated: 2023-04-24
+updated: 2024-03-13
 ---
 
 > [!primary]
@@ -206,16 +206,6 @@ show variables like "version";
 > 
 
 ### Logs e métricas
-
-#### Conhecer o tempo de execução dos pedidos
-
-Isto permite-lhe visualizar o tempo de execução dos pedidos no servidor de bases de dados nas últimas 24 horas.
-
-Aceda à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt). Clique no separador `Web Cloud` e, a seguir, em `Web Cloud Databases`{.action}. Selecione o nome do seu servidor de bases de dados. 
-
-Aceda ao separador `Métricas` do servidor de bases de dados. Vai encontrar o gráfico **«Estatísticas do tempo de execução dos pedidos»**.
-
-![Web Cloud Databases](images/query-runtime-statistics.png){.thumbnail}
 
 #### Acesso aos logs «Slow Query»
 


### PR DESCRIPTION
Updates : 

- delete obsolete paragraph about a runtime queries stats already unavailable.
- replace "slow query logs" paragraph by a "log" part. In this new part, I add the link to the new "WCDB log" part (for the moment only FRFR and FRCA available).

I wait the agreement of @Y0Coss for FRFR version.

I'll push this PR to delete quickly the obsolete paragraph.
I'll create another PR for translations of the new part in a second time.