### PR TITLE
S3 Object Storage - SSE-C / SSE-S3 encryption - Update

### DIFF
--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.de-de.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Verschlüsseln Ihrer serverseitigen Objekte mit SSE-C (EN)
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C
-updated: 2022-04-15
+updated: 2024-04-10
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objective
 
-Using server-side encryption with customer-provided encryption keys (SSE-C) allows you to set your own encryption keys.  
+At OVHcloud, we understand the crucial importance of data protection in today’s digital ecosystem. In the face of ever-evolving security threats and increasingly stringent regulatory requirements, it’s essential to implement robust measures to secure data at all times. This includes not only data in transit, but also data at rest.
 
-When you upload an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you retrieve an object, you must provide the same encryption key as part of your request. S3 Object Storage first verifies that the encryption key you provided matches and then decrypts the object before returning the object data to you.
+Protecting *at rest* data, i.e. data stored on physical devices or in the cloud, is a crucial part of any organization’s IT security strategy. In this context, there are two main approaches to encrypting this data: client-side encryption (CSE) and server-side encryption (SSE).
 
-**This guide explains how to encrypt your server-side objects with SSE-C.**
+Client-Side Encryption (CSE) allows our customers to encrypt their data on their own device before sending it to our servers for storage. This ensures that data remains encrypted throughout its lifecycle, offering a high degree of security, as encryption keys are managed by the customer and never shared with OVHcloud or any other third party.
+
+While this approach requires the customer to strictly manage the keys, it is an ideal solution for those who require complete control over their data security.
+
+At the same time, server-side encryption (SSE) offers an alternative where data is encrypted when it arrives at our servers. This is the responsibility of OVHcloud, which greatly reduces the burden of security management for our customers. Two server-side encryption methods are available: 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)**: You can provide and manage your own encryption keys, giving you complete control over your data security. This option is particularly well-suited to organizations with specific compliance and data security needs, as it allows for exclusive management of encryption keys.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)**: Simplifies the encryption process by using keys managed by OVHcloud. This method is ideal for customers who want a robust encryption solution without the complexities of key management.
+
+Our goal is to help you choose the type of encryption that is best for you. This page gives you all the information you need to make an informed choice. Whether you prefer to manage yourself with SSE-C or opt for the ease of SSE-S3, we are committed to offering you flexible and secure solutions to protect your data when it is stored.
+
+**This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3.**
 
 > [!warning]
 >
@@ -31,13 +42,17 @@ When you upload an object, S3 Object Storage uses the encryption key you provide
 
 ## Requirements
 
-- A bucket
+- An S3 bucket
 - A user with the required access rights on the bucket
-- Have installed and configured aws-cli
+- Have installed and configured the AWS command line interface (aws-cli)
 
 See our [Getting started with S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) guide.
 
 ## Instructions
+
+Using server-side encryption with client-provided encryption keys (SSE-C) allows you to define your own encryption keys.
+
+When you download an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you check out an object, you must provide the same encryption key as part of your request. S3 Object Storage first checks that the encryption key you provided matches, then decrypts the object before returning the object data to you.
 
 When you use SSE-C, you must provide encryption key information using the following request headers.
 
@@ -47,7 +62,9 @@ When you use SSE-C, you must provide encryption key information using the follow
 | --sse-customer-key | Use this header to provide the 256-bit, base64-encoded encryption key for S3 Object Storage to use to encrypt or decrypt your data. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Use this header to provide the base64-encoded 128-bit MD5 digest of the encryption key according to RFC 1321. S3 Object Storage uses this header for a message integrity check to ensure that the encryption key was transmitted without error. |
 
-### Creating an encryption key
+### SSE-C - Server-Side Encryption with Client Encryption Keys
+
+#### Creating an encryption key
 
 Example of creating an encryption key ( *--sse-customer-key* ):
 
@@ -61,7 +78,7 @@ and the MD5 key ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Uploading an object with SSE-C
+#### Uploading an object with SSE-C
 
 To upload an object with SSE-C and aws-cli, proceed as follows:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Downloading an object with SSE-C
+#### Downloading an object with SSE-C
 
 To download an object with SSE-C and aws-cli, proceed as follows:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Getting object metadata with SSE-C
+#### Getting object metadata with SSE-C
 
 To get an object metadata with SSE-C and aws-cli, proceed as follows:
 
@@ -129,7 +146,7 @@ Output should look like:
 
 Without encryption headers, you will get a `Bad Request` error.
 
-### Deleting an encrypted object with SSE-C
+#### Deleting an encrypted object with SSE-C
 
 To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 
@@ -137,7 +154,7 @@ To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### Presigned URLs and SSE-C
+#### Presigned URLs and SSE-C
 
 Presigned URLs, that can be used for operations such as upload a new object, retrieve an existing object, or object metadata, support the SSE-C as follows:
 
@@ -149,6 +166,248 @@ Presigned URLs, that can be used for operations such as upload a new object, ret
 >
 > You can use the presigned URL for SSE-C objects only programmatically, because in addition to the presigned URL, you also need to include HTTP headers that are specific to SSE-C objects.
 >
+
+### SSE-S3 - Server-side encryption with keys managed by OVHcloud
+
+Using server-side encryption with keys managed by OVHcloud (SSE-S3) helps protect your data stored on OVHcloud by encrypting it automatically at rest. SSE-S3 uses keys managed and protected by OVHcloud, eliminating the need for the user to manually manage these encryption keys.
+
+#### Benefits
+
+- **Simplified Key Management**
+
+With OVHcloud supporting secure encryption key management, users benefit from simplified key management. This approach eliminates the complexities of key rotation while maintaining a high level of data security. It balances security with operational efficiency, eliminating the administrative burden of manually managing encryption keys.
+
+- **Enhanced Security**
+
+We use an advanced encryption strategy to offer maximum protection for your data. Each bucket has a unique key, and for each stored object, a separate encryption key is generated. This key is obtained by combining the unique key of the bucket with a random salt, which ensures that each object is encrypted with its own key. This key derivation method reduces the risk associated with exposing a single key and ensures enhanced security for your data.
+
+- **Transparency**
+
+The encryption and decryption process is completely transparent to the user, allowing encrypted data to be accessed and managed as easily as unencrypted data.
+
+- **Enhanced security with OVHcloud Key Management Service (KMS)**
+
+Our commitment to securing your data is reinforced through the use of OVHcloud Key Management Service (KMS), an advanced platform for secure storage and encryption key management. This approach ensures optimal data protection, setting up a robust security infrastructure without the complexities of directly managing encryption keys.
+
+To further your understanding of OVHcloud Key Management Service (KMS) and its applications in various cloud infrastructure contexts, we recommend reading the following resources:
+
+- **[Getting started with the KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)**: this guide provides a detailed overview of how to implement and use the KMS to secure your data.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)**: practical guide on enabling VM encryption using KMS capabilities.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)**: detailed instructions on using KMS in conjunction with the vSphere Native Key Provider for VM encryption.
+
+These documents provide valuable information on how the KMS can be used to enhance security in different cloud infrastructure scenarios.
+
+#### Implementation
+
+To enhance the security of data uploaded to OVHcloud, enabling server-side encryption (SSE-S3) has been designed to be both easy and transparent. By configuring a default encryption method on your bucket via the `PutBucketEncryption` request, any uploaded object will be automatically encrypted without requiring any additional actions on your side. When uploading an object, simply specify the encryption option in the API request or via the AWS CLI command line. OVHcloud takes care of the rest, encrypting your data before it is stored using an automatically generated unique key for the bucket.
+
+### Secure encryption key management with SSE-S3 on OVHcloud S3
+
+The implementation of SSE-S3 encryption on OVHcloud S3 is designed to provide encryption key management that is both secure and transparent for the user. Each bucket has a separate key, which ensures that data is secured individually and in isolation. This encryption method, integrated and managed by the platform, eliminates the complexities associated with manual key management by users. While making the user process as smooth and intuitive as possible, it maintains robust security and complies with the very strictest data protection standards.
+
+#### Sending an object with SSE-S3 on OVHcloud S3
+
+##### Uploading an object on OVHcloud S3 with SSE-S3 encryption
+
+To send an object in your S3 bucket on OVHcloud with SSE-S3 encryption, use the following Bash command via the AWS CLI. This command includes the server-side encryption option to enhance the security of your stored data.
+
+```bash
+aws s3api put-object --bucket your-bucket --key your-object --body path/to/your/file --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+When using the AWS CLI command to upload an object with SSE-S3 encryption to OVHcloud S3, make sure to replace the following values based on your specific information:
+
+- `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
+- `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
+- `path/to/your/file`: Specify the full path to the file you plan to send.
+
+The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
+
+##### Downloading an Object with SSE-S3 to OVHcloud S3
+
+To download an object that has been encrypted with SSE-S3 from OVHcloud S3, you do not need to specify encryption headers in the command. The object can be downloaded directly without any additional manipulation linked to the encryption, because the decryption is managed automatically on the server side. Here is an example of a download command:
+
+```bash
+aws s3api get-object --bucket your-bucket --key your-object path/to/destination/file --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- Replace `your-object` with the key of the object you want to download.
+- Replace `path/to/destination/file` with the path where you want to save the downloaded file.
+
+Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
+
+#### Adding encryption to an existing bucket on OVHcloud S3
+
+To add SSE-S3 encryption to an existing S3 bucket on OVHcloud, you must use the `put-bucket-encryption` command from the AWS CLI. This command configures bucket encryption so that all newly added objects are automatically encrypted with SSE-S3. Here is the specific command you would use:
+
+```bash
+aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your S3 bucket.
+
+This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
+
+##### Viewing bucket encryption configuration
+
+After configuring your bucket encryption via `PutBucketEncryption` to use SSE-S3, make sure everything is set up correctly using the following command with the AWS CLI:
+
+```bash
+aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+
+With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
+
+In this order, replace `your-bucket` with the name of your bucket. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+
+This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
+
+##### Deleting an encrypted object with SSE-S3
+
+Deleting objects encrypted with SSE-S3 is no different from deleting objects that are not encrypted. You can use the following command to delete an object:
+
+```bash
+aws s3 rm s3://my-Bucket/my-object
+```
+
+- Replace `my-Bucket` with the name of your bucket
+- Replace `my-object` by the name of the object you want to delete.
+
+With this command, you can effectively delete an object, whether it is encrypted or not, from your bucket on OVHcloud S3.
+
+### SSE-S3 Encryption considerations
+
+When using SSE-S3 encryption on OVHcloud S3, it is important to consider the following:
+
+#### Performance
+
+- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+
+#### Security
+
+- **Key Management**: SSE-S3 offers a high level of security by automatically managing encryption keys. This simplifies security management for users.
+- **Additional security practices**: Combining SSE-S3 encryption with other security practices is crucial for optimal protection. This includes the use of strict IAM policies and log access tracking to monitor and control data access.
+
+#### Comparison of encryption methods
+
+It’s essential to compare the different encryption methods available to choose the one that best suits your specific needs. Methods to consider include client-side encryption (CSE) and server-side encryption (SSE), with its SSE-C and SSE-S3 variants.
+
+#### Pros and cons
+
+- **CSE vs SSE**: Each method has its own advantages and disadvantages in terms of manageability, security and performance impact.
+- **Recommended use cases**: depending on your specific situation, some methods may be more appropriate than others. It is important to evaluate the recommended use cases for each encryption method.
+
+A comparative table may be useful for summarizing these elements, providing a clear overview that facilitates decision-making.
+
+| Encryption method | Benefits | Cons | Recommended Use Cases |
+|-------------------|----------|------|-----------------------|
+| **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+
+Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+### Recommended use cases for encryption on OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Ideal for**: Organizations with very high security requirements, requiring encryption keys to remain under exclusive control.
+- **Suitable for**: strictly regulated environments, such as financial institutions or healthcare services.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Suitable for**: Organizations seeking a balance between key control and manageability.
+- **Useful for**: when customers are ready to manage keys but want to delegate encryption and decryption.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Perfect for**: users who prefer a turnkey solution without the burden of key management.
+- **Preferred method for**: companies looking to protect their data without specific encryption compliance needs.
+
+The choice between these methods should be guided by security policies and regulatory requirements, as well as the ability to manage encryption keys. A balance between ease of use and security is essential.
+
+### Examples of scripts and commands
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Generating a client-side encryption key
+client_key=$(openssl rand -base64 32)
+# Encryption of a file before sending
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Sending encrypted file to S3 bucket
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Creating an encryption key and its MD5 fingerprint
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Uploading an object with SSE-C encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Retrieving an object with SSE-C encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Sending an object with SSE-S3 encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Uploading an object with SSE-S3 encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Troubleshooting and Common Error Resolution
+
+### Error using SSE-C without proper encryption headers
+
+- **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
+- **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
+
+### Bad query error when using SSE-S3
+
+- **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
+- **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
+
+### Performance or latency issues during encryption/decryption
+
+- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
+
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
+## Conclusion
+
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+
+The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 
 ## Go further
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-asia.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C
-updated: 2022-04-15
+updated: 2024-04-10
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objective
 
-Using server-side encryption with customer-provided encryption keys (SSE-C) allows you to set your own encryption keys.  
+At OVHcloud, we understand the crucial importance of data protection in today’s digital ecosystem. In the face of ever-evolving security threats and increasingly stringent regulatory requirements, it’s essential to implement robust measures to secure data at all times. This includes not only data in transit, but also data at rest.
 
-When you upload an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you retrieve an object, you must provide the same encryption key as part of your request. S3 Object Storage first verifies that the encryption key you provided matches and then decrypts the object before returning the object data to you.
+Protecting *at rest* data, i.e. data stored on physical devices or in the cloud, is a crucial part of any organization’s IT security strategy. In this context, there are two main approaches to encrypting this data: client-side encryption (CSE) and server-side encryption (SSE).
 
-**This guide explains how to encrypt your server-side objects with SSE-C.**
+Client-Side Encryption (CSE) allows our customers to encrypt their data on their own device before sending it to our servers for storage. This ensures that data remains encrypted throughout its lifecycle, offering a high degree of security, as encryption keys are managed by the customer and never shared with OVHcloud or any other third party.
+
+While this approach requires the customer to strictly manage the keys, it is an ideal solution for those who require complete control over their data security.
+
+At the same time, server-side encryption (SSE) offers an alternative where data is encrypted when it arrives at our servers. This is the responsibility of OVHcloud, which greatly reduces the burden of security management for our customers. Two server-side encryption methods are available: 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)**: You can provide and manage your own encryption keys, giving you complete control over your data security. This option is particularly well-suited to organizations with specific compliance and data security needs, as it allows for exclusive management of encryption keys.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)**: Simplifies the encryption process by using keys managed by OVHcloud. This method is ideal for customers who want a robust encryption solution without the complexities of key management.
+
+Our goal is to help you choose the type of encryption that is best for you. This page gives you all the information you need to make an informed choice. Whether you prefer to manage yourself with SSE-C or opt for the ease of SSE-S3, we are committed to offering you flexible and secure solutions to protect your data when it is stored.
+
+**This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3.**
 
 > [!warning]
 >
@@ -31,13 +42,17 @@ When you upload an object, S3 Object Storage uses the encryption key you provide
 
 ## Requirements
 
-- A bucket
+- An S3 bucket
 - A user with the required access rights on the bucket
-- Have installed and configured aws-cli
+- Have installed and configured the AWS command line interface (aws-cli)
 
 See our [Getting started with S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) guide.
 
 ## Instructions
+
+Using server-side encryption with client-provided encryption keys (SSE-C) allows you to define your own encryption keys.
+
+When you download an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you check out an object, you must provide the same encryption key as part of your request. S3 Object Storage first checks that the encryption key you provided matches, then decrypts the object before returning the object data to you.
 
 When you use SSE-C, you must provide encryption key information using the following request headers.
 
@@ -47,7 +62,9 @@ When you use SSE-C, you must provide encryption key information using the follow
 | --sse-customer-key | Use this header to provide the 256-bit, base64-encoded encryption key for S3 Object Storage to use to encrypt or decrypt your data. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Use this header to provide the base64-encoded 128-bit MD5 digest of the encryption key according to RFC 1321. S3 Object Storage uses this header for a message integrity check to ensure that the encryption key was transmitted without error. |
 
-### Creating an encryption key
+### SSE-C - Server-Side Encryption with Client Encryption Keys
+
+#### Creating an encryption key
 
 Example of creating an encryption key ( *--sse-customer-key* ):
 
@@ -61,7 +78,7 @@ and the MD5 key ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Uploading an object with SSE-C
+#### Uploading an object with SSE-C
 
 To upload an object with SSE-C and aws-cli, proceed as follows:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Downloading an object with SSE-C
+#### Downloading an object with SSE-C
 
 To download an object with SSE-C and aws-cli, proceed as follows:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Getting object metadata with SSE-C
+#### Getting object metadata with SSE-C
 
 To get an object metadata with SSE-C and aws-cli, proceed as follows:
 
@@ -129,7 +146,7 @@ Output should look like:
 
 Without encryption headers, you will get a `Bad Request` error.
 
-### Deleting an encrypted object with SSE-C
+#### Deleting an encrypted object with SSE-C
 
 To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 
@@ -137,7 +154,7 @@ To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### Presigned URLs and SSE-C
+#### Presigned URLs and SSE-C
 
 Presigned URLs, that can be used for operations such as upload a new object, retrieve an existing object, or object metadata, support the SSE-C as follows:
 
@@ -149,6 +166,248 @@ Presigned URLs, that can be used for operations such as upload a new object, ret
 >
 > You can use the presigned URL for SSE-C objects only programmatically, because in addition to the presigned URL, you also need to include HTTP headers that are specific to SSE-C objects.
 >
+
+### SSE-S3 - Server-side encryption with keys managed by OVHcloud
+
+Using server-side encryption with keys managed by OVHcloud (SSE-S3) helps protect your data stored on OVHcloud by encrypting it automatically at rest. SSE-S3 uses keys managed and protected by OVHcloud, eliminating the need for the user to manually manage these encryption keys.
+
+#### Benefits
+
+- **Simplified Key Management**
+
+With OVHcloud supporting secure encryption key management, users benefit from simplified key management. This approach eliminates the complexities of key rotation while maintaining a high level of data security. It balances security with operational efficiency, eliminating the administrative burden of manually managing encryption keys.
+
+- **Enhanced Security**
+
+We use an advanced encryption strategy to offer maximum protection for your data. Each bucket has a unique key, and for each stored object, a separate encryption key is generated. This key is obtained by combining the unique key of the bucket with a random salt, which ensures that each object is encrypted with its own key. This key derivation method reduces the risk associated with exposing a single key and ensures enhanced security for your data.
+
+- **Transparency**
+
+The encryption and decryption process is completely transparent to the user, allowing encrypted data to be accessed and managed as easily as unencrypted data.
+
+- **Enhanced security with OVHcloud Key Management Service (KMS)**
+
+Our commitment to securing your data is reinforced through the use of OVHcloud Key Management Service (KMS), an advanced platform for secure storage and encryption key management. This approach ensures optimal data protection, setting up a robust security infrastructure without the complexities of directly managing encryption keys.
+
+To further your understanding of OVHcloud Key Management Service (KMS) and its applications in various cloud infrastructure contexts, we recommend reading the following resources:
+
+- **[Getting started with the KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)**: this guide provides a detailed overview of how to implement and use the KMS to secure your data.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)**: practical guide on enabling VM encryption using KMS capabilities.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)**: detailed instructions on using KMS in conjunction with the vSphere Native Key Provider for VM encryption.
+
+These documents provide valuable information on how the KMS can be used to enhance security in different cloud infrastructure scenarios.
+
+#### Implementation
+
+To enhance the security of data uploaded to OVHcloud, enabling server-side encryption (SSE-S3) has been designed to be both easy and transparent. By configuring a default encryption method on your bucket via the `PutBucketEncryption` request, any uploaded object will be automatically encrypted without requiring any additional actions on your side. When uploading an object, simply specify the encryption option in the API request or via the AWS CLI command line. OVHcloud takes care of the rest, encrypting your data before it is stored using an automatically generated unique key for the bucket.
+
+### Secure encryption key management with SSE-S3 on OVHcloud S3
+
+The implementation of SSE-S3 encryption on OVHcloud S3 is designed to provide encryption key management that is both secure and transparent for the user. Each bucket has a separate key, which ensures that data is secured individually and in isolation. This encryption method, integrated and managed by the platform, eliminates the complexities associated with manual key management by users. While making the user process as smooth and intuitive as possible, it maintains robust security and complies with the very strictest data protection standards.
+
+#### Sending an object with SSE-S3 on OVHcloud S3
+
+##### Uploading an object on OVHcloud S3 with SSE-S3 encryption
+
+To send an object in your S3 bucket on OVHcloud with SSE-S3 encryption, use the following Bash command via the AWS CLI. This command includes the server-side encryption option to enhance the security of your stored data.
+
+```bash
+aws s3api put-object --bucket your-bucket --key your-object --body path/to/your/file --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+When using the AWS CLI command to upload an object with SSE-S3 encryption to OVHcloud S3, make sure to replace the following values based on your specific information:
+
+- `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
+- `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
+- `path/to/your/file`: Specify the full path to the file you plan to send.
+
+The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
+
+##### Downloading an Object with SSE-S3 to OVHcloud S3
+
+To download an object that has been encrypted with SSE-S3 from OVHcloud S3, you do not need to specify encryption headers in the command. The object can be downloaded directly without any additional manipulation linked to the encryption, because the decryption is managed automatically on the server side. Here is an example of a download command:
+
+```bash
+aws s3api get-object --bucket your-bucket --key your-object path/to/destination/file --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- Replace `your-object` with the key of the object you want to download.
+- Replace `path/to/destination/file` with the path where you want to save the downloaded file.
+
+Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
+
+#### Adding encryption to an existing bucket on OVHcloud S3
+
+To add SSE-S3 encryption to an existing S3 bucket on OVHcloud, you must use the `put-bucket-encryption` command from the AWS CLI. This command configures bucket encryption so that all newly added objects are automatically encrypted with SSE-S3. Here is the specific command you would use:
+
+```bash
+aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your S3 bucket.
+
+This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
+
+##### Viewing bucket encryption configuration
+
+After configuring your bucket encryption via `PutBucketEncryption` to use SSE-S3, make sure everything is set up correctly using the following command with the AWS CLI:
+
+```bash
+aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+
+With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
+
+In this order, replace `your-bucket` with the name of your bucket. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+
+This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
+
+##### Deleting an encrypted object with SSE-S3
+
+Deleting objects encrypted with SSE-S3 is no different from deleting objects that are not encrypted. You can use the following command to delete an object:
+
+```bash
+aws s3 rm s3://my-Bucket/my-object
+```
+
+- Replace `my-Bucket` with the name of your bucket
+- Replace `my-object` by the name of the object you want to delete.
+
+With this command, you can effectively delete an object, whether it is encrypted or not, from your bucket on OVHcloud S3.
+
+### SSE-S3 Encryption considerations
+
+When using SSE-S3 encryption on OVHcloud S3, it is important to consider the following:
+
+#### Performance
+
+- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+
+#### Security
+
+- **Key Management**: SSE-S3 offers a high level of security by automatically managing encryption keys. This simplifies security management for users.
+- **Additional security practices**: Combining SSE-S3 encryption with other security practices is crucial for optimal protection. This includes the use of strict IAM policies and log access tracking to monitor and control data access.
+
+#### Comparison of encryption methods
+
+It’s essential to compare the different encryption methods available to choose the one that best suits your specific needs. Methods to consider include client-side encryption (CSE) and server-side encryption (SSE), with its SSE-C and SSE-S3 variants.
+
+#### Pros and cons
+
+- **CSE vs SSE**: Each method has its own advantages and disadvantages in terms of manageability, security and performance impact.
+- **Recommended use cases**: depending on your specific situation, some methods may be more appropriate than others. It is important to evaluate the recommended use cases for each encryption method.
+
+A comparative table may be useful for summarizing these elements, providing a clear overview that facilitates decision-making.
+
+| Encryption method | Benefits | Cons | Recommended Use Cases |
+|-------------------|----------|------|-----------------------|
+| **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+
+Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+### Recommended use cases for encryption on OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Ideal for**: Organizations with very high security requirements, requiring encryption keys to remain under exclusive control.
+- **Suitable for**: strictly regulated environments, such as financial institutions or healthcare services.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Suitable for**: Organizations seeking a balance between key control and manageability.
+- **Useful for**: when customers are ready to manage keys but want to delegate encryption and decryption.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Perfect for**: users who prefer a turnkey solution without the burden of key management.
+- **Preferred method for**: companies looking to protect their data without specific encryption compliance needs.
+
+The choice between these methods should be guided by security policies and regulatory requirements, as well as the ability to manage encryption keys. A balance between ease of use and security is essential.
+
+### Examples of scripts and commands
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Generating a client-side encryption key
+client_key=$(openssl rand -base64 32)
+# Encryption of a file before sending
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Sending encrypted file to S3 bucket
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Creating an encryption key and its MD5 fingerprint
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Uploading an object with SSE-C encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Retrieving an object with SSE-C encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Sending an object with SSE-S3 encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Uploading an object with SSE-S3 encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Troubleshooting and Common Error Resolution
+
+### Error using SSE-C without proper encryption headers
+
+- **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
+- **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
+
+### Bad query error when using SSE-S3
+
+- **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
+- **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
+
+### Performance or latency issues during encryption/decryption
+
+- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
+
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
+## Conclusion
+
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+
+The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 
 ## Go further
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-au.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C
-updated: 2022-04-15
+updated: 2024-04-10
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objective
 
-Using server-side encryption with customer-provided encryption keys (SSE-C) allows you to set your own encryption keys.  
+At OVHcloud, we understand the crucial importance of data protection in today’s digital ecosystem. In the face of ever-evolving security threats and increasingly stringent regulatory requirements, it’s essential to implement robust measures to secure data at all times. This includes not only data in transit, but also data at rest.
 
-When you upload an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you retrieve an object, you must provide the same encryption key as part of your request. S3 Object Storage first verifies that the encryption key you provided matches and then decrypts the object before returning the object data to you.
+Protecting *at rest* data, i.e. data stored on physical devices or in the cloud, is a crucial part of any organization’s IT security strategy. In this context, there are two main approaches to encrypting this data: client-side encryption (CSE) and server-side encryption (SSE).
 
-**This guide explains how to encrypt your server-side objects with SSE-C.**
+Client-Side Encryption (CSE) allows our customers to encrypt their data on their own device before sending it to our servers for storage. This ensures that data remains encrypted throughout its lifecycle, offering a high degree of security, as encryption keys are managed by the customer and never shared with OVHcloud or any other third party.
+
+While this approach requires the customer to strictly manage the keys, it is an ideal solution for those who require complete control over their data security.
+
+At the same time, server-side encryption (SSE) offers an alternative where data is encrypted when it arrives at our servers. This is the responsibility of OVHcloud, which greatly reduces the burden of security management for our customers. Two server-side encryption methods are available: 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)**: You can provide and manage your own encryption keys, giving you complete control over your data security. This option is particularly well-suited to organizations with specific compliance and data security needs, as it allows for exclusive management of encryption keys.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)**: Simplifies the encryption process by using keys managed by OVHcloud. This method is ideal for customers who want a robust encryption solution without the complexities of key management.
+
+Our goal is to help you choose the type of encryption that is best for you. This page gives you all the information you need to make an informed choice. Whether you prefer to manage yourself with SSE-C or opt for the ease of SSE-S3, we are committed to offering you flexible and secure solutions to protect your data when it is stored.
+
+**This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3.**
 
 > [!warning]
 >
@@ -31,13 +42,17 @@ When you upload an object, S3 Object Storage uses the encryption key you provide
 
 ## Requirements
 
-- A bucket
+- An S3 bucket
 - A user with the required access rights on the bucket
-- Have installed and configured aws-cli
+- Have installed and configured the AWS command line interface (aws-cli)
 
 See our [Getting started with S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) guide.
 
 ## Instructions
+
+Using server-side encryption with client-provided encryption keys (SSE-C) allows you to define your own encryption keys.
+
+When you download an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you check out an object, you must provide the same encryption key as part of your request. S3 Object Storage first checks that the encryption key you provided matches, then decrypts the object before returning the object data to you.
 
 When you use SSE-C, you must provide encryption key information using the following request headers.
 
@@ -47,7 +62,9 @@ When you use SSE-C, you must provide encryption key information using the follow
 | --sse-customer-key | Use this header to provide the 256-bit, base64-encoded encryption key for S3 Object Storage to use to encrypt or decrypt your data. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Use this header to provide the base64-encoded 128-bit MD5 digest of the encryption key according to RFC 1321. S3 Object Storage uses this header for a message integrity check to ensure that the encryption key was transmitted without error. |
 
-### Creating an encryption key
+### SSE-C - Server-Side Encryption with Client Encryption Keys
+
+#### Creating an encryption key
 
 Example of creating an encryption key ( *--sse-customer-key* ):
 
@@ -61,7 +78,7 @@ and the MD5 key ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Uploading an object with SSE-C
+#### Uploading an object with SSE-C
 
 To upload an object with SSE-C and aws-cli, proceed as follows:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Downloading an object with SSE-C
+#### Downloading an object with SSE-C
 
 To download an object with SSE-C and aws-cli, proceed as follows:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Getting object metadata with SSE-C
+#### Getting object metadata with SSE-C
 
 To get an object metadata with SSE-C and aws-cli, proceed as follows:
 
@@ -129,7 +146,7 @@ Output should look like:
 
 Without encryption headers, you will get a `Bad Request` error.
 
-### Deleting an encrypted object with SSE-C
+#### Deleting an encrypted object with SSE-C
 
 To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 
@@ -137,7 +154,7 @@ To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### Presigned URLs and SSE-C
+#### Presigned URLs and SSE-C
 
 Presigned URLs, that can be used for operations such as upload a new object, retrieve an existing object, or object metadata, support the SSE-C as follows:
 
@@ -149,6 +166,248 @@ Presigned URLs, that can be used for operations such as upload a new object, ret
 >
 > You can use the presigned URL for SSE-C objects only programmatically, because in addition to the presigned URL, you also need to include HTTP headers that are specific to SSE-C objects.
 >
+
+### SSE-S3 - Server-side encryption with keys managed by OVHcloud
+
+Using server-side encryption with keys managed by OVHcloud (SSE-S3) helps protect your data stored on OVHcloud by encrypting it automatically at rest. SSE-S3 uses keys managed and protected by OVHcloud, eliminating the need for the user to manually manage these encryption keys.
+
+#### Benefits
+
+- **Simplified Key Management**
+
+With OVHcloud supporting secure encryption key management, users benefit from simplified key management. This approach eliminates the complexities of key rotation while maintaining a high level of data security. It balances security with operational efficiency, eliminating the administrative burden of manually managing encryption keys.
+
+- **Enhanced Security**
+
+We use an advanced encryption strategy to offer maximum protection for your data. Each bucket has a unique key, and for each stored object, a separate encryption key is generated. This key is obtained by combining the unique key of the bucket with a random salt, which ensures that each object is encrypted with its own key. This key derivation method reduces the risk associated with exposing a single key and ensures enhanced security for your data.
+
+- **Transparency**
+
+The encryption and decryption process is completely transparent to the user, allowing encrypted data to be accessed and managed as easily as unencrypted data.
+
+- **Enhanced security with OVHcloud Key Management Service (KMS)**
+
+Our commitment to securing your data is reinforced through the use of OVHcloud Key Management Service (KMS), an advanced platform for secure storage and encryption key management. This approach ensures optimal data protection, setting up a robust security infrastructure without the complexities of directly managing encryption keys.
+
+To further your understanding of OVHcloud Key Management Service (KMS) and its applications in various cloud infrastructure contexts, we recommend reading the following resources:
+
+- **[Getting started with the KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)**: this guide provides a detailed overview of how to implement and use the KMS to secure your data.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)**: practical guide on enabling VM encryption using KMS capabilities.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)**: detailed instructions on using KMS in conjunction with the vSphere Native Key Provider for VM encryption.
+
+These documents provide valuable information on how the KMS can be used to enhance security in different cloud infrastructure scenarios.
+
+#### Implementation
+
+To enhance the security of data uploaded to OVHcloud, enabling server-side encryption (SSE-S3) has been designed to be both easy and transparent. By configuring a default encryption method on your bucket via the `PutBucketEncryption` request, any uploaded object will be automatically encrypted without requiring any additional actions on your side. When uploading an object, simply specify the encryption option in the API request or via the AWS CLI command line. OVHcloud takes care of the rest, encrypting your data before it is stored using an automatically generated unique key for the bucket.
+
+### Secure encryption key management with SSE-S3 on OVHcloud S3
+
+The implementation of SSE-S3 encryption on OVHcloud S3 is designed to provide encryption key management that is both secure and transparent for the user. Each bucket has a separate key, which ensures that data is secured individually and in isolation. This encryption method, integrated and managed by the platform, eliminates the complexities associated with manual key management by users. While making the user process as smooth and intuitive as possible, it maintains robust security and complies with the very strictest data protection standards.
+
+#### Sending an object with SSE-S3 on OVHcloud S3
+
+##### Uploading an object on OVHcloud S3 with SSE-S3 encryption
+
+To send an object in your S3 bucket on OVHcloud with SSE-S3 encryption, use the following Bash command via the AWS CLI. This command includes the server-side encryption option to enhance the security of your stored data.
+
+```bash
+aws s3api put-object --bucket your-bucket --key your-object --body path/to/your/file --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+When using the AWS CLI command to upload an object with SSE-S3 encryption to OVHcloud S3, make sure to replace the following values based on your specific information:
+
+- `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
+- `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
+- `path/to/your/file`: Specify the full path to the file you plan to send.
+
+The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
+
+##### Downloading an Object with SSE-S3 to OVHcloud S3
+
+To download an object that has been encrypted with SSE-S3 from OVHcloud S3, you do not need to specify encryption headers in the command. The object can be downloaded directly without any additional manipulation linked to the encryption, because the decryption is managed automatically on the server side. Here is an example of a download command:
+
+```bash
+aws s3api get-object --bucket your-bucket --key your-object path/to/destination/file --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- Replace `your-object` with the key of the object you want to download.
+- Replace `path/to/destination/file` with the path where you want to save the downloaded file.
+
+Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
+
+#### Adding encryption to an existing bucket on OVHcloud S3
+
+To add SSE-S3 encryption to an existing S3 bucket on OVHcloud, you must use the `put-bucket-encryption` command from the AWS CLI. This command configures bucket encryption so that all newly added objects are automatically encrypted with SSE-S3. Here is the specific command you would use:
+
+```bash
+aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your S3 bucket.
+
+This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
+
+##### Viewing bucket encryption configuration
+
+After configuring your bucket encryption via `PutBucketEncryption` to use SSE-S3, make sure everything is set up correctly using the following command with the AWS CLI:
+
+```bash
+aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+
+With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
+
+In this order, replace `your-bucket` with the name of your bucket. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+
+This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
+
+##### Deleting an encrypted object with SSE-S3
+
+Deleting objects encrypted with SSE-S3 is no different from deleting objects that are not encrypted. You can use the following command to delete an object:
+
+```bash
+aws s3 rm s3://my-Bucket/my-object
+```
+
+- Replace `my-Bucket` with the name of your bucket
+- Replace `my-object` by the name of the object you want to delete.
+
+With this command, you can effectively delete an object, whether it is encrypted or not, from your bucket on OVHcloud S3.
+
+### SSE-S3 Encryption considerations
+
+When using SSE-S3 encryption on OVHcloud S3, it is important to consider the following:
+
+#### Performance
+
+- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+
+#### Security
+
+- **Key Management**: SSE-S3 offers a high level of security by automatically managing encryption keys. This simplifies security management for users.
+- **Additional security practices**: Combining SSE-S3 encryption with other security practices is crucial for optimal protection. This includes the use of strict IAM policies and log access tracking to monitor and control data access.
+
+#### Comparison of encryption methods
+
+It’s essential to compare the different encryption methods available to choose the one that best suits your specific needs. Methods to consider include client-side encryption (CSE) and server-side encryption (SSE), with its SSE-C and SSE-S3 variants.
+
+#### Pros and cons
+
+- **CSE vs SSE**: Each method has its own advantages and disadvantages in terms of manageability, security and performance impact.
+- **Recommended use cases**: depending on your specific situation, some methods may be more appropriate than others. It is important to evaluate the recommended use cases for each encryption method.
+
+A comparative table may be useful for summarizing these elements, providing a clear overview that facilitates decision-making.
+
+| Encryption method | Benefits | Cons | Recommended Use Cases |
+|-------------------|----------|------|-----------------------|
+| **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+
+Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+### Recommended use cases for encryption on OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Ideal for**: Organizations with very high security requirements, requiring encryption keys to remain under exclusive control.
+- **Suitable for**: strictly regulated environments, such as financial institutions or healthcare services.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Suitable for**: Organizations seeking a balance between key control and manageability.
+- **Useful for**: when customers are ready to manage keys but want to delegate encryption and decryption.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Perfect for**: users who prefer a turnkey solution without the burden of key management.
+- **Preferred method for**: companies looking to protect their data without specific encryption compliance needs.
+
+The choice between these methods should be guided by security policies and regulatory requirements, as well as the ability to manage encryption keys. A balance between ease of use and security is essential.
+
+### Examples of scripts and commands
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Generating a client-side encryption key
+client_key=$(openssl rand -base64 32)
+# Encryption of a file before sending
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Sending encrypted file to S3 bucket
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Creating an encryption key and its MD5 fingerprint
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Uploading an object with SSE-C encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Retrieving an object with SSE-C encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Sending an object with SSE-S3 encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Uploading an object with SSE-S3 encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Troubleshooting and Common Error Resolution
+
+### Error using SSE-C without proper encryption headers
+
+- **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
+- **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
+
+### Bad query error when using SSE-S3
+
+- **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
+- **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
+
+### Performance or latency issues during encryption/decryption
+
+- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
+
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
+## Conclusion
+
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+
+The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 
 ## Go further
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-ca.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C
-updated: 2022-04-15
+updated: 2024-04-10
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objective
 
-Using server-side encryption with customer-provided encryption keys (SSE-C) allows you to set your own encryption keys.  
+At OVHcloud, we understand the crucial importance of data protection in today’s digital ecosystem. In the face of ever-evolving security threats and increasingly stringent regulatory requirements, it’s essential to implement robust measures to secure data at all times. This includes not only data in transit, but also data at rest.
 
-When you upload an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you retrieve an object, you must provide the same encryption key as part of your request. S3 Object Storage first verifies that the encryption key you provided matches and then decrypts the object before returning the object data to you.
+Protecting *at rest* data, i.e. data stored on physical devices or in the cloud, is a crucial part of any organization’s IT security strategy. In this context, there are two main approaches to encrypting this data: client-side encryption (CSE) and server-side encryption (SSE).
 
-**This guide explains how to encrypt your server-side objects with SSE-C.**
+Client-Side Encryption (CSE) allows our customers to encrypt their data on their own device before sending it to our servers for storage. This ensures that data remains encrypted throughout its lifecycle, offering a high degree of security, as encryption keys are managed by the customer and never shared with OVHcloud or any other third party.
+
+While this approach requires the customer to strictly manage the keys, it is an ideal solution for those who require complete control over their data security.
+
+At the same time, server-side encryption (SSE) offers an alternative where data is encrypted when it arrives at our servers. This is the responsibility of OVHcloud, which greatly reduces the burden of security management for our customers. Two server-side encryption methods are available: 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)**: You can provide and manage your own encryption keys, giving you complete control over your data security. This option is particularly well-suited to organizations with specific compliance and data security needs, as it allows for exclusive management of encryption keys.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)**: Simplifies the encryption process by using keys managed by OVHcloud. This method is ideal for customers who want a robust encryption solution without the complexities of key management.
+
+Our goal is to help you choose the type of encryption that is best for you. This page gives you all the information you need to make an informed choice. Whether you prefer to manage yourself with SSE-C or opt for the ease of SSE-S3, we are committed to offering you flexible and secure solutions to protect your data when it is stored.
+
+**This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3.**
 
 > [!warning]
 >
@@ -31,13 +42,17 @@ When you upload an object, S3 Object Storage uses the encryption key you provide
 
 ## Requirements
 
-- A bucket
+- An S3 bucket
 - A user with the required access rights on the bucket
-- Have installed and configured aws-cli
+- Have installed and configured the AWS command line interface (aws-cli)
 
 See our [Getting started with S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) guide.
 
 ## Instructions
+
+Using server-side encryption with client-provided encryption keys (SSE-C) allows you to define your own encryption keys.
+
+When you download an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you check out an object, you must provide the same encryption key as part of your request. S3 Object Storage first checks that the encryption key you provided matches, then decrypts the object before returning the object data to you.
 
 When you use SSE-C, you must provide encryption key information using the following request headers.
 
@@ -47,7 +62,9 @@ When you use SSE-C, you must provide encryption key information using the follow
 | --sse-customer-key | Use this header to provide the 256-bit, base64-encoded encryption key for S3 Object Storage to use to encrypt or decrypt your data. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Use this header to provide the base64-encoded 128-bit MD5 digest of the encryption key according to RFC 1321. S3 Object Storage uses this header for a message integrity check to ensure that the encryption key was transmitted without error. |
 
-### Creating an encryption key
+### SSE-C - Server-Side Encryption with Client Encryption Keys
+
+#### Creating an encryption key
 
 Example of creating an encryption key ( *--sse-customer-key* ):
 
@@ -61,7 +78,7 @@ and the MD5 key ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Uploading an object with SSE-C
+#### Uploading an object with SSE-C
 
 To upload an object with SSE-C and aws-cli, proceed as follows:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Downloading an object with SSE-C
+#### Downloading an object with SSE-C
 
 To download an object with SSE-C and aws-cli, proceed as follows:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Getting object metadata with SSE-C
+#### Getting object metadata with SSE-C
 
 To get an object metadata with SSE-C and aws-cli, proceed as follows:
 
@@ -129,7 +146,7 @@ Output should look like:
 
 Without encryption headers, you will get a `Bad Request` error.
 
-### Deleting an encrypted object with SSE-C
+#### Deleting an encrypted object with SSE-C
 
 To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 
@@ -137,7 +154,7 @@ To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### Presigned URLs and SSE-C
+#### Presigned URLs and SSE-C
 
 Presigned URLs, that can be used for operations such as upload a new object, retrieve an existing object, or object metadata, support the SSE-C as follows:
 
@@ -149,6 +166,248 @@ Presigned URLs, that can be used for operations such as upload a new object, ret
 >
 > You can use the presigned URL for SSE-C objects only programmatically, because in addition to the presigned URL, you also need to include HTTP headers that are specific to SSE-C objects.
 >
+
+### SSE-S3 - Server-side encryption with keys managed by OVHcloud
+
+Using server-side encryption with keys managed by OVHcloud (SSE-S3) helps protect your data stored on OVHcloud by encrypting it automatically at rest. SSE-S3 uses keys managed and protected by OVHcloud, eliminating the need for the user to manually manage these encryption keys.
+
+#### Benefits
+
+- **Simplified Key Management**
+
+With OVHcloud supporting secure encryption key management, users benefit from simplified key management. This approach eliminates the complexities of key rotation while maintaining a high level of data security. It balances security with operational efficiency, eliminating the administrative burden of manually managing encryption keys.
+
+- **Enhanced Security**
+
+We use an advanced encryption strategy to offer maximum protection for your data. Each bucket has a unique key, and for each stored object, a separate encryption key is generated. This key is obtained by combining the unique key of the bucket with a random salt, which ensures that each object is encrypted with its own key. This key derivation method reduces the risk associated with exposing a single key and ensures enhanced security for your data.
+
+- **Transparency**
+
+The encryption and decryption process is completely transparent to the user, allowing encrypted data to be accessed and managed as easily as unencrypted data.
+
+- **Enhanced security with OVHcloud Key Management Service (KMS)**
+
+Our commitment to securing your data is reinforced through the use of OVHcloud Key Management Service (KMS), an advanced platform for secure storage and encryption key management. This approach ensures optimal data protection, setting up a robust security infrastructure without the complexities of directly managing encryption keys.
+
+To further your understanding of OVHcloud Key Management Service (KMS) and its applications in various cloud infrastructure contexts, we recommend reading the following resources:
+
+- **[Getting started with the KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)**: this guide provides a detailed overview of how to implement and use the KMS to secure your data.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)**: practical guide on enabling VM encryption using KMS capabilities.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)**: detailed instructions on using KMS in conjunction with the vSphere Native Key Provider for VM encryption.
+
+These documents provide valuable information on how the KMS can be used to enhance security in different cloud infrastructure scenarios.
+
+#### Implementation
+
+To enhance the security of data uploaded to OVHcloud, enabling server-side encryption (SSE-S3) has been designed to be both easy and transparent. By configuring a default encryption method on your bucket via the `PutBucketEncryption` request, any uploaded object will be automatically encrypted without requiring any additional actions on your side. When uploading an object, simply specify the encryption option in the API request or via the AWS CLI command line. OVHcloud takes care of the rest, encrypting your data before it is stored using an automatically generated unique key for the bucket.
+
+### Secure encryption key management with SSE-S3 on OVHcloud S3
+
+The implementation of SSE-S3 encryption on OVHcloud S3 is designed to provide encryption key management that is both secure and transparent for the user. Each bucket has a separate key, which ensures that data is secured individually and in isolation. This encryption method, integrated and managed by the platform, eliminates the complexities associated with manual key management by users. While making the user process as smooth and intuitive as possible, it maintains robust security and complies with the very strictest data protection standards.
+
+#### Sending an object with SSE-S3 on OVHcloud S3
+
+##### Uploading an object on OVHcloud S3 with SSE-S3 encryption
+
+To send an object in your S3 bucket on OVHcloud with SSE-S3 encryption, use the following Bash command via the AWS CLI. This command includes the server-side encryption option to enhance the security of your stored data.
+
+```bash
+aws s3api put-object --bucket your-bucket --key your-object --body path/to/your/file --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+When using the AWS CLI command to upload an object with SSE-S3 encryption to OVHcloud S3, make sure to replace the following values based on your specific information:
+
+- `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
+- `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
+- `path/to/your/file`: Specify the full path to the file you plan to send.
+
+The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
+
+##### Downloading an Object with SSE-S3 to OVHcloud S3
+
+To download an object that has been encrypted with SSE-S3 from OVHcloud S3, you do not need to specify encryption headers in the command. The object can be downloaded directly without any additional manipulation linked to the encryption, because the decryption is managed automatically on the server side. Here is an example of a download command:
+
+```bash
+aws s3api get-object --bucket your-bucket --key your-object path/to/destination/file --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- Replace `your-object` with the key of the object you want to download.
+- Replace `path/to/destination/file` with the path where you want to save the downloaded file.
+
+Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
+
+#### Adding encryption to an existing bucket on OVHcloud S3
+
+To add SSE-S3 encryption to an existing S3 bucket on OVHcloud, you must use the `put-bucket-encryption` command from the AWS CLI. This command configures bucket encryption so that all newly added objects are automatically encrypted with SSE-S3. Here is the specific command you would use:
+
+```bash
+aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your S3 bucket.
+
+This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
+
+##### Viewing bucket encryption configuration
+
+After configuring your bucket encryption via `PutBucketEncryption` to use SSE-S3, make sure everything is set up correctly using the following command with the AWS CLI:
+
+```bash
+aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+
+With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
+
+In this order, replace `your-bucket` with the name of your bucket. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+
+This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
+
+##### Deleting an encrypted object with SSE-S3
+
+Deleting objects encrypted with SSE-S3 is no different from deleting objects that are not encrypted. You can use the following command to delete an object:
+
+```bash
+aws s3 rm s3://my-Bucket/my-object
+```
+
+- Replace `my-Bucket` with the name of your bucket
+- Replace `my-object` by the name of the object you want to delete.
+
+With this command, you can effectively delete an object, whether it is encrypted or not, from your bucket on OVHcloud S3.
+
+### SSE-S3 Encryption considerations
+
+When using SSE-S3 encryption on OVHcloud S3, it is important to consider the following:
+
+#### Performance
+
+- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+
+#### Security
+
+- **Key Management**: SSE-S3 offers a high level of security by automatically managing encryption keys. This simplifies security management for users.
+- **Additional security practices**: Combining SSE-S3 encryption with other security practices is crucial for optimal protection. This includes the use of strict IAM policies and log access tracking to monitor and control data access.
+
+#### Comparison of encryption methods
+
+It’s essential to compare the different encryption methods available to choose the one that best suits your specific needs. Methods to consider include client-side encryption (CSE) and server-side encryption (SSE), with its SSE-C and SSE-S3 variants.
+
+#### Pros and cons
+
+- **CSE vs SSE**: Each method has its own advantages and disadvantages in terms of manageability, security and performance impact.
+- **Recommended use cases**: depending on your specific situation, some methods may be more appropriate than others. It is important to evaluate the recommended use cases for each encryption method.
+
+A comparative table may be useful for summarizing these elements, providing a clear overview that facilitates decision-making.
+
+| Encryption method | Benefits | Cons | Recommended Use Cases |
+|-------------------|----------|------|-----------------------|
+| **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+
+Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+### Recommended use cases for encryption on OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Ideal for**: Organizations with very high security requirements, requiring encryption keys to remain under exclusive control.
+- **Suitable for**: strictly regulated environments, such as financial institutions or healthcare services.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Suitable for**: Organizations seeking a balance between key control and manageability.
+- **Useful for**: when customers are ready to manage keys but want to delegate encryption and decryption.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Perfect for**: users who prefer a turnkey solution without the burden of key management.
+- **Preferred method for**: companies looking to protect their data without specific encryption compliance needs.
+
+The choice between these methods should be guided by security policies and regulatory requirements, as well as the ability to manage encryption keys. A balance between ease of use and security is essential.
+
+### Examples of scripts and commands
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Generating a client-side encryption key
+client_key=$(openssl rand -base64 32)
+# Encryption of a file before sending
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Sending encrypted file to S3 bucket
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Creating an encryption key and its MD5 fingerprint
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Uploading an object with SSE-C encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Retrieving an object with SSE-C encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Sending an object with SSE-S3 encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Uploading an object with SSE-S3 encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Troubleshooting and Common Error Resolution
+
+### Error using SSE-C without proper encryption headers
+
+- **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
+- **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
+
+### Bad query error when using SSE-S3
+
+- **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
+- **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
+
+### Performance or latency issues during encryption/decryption
+
+- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
+
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
+## Conclusion
+
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+
+The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 
 ## Go further
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-gb.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C or SSE-S3
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-08
+updated: 2024-04-10
 ---
 
 <style>

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-gb.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
-title: Object Storage - Encrypt your server-side objects with SSE-C
-excerpt: This guide explains how to encrypt your server-side objects with SSE-C
-updated: 2022-04-15
+title: Object Storage - Encrypt your server-side objects with SSE-C or SSE-S3
+excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
+updated: 2024-04-08
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objective
 
-Using server-side encryption with customer-provided encryption keys (SSE-C) allows you to set your own encryption keys.  
+At OVHcloud, we understand the crucial importance of data protection in today’s digital ecosystem. In the face of ever-evolving security threats and increasingly stringent regulatory requirements, it’s essential to implement robust measures to secure data at all times. This includes not only data in transit, but also data at rest.
 
-When you upload an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you retrieve an object, you must provide the same encryption key as part of your request. S3 Object Storage first verifies that the encryption key you provided matches and then decrypts the object before returning the object data to you.
+Protecting *at rest* data, i.e. data stored on physical devices or in the cloud, is a crucial part of any organization’s IT security strategy. In this context, there are two main approaches to encrypting this data: client-side encryption (CSE) and server-side encryption (SSE).
 
-**This guide explains how to encrypt your server-side objects with SSE-C.**
+Client-Side Encryption (CSE) allows our customers to encrypt their data on their own device before sending it to our servers for storage. This ensures that data remains encrypted throughout its lifecycle, offering a high degree of security, as encryption keys are managed by the customer and never shared with OVHcloud or any other third party.
+
+While this approach requires the customer to strictly manage the keys, it is an ideal solution for those who require complete control over their data security.
+
+At the same time, server-side encryption (SSE) offers an alternative where data is encrypted when it arrives at our servers. This is the responsibility of OVHcloud, which greatly reduces the burden of security management for our customers. Two server-side encryption methods are available: 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)**: You can provide and manage your own encryption keys, giving you complete control over your data security. This option is particularly well-suited to organizations with specific compliance and data security needs, as it allows for exclusive management of encryption keys.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)**: Simplifies the encryption process by using keys managed by OVHcloud. This method is ideal for customers who want a robust encryption solution without the complexities of key management.
+
+Our goal is to help you choose the type of encryption that is best for you. This page gives you all the information you need to make an informed choice. Whether you prefer to manage yourself with SSE-C or opt for the ease of SSE-S3, we are committed to offering you flexible and secure solutions to protect your data when it is stored.
+
+**This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3.**
 
 > [!warning]
 >
@@ -31,13 +42,17 @@ When you upload an object, S3 Object Storage uses the encryption key you provide
 
 ## Requirements
 
-- A bucket
+- An S3 bucket
 - A user with the required access rights on the bucket
-- Have installed and configured aws-cli
+- Have installed and configured the AWS command line interface (aws-cli)
 
 See our [Getting started with S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) guide.
 
 ## Instructions
+
+Using server-side encryption with client-provided encryption keys (SSE-C) allows you to define your own encryption keys.
+
+When you download an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you check out an object, you must provide the same encryption key as part of your request. S3 Object Storage first checks that the encryption key you provided matches, then decrypts the object before returning the object data to you.
 
 When you use SSE-C, you must provide encryption key information using the following request headers.
 
@@ -47,7 +62,9 @@ When you use SSE-C, you must provide encryption key information using the follow
 | --sse-customer-key | Use this header to provide the 256-bit, base64-encoded encryption key for S3 Object Storage to use to encrypt or decrypt your data. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Use this header to provide the base64-encoded 128-bit MD5 digest of the encryption key according to RFC 1321. S3 Object Storage uses this header for a message integrity check to ensure that the encryption key was transmitted without error. |
 
-### Creating an encryption key
+### SSE-C - Server-Side Encryption with Client Encryption Keys
+
+#### Creating an encryption key
 
 Example of creating an encryption key ( *--sse-customer-key* ):
 
@@ -61,7 +78,7 @@ and the MD5 key ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Uploading an object with SSE-C
+#### Uploading an object with SSE-C
 
 To upload an object with SSE-C and aws-cli, proceed as follows:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Downloading an object with SSE-C
+#### Downloading an object with SSE-C
 
 To download an object with SSE-C and aws-cli, proceed as follows:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Getting object metadata with SSE-C
+#### Getting object metadata with SSE-C
 
 To get an object metadata with SSE-C and aws-cli, proceed as follows:
 
@@ -129,7 +146,7 @@ Output should look like:
 
 Without encryption headers, you will get a `Bad Request` error.
 
-### Deleting an encrypted object with SSE-C
+#### Deleting an encrypted object with SSE-C
 
 To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 
@@ -137,7 +154,7 @@ To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### Presigned URLs and SSE-C
+#### Presigned URLs and SSE-C
 
 Presigned URLs, that can be used for operations such as upload a new object, retrieve an existing object, or object metadata, support the SSE-C as follows:
 
@@ -149,6 +166,252 @@ Presigned URLs, that can be used for operations such as upload a new object, ret
 >
 > You can use the presigned URL for SSE-C objects only programmatically, because in addition to the presigned URL, you also need to include HTTP headers that are specific to SSE-C objects.
 >
+
+### SSE-S3 - Server-side encryption with keys managed by OVHcloud
+
+Using server-side encryption with keys managed by OVHcloud (SSE-S3) helps protect your data stored on OVHcloud by encrypting it automatically at rest. SSE-S3 uses keys managed and protected by OVHcloud, eliminating the need for the user to manually manage these encryption keys.
+
+#### Benefits
+
+- **Simplified Key Management**
+
+With OVHcloud supporting secure encryption key management, users benefit from simplified key management. This approach eliminates the complexities of key rotation while maintaining a high level of data security. It balances security with operational efficiency, eliminating the administrative burden of manually managing encryption keys.
+
+- **Enhanced Security**
+
+We use an advanced encryption strategy to offer maximum protection for your data. Each bucket has a unique key, and for each stored object, a separate encryption key is generated. This key is obtained by combining the unique key of the bucket with a random salt, which ensures that each object is encrypted with its own key. This key derivation method reduces the risk associated with exposing a single key and ensures enhanced security for your data.
+
+- **Transparency**
+
+The encryption and decryption process is completely transparent to the user, allowing encrypted data to be accessed and managed as easily as unencrypted data.
+
+- **Enhanced security with OVHcloud Key Management Service (KMS)**
+
+Our commitment to securing your data is reinforced through the use of OVHcloud Key Management Service (KMS), an advanced platform for secure storage and encryption key management. This approach ensures optimal data protection, setting up a robust security infrastructure without the complexities of directly managing encryption keys.
+
+To further your understanding of OVHcloud Key Management Service (KMS) and its applications in various cloud infrastructure contexts, we recommend reading the following resources:
+
+- **[Getting started with the KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)**: this guide provides a detailed overview of how to implement and use the KMS to secure your data.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)**: practical guide on enabling VM encryption using KMS capabilities.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)**: detailed instructions on using KMS in conjunction with the vSphere Native Key Provider for VM encryption.
+
+These documents provide valuable information on how the KMS can be used to enhance security in different cloud infrastructure scenarios.
+
+#### Implementation
+
+To enhance the security of data uploaded to OVHcloud, enabling server-side encryption (SSE-S3) has been designed to be both easy and transparent. By configuring a default encryption method on your bucket via the `PutBucketEncryption` request, any uploaded object will be automatically encrypted without requiring any additional actions on your side. When uploading an object, simply specify the encryption option in the API request or via the AWS CLI command line. OVHcloud takes care of the rest, encrypting your data before it is stored using an automatically generated unique key for the bucket.
+
+### Secure encryption key management with SSE-S3 on OVHcloud S3
+
+The implementation of SSE-S3 encryption on OVHcloud S3 is designed to provide encryption key management that is both secure and transparent for the user. Each bucket has a separate key, which ensures that data is secured individually and in isolation. This encryption method, integrated and managed by the platform, eliminates the complexities associated with manual key management by users. While making the user process as smooth and intuitive as possible, it maintains robust security and complies with the very strictest data protection standards.
+
+#### Sending an object with SSE-S3 on OVHcloud S3
+
+##### Uploading an object on OVHcloud S3 with SSE-S3 encryption
+
+To send an object in your S3 bucket on OVHcloud with SSE-S3 encryption, use the following Bash command via the AWS CLI. This command includes the server-side encryption option to enhance the security of your stored data.
+
+```bash
+aws s3api put-object --bucket your-bucket --key your-object --body path/to/your/file --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+When using the AWS CLI command to upload an object with SSE-S3 encryption to OVHcloud S3, make sure to replace the following values based on your specific information:
+
+- `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
+- `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
+- `path/to/your/file`: Specify the full path to the file you plan to send.
+- `<region>`: replace with the region of your OVHcloud S3 service, which hosts your bucket.
+
+The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
+
+##### Downloading an Object with SSE-S3 to OVHcloud S3
+
+To download an object that has been encrypted with SSE-S3 from OVHcloud S3, you do not need to specify encryption headers in the command. The object can be downloaded directly without any additional manipulation linked to the encryption, because the decryption is managed automatically on the server side. Here is an example of a download command:
+
+```bash
+aws s3api get-object --bucket your-bucket --key your-object path/to/destination/file --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- Replace `your-object` with the key of the object you want to download.
+- Replace `path/to/destination/file` with the path where you want to save the downloaded file.
+- The parameter `--endpoint-url https://s3.io.cloud.ovh.net` must be adjusted to the region of your OVHcloud S3 service.
+
+Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
+
+#### Adding encryption to an existing bucket on OVHcloud S3
+
+To add SSE-S3 encryption to an existing S3 bucket on OVHcloud, you must use the `put-bucket-encryption` command from the AWS CLI. This command configures bucket encryption so that all newly added objects are automatically encrypted with SSE-S3. Here is the specific command you would use:
+
+```bash
+aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your S3 bucket.
+- Replace `<region>` with the region of your OVHcloud S3 service where your bucket is located.
+
+This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
+
+##### Viewing bucket encryption configuration
+
+After configuring your bucket encryption via `PutBucketEncryption` to use SSE-S3, make sure everything is set up correctly using the following command with the AWS CLI:
+
+```bash
+aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- And `<region>` by the region of your OVHcloud S3 service.
+
+With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
+
+In this order, replace `your-bucket` with the name of your bucket and `<region>` with the region of your OVHcloud S3 service. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+
+This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
+
+##### Deleting an encrypted object with SSE-S3
+
+Deleting objects encrypted with SSE-S3 is no different from deleting objects that are not encrypted. You can use the following command to delete an object:
+
+```bash
+aws s3 rm s3://my-Bucket/my-object
+```
+
+- Replace `my-Bucket` with the name of your bucket
+- Replace `my-object` by the name of the object you want to delete.
+
+With this command, you can effectively delete an object, whether it is encrypted or not, from your bucket on OVHcloud S3.
+
+### SSE-S3 Encryption considerations
+
+When using SSE-S3 encryption on OVHcloud S3, it is important to consider the following:
+
+#### Performance
+
+- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+
+#### Security
+
+- **Key Management**: SSE-S3 offers a high level of security by automatically managing encryption keys. This simplifies security management for users.
+- **Additional security practices**: Combining SSE-S3 encryption with other security practices is crucial for optimal protection. This includes the use of strict IAM policies and log access tracking to monitor and control data access.
+
+#### Comparison of encryption methods
+
+It’s essential to compare the different encryption methods available to choose the one that best suits your specific needs. Methods to consider include client-side encryption (CSE) and server-side encryption (SSE), with its SSE-C and SSE-S3 variants.
+
+#### Pros and cons
+
+- **CSE vs SSE**: Each method has its own advantages and disadvantages in terms of manageability, security and performance impact.
+- **Recommended use cases**: depending on your specific situation, some methods may be more appropriate than others. It is important to evaluate the recommended use cases for each encryption method.
+
+A comparative table may be useful for summarizing these elements, providing a clear overview that facilitates decision-making.
+
+| Encryption method | Benefits | Cons | Recommended Use Cases |
+|-------------------|----------|------|-----------------------|
+| **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+
+Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+### Recommended use cases for encryption on OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Ideal for**: Organizations with very high security requirements, requiring encryption keys to remain under exclusive control.
+- **Suitable for**: strictly regulated environments, such as financial institutions or healthcare services.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Suitable for**: Organizations seeking a balance between key control and manageability.
+- **Useful for**: when customers are ready to manage keys but want to delegate encryption and decryption.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Perfect for**: users who prefer a turnkey solution without the burden of key management.
+- **Preferred method for**: companies looking to protect their data without specific encryption compliance needs.
+
+The choice between these methods should be guided by security policies and regulatory requirements, as well as the ability to manage encryption keys. A balance between ease of use and security is essential.
+
+### Examples of scripts and commands
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Generating a client-side encryption key
+client_key=$(openssl rand -base64 32)
+# Encryption of a file before sending
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Sending encrypted file to S3 bucket
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Creating an encryption key and its MD5 fingerprint
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Uploading an object with SSE-C encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Retrieving an object with SSE-C encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Sending an object with SSE-S3 encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Uploading an object with SSE-S3 encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Troubleshooting and Common Error Resolution
+
+### Error using SSE-C without proper encryption headers
+
+- **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
+- **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
+
+### Bad query error when using SSE-S3
+
+- **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
+- **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
+
+### Performance or latency issues during encryption/decryption
+
+- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
+
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
+## Conclusion
+
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+
+The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 
 ## Go further
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-gb.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-gb.md
@@ -220,7 +220,6 @@ When using the AWS CLI command to upload an object with SSE-S3 encryption to OVH
 - `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
 - `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
 - `path/to/your/file`: Specify the full path to the file you plan to send.
-- `<region>`: replace with the region of your OVHcloud S3 service, which hosts your bucket.
 
 The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
 
@@ -235,7 +234,6 @@ aws s3api get-object --bucket your-bucket --key your-object path/to/destination/
 - Replace `your-bucket` with the name of your bucket.
 - Replace `your-object` with the key of the object you want to download.
 - Replace `path/to/destination/file` with the path where you want to save the downloaded file.
-- The parameter `--endpoint-url https://s3.io.cloud.ovh.net` must be adjusted to the region of your OVHcloud S3 service.
 
 Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
 
@@ -248,7 +246,6 @@ aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-co
 ```
 
 - Replace `your-bucket` with the name of your S3 bucket.
-- Replace `<region>` with the region of your OVHcloud S3 service where your bucket is located.
 
 This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
 
@@ -261,11 +258,10 @@ aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.i
 ```
 
 - Replace `your-bucket` with the name of your bucket.
-- And `<region>` by the region of your OVHcloud S3 service.
 
 With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
 
-In this order, replace `your-bucket` with the name of your bucket and `<region>` with the region of your OVHcloud S3 service. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+In this order, replace `your-bucket` with the name of your bucket. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
 
 This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-ie.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C
-updated: 2022-04-15
+updated: 2024-04-10
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objective
 
-Using server-side encryption with customer-provided encryption keys (SSE-C) allows you to set your own encryption keys.  
+At OVHcloud, we understand the crucial importance of data protection in today’s digital ecosystem. In the face of ever-evolving security threats and increasingly stringent regulatory requirements, it’s essential to implement robust measures to secure data at all times. This includes not only data in transit, but also data at rest.
 
-When you upload an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you retrieve an object, you must provide the same encryption key as part of your request. S3 Object Storage first verifies that the encryption key you provided matches and then decrypts the object before returning the object data to you.
+Protecting *at rest* data, i.e. data stored on physical devices or in the cloud, is a crucial part of any organization’s IT security strategy. In this context, there are two main approaches to encrypting this data: client-side encryption (CSE) and server-side encryption (SSE).
 
-**This guide explains how to encrypt your server-side objects with SSE-C.**
+Client-Side Encryption (CSE) allows our customers to encrypt their data on their own device before sending it to our servers for storage. This ensures that data remains encrypted throughout its lifecycle, offering a high degree of security, as encryption keys are managed by the customer and never shared with OVHcloud or any other third party.
+
+While this approach requires the customer to strictly manage the keys, it is an ideal solution for those who require complete control over their data security.
+
+At the same time, server-side encryption (SSE) offers an alternative where data is encrypted when it arrives at our servers. This is the responsibility of OVHcloud, which greatly reduces the burden of security management for our customers. Two server-side encryption methods are available: 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)**: You can provide and manage your own encryption keys, giving you complete control over your data security. This option is particularly well-suited to organizations with specific compliance and data security needs, as it allows for exclusive management of encryption keys.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)**: Simplifies the encryption process by using keys managed by OVHcloud. This method is ideal for customers who want a robust encryption solution without the complexities of key management.
+
+Our goal is to help you choose the type of encryption that is best for you. This page gives you all the information you need to make an informed choice. Whether you prefer to manage yourself with SSE-C or opt for the ease of SSE-S3, we are committed to offering you flexible and secure solutions to protect your data when it is stored.
+
+**This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3.**
 
 > [!warning]
 >
@@ -31,13 +42,17 @@ When you upload an object, S3 Object Storage uses the encryption key you provide
 
 ## Requirements
 
-- A bucket
+- An S3 bucket
 - A user with the required access rights on the bucket
-- Have installed and configured aws-cli
+- Have installed and configured the AWS command line interface (aws-cli)
 
 See our [Getting started with S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) guide.
 
 ## Instructions
+
+Using server-side encryption with client-provided encryption keys (SSE-C) allows you to define your own encryption keys.
+
+When you download an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you check out an object, you must provide the same encryption key as part of your request. S3 Object Storage first checks that the encryption key you provided matches, then decrypts the object before returning the object data to you.
 
 When you use SSE-C, you must provide encryption key information using the following request headers.
 
@@ -47,7 +62,9 @@ When you use SSE-C, you must provide encryption key information using the follow
 | --sse-customer-key | Use this header to provide the 256-bit, base64-encoded encryption key for S3 Object Storage to use to encrypt or decrypt your data. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Use this header to provide the base64-encoded 128-bit MD5 digest of the encryption key according to RFC 1321. S3 Object Storage uses this header for a message integrity check to ensure that the encryption key was transmitted without error. |
 
-### Creating an encryption key
+### SSE-C - Server-Side Encryption with Client Encryption Keys
+
+#### Creating an encryption key
 
 Example of creating an encryption key ( *--sse-customer-key* ):
 
@@ -61,7 +78,7 @@ and the MD5 key ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Uploading an object with SSE-C
+#### Uploading an object with SSE-C
 
 To upload an object with SSE-C and aws-cli, proceed as follows:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Downloading an object with SSE-C
+#### Downloading an object with SSE-C
 
 To download an object with SSE-C and aws-cli, proceed as follows:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Getting object metadata with SSE-C
+#### Getting object metadata with SSE-C
 
 To get an object metadata with SSE-C and aws-cli, proceed as follows:
 
@@ -129,7 +146,7 @@ Output should look like:
 
 Without encryption headers, you will get a `Bad Request` error.
 
-### Deleting an encrypted object with SSE-C
+#### Deleting an encrypted object with SSE-C
 
 To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 
@@ -137,7 +154,7 @@ To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### Presigned URLs and SSE-C
+#### Presigned URLs and SSE-C
 
 Presigned URLs, that can be used for operations such as upload a new object, retrieve an existing object, or object metadata, support the SSE-C as follows:
 
@@ -149,6 +166,248 @@ Presigned URLs, that can be used for operations such as upload a new object, ret
 >
 > You can use the presigned URL for SSE-C objects only programmatically, because in addition to the presigned URL, you also need to include HTTP headers that are specific to SSE-C objects.
 >
+
+### SSE-S3 - Server-side encryption with keys managed by OVHcloud
+
+Using server-side encryption with keys managed by OVHcloud (SSE-S3) helps protect your data stored on OVHcloud by encrypting it automatically at rest. SSE-S3 uses keys managed and protected by OVHcloud, eliminating the need for the user to manually manage these encryption keys.
+
+#### Benefits
+
+- **Simplified Key Management**
+
+With OVHcloud supporting secure encryption key management, users benefit from simplified key management. This approach eliminates the complexities of key rotation while maintaining a high level of data security. It balances security with operational efficiency, eliminating the administrative burden of manually managing encryption keys.
+
+- **Enhanced Security**
+
+We use an advanced encryption strategy to offer maximum protection for your data. Each bucket has a unique key, and for each stored object, a separate encryption key is generated. This key is obtained by combining the unique key of the bucket with a random salt, which ensures that each object is encrypted with its own key. This key derivation method reduces the risk associated with exposing a single key and ensures enhanced security for your data.
+
+- **Transparency**
+
+The encryption and decryption process is completely transparent to the user, allowing encrypted data to be accessed and managed as easily as unencrypted data.
+
+- **Enhanced security with OVHcloud Key Management Service (KMS)**
+
+Our commitment to securing your data is reinforced through the use of OVHcloud Key Management Service (KMS), an advanced platform for secure storage and encryption key management. This approach ensures optimal data protection, setting up a robust security infrastructure without the complexities of directly managing encryption keys.
+
+To further your understanding of OVHcloud Key Management Service (KMS) and its applications in various cloud infrastructure contexts, we recommend reading the following resources:
+
+- **[Getting started with the KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)**: this guide provides a detailed overview of how to implement and use the KMS to secure your data.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)**: practical guide on enabling VM encryption using KMS capabilities.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)**: detailed instructions on using KMS in conjunction with the vSphere Native Key Provider for VM encryption.
+
+These documents provide valuable information on how the KMS can be used to enhance security in different cloud infrastructure scenarios.
+
+#### Implementation
+
+To enhance the security of data uploaded to OVHcloud, enabling server-side encryption (SSE-S3) has been designed to be both easy and transparent. By configuring a default encryption method on your bucket via the `PutBucketEncryption` request, any uploaded object will be automatically encrypted without requiring any additional actions on your side. When uploading an object, simply specify the encryption option in the API request or via the AWS CLI command line. OVHcloud takes care of the rest, encrypting your data before it is stored using an automatically generated unique key for the bucket.
+
+### Secure encryption key management with SSE-S3 on OVHcloud S3
+
+The implementation of SSE-S3 encryption on OVHcloud S3 is designed to provide encryption key management that is both secure and transparent for the user. Each bucket has a separate key, which ensures that data is secured individually and in isolation. This encryption method, integrated and managed by the platform, eliminates the complexities associated with manual key management by users. While making the user process as smooth and intuitive as possible, it maintains robust security and complies with the very strictest data protection standards.
+
+#### Sending an object with SSE-S3 on OVHcloud S3
+
+##### Uploading an object on OVHcloud S3 with SSE-S3 encryption
+
+To send an object in your S3 bucket on OVHcloud with SSE-S3 encryption, use the following Bash command via the AWS CLI. This command includes the server-side encryption option to enhance the security of your stored data.
+
+```bash
+aws s3api put-object --bucket your-bucket --key your-object --body path/to/your/file --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+When using the AWS CLI command to upload an object with SSE-S3 encryption to OVHcloud S3, make sure to replace the following values based on your specific information:
+
+- `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
+- `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
+- `path/to/your/file`: Specify the full path to the file you plan to send.
+
+The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
+
+##### Downloading an Object with SSE-S3 to OVHcloud S3
+
+To download an object that has been encrypted with SSE-S3 from OVHcloud S3, you do not need to specify encryption headers in the command. The object can be downloaded directly without any additional manipulation linked to the encryption, because the decryption is managed automatically on the server side. Here is an example of a download command:
+
+```bash
+aws s3api get-object --bucket your-bucket --key your-object path/to/destination/file --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- Replace `your-object` with the key of the object you want to download.
+- Replace `path/to/destination/file` with the path where you want to save the downloaded file.
+
+Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
+
+#### Adding encryption to an existing bucket on OVHcloud S3
+
+To add SSE-S3 encryption to an existing S3 bucket on OVHcloud, you must use the `put-bucket-encryption` command from the AWS CLI. This command configures bucket encryption so that all newly added objects are automatically encrypted with SSE-S3. Here is the specific command you would use:
+
+```bash
+aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your S3 bucket.
+
+This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
+
+##### Viewing bucket encryption configuration
+
+After configuring your bucket encryption via `PutBucketEncryption` to use SSE-S3, make sure everything is set up correctly using the following command with the AWS CLI:
+
+```bash
+aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+
+With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
+
+In this order, replace `your-bucket` with the name of your bucket. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+
+This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
+
+##### Deleting an encrypted object with SSE-S3
+
+Deleting objects encrypted with SSE-S3 is no different from deleting objects that are not encrypted. You can use the following command to delete an object:
+
+```bash
+aws s3 rm s3://my-Bucket/my-object
+```
+
+- Replace `my-Bucket` with the name of your bucket
+- Replace `my-object` by the name of the object you want to delete.
+
+With this command, you can effectively delete an object, whether it is encrypted or not, from your bucket on OVHcloud S3.
+
+### SSE-S3 Encryption considerations
+
+When using SSE-S3 encryption on OVHcloud S3, it is important to consider the following:
+
+#### Performance
+
+- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+
+#### Security
+
+- **Key Management**: SSE-S3 offers a high level of security by automatically managing encryption keys. This simplifies security management for users.
+- **Additional security practices**: Combining SSE-S3 encryption with other security practices is crucial for optimal protection. This includes the use of strict IAM policies and log access tracking to monitor and control data access.
+
+#### Comparison of encryption methods
+
+It’s essential to compare the different encryption methods available to choose the one that best suits your specific needs. Methods to consider include client-side encryption (CSE) and server-side encryption (SSE), with its SSE-C and SSE-S3 variants.
+
+#### Pros and cons
+
+- **CSE vs SSE**: Each method has its own advantages and disadvantages in terms of manageability, security and performance impact.
+- **Recommended use cases**: depending on your specific situation, some methods may be more appropriate than others. It is important to evaluate the recommended use cases for each encryption method.
+
+A comparative table may be useful for summarizing these elements, providing a clear overview that facilitates decision-making.
+
+| Encryption method | Benefits | Cons | Recommended Use Cases |
+|-------------------|----------|------|-----------------------|
+| **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+
+Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+### Recommended use cases for encryption on OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Ideal for**: Organizations with very high security requirements, requiring encryption keys to remain under exclusive control.
+- **Suitable for**: strictly regulated environments, such as financial institutions or healthcare services.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Suitable for**: Organizations seeking a balance between key control and manageability.
+- **Useful for**: when customers are ready to manage keys but want to delegate encryption and decryption.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Perfect for**: users who prefer a turnkey solution without the burden of key management.
+- **Preferred method for**: companies looking to protect their data without specific encryption compliance needs.
+
+The choice between these methods should be guided by security policies and regulatory requirements, as well as the ability to manage encryption keys. A balance between ease of use and security is essential.
+
+### Examples of scripts and commands
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Generating a client-side encryption key
+client_key=$(openssl rand -base64 32)
+# Encryption of a file before sending
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Sending encrypted file to S3 bucket
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Creating an encryption key and its MD5 fingerprint
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Uploading an object with SSE-C encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Retrieving an object with SSE-C encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Sending an object with SSE-S3 encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Uploading an object with SSE-S3 encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Troubleshooting and Common Error Resolution
+
+### Error using SSE-C without proper encryption headers
+
+- **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
+- **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
+
+### Bad query error when using SSE-S3
+
+- **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
+- **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
+
+### Performance or latency issues during encryption/decryption
+
+- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
+
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
+## Conclusion
+
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+
+The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 
 ## Go further
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-sg.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C
-updated: 2022-04-15
+updated: 2024-04-10
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objective
 
-Using server-side encryption with customer-provided encryption keys (SSE-C) allows you to set your own encryption keys.  
+At OVHcloud, we understand the crucial importance of data protection in today’s digital ecosystem. In the face of ever-evolving security threats and increasingly stringent regulatory requirements, it’s essential to implement robust measures to secure data at all times. This includes not only data in transit, but also data at rest.
 
-When you upload an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you retrieve an object, you must provide the same encryption key as part of your request. S3 Object Storage first verifies that the encryption key you provided matches and then decrypts the object before returning the object data to you.
+Protecting *at rest* data, i.e. data stored on physical devices or in the cloud, is a crucial part of any organization’s IT security strategy. In this context, there are two main approaches to encrypting this data: client-side encryption (CSE) and server-side encryption (SSE).
 
-**This guide explains how to encrypt your server-side objects with SSE-C.**
+Client-Side Encryption (CSE) allows our customers to encrypt their data on their own device before sending it to our servers for storage. This ensures that data remains encrypted throughout its lifecycle, offering a high degree of security, as encryption keys are managed by the customer and never shared with OVHcloud or any other third party.
+
+While this approach requires the customer to strictly manage the keys, it is an ideal solution for those who require complete control over their data security.
+
+At the same time, server-side encryption (SSE) offers an alternative where data is encrypted when it arrives at our servers. This is the responsibility of OVHcloud, which greatly reduces the burden of security management for our customers. Two server-side encryption methods are available: 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)**: You can provide and manage your own encryption keys, giving you complete control over your data security. This option is particularly well-suited to organizations with specific compliance and data security needs, as it allows for exclusive management of encryption keys.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)**: Simplifies the encryption process by using keys managed by OVHcloud. This method is ideal for customers who want a robust encryption solution without the complexities of key management.
+
+Our goal is to help you choose the type of encryption that is best for you. This page gives you all the information you need to make an informed choice. Whether you prefer to manage yourself with SSE-C or opt for the ease of SSE-S3, we are committed to offering you flexible and secure solutions to protect your data when it is stored.
+
+**This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3.**
 
 > [!warning]
 >
@@ -31,13 +42,17 @@ When you upload an object, S3 Object Storage uses the encryption key you provide
 
 ## Requirements
 
-- A bucket
+- An S3 bucket
 - A user with the required access rights on the bucket
-- Have installed and configured aws-cli
+- Have installed and configured the AWS command line interface (aws-cli)
 
 See our [Getting started with S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) guide.
 
 ## Instructions
+
+Using server-side encryption with client-provided encryption keys (SSE-C) allows you to define your own encryption keys.
+
+When you download an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you check out an object, you must provide the same encryption key as part of your request. S3 Object Storage first checks that the encryption key you provided matches, then decrypts the object before returning the object data to you.
 
 When you use SSE-C, you must provide encryption key information using the following request headers.
 
@@ -47,7 +62,9 @@ When you use SSE-C, you must provide encryption key information using the follow
 | --sse-customer-key | Use this header to provide the 256-bit, base64-encoded encryption key for S3 Object Storage to use to encrypt or decrypt your data. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Use this header to provide the base64-encoded 128-bit MD5 digest of the encryption key according to RFC 1321. S3 Object Storage uses this header for a message integrity check to ensure that the encryption key was transmitted without error. |
 
-### Creating an encryption key
+### SSE-C - Server-Side Encryption with Client Encryption Keys
+
+#### Creating an encryption key
 
 Example of creating an encryption key ( *--sse-customer-key* ):
 
@@ -61,7 +78,7 @@ and the MD5 key ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Uploading an object with SSE-C
+#### Uploading an object with SSE-C
 
 To upload an object with SSE-C and aws-cli, proceed as follows:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Downloading an object with SSE-C
+#### Downloading an object with SSE-C
 
 To download an object with SSE-C and aws-cli, proceed as follows:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Getting object metadata with SSE-C
+#### Getting object metadata with SSE-C
 
 To get an object metadata with SSE-C and aws-cli, proceed as follows:
 
@@ -129,7 +146,7 @@ Output should look like:
 
 Without encryption headers, you will get a `Bad Request` error.
 
-### Deleting an encrypted object with SSE-C
+#### Deleting an encrypted object with SSE-C
 
 To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 
@@ -137,7 +154,7 @@ To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### Presigned URLs and SSE-C
+#### Presigned URLs and SSE-C
 
 Presigned URLs, that can be used for operations such as upload a new object, retrieve an existing object, or object metadata, support the SSE-C as follows:
 
@@ -149,6 +166,248 @@ Presigned URLs, that can be used for operations such as upload a new object, ret
 >
 > You can use the presigned URL for SSE-C objects only programmatically, because in addition to the presigned URL, you also need to include HTTP headers that are specific to SSE-C objects.
 >
+
+### SSE-S3 - Server-side encryption with keys managed by OVHcloud
+
+Using server-side encryption with keys managed by OVHcloud (SSE-S3) helps protect your data stored on OVHcloud by encrypting it automatically at rest. SSE-S3 uses keys managed and protected by OVHcloud, eliminating the need for the user to manually manage these encryption keys.
+
+#### Benefits
+
+- **Simplified Key Management**
+
+With OVHcloud supporting secure encryption key management, users benefit from simplified key management. This approach eliminates the complexities of key rotation while maintaining a high level of data security. It balances security with operational efficiency, eliminating the administrative burden of manually managing encryption keys.
+
+- **Enhanced Security**
+
+We use an advanced encryption strategy to offer maximum protection for your data. Each bucket has a unique key, and for each stored object, a separate encryption key is generated. This key is obtained by combining the unique key of the bucket with a random salt, which ensures that each object is encrypted with its own key. This key derivation method reduces the risk associated with exposing a single key and ensures enhanced security for your data.
+
+- **Transparency**
+
+The encryption and decryption process is completely transparent to the user, allowing encrypted data to be accessed and managed as easily as unencrypted data.
+
+- **Enhanced security with OVHcloud Key Management Service (KMS)**
+
+Our commitment to securing your data is reinforced through the use of OVHcloud Key Management Service (KMS), an advanced platform for secure storage and encryption key management. This approach ensures optimal data protection, setting up a robust security infrastructure without the complexities of directly managing encryption keys.
+
+To further your understanding of OVHcloud Key Management Service (KMS) and its applications in various cloud infrastructure contexts, we recommend reading the following resources:
+
+- **[Getting started with the KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)**: this guide provides a detailed overview of how to implement and use the KMS to secure your data.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)**: practical guide on enabling VM encryption using KMS capabilities.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)**: detailed instructions on using KMS in conjunction with the vSphere Native Key Provider for VM encryption.
+
+These documents provide valuable information on how the KMS can be used to enhance security in different cloud infrastructure scenarios.
+
+#### Implementation
+
+To enhance the security of data uploaded to OVHcloud, enabling server-side encryption (SSE-S3) has been designed to be both easy and transparent. By configuring a default encryption method on your bucket via the `PutBucketEncryption` request, any uploaded object will be automatically encrypted without requiring any additional actions on your side. When uploading an object, simply specify the encryption option in the API request or via the AWS CLI command line. OVHcloud takes care of the rest, encrypting your data before it is stored using an automatically generated unique key for the bucket.
+
+### Secure encryption key management with SSE-S3 on OVHcloud S3
+
+The implementation of SSE-S3 encryption on OVHcloud S3 is designed to provide encryption key management that is both secure and transparent for the user. Each bucket has a separate key, which ensures that data is secured individually and in isolation. This encryption method, integrated and managed by the platform, eliminates the complexities associated with manual key management by users. While making the user process as smooth and intuitive as possible, it maintains robust security and complies with the very strictest data protection standards.
+
+#### Sending an object with SSE-S3 on OVHcloud S3
+
+##### Uploading an object on OVHcloud S3 with SSE-S3 encryption
+
+To send an object in your S3 bucket on OVHcloud with SSE-S3 encryption, use the following Bash command via the AWS CLI. This command includes the server-side encryption option to enhance the security of your stored data.
+
+```bash
+aws s3api put-object --bucket your-bucket --key your-object --body path/to/your/file --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+When using the AWS CLI command to upload an object with SSE-S3 encryption to OVHcloud S3, make sure to replace the following values based on your specific information:
+
+- `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
+- `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
+- `path/to/your/file`: Specify the full path to the file you plan to send.
+
+The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
+
+##### Downloading an Object with SSE-S3 to OVHcloud S3
+
+To download an object that has been encrypted with SSE-S3 from OVHcloud S3, you do not need to specify encryption headers in the command. The object can be downloaded directly without any additional manipulation linked to the encryption, because the decryption is managed automatically on the server side. Here is an example of a download command:
+
+```bash
+aws s3api get-object --bucket your-bucket --key your-object path/to/destination/file --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- Replace `your-object` with the key of the object you want to download.
+- Replace `path/to/destination/file` with the path where you want to save the downloaded file.
+
+Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
+
+#### Adding encryption to an existing bucket on OVHcloud S3
+
+To add SSE-S3 encryption to an existing S3 bucket on OVHcloud, you must use the `put-bucket-encryption` command from the AWS CLI. This command configures bucket encryption so that all newly added objects are automatically encrypted with SSE-S3. Here is the specific command you would use:
+
+```bash
+aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your S3 bucket.
+
+This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
+
+##### Viewing bucket encryption configuration
+
+After configuring your bucket encryption via `PutBucketEncryption` to use SSE-S3, make sure everything is set up correctly using the following command with the AWS CLI:
+
+```bash
+aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+
+With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
+
+In this order, replace `your-bucket` with the name of your bucket. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+
+This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
+
+##### Deleting an encrypted object with SSE-S3
+
+Deleting objects encrypted with SSE-S3 is no different from deleting objects that are not encrypted. You can use the following command to delete an object:
+
+```bash
+aws s3 rm s3://my-Bucket/my-object
+```
+
+- Replace `my-Bucket` with the name of your bucket
+- Replace `my-object` by the name of the object you want to delete.
+
+With this command, you can effectively delete an object, whether it is encrypted or not, from your bucket on OVHcloud S3.
+
+### SSE-S3 Encryption considerations
+
+When using SSE-S3 encryption on OVHcloud S3, it is important to consider the following:
+
+#### Performance
+
+- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+
+#### Security
+
+- **Key Management**: SSE-S3 offers a high level of security by automatically managing encryption keys. This simplifies security management for users.
+- **Additional security practices**: Combining SSE-S3 encryption with other security practices is crucial for optimal protection. This includes the use of strict IAM policies and log access tracking to monitor and control data access.
+
+#### Comparison of encryption methods
+
+It’s essential to compare the different encryption methods available to choose the one that best suits your specific needs. Methods to consider include client-side encryption (CSE) and server-side encryption (SSE), with its SSE-C and SSE-S3 variants.
+
+#### Pros and cons
+
+- **CSE vs SSE**: Each method has its own advantages and disadvantages in terms of manageability, security and performance impact.
+- **Recommended use cases**: depending on your specific situation, some methods may be more appropriate than others. It is important to evaluate the recommended use cases for each encryption method.
+
+A comparative table may be useful for summarizing these elements, providing a clear overview that facilitates decision-making.
+
+| Encryption method | Benefits | Cons | Recommended Use Cases |
+|-------------------|----------|------|-----------------------|
+| **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+
+Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+### Recommended use cases for encryption on OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Ideal for**: Organizations with very high security requirements, requiring encryption keys to remain under exclusive control.
+- **Suitable for**: strictly regulated environments, such as financial institutions or healthcare services.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Suitable for**: Organizations seeking a balance between key control and manageability.
+- **Useful for**: when customers are ready to manage keys but want to delegate encryption and decryption.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Perfect for**: users who prefer a turnkey solution without the burden of key management.
+- **Preferred method for**: companies looking to protect their data without specific encryption compliance needs.
+
+The choice between these methods should be guided by security policies and regulatory requirements, as well as the ability to manage encryption keys. A balance between ease of use and security is essential.
+
+### Examples of scripts and commands
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Generating a client-side encryption key
+client_key=$(openssl rand -base64 32)
+# Encryption of a file before sending
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Sending encrypted file to S3 bucket
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Creating an encryption key and its MD5 fingerprint
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Uploading an object with SSE-C encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Retrieving an object with SSE-C encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Sending an object with SSE-S3 encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Uploading an object with SSE-S3 encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Troubleshooting and Common Error Resolution
+
+### Error using SSE-C without proper encryption headers
+
+- **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
+- **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
+
+### Bad query error when using SSE-S3
+
+- **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
+- **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
+
+### Performance or latency issues during encryption/decryption
+
+- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
+
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
+## Conclusion
+
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+
+The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 
 ## Go further
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-us.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C
-updated: 2022-04-15
+updated: 2024-04-10
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objective
 
-Using server-side encryption with customer-provided encryption keys (SSE-C) allows you to set your own encryption keys.  
+At OVHcloud, we understand the crucial importance of data protection in today’s digital ecosystem. In the face of ever-evolving security threats and increasingly stringent regulatory requirements, it’s essential to implement robust measures to secure data at all times. This includes not only data in transit, but also data at rest.
 
-When you upload an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you retrieve an object, you must provide the same encryption key as part of your request. S3 Object Storage first verifies that the encryption key you provided matches and then decrypts the object before returning the object data to you.
+Protecting *at rest* data, i.e. data stored on physical devices or in the cloud, is a crucial part of any organization’s IT security strategy. In this context, there are two main approaches to encrypting this data: client-side encryption (CSE) and server-side encryption (SSE).
 
-**This guide explains how to encrypt your server-side objects with SSE-C.**
+Client-Side Encryption (CSE) allows our customers to encrypt their data on their own device before sending it to our servers for storage. This ensures that data remains encrypted throughout its lifecycle, offering a high degree of security, as encryption keys are managed by the customer and never shared with OVHcloud or any other third party.
+
+While this approach requires the customer to strictly manage the keys, it is an ideal solution for those who require complete control over their data security.
+
+At the same time, server-side encryption (SSE) offers an alternative where data is encrypted when it arrives at our servers. This is the responsibility of OVHcloud, which greatly reduces the burden of security management for our customers. Two server-side encryption methods are available: 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)**: You can provide and manage your own encryption keys, giving you complete control over your data security. This option is particularly well-suited to organizations with specific compliance and data security needs, as it allows for exclusive management of encryption keys.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)**: Simplifies the encryption process by using keys managed by OVHcloud. This method is ideal for customers who want a robust encryption solution without the complexities of key management.
+
+Our goal is to help you choose the type of encryption that is best for you. This page gives you all the information you need to make an informed choice. Whether you prefer to manage yourself with SSE-C or opt for the ease of SSE-S3, we are committed to offering you flexible and secure solutions to protect your data when it is stored.
+
+**This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3.**
 
 > [!warning]
 >
@@ -31,13 +42,17 @@ When you upload an object, S3 Object Storage uses the encryption key you provide
 
 ## Requirements
 
-- A bucket
+- An S3 bucket
 - A user with the required access rights on the bucket
-- Have installed and configured aws-cli
+- Have installed and configured the AWS command line interface (aws-cli)
 
 See our [Getting started with S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) guide.
 
 ## Instructions
+
+Using server-side encryption with client-provided encryption keys (SSE-C) allows you to define your own encryption keys.
+
+When you download an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you check out an object, you must provide the same encryption key as part of your request. S3 Object Storage first checks that the encryption key you provided matches, then decrypts the object before returning the object data to you.
 
 When you use SSE-C, you must provide encryption key information using the following request headers.
 
@@ -47,7 +62,9 @@ When you use SSE-C, you must provide encryption key information using the follow
 | --sse-customer-key | Use this header to provide the 256-bit, base64-encoded encryption key for S3 Object Storage to use to encrypt or decrypt your data. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Use this header to provide the base64-encoded 128-bit MD5 digest of the encryption key according to RFC 1321. S3 Object Storage uses this header for a message integrity check to ensure that the encryption key was transmitted without error. |
 
-### Creating an encryption key
+### SSE-C - Server-Side Encryption with Client Encryption Keys
+
+#### Creating an encryption key
 
 Example of creating an encryption key ( *--sse-customer-key* ):
 
@@ -61,7 +78,7 @@ and the MD5 key ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Uploading an object with SSE-C
+#### Uploading an object with SSE-C
 
 To upload an object with SSE-C and aws-cli, proceed as follows:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Downloading an object with SSE-C
+#### Downloading an object with SSE-C
 
 To download an object with SSE-C and aws-cli, proceed as follows:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Getting object metadata with SSE-C
+#### Getting object metadata with SSE-C
 
 To get an object metadata with SSE-C and aws-cli, proceed as follows:
 
@@ -129,7 +146,7 @@ Output should look like:
 
 Without encryption headers, you will get a `Bad Request` error.
 
-### Deleting an encrypted object with SSE-C
+#### Deleting an encrypted object with SSE-C
 
 To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 
@@ -137,7 +154,7 @@ To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### Presigned URLs and SSE-C
+#### Presigned URLs and SSE-C
 
 Presigned URLs, that can be used for operations such as upload a new object, retrieve an existing object, or object metadata, support the SSE-C as follows:
 
@@ -149,6 +166,248 @@ Presigned URLs, that can be used for operations such as upload a new object, ret
 >
 > You can use the presigned URL for SSE-C objects only programmatically, because in addition to the presigned URL, you also need to include HTTP headers that are specific to SSE-C objects.
 >
+
+### SSE-S3 - Server-side encryption with keys managed by OVHcloud
+
+Using server-side encryption with keys managed by OVHcloud (SSE-S3) helps protect your data stored on OVHcloud by encrypting it automatically at rest. SSE-S3 uses keys managed and protected by OVHcloud, eliminating the need for the user to manually manage these encryption keys.
+
+#### Benefits
+
+- **Simplified Key Management**
+
+With OVHcloud supporting secure encryption key management, users benefit from simplified key management. This approach eliminates the complexities of key rotation while maintaining a high level of data security. It balances security with operational efficiency, eliminating the administrative burden of manually managing encryption keys.
+
+- **Enhanced Security**
+
+We use an advanced encryption strategy to offer maximum protection for your data. Each bucket has a unique key, and for each stored object, a separate encryption key is generated. This key is obtained by combining the unique key of the bucket with a random salt, which ensures that each object is encrypted with its own key. This key derivation method reduces the risk associated with exposing a single key and ensures enhanced security for your data.
+
+- **Transparency**
+
+The encryption and decryption process is completely transparent to the user, allowing encrypted data to be accessed and managed as easily as unencrypted data.
+
+- **Enhanced security with OVHcloud Key Management Service (KMS)**
+
+Our commitment to securing your data is reinforced through the use of OVHcloud Key Management Service (KMS), an advanced platform for secure storage and encryption key management. This approach ensures optimal data protection, setting up a robust security infrastructure without the complexities of directly managing encryption keys.
+
+To further your understanding of OVHcloud Key Management Service (KMS) and its applications in various cloud infrastructure contexts, we recommend reading the following resources:
+
+- **[Getting started with the KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)**: this guide provides a detailed overview of how to implement and use the KMS to secure your data.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)**: practical guide on enabling VM encryption using KMS capabilities.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)**: detailed instructions on using KMS in conjunction with the vSphere Native Key Provider for VM encryption.
+
+These documents provide valuable information on how the KMS can be used to enhance security in different cloud infrastructure scenarios.
+
+#### Implementation
+
+To enhance the security of data uploaded to OVHcloud, enabling server-side encryption (SSE-S3) has been designed to be both easy and transparent. By configuring a default encryption method on your bucket via the `PutBucketEncryption` request, any uploaded object will be automatically encrypted without requiring any additional actions on your side. When uploading an object, simply specify the encryption option in the API request or via the AWS CLI command line. OVHcloud takes care of the rest, encrypting your data before it is stored using an automatically generated unique key for the bucket.
+
+### Secure encryption key management with SSE-S3 on OVHcloud S3
+
+The implementation of SSE-S3 encryption on OVHcloud S3 is designed to provide encryption key management that is both secure and transparent for the user. Each bucket has a separate key, which ensures that data is secured individually and in isolation. This encryption method, integrated and managed by the platform, eliminates the complexities associated with manual key management by users. While making the user process as smooth and intuitive as possible, it maintains robust security and complies with the very strictest data protection standards.
+
+#### Sending an object with SSE-S3 on OVHcloud S3
+
+##### Uploading an object on OVHcloud S3 with SSE-S3 encryption
+
+To send an object in your S3 bucket on OVHcloud with SSE-S3 encryption, use the following Bash command via the AWS CLI. This command includes the server-side encryption option to enhance the security of your stored data.
+
+```bash
+aws s3api put-object --bucket your-bucket --key your-object --body path/to/your/file --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+When using the AWS CLI command to upload an object with SSE-S3 encryption to OVHcloud S3, make sure to replace the following values based on your specific information:
+
+- `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
+- `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
+- `path/to/your/file`: Specify the full path to the file you plan to send.
+
+The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
+
+##### Downloading an Object with SSE-S3 to OVHcloud S3
+
+To download an object that has been encrypted with SSE-S3 from OVHcloud S3, you do not need to specify encryption headers in the command. The object can be downloaded directly without any additional manipulation linked to the encryption, because the decryption is managed automatically on the server side. Here is an example of a download command:
+
+```bash
+aws s3api get-object --bucket your-bucket --key your-object path/to/destination/file --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- Replace `your-object` with the key of the object you want to download.
+- Replace `path/to/destination/file` with the path where you want to save the downloaded file.
+
+Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
+
+#### Adding encryption to an existing bucket on OVHcloud S3
+
+To add SSE-S3 encryption to an existing S3 bucket on OVHcloud, you must use the `put-bucket-encryption` command from the AWS CLI. This command configures bucket encryption so that all newly added objects are automatically encrypted with SSE-S3. Here is the specific command you would use:
+
+```bash
+aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your S3 bucket.
+
+This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
+
+##### Viewing bucket encryption configuration
+
+After configuring your bucket encryption via `PutBucketEncryption` to use SSE-S3, make sure everything is set up correctly using the following command with the AWS CLI:
+
+```bash
+aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+
+With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
+
+In this order, replace `your-bucket` with the name of your bucket. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+
+This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
+
+##### Deleting an encrypted object with SSE-S3
+
+Deleting objects encrypted with SSE-S3 is no different from deleting objects that are not encrypted. You can use the following command to delete an object:
+
+```bash
+aws s3 rm s3://my-Bucket/my-object
+```
+
+- Replace `my-Bucket` with the name of your bucket
+- Replace `my-object` by the name of the object you want to delete.
+
+With this command, you can effectively delete an object, whether it is encrypted or not, from your bucket on OVHcloud S3.
+
+### SSE-S3 Encryption considerations
+
+When using SSE-S3 encryption on OVHcloud S3, it is important to consider the following:
+
+#### Performance
+
+- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+
+#### Security
+
+- **Key Management**: SSE-S3 offers a high level of security by automatically managing encryption keys. This simplifies security management for users.
+- **Additional security practices**: Combining SSE-S3 encryption with other security practices is crucial for optimal protection. This includes the use of strict IAM policies and log access tracking to monitor and control data access.
+
+#### Comparison of encryption methods
+
+It’s essential to compare the different encryption methods available to choose the one that best suits your specific needs. Methods to consider include client-side encryption (CSE) and server-side encryption (SSE), with its SSE-C and SSE-S3 variants.
+
+#### Pros and cons
+
+- **CSE vs SSE**: Each method has its own advantages and disadvantages in terms of manageability, security and performance impact.
+- **Recommended use cases**: depending on your specific situation, some methods may be more appropriate than others. It is important to evaluate the recommended use cases for each encryption method.
+
+A comparative table may be useful for summarizing these elements, providing a clear overview that facilitates decision-making.
+
+| Encryption method | Benefits | Cons | Recommended Use Cases |
+|-------------------|----------|------|-----------------------|
+| **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+
+Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+### Recommended use cases for encryption on OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Ideal for**: Organizations with very high security requirements, requiring encryption keys to remain under exclusive control.
+- **Suitable for**: strictly regulated environments, such as financial institutions or healthcare services.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Suitable for**: Organizations seeking a balance between key control and manageability.
+- **Useful for**: when customers are ready to manage keys but want to delegate encryption and decryption.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Perfect for**: users who prefer a turnkey solution without the burden of key management.
+- **Preferred method for**: companies looking to protect their data without specific encryption compliance needs.
+
+The choice between these methods should be guided by security policies and regulatory requirements, as well as the ability to manage encryption keys. A balance between ease of use and security is essential.
+
+### Examples of scripts and commands
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Generating a client-side encryption key
+client_key=$(openssl rand -base64 32)
+# Encryption of a file before sending
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Sending encrypted file to S3 bucket
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Creating an encryption key and its MD5 fingerprint
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Uploading an object with SSE-C encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Retrieving an object with SSE-C encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Sending an object with SSE-S3 encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Uploading an object with SSE-S3 encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Troubleshooting and Common Error Resolution
+
+### Error using SSE-C without proper encryption headers
+
+- **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
+- **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
+
+### Bad query error when using SSE-S3
+
+- **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
+- **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
+
+### Performance or latency issues during encryption/decryption
+
+- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
+
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
+## Conclusion
+
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+
+The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 
 ## Go further
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.es-es.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Cifre sus objetos del lado del servidor con SSE-C (EN)
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C
-updated: 2022-04-15
+updated: 2024-04-10
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objective
 
-Using server-side encryption with customer-provided encryption keys (SSE-C) allows you to set your own encryption keys.  
+At OVHcloud, we understand the crucial importance of data protection in today’s digital ecosystem. In the face of ever-evolving security threats and increasingly stringent regulatory requirements, it’s essential to implement robust measures to secure data at all times. This includes not only data in transit, but also data at rest.
 
-When you upload an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you retrieve an object, you must provide the same encryption key as part of your request. S3 Object Storage first verifies that the encryption key you provided matches and then decrypts the object before returning the object data to you.
+Protecting *at rest* data, i.e. data stored on physical devices or in the cloud, is a crucial part of any organization’s IT security strategy. In this context, there are two main approaches to encrypting this data: client-side encryption (CSE) and server-side encryption (SSE).
 
-**This guide explains how to encrypt your server-side objects with SSE-C.**
+Client-Side Encryption (CSE) allows our customers to encrypt their data on their own device before sending it to our servers for storage. This ensures that data remains encrypted throughout its lifecycle, offering a high degree of security, as encryption keys are managed by the customer and never shared with OVHcloud or any other third party.
+
+While this approach requires the customer to strictly manage the keys, it is an ideal solution for those who require complete control over their data security.
+
+At the same time, server-side encryption (SSE) offers an alternative where data is encrypted when it arrives at our servers. This is the responsibility of OVHcloud, which greatly reduces the burden of security management for our customers. Two server-side encryption methods are available: 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)**: You can provide and manage your own encryption keys, giving you complete control over your data security. This option is particularly well-suited to organizations with specific compliance and data security needs, as it allows for exclusive management of encryption keys.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)**: Simplifies the encryption process by using keys managed by OVHcloud. This method is ideal for customers who want a robust encryption solution without the complexities of key management.
+
+Our goal is to help you choose the type of encryption that is best for you. This page gives you all the information you need to make an informed choice. Whether you prefer to manage yourself with SSE-C or opt for the ease of SSE-S3, we are committed to offering you flexible and secure solutions to protect your data when it is stored.
+
+**This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3.**
 
 > [!warning]
 >
@@ -31,13 +42,17 @@ When you upload an object, S3 Object Storage uses the encryption key you provide
 
 ## Requirements
 
-- A bucket
+- An S3 bucket
 - A user with the required access rights on the bucket
-- Have installed and configured aws-cli
+- Have installed and configured the AWS command line interface (aws-cli)
 
 See our [Getting started with S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) guide.
 
 ## Instructions
+
+Using server-side encryption with client-provided encryption keys (SSE-C) allows you to define your own encryption keys.
+
+When you download an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you check out an object, you must provide the same encryption key as part of your request. S3 Object Storage first checks that the encryption key you provided matches, then decrypts the object before returning the object data to you.
 
 When you use SSE-C, you must provide encryption key information using the following request headers.
 
@@ -47,7 +62,9 @@ When you use SSE-C, you must provide encryption key information using the follow
 | --sse-customer-key | Use this header to provide the 256-bit, base64-encoded encryption key for S3 Object Storage to use to encrypt or decrypt your data. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Use this header to provide the base64-encoded 128-bit MD5 digest of the encryption key according to RFC 1321. S3 Object Storage uses this header for a message integrity check to ensure that the encryption key was transmitted without error. |
 
-### Creating an encryption key
+### SSE-C - Server-Side Encryption with Client Encryption Keys
+
+#### Creating an encryption key
 
 Example of creating an encryption key ( *--sse-customer-key* ):
 
@@ -61,7 +78,7 @@ and the MD5 key ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Uploading an object with SSE-C
+#### Uploading an object with SSE-C
 
 To upload an object with SSE-C and aws-cli, proceed as follows:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Downloading an object with SSE-C
+#### Downloading an object with SSE-C
 
 To download an object with SSE-C and aws-cli, proceed as follows:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Getting object metadata with SSE-C
+#### Getting object metadata with SSE-C
 
 To get an object metadata with SSE-C and aws-cli, proceed as follows:
 
@@ -129,7 +146,7 @@ Output should look like:
 
 Without encryption headers, you will get a `Bad Request` error.
 
-### Deleting an encrypted object with SSE-C
+#### Deleting an encrypted object with SSE-C
 
 To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 
@@ -137,7 +154,7 @@ To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### Presigned URLs and SSE-C
+#### Presigned URLs and SSE-C
 
 Presigned URLs, that can be used for operations such as upload a new object, retrieve an existing object, or object metadata, support the SSE-C as follows:
 
@@ -149,6 +166,248 @@ Presigned URLs, that can be used for operations such as upload a new object, ret
 >
 > You can use the presigned URL for SSE-C objects only programmatically, because in addition to the presigned URL, you also need to include HTTP headers that are specific to SSE-C objects.
 >
+
+### SSE-S3 - Server-side encryption with keys managed by OVHcloud
+
+Using server-side encryption with keys managed by OVHcloud (SSE-S3) helps protect your data stored on OVHcloud by encrypting it automatically at rest. SSE-S3 uses keys managed and protected by OVHcloud, eliminating the need for the user to manually manage these encryption keys.
+
+#### Benefits
+
+- **Simplified Key Management**
+
+With OVHcloud supporting secure encryption key management, users benefit from simplified key management. This approach eliminates the complexities of key rotation while maintaining a high level of data security. It balances security with operational efficiency, eliminating the administrative burden of manually managing encryption keys.
+
+- **Enhanced Security**
+
+We use an advanced encryption strategy to offer maximum protection for your data. Each bucket has a unique key, and for each stored object, a separate encryption key is generated. This key is obtained by combining the unique key of the bucket with a random salt, which ensures that each object is encrypted with its own key. This key derivation method reduces the risk associated with exposing a single key and ensures enhanced security for your data.
+
+- **Transparency**
+
+The encryption and decryption process is completely transparent to the user, allowing encrypted data to be accessed and managed as easily as unencrypted data.
+
+- **Enhanced security with OVHcloud Key Management Service (KMS)**
+
+Our commitment to securing your data is reinforced through the use of OVHcloud Key Management Service (KMS), an advanced platform for secure storage and encryption key management. This approach ensures optimal data protection, setting up a robust security infrastructure without the complexities of directly managing encryption keys.
+
+To further your understanding of OVHcloud Key Management Service (KMS) and its applications in various cloud infrastructure contexts, we recommend reading the following resources:
+
+- **[Getting started with the KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)**: this guide provides a detailed overview of how to implement and use the KMS to secure your data.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)**: practical guide on enabling VM encryption using KMS capabilities.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)**: detailed instructions on using KMS in conjunction with the vSphere Native Key Provider for VM encryption.
+
+These documents provide valuable information on how the KMS can be used to enhance security in different cloud infrastructure scenarios.
+
+#### Implementation
+
+To enhance the security of data uploaded to OVHcloud, enabling server-side encryption (SSE-S3) has been designed to be both easy and transparent. By configuring a default encryption method on your bucket via the `PutBucketEncryption` request, any uploaded object will be automatically encrypted without requiring any additional actions on your side. When uploading an object, simply specify the encryption option in the API request or via the AWS CLI command line. OVHcloud takes care of the rest, encrypting your data before it is stored using an automatically generated unique key for the bucket.
+
+### Secure encryption key management with SSE-S3 on OVHcloud S3
+
+The implementation of SSE-S3 encryption on OVHcloud S3 is designed to provide encryption key management that is both secure and transparent for the user. Each bucket has a separate key, which ensures that data is secured individually and in isolation. This encryption method, integrated and managed by the platform, eliminates the complexities associated with manual key management by users. While making the user process as smooth and intuitive as possible, it maintains robust security and complies with the very strictest data protection standards.
+
+#### Sending an object with SSE-S3 on OVHcloud S3
+
+##### Uploading an object on OVHcloud S3 with SSE-S3 encryption
+
+To send an object in your S3 bucket on OVHcloud with SSE-S3 encryption, use the following Bash command via the AWS CLI. This command includes the server-side encryption option to enhance the security of your stored data.
+
+```bash
+aws s3api put-object --bucket your-bucket --key your-object --body path/to/your/file --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+When using the AWS CLI command to upload an object with SSE-S3 encryption to OVHcloud S3, make sure to replace the following values based on your specific information:
+
+- `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
+- `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
+- `path/to/your/file`: Specify the full path to the file you plan to send.
+
+The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
+
+##### Downloading an Object with SSE-S3 to OVHcloud S3
+
+To download an object that has been encrypted with SSE-S3 from OVHcloud S3, you do not need to specify encryption headers in the command. The object can be downloaded directly without any additional manipulation linked to the encryption, because the decryption is managed automatically on the server side. Here is an example of a download command:
+
+```bash
+aws s3api get-object --bucket your-bucket --key your-object path/to/destination/file --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- Replace `your-object` with the key of the object you want to download.
+- Replace `path/to/destination/file` with the path where you want to save the downloaded file.
+
+Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
+
+#### Adding encryption to an existing bucket on OVHcloud S3
+
+To add SSE-S3 encryption to an existing S3 bucket on OVHcloud, you must use the `put-bucket-encryption` command from the AWS CLI. This command configures bucket encryption so that all newly added objects are automatically encrypted with SSE-S3. Here is the specific command you would use:
+
+```bash
+aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your S3 bucket.
+
+This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
+
+##### Viewing bucket encryption configuration
+
+After configuring your bucket encryption via `PutBucketEncryption` to use SSE-S3, make sure everything is set up correctly using the following command with the AWS CLI:
+
+```bash
+aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+
+With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
+
+In this order, replace `your-bucket` with the name of your bucket. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+
+This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
+
+##### Deleting an encrypted object with SSE-S3
+
+Deleting objects encrypted with SSE-S3 is no different from deleting objects that are not encrypted. You can use the following command to delete an object:
+
+```bash
+aws s3 rm s3://my-Bucket/my-object
+```
+
+- Replace `my-Bucket` with the name of your bucket
+- Replace `my-object` by the name of the object you want to delete.
+
+With this command, you can effectively delete an object, whether it is encrypted or not, from your bucket on OVHcloud S3.
+
+### SSE-S3 Encryption considerations
+
+When using SSE-S3 encryption on OVHcloud S3, it is important to consider the following:
+
+#### Performance
+
+- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+
+#### Security
+
+- **Key Management**: SSE-S3 offers a high level of security by automatically managing encryption keys. This simplifies security management for users.
+- **Additional security practices**: Combining SSE-S3 encryption with other security practices is crucial for optimal protection. This includes the use of strict IAM policies and log access tracking to monitor and control data access.
+
+#### Comparison of encryption methods
+
+It’s essential to compare the different encryption methods available to choose the one that best suits your specific needs. Methods to consider include client-side encryption (CSE) and server-side encryption (SSE), with its SSE-C and SSE-S3 variants.
+
+#### Pros and cons
+
+- **CSE vs SSE**: Each method has its own advantages and disadvantages in terms of manageability, security and performance impact.
+- **Recommended use cases**: depending on your specific situation, some methods may be more appropriate than others. It is important to evaluate the recommended use cases for each encryption method.
+
+A comparative table may be useful for summarizing these elements, providing a clear overview that facilitates decision-making.
+
+| Encryption method | Benefits | Cons | Recommended Use Cases |
+|-------------------|----------|------|-----------------------|
+| **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+
+Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+### Recommended use cases for encryption on OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Ideal for**: Organizations with very high security requirements, requiring encryption keys to remain under exclusive control.
+- **Suitable for**: strictly regulated environments, such as financial institutions or healthcare services.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Suitable for**: Organizations seeking a balance between key control and manageability.
+- **Useful for**: when customers are ready to manage keys but want to delegate encryption and decryption.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Perfect for**: users who prefer a turnkey solution without the burden of key management.
+- **Preferred method for**: companies looking to protect their data without specific encryption compliance needs.
+
+The choice between these methods should be guided by security policies and regulatory requirements, as well as the ability to manage encryption keys. A balance between ease of use and security is essential.
+
+### Examples of scripts and commands
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Generating a client-side encryption key
+client_key=$(openssl rand -base64 32)
+# Encryption of a file before sending
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Sending encrypted file to S3 bucket
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Creating an encryption key and its MD5 fingerprint
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Uploading an object with SSE-C encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Retrieving an object with SSE-C encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Sending an object with SSE-S3 encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Uploading an object with SSE-S3 encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Troubleshooting and Common Error Resolution
+
+### Error using SSE-C without proper encryption headers
+
+- **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
+- **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
+
+### Bad query error when using SSE-S3
+
+- **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
+- **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
+
+### Performance or latency issues during encryption/decryption
+
+- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
+
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
+## Conclusion
+
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+
+The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 
 ## Go further
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.es-us.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Cifre sus objetos del lado del servidor con SSE-C (EN)
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C
-updated: 2022-04-15
+updated: 2024-04-10
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objective
 
-Using server-side encryption with customer-provided encryption keys (SSE-C) allows you to set your own encryption keys.  
+At OVHcloud, we understand the crucial importance of data protection in today’s digital ecosystem. In the face of ever-evolving security threats and increasingly stringent regulatory requirements, it’s essential to implement robust measures to secure data at all times. This includes not only data in transit, but also data at rest.
 
-When you upload an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you retrieve an object, you must provide the same encryption key as part of your request. S3 Object Storage first verifies that the encryption key you provided matches and then decrypts the object before returning the object data to you.
+Protecting *at rest* data, i.e. data stored on physical devices or in the cloud, is a crucial part of any organization’s IT security strategy. In this context, there are two main approaches to encrypting this data: client-side encryption (CSE) and server-side encryption (SSE).
 
-**This guide explains how to encrypt your server-side objects with SSE-C.**
+Client-Side Encryption (CSE) allows our customers to encrypt their data on their own device before sending it to our servers for storage. This ensures that data remains encrypted throughout its lifecycle, offering a high degree of security, as encryption keys are managed by the customer and never shared with OVHcloud or any other third party.
+
+While this approach requires the customer to strictly manage the keys, it is an ideal solution for those who require complete control over their data security.
+
+At the same time, server-side encryption (SSE) offers an alternative where data is encrypted when it arrives at our servers. This is the responsibility of OVHcloud, which greatly reduces the burden of security management for our customers. Two server-side encryption methods are available: 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)**: You can provide and manage your own encryption keys, giving you complete control over your data security. This option is particularly well-suited to organizations with specific compliance and data security needs, as it allows for exclusive management of encryption keys.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)**: Simplifies the encryption process by using keys managed by OVHcloud. This method is ideal for customers who want a robust encryption solution without the complexities of key management.
+
+Our goal is to help you choose the type of encryption that is best for you. This page gives you all the information you need to make an informed choice. Whether you prefer to manage yourself with SSE-C or opt for the ease of SSE-S3, we are committed to offering you flexible and secure solutions to protect your data when it is stored.
+
+**This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3.**
 
 > [!warning]
 >
@@ -31,13 +42,17 @@ When you upload an object, S3 Object Storage uses the encryption key you provide
 
 ## Requirements
 
-- A bucket
+- An S3 bucket
 - A user with the required access rights on the bucket
-- Have installed and configured aws-cli
+- Have installed and configured the AWS command line interface (aws-cli)
 
 See our [Getting started with S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) guide.
 
 ## Instructions
+
+Using server-side encryption with client-provided encryption keys (SSE-C) allows you to define your own encryption keys.
+
+When you download an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you check out an object, you must provide the same encryption key as part of your request. S3 Object Storage first checks that the encryption key you provided matches, then decrypts the object before returning the object data to you.
 
 When you use SSE-C, you must provide encryption key information using the following request headers.
 
@@ -47,7 +62,9 @@ When you use SSE-C, you must provide encryption key information using the follow
 | --sse-customer-key | Use this header to provide the 256-bit, base64-encoded encryption key for S3 Object Storage to use to encrypt or decrypt your data. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Use this header to provide the base64-encoded 128-bit MD5 digest of the encryption key according to RFC 1321. S3 Object Storage uses this header for a message integrity check to ensure that the encryption key was transmitted without error. |
 
-### Creating an encryption key
+### SSE-C - Server-Side Encryption with Client Encryption Keys
+
+#### Creating an encryption key
 
 Example of creating an encryption key ( *--sse-customer-key* ):
 
@@ -61,7 +78,7 @@ and the MD5 key ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Uploading an object with SSE-C
+#### Uploading an object with SSE-C
 
 To upload an object with SSE-C and aws-cli, proceed as follows:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Downloading an object with SSE-C
+#### Downloading an object with SSE-C
 
 To download an object with SSE-C and aws-cli, proceed as follows:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Getting object metadata with SSE-C
+#### Getting object metadata with SSE-C
 
 To get an object metadata with SSE-C and aws-cli, proceed as follows:
 
@@ -129,7 +146,7 @@ Output should look like:
 
 Without encryption headers, you will get a `Bad Request` error.
 
-### Deleting an encrypted object with SSE-C
+#### Deleting an encrypted object with SSE-C
 
 To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 
@@ -137,7 +154,7 @@ To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### Presigned URLs and SSE-C
+#### Presigned URLs and SSE-C
 
 Presigned URLs, that can be used for operations such as upload a new object, retrieve an existing object, or object metadata, support the SSE-C as follows:
 
@@ -149,6 +166,248 @@ Presigned URLs, that can be used for operations such as upload a new object, ret
 >
 > You can use the presigned URL for SSE-C objects only programmatically, because in addition to the presigned URL, you also need to include HTTP headers that are specific to SSE-C objects.
 >
+
+### SSE-S3 - Server-side encryption with keys managed by OVHcloud
+
+Using server-side encryption with keys managed by OVHcloud (SSE-S3) helps protect your data stored on OVHcloud by encrypting it automatically at rest. SSE-S3 uses keys managed and protected by OVHcloud, eliminating the need for the user to manually manage these encryption keys.
+
+#### Benefits
+
+- **Simplified Key Management**
+
+With OVHcloud supporting secure encryption key management, users benefit from simplified key management. This approach eliminates the complexities of key rotation while maintaining a high level of data security. It balances security with operational efficiency, eliminating the administrative burden of manually managing encryption keys.
+
+- **Enhanced Security**
+
+We use an advanced encryption strategy to offer maximum protection for your data. Each bucket has a unique key, and for each stored object, a separate encryption key is generated. This key is obtained by combining the unique key of the bucket with a random salt, which ensures that each object is encrypted with its own key. This key derivation method reduces the risk associated with exposing a single key and ensures enhanced security for your data.
+
+- **Transparency**
+
+The encryption and decryption process is completely transparent to the user, allowing encrypted data to be accessed and managed as easily as unencrypted data.
+
+- **Enhanced security with OVHcloud Key Management Service (KMS)**
+
+Our commitment to securing your data is reinforced through the use of OVHcloud Key Management Service (KMS), an advanced platform for secure storage and encryption key management. This approach ensures optimal data protection, setting up a robust security infrastructure without the complexities of directly managing encryption keys.
+
+To further your understanding of OVHcloud Key Management Service (KMS) and its applications in various cloud infrastructure contexts, we recommend reading the following resources:
+
+- **[Getting started with the KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)**: this guide provides a detailed overview of how to implement and use the KMS to secure your data.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)**: practical guide on enabling VM encryption using KMS capabilities.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)**: detailed instructions on using KMS in conjunction with the vSphere Native Key Provider for VM encryption.
+
+These documents provide valuable information on how the KMS can be used to enhance security in different cloud infrastructure scenarios.
+
+#### Implementation
+
+To enhance the security of data uploaded to OVHcloud, enabling server-side encryption (SSE-S3) has been designed to be both easy and transparent. By configuring a default encryption method on your bucket via the `PutBucketEncryption` request, any uploaded object will be automatically encrypted without requiring any additional actions on your side. When uploading an object, simply specify the encryption option in the API request or via the AWS CLI command line. OVHcloud takes care of the rest, encrypting your data before it is stored using an automatically generated unique key for the bucket.
+
+### Secure encryption key management with SSE-S3 on OVHcloud S3
+
+The implementation of SSE-S3 encryption on OVHcloud S3 is designed to provide encryption key management that is both secure and transparent for the user. Each bucket has a separate key, which ensures that data is secured individually and in isolation. This encryption method, integrated and managed by the platform, eliminates the complexities associated with manual key management by users. While making the user process as smooth and intuitive as possible, it maintains robust security and complies with the very strictest data protection standards.
+
+#### Sending an object with SSE-S3 on OVHcloud S3
+
+##### Uploading an object on OVHcloud S3 with SSE-S3 encryption
+
+To send an object in your S3 bucket on OVHcloud with SSE-S3 encryption, use the following Bash command via the AWS CLI. This command includes the server-side encryption option to enhance the security of your stored data.
+
+```bash
+aws s3api put-object --bucket your-bucket --key your-object --body path/to/your/file --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+When using the AWS CLI command to upload an object with SSE-S3 encryption to OVHcloud S3, make sure to replace the following values based on your specific information:
+
+- `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
+- `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
+- `path/to/your/file`: Specify the full path to the file you plan to send.
+
+The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
+
+##### Downloading an Object with SSE-S3 to OVHcloud S3
+
+To download an object that has been encrypted with SSE-S3 from OVHcloud S3, you do not need to specify encryption headers in the command. The object can be downloaded directly without any additional manipulation linked to the encryption, because the decryption is managed automatically on the server side. Here is an example of a download command:
+
+```bash
+aws s3api get-object --bucket your-bucket --key your-object path/to/destination/file --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- Replace `your-object` with the key of the object you want to download.
+- Replace `path/to/destination/file` with the path where you want to save the downloaded file.
+
+Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
+
+#### Adding encryption to an existing bucket on OVHcloud S3
+
+To add SSE-S3 encryption to an existing S3 bucket on OVHcloud, you must use the `put-bucket-encryption` command from the AWS CLI. This command configures bucket encryption so that all newly added objects are automatically encrypted with SSE-S3. Here is the specific command you would use:
+
+```bash
+aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your S3 bucket.
+
+This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
+
+##### Viewing bucket encryption configuration
+
+After configuring your bucket encryption via `PutBucketEncryption` to use SSE-S3, make sure everything is set up correctly using the following command with the AWS CLI:
+
+```bash
+aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+
+With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
+
+In this order, replace `your-bucket` with the name of your bucket. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+
+This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
+
+##### Deleting an encrypted object with SSE-S3
+
+Deleting objects encrypted with SSE-S3 is no different from deleting objects that are not encrypted. You can use the following command to delete an object:
+
+```bash
+aws s3 rm s3://my-Bucket/my-object
+```
+
+- Replace `my-Bucket` with the name of your bucket
+- Replace `my-object` by the name of the object you want to delete.
+
+With this command, you can effectively delete an object, whether it is encrypted or not, from your bucket on OVHcloud S3.
+
+### SSE-S3 Encryption considerations
+
+When using SSE-S3 encryption on OVHcloud S3, it is important to consider the following:
+
+#### Performance
+
+- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+
+#### Security
+
+- **Key Management**: SSE-S3 offers a high level of security by automatically managing encryption keys. This simplifies security management for users.
+- **Additional security practices**: Combining SSE-S3 encryption with other security practices is crucial for optimal protection. This includes the use of strict IAM policies and log access tracking to monitor and control data access.
+
+#### Comparison of encryption methods
+
+It’s essential to compare the different encryption methods available to choose the one that best suits your specific needs. Methods to consider include client-side encryption (CSE) and server-side encryption (SSE), with its SSE-C and SSE-S3 variants.
+
+#### Pros and cons
+
+- **CSE vs SSE**: Each method has its own advantages and disadvantages in terms of manageability, security and performance impact.
+- **Recommended use cases**: depending on your specific situation, some methods may be more appropriate than others. It is important to evaluate the recommended use cases for each encryption method.
+
+A comparative table may be useful for summarizing these elements, providing a clear overview that facilitates decision-making.
+
+| Encryption method | Benefits | Cons | Recommended Use Cases |
+|-------------------|----------|------|-----------------------|
+| **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+
+Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+### Recommended use cases for encryption on OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Ideal for**: Organizations with very high security requirements, requiring encryption keys to remain under exclusive control.
+- **Suitable for**: strictly regulated environments, such as financial institutions or healthcare services.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Suitable for**: Organizations seeking a balance between key control and manageability.
+- **Useful for**: when customers are ready to manage keys but want to delegate encryption and decryption.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Perfect for**: users who prefer a turnkey solution without the burden of key management.
+- **Preferred method for**: companies looking to protect their data without specific encryption compliance needs.
+
+The choice between these methods should be guided by security policies and regulatory requirements, as well as the ability to manage encryption keys. A balance between ease of use and security is essential.
+
+### Examples of scripts and commands
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Generating a client-side encryption key
+client_key=$(openssl rand -base64 32)
+# Encryption of a file before sending
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Sending encrypted file to S3 bucket
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Creating an encryption key and its MD5 fingerprint
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Uploading an object with SSE-C encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Retrieving an object with SSE-C encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Sending an object with SSE-S3 encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Uploading an object with SSE-S3 encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Troubleshooting and Common Error Resolution
+
+### Error using SSE-C without proper encryption headers
+
+- **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
+- **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
+
+### Bad query error when using SSE-S3
+
+- **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
+- **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
+
+### Performance or latency issues during encryption/decryption
+
+- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
+
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
+## Conclusion
+
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+
+The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 
 ## Go further
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-ca.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Chiffrez vos objets côté serveur avec SSE-C
 excerpt: Ce guide explique comment chiffrer vos objets côté serveur avec SSE-C
-updated: 2022-04-15
+updated: 2024-04-10
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objectif
 
-L'utilisation du chiffrement côté serveur avec des clés de chiffrement fournies par le client (SSE-C) vous permet de définir vos propres clés de chiffrement.  
+Chez OVHcloud, nous comprenons l'importance cruciale de la protection des données dans l'écosystème numérique actuel. Face à des menaces de sécurité en constante évolution et à des exigences réglementaires de plus en plus strictes, il est essentiel de mettre en place des mesures robustes pour sécuriser les données à tout moment. Cela inclut non seulement les données en transit mais également les données au repos.
 
-Lorsque vous téléchargez un objet, S3 Object Storage utilise la clé de chiffrement que vous fournissez pour appliquer le chiffrement AES-256 à vos données. Lorsque vous récupérez un objet, vous devez fournir la même clé de cryptage dans le cadre de votre demande. S3 Object Storage vérifie d'abord que la clé de chiffrement que vous avez fournie correspond, puis déchiffre l'objet avant de vous renvoyer les données de l'objet.
+La protection des données « *at rest* », c'est-à-dire des données stockées sur des dispositifs physiques ou dans le cloud, est un élément crucial de la stratégie de sécurité informatique de toute organisation. Dans ce contexte, deux approches principales se distinguent pour le chiffrement de ces données : le chiffrement côté client (Client-Side Encryption, CSE) et le chiffrement côté serveur (Server-Side Encryption, SSE).
 
-**Ce guide explique comment chiffrer vos objets côté serveur avec SSE-C.**
+Le chiffrement côté client (Client-Side Encryption, CSE) permet à nos clients de chiffrer leurs données sur leur propre dispositif avant de les envoyer vers nos serveurs pour stockage. Cette méthode assure que les données restent cryptées tout au long de leur cycle de vie, offrant un haut degré de sécurité, puisque les clés de chiffrement sont gérées par le client et jamais partagées avec OVHcloud ou tout autre tiers.
+
+Bien que cette approche exige une gestion rigoureuse des clés de la part du client, elle représente une solution idéale pour ceux qui requièrent un contrôle total sur la sécurité de leurs données.
+
+En parallèle, le chiffrement côté serveur (Server-Side Encryption, SSE) propose une alternative où les données sont chiffrées à leur arrivée sur nos serveurs. Cette responsabilité incombe à OVHcloud, ce qui allège considérablement la charge de gestion de la sécurité pour nos clients. Deux méthodes de chiffrement côté serveur sont disponibles : 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)** : vous pouvez fournir et gérer vos propres clés de chiffrement, vous offrant ainsi une maîtrise complète sur la sécurité de vos données. Cette option est particulièrement adaptée aux organisations ayant des besoins spécifiques en matière de conformité et de sécurité des données, puisqu'elle permet une gestion exclusive des clés de chiffrement.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** : simplifie le processus de chiffrement en utilisant des clés gérées par OVHcloud. Cette méthode est idéale pour les clients qui souhaitent bénéficier d'une solution de chiffrement robuste sans les complexités liées à la gestion des clés.
+
+Notre objectif est vous aider à choisir le meilleur type de chiffrement pour vous. Cette page vous donne toutes les informations nécessaires pour faire un choix éclairé. Que vous préfériez gérer vous-même avec SSE-C ou opter pour la facilité de SSE-S3, Nous nous engageons à vous offrir des solutions flexibles et sûres pour protéger vos données quand elles sont stockées.
+
+**Ce guide explique comment chiffrer vos objets côté serveur avec SSE-C et SSE-S3.**
 
 > [!warning]
 >
@@ -31,23 +42,29 @@ Lorsque vous téléchargez un objet, S3 Object Storage utilise la clé de chiffr
 
 ## Prérequis
 
-- Avoir créé un bucket
+- Avoir créé un bucket S3
 - Avoir créé un utilisateur et avoir défini les droits d'accès requis sur le bucket
-- Avoir installé et configuré aws-cli
+- Avoir installé et configuré l'interface de ligne de commande AWS (aws-cli)
 
 Consultez notre guide « [Débuter avec S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) » pour plus de détails.
 
 ## En pratique
 
+L'utilisation du chiffrement côté serveur avec des clés de chiffrement fournies par le client (SSE-C) vous permet de définir vos propres clés de chiffrement.
+
+Lorsque vous téléchargez un objet, S3 Object Storage utilise la clé de chiffrement que vous fournissez pour appliquer le chiffrement AES-256 à vos données. Lorsque vous récupérez un objet, vous devez fournir la même clé de cryptage dans le cadre de votre demande. S3 Object Storage vérifie d'abord que la clé de chiffrement que vous avez fournie correspond, puis déchiffre l'objet avant de vous renvoyer les données de l'objet.
+
 Lorsque vous utilisez SSE-C, vous devez fournir des informations sur la clé de chiffrement à l'aide des en-têtes de requête suivants.
 
-| Name | Description |
+| Nom | Description |
 |:-----|:------------|
 | --sse​-customer-algorithm | Utilisez cet en-tête pour spécifier l'algorithme du chiffrement. La valeur de l'en-tête doit être *AES256*.  |
 | --sse-customer-key | Utilisez cet en-tête pour fournir la clé de chiffrement de 256 bits encodée en Base64 pour chiffrer ou déchiffrer les données. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Utilisez cet en-tête pour fournir la valeur de hachage MD5 128 bits encodée en Base64 de la clé de chiffrement conformément à la norme RFC 1321. Cet en-tête est utilisé pour vérifier l'intégrité du message et veiller à ce que la clé de chiffrement ait été transmise sans erreur. |
 
-### Création d'une clé de chiffrement
+### SSE-C - Chiffrement côté serveur avec clés de chiffrement client
+
+#### Création d'une clé de chiffrement
 
 Exemple de création d'une clé de chiffrement ( *--sse-customer-key* ) :
 
@@ -61,7 +78,7 @@ et de la clé MD5 ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Envoi d'un objet avec SSE-C
+#### Envoi d'un objet avec SSE-C
 
 Pour envoyer un objet avec SSE-C et aws-cli, procédez comme suit:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Réception d'un objet avec SSE-C
+#### Réception d'un objet avec SSE-C
 
 Pour recevoir un objet avec SSE-C et aws-cli, procédez comme suit:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Obtenir les métadonnées d'un objet avec SSE-C
+#### Obtenir les métadonnées d'un objet avec SSE-C
 
 Pour obtenir les métadonnées d'un objet avec SSE-C et aws-cli, procédez comme suit:
 
@@ -137,9 +154,9 @@ Pour supprimer un objet chiffré avec SSE-C et aws-cli, procédez comme suit:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### URLs présignées et SSE-C
+#### URLs présignées et SSE-C
 
-Les URL pré-signées, qui peuvent être utilisées pour des opérations telles que l'envoi d'un nouvel objet, la récupération d'un objet existant ou des métadonnées d'un objet, prennent en charge le SSE-C comme suit:
+Les URL pré-signées, qui peuvent être utilisées pour des opérations telles que l'envoi d'un nouvel objet, la récupération d'un objet existant ou des métadonnées d'un objet, prennent en charge le SSE-C comme suit :
 
 - Lorsque vous créez une URL pré-signée, vous devez spécifier l'algorithme en utilisant l'en-tête `x-amz-server-side-encryption-customer-algorithm` dans le calcul de la signature.
 
@@ -148,7 +165,249 @@ Les URL pré-signées, qui peuvent être utilisées pour des opérations telles 
 > [!primary]
 >
 > Vous pouvez donc utiliser l'URL pré-signée pour les objets SSE-C uniquement par programmation, car en plus de l'URL pré-signée, vous devez également inclure des en-têtes HTTP spécifiques aux objets SSE-C.
->
+
+### SSE-S3 - Chiffrement côté serveur avec clés gérées par OVHcloud
+
+L'utilisation du chiffrement côté serveur avec des clés gérées par OVHcloud (SSE-S3) permet de protéger vos données stockées sur OVHcloud en les chiffrant automatiquement au repos. SSE-S3 utilise des clés gérées et protégées par OVHcloud, éliminant ainsi le besoin pour l'utilisateur de gérer manuellement ces clés de chiffrement.
+
+#### Avantages
+
+- **Gestion des Clés Simplifiée**
+
+Avec OVHcloud prenant en charge la gestion sécurisée des clés de chiffrement, les utilisateurs bénéficient d'une gestion des clés simplifiée. Cette approche élimine les complexités liées à la rotation des clés tout en maintenant un niveau élevé de sécurité pour les données. Elle permet de concilier sécurité et efficacité opérationnelle, en éliminant la charge administrative de la gestion manuelle des clés de chiffrement.
+
+- **Sécurité Renforcée**
+
+Nous employons une stratégie de chiffrement avancée pour offrir une protection maximale de vos données. Chaque bucket bénéficie d'une clé unique, et pour chaque objet stocké, une clé de chiffrement distincte est générée. Cette clé est obtenue en combinant la clé unique du bucket avec un sel aléatoire, ce qui assure que chaque objet est chiffré avec sa propre clé. Cette méthode de dérivation de clés limite le risque associé à l'exposition d'une clé unique et garantit une sécurité renforcée pour vos données.
+
+- **Transparence**
+
+Le processus de chiffrement et de déchiffrement est entièrement transparent pour l'utilisateur, permettant d'accéder et de gérer les données chiffrées aussi aisément que s'il s'agissait de données non chiffrées.
+
+- **Sécurité renforcée grâce à OVHcloud Key Management Service (KMS)**
+
+Notre engagement envers la sécurité de vos données est renforcé par l'utilisation d'OVHcloud Key Management Service (KMS), une plateforme avancée pour le stockage sécurisé et la gestion des clés de chiffrement. Cette approche garantit une protection optimale de vos données, mettant en place une infrastructure de sécurité robuste sans les complexités liées à la gestion directe des clés de chiffrement.
+
+Pour approfondir votre compréhension du Key Management Service (KMS) d'OVHcloud et de ses applications dans divers contextes d'infrastructure cloud, nous vous recommandons de consulter les ressources suivantes :
+
+- **[Mise en route du KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)** : ce guide offre un aperçu détaillé de la mise en œuvre et de l'utilisation du KMS pour sécuriser vos données.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)** : guide pratique sur l'activation du chiffrement de machines virtuelles en utilisant les capacités de KMS.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)** : instructions détaillées sur l'utilisation de KMS en conjonction avec le fournisseur de clés natif vSphere pour le chiffrement de machines virtuelles.
+
+Ces documents fournissent des informations précieuses sur la manière dont le KMS peut être utilisé pour renforcer la sécurité dans différents scénarios d'infrastructure cloud.
+
+#### Mise en œuvre
+
+Pour renforcer la sécurité des données uploadées chez OVHcloud, l'activation du chiffrement côté serveur (SSE-S3) a été conçue pour être à la fois facile et transparente. En configurant une méthode de chiffrement par défaut sur votre bucket via la requête `PutBucketEncryption`, tout objet uploadé sera automatiquement chiffré sans nécessiter d'actions supplémentaires de votre part. Lors de l'upload d'un objet, il suffit de spécifier l'option de chiffrement dans la requête d'API ou via la ligne de commande AWS CLI. OVHcloud prend en charge le reste, chiffrant vos données avant leur stockage en utilisant une clé unique générée automatiquement pour le bucket.
+
+#### Gestion sécurisée des clés de chiffrement avec SSE-S3 sur OVHcloud S3
+
+L'implémentation du chiffrement SSE-S3 sur OVHcloud S3 est conçue pour offrir une gestion des clés de chiffrement à la fois sécurisée et transparente pour l'utilisateur. Chaque bucket bénéficie d'une clé distincte, ce qui assure que les données y sont sécurisées de façon individuelle et isolée. Cette méthode de chiffrement, intégrée et gérée par la plateforme, élimine les complexités associées à la gestion manuelle des clés par les utilisateurs. Tout en rendant le processus utilisateur aussi fluide et intuitif que possible, elle maintient une sécurité robuste et conforme aux standards les plus stricts en matière de protection des données.
+
+#### Envoi d'un objet avec SSE-S3 sur OVHcloud S3
+
+##### Upload d'un objet sur OVHcloud S3 avec chiffrement SSE-S3
+
+Pour envoyer un objet dans votre bucket S3 sur OVHcloud avec chiffrement SSE-S3, utilisez la commande Bash suivante via l'AWS CLI. Cette commande intègre l'option de chiffrement côté serveur pour renforcer la sécurité de vos données stockées.
+
+```bash
+aws s3api put-object --bucket votre-bucket --key votre-objet --body chemin/vers/votre/fichier --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+Lorsque vous utilisez la commande AWS CLI pour uploader un objet avec chiffrement SSE-S3 sur OVHcloud S3, assurez-vous de remplacer les valeurs suivantes selon vos informations spécifiques :
+
+- `votre-bucket` : remplacez cette valeur par le nom de votre bucket S3 où vous souhaitez envoyer l'objet.
+- `votre-objet` : remplacez par la clé ou le nom sous lequel vous voulez que l'objet soit stocké dans le bucket.
+- `chemin/vers/votre/fichier` : indiquez le chemin d'accès complet au fichier que vous prévoyez d'envoyer.
+
+L'option `--server-side-encryption AES256` dans la commande indique que vous souhaitez appliquer le chiffrement SSE-S3. Cela garantit que l'objet envoyé est chiffré de manière sécurisée directement sur le serveur OVHcloud, offrant une couche supplémentaire de protection pour vos données.
+
+##### Téléchargement d'un Objet avec SSE-S3 sur OVHcloud S3
+
+Pour télécharger un objet qui a été chiffré avec SSE-S3 depuis OVHcloud S3, il n'est pas nécessaire de spécifier des headers du chiffrement dans la commande. En effet, l'objet peut être téléchargé directement sans manipulation supplémentaire liée au chiffrement, car le déchiffrement est géré automatiquement côté serveur. Voici un exemple de commande de téléchargement :
+
+```bash
+aws s3api get-object --bucket votre-bucket --key votre-objet chemin/vers/destination/fichier --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Remplacez `votre-bucket` par le nom de votre bucket.
+- Remplacez `votre-objet` par la clé de l'objet que vous souhaitez télécharger.
+- Remplacez `chemin/vers/destination/fichier` par le chemin où vous souhaitez sauvegarder le fichier téléchargé.
+- Le paramètre `--endpoint-url https://s3.io.cloud.ovh.net` doit être ajusté à la région de votre service OVHcloud S3.
+
+Attention de ne pas inclure de headers de chiffrement spécifiques lors du téléchargement d'un objet chiffré avec SSE-S3 pour éviter des erreurs, telles qu'une erreur 400 Bad Request. 
+
+#### Ajout du chiffrement à un bucket existant sur OVHcloud S3
+
+Pour ajouter le chiffrement SSE-S3 à un bucket S3 existant sur OVHcloud, vous devez utiliser la commande `put-bucket-encryption` de l'AWS CLI. Cette commande configure le chiffrement du bucket pour que tous les nouveaux objets ajoutés soient automatiquement chiffrés avec SSE-S3. Voici la commande spécifique que vous utiliseriez :
+
+```bash
+aws s3api put-bucket-encryption --bucket votre-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Remplacez `votre-bucket` par le nom de votre bucket S3.
+
+Cela va configurer le bucket pour utiliser le chiffrement SSE-S3 avec les clés gérées par S3 (AES256) pour tous les nouveaux objets. Les objets existants ne seront pas affectés. Si vous souhaitez également les chiffrer, vous devrez les copier ou les uploader à nouveau après avoir changé cette configuration.
+
+##### Affichage de la configuration du chiffrement du Bucket
+
+Après avoir configuré le chiffrement de votre bucket via `PutBucketEncryption` pour utiliser SSE-S3, assurez-vous que tout est correctement mis en place en utilisant la commande suivante avec l'AWS CLI :
+
+```bash
+aws s3api get-bucket-encryption --bucket votre-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Remplacez `votre-bucket` par le nom de votre bucket.
+
+Cette commande vous permet de vérifier la configuration actuelle du chiffrement de votre bucket pour vous assurer que le chiffrement SSE-S3 est bien activé.
+
+Dans cette commande, remplacez `votre-bucket` par le nom de votre bucket. Cette commande vous renvoie les détails de la configuration du chiffrement actuelle de votre bucket, vous confirmant l'utilisation de SSE-S3 pour le chiffrement des données au repos.
+
+Cette étape supplémentaire garantit une transparence totale et vous permet de vous assurer que la sécurité de vos données est maintenue selon les normes les plus élevées, avec la simplicité et l'efficacité que propose le chiffrement SSE-S3 gérée par OVHcloud.
+
+##### Suppression d'un objet chiffré avec SSE-S3
+
+La suppression d'objets chiffrés avec SSE-S3 ne diffère pas de la suppression d'objets non chiffrés. Vous pouvez utiliser la commande suivante pour supprimer un objet :
+
+```bash
+aws s3 rm s3://mon-Bucket/mon-objet
+```
+
+- Remplacez `mon-Bucket` par le nom de votre bucket
+- Remplacez `mon-objet` par le nom de l'objet que vous souhaitez supprimer.
+
+Cette commande permet de supprimer efficacement un objet, qu'il soit chiffré ou non, de votre bucket sur OVHcloud S3.
+
+### Considérations sur le Chiffrement SSE-S3
+
+Lors de l'utilisation du chiffrement SSE-S3 sur OVHcloud S3, il est important de prendre en compte les éléments suivants :
+
+#### Performances
+
+- **Surcharge** : le chiffrement SSE-S3 peut introduire une légère surcharge due au processus de chiffrement et de déchiffrement. Cependant, cette surcharge est généralement minime et n'affecte pas significativement les performances globales.
+
+#### Sécurité
+
+- **Gestion des clés** : SSE-S3 offre un haut niveau de sécurité en gérant automatiquement les clés de chiffrement. Cela simplifie la gestion de la sécurité pour les utilisateurs.
+- **Pratiques de sécurité supplémentaires** : il est crucial de combiner le chiffrement SSE-S3 avec d'autres pratiques de sécurité pour une protection optimale. Cela inclut l'utilisation de politiques IAM strictes et le suivi des accès aux logs pour surveiller et contrôler l'accès aux données.
+
+#### Comparaison des méthodes de chiffrement
+
+Il est essentiel de comparer les différentes méthodes de chiffrement disponibles pour choisir celle qui convient le mieux à vos besoins spécifiques. Les méthodes à considérer incluent le chiffrement côté client (CSE) et le chiffrement côté serveur (SSE), avec ses variantes SSE-C et SSE-S3.
+
+#### Avantages et inconvénients
+
+- **CSE vs SSE** : chaque méthode a ses propres avantages et inconvénients en termes de facilité de gestion, de sécurité et d'impact sur les performances.
+- **Cas d'usage recommandés** : selon votre situation spécifique, certaines méthodes peuvent être plus appropriées que d'autres. Il est important d'évaluer les cas d'usage recommandés pour chaque méthode de chiffrement.
+
+Un tableau comparatif peut être utile pour résumer ces éléments, offrant une vue d'ensemble claire qui facilite la prise de décision.
+
+| Méthode de Chiffrement | Avantages | Inconvénients | Cas d’Usage Recommandés |
+|------------------------|-----------|---------------|-------------------------|
+| **CSE (Client-Side Encryption)** | - Contrôle total sur les clés de chiffrement<br>- Sécurité maximisée car les clés ne quittent jamais le client | - Gestion complexe des clés<br>- Responsabilité complète de la sécurité des clés | - Scénarios nécessitant une conformité spécifique<br>- Haute sensibilité des données |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Maîtrise sur les clés de chiffrement<br>- Sécurité renforcée sans la complexité totale de CSE | - Nécessité de fournir les clés à chaque requête<br>- Gestion des clés plus complexe que SSE-S3 | - Conformité et contrôle sur les clés<br>- Besoins intermédiaires en sécurité |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simplicité de mise en œuvre<br>- Gestion des clés automatique par OVHcloud<br>- Transparence d'utilisation | - Moins de contrôle sur les clés de chiffrement par rapport à CSE et SSE-C | - Usage général où la facilité de gestion est prioritaire<br>- Données moins sensibles |
+
+Chaque méthode de chiffrement a ses propres forces et faiblesses. Le choix de la méthode dépend de plusieurs facteurs, notamment le niveau de sécurité requis, la complexité de la gestion des clés que vous êtes prêt à assumer, et les spécificités réglementaires ou de conformité auxquelles votre organisation doit adhérer.
+
+### Cas d'usage recommandés pour le chiffrement sur OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Idéal pour** : organisations avec des exigences de sécurité très élevées, nécessitant que les clés de chiffrement restent sous contrôle exclusif.
+- **Adapté pour** : environnements réglementés strictement, tels que les institutions financières ou les services de santé.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Convient aux** : organisations recherchant un équilibre entre le contrôle des clés et la facilité de gestion.
+- **Utile pour** : cas où les clients sont prêts à gérer les clés mais souhaitent déléguer le chiffrement et le déchiffrement.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Parfait pour**:  utilisateurs préférant une solution clé en main sans la charge de la gestion des clés.
+- **Méthode privilégiée pour** : entreprises cherchant à protéger leurs données sans nécessités spécifiques de conformité en matière de chiffrement.
+
+Le choix entre ces méthodes doit être guidé par les politiques de sécurité et exigences réglementaires, ainsi que la capacité à gérer les clés de chiffrement. Un équilibre entre facilité d'utilisation et sécurité est essentiel.
+
+### Exemples de scripts et commandes
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Génération d'une clé de chiffrement côté client
+client_key=$(openssl rand -base64 32)
+# Chiffrement d'un fichier avant l'envoi
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Envoi du fichier chiffré vers le bucket S3
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Création d'une clé de chiffrement et de son empreinte MD5
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Téléchargement d'un objet avec chiffrement SSE-C
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Récupération d'un objet avec chiffrement SSE-C
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+```bash
+# Envoi d'un objet avec chiffrement SSE-S3
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Téléchargement d'un objet avec chiffrement SSE-S3
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Dépannage et Résolution d'erreurs communnes
+
+### Erreur lors de l'utilisation de SSE-C sans les en-têtes de chiffrement appropriés
+
+- **En-têtes nécessaires** : assurez-vous que les en-têtes `--sse-customer-algorithm`, `--sse-customer-key`, et `--sse-customer-key-md5` sont inclus correctement dans votre commande.
+- **Vérification de la clé**: Confirmez que la clé de chiffrement est exacte et n'a subi aucune modification ou altération depuis son utilisation pour chiffrer l'objet.
+
+### Erreur de requête incorrecte lors de l'utilisation de SSE-S3
+
+- **Sans en-têtes spécifiques** : pour SSE-S3, évitez de spécifier des en-têtes de chiffrement lors du téléchargement. L'option `--server-side-encryption AES256` suffit.
+- **Vérification de la méthode de chiffrement**: assurez-vous que l'objet n'a pas été chiffré initialement avec une méthode différente.
+
+### Problèmes de performance ou de latence lors du chiffrement/déchiffrement
+
+- **Surcharge potentielle** : le chiffrement et le déchiffrement peuvent causer une surcharge. Vérifiez que votre infrastructure réseau et système est capable de gérer cette charge additionnelle.
+- **Optimisation de performance** : pour améliorer les performances, réalisez le chiffrement et le déchiffrement dans une région géographique proche de votre localisation pour minimiser la latence.
+
+### En cas de perte de la clé de chiffrement SSE-C
+
+- **Récupération impossible**: si la clé de chiffrement est perdue, il est impossible de récupérer les données chiffrées avec SSE-C. Gardez vos clés dans un endroit sûr et envisagez l'utilisation de services de gestion des clés pour améliorer la sécurité.
+
+## Conclusion
+
+Cette documentation met en évidence notre engagement à fournir des solutions de sécurité des données avancées. Que vous optiez pour le chiffrement côté client (CSE) ou côté serveur (SSE-S3), notre objectif est de vous offrir une sécurité optimale sans surcharge opérationnelle.
+
+L'OVHcloud Key Management Service (KMS) témoigne de notre engagement dans la sécurisation de vos données, offrant une protection complète sans les complexités de gestion directe des clés. Nous encourageons l'adoption de ces pratiques de chiffrement pour sécuriser vos données au repos, vous fournissant les outils et les connaissances nécessaires pour une mise en œuvre efficace. OVHcloud est à votre disposition pour toute assistance supplémentaire concernant le chiffrement et la sécurité des données. N'hésitez pas à consulter nos ressources supplémentaires ou à contacter notre support technique pour toute clarification ou assistance.
 
 ## Aller plus loin
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
-title: Object Storage - Chiffrez vos objets côté serveur avec SSE-C
+title: Object Storage - Chiffrez vos objets côté serveur avec SSE-C ou SSE-S3
 excerpt: Ce guide explique comment chiffrer vos objets côté serveur avec SSE-C
-updated: 2022-04-15
+updated: 2024-03-22
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objectif
 
-L'utilisation du chiffrement côté serveur avec des clés de chiffrement fournies par le client (SSE-C) vous permet de définir vos propres clés de chiffrement.  
+Chez OVHcloud, nous comprenons l'importance cruciale de la protection des données dans l'écosystème numérique actuel. Face à des menaces de sécurité en constante évolution et à des exigences réglementaires de plus en plus strictes, il est essentiel de mettre en place des mesures robustes pour sécuriser les données à tout moment. Cela inclut non seulement les données en transit mais également les données au repos.
 
-Lorsque vous téléchargez un objet, S3 Object Storage utilise la clé de chiffrement que vous fournissez pour appliquer le chiffrement AES-256 à vos données. Lorsque vous récupérez un objet, vous devez fournir la même clé de cryptage dans le cadre de votre demande. S3 Object Storage vérifie d'abord que la clé de chiffrement que vous avez fournie correspond, puis déchiffre l'objet avant de vous renvoyer les données de l'objet.
+La protection des données « *at rest* », c'est-à-dire des données stockées sur des dispositifs physiques ou dans le cloud, est un élément crucial de la stratégie de sécurité informatique de toute organisation. Dans ce contexte, deux approches principales se distinguent pour le chiffrement de ces données : le chiffrement côté client (Client-Side Encryption, CSE) et le chiffrement côté serveur (Server-Side Encryption, SSE).
 
-**Ce guide explique comment chiffrer vos objets côté serveur avec SSE-C.**
+Le chiffrement côté client (Client-Side Encryption, CSE) permet à nos clients de chiffrer leurs données sur leur propre dispositif avant de les envoyer vers nos serveurs pour stockage. Cette méthode assure que les données restent cryptées tout au long de leur cycle de vie, offrant un haut degré de sécurité, puisque les clés de chiffrement sont gérées par le client et jamais partagées avec OVHcloud ou tout autre tiers.
+
+Bien que cette approche exige une gestion rigoureuse des clés de la part du client, elle représente une solution idéale pour ceux qui requièrent un contrôle total sur la sécurité de leurs données.
+
+En parallèle, le chiffrement côté serveur (Server-Side Encryption, SSE) propose une alternative où les données sont chiffrées à leur arrivée sur nos serveurs. Cette responsabilité incombe à OVHcloud, ce qui allège considérablement la charge de gestion de la sécurité pour nos clients. Deux méthodes de chiffrement côté serveur sont disponibles : 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)** : vous pouvez fournir et gérer vos propres clés de chiffrement, vous offrant ainsi une maîtrise complète sur la sécurité de vos données. Cette option est particulièrement adaptée aux organisations ayant des besoins spécifiques en matière de conformité et de sécurité des données, puisqu'elle permet une gestion exclusive des clés de chiffrement.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** : simplifie le processus de chiffrement en utilisant des clés gérées par OVHcloud. Cette méthode est idéale pour les clients qui souhaitent bénéficier d'une solution de chiffrement robuste sans les complexités liées à la gestion des clés.
+
+Notre objectif est vous aider à choisir le meilleur type de chiffrement pour vous. Cette page vous donne toutes les informations nécessaires pour faire un choix éclairé. Que vous préfériez gérer vous-même avec SSE-C ou opter pour la facilité de SSE-S3, Nous nous engageons à vous offrir des solutions flexibles et sûres pour protéger vos données quand elles sont stockées.
+
+**Ce guide explique comment chiffrer vos objets côté serveur avec SSE-C et SSE-S3.**
 
 > [!warning]
 >
@@ -31,23 +42,29 @@ Lorsque vous téléchargez un objet, S3 Object Storage utilise la clé de chiffr
 
 ## Prérequis
 
-- Avoir créé un bucket
+- Avoir créé un bucket S3
 - Avoir créé un utilisateur et avoir défini les droits d'accès requis sur le bucket
-- Avoir installé et configuré aws-cli
+- Avoir installé et configuré l'interface de ligne de commande AWS (aws-cli)
 
 Consultez notre guide « [Débuter avec S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) » pour plus de détails.
 
 ## En pratique
 
+L'utilisation du chiffrement côté serveur avec des clés de chiffrement fournies par le client (SSE-C) vous permet de définir vos propres clés de chiffrement.
+
+Lorsque vous téléchargez un objet, S3 Object Storage utilise la clé de chiffrement que vous fournissez pour appliquer le chiffrement AES-256 à vos données. Lorsque vous récupérez un objet, vous devez fournir la même clé de cryptage dans le cadre de votre demande. S3 Object Storage vérifie d'abord que la clé de chiffrement que vous avez fournie correspond, puis déchiffre l'objet avant de vous renvoyer les données de l'objet.
+
 Lorsque vous utilisez SSE-C, vous devez fournir des informations sur la clé de chiffrement à l'aide des en-têtes de requête suivants.
 
-| Name | Description |
+| Nom | Description |
 |:-----|:------------|
 | --sse​-customer-algorithm | Utilisez cet en-tête pour spécifier l'algorithme du chiffrement. La valeur de l'en-tête doit être *AES256*.  |
 | --sse-customer-key | Utilisez cet en-tête pour fournir la clé de chiffrement de 256 bits encodée en Base64 pour chiffrer ou déchiffrer les données. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Utilisez cet en-tête pour fournir la valeur de hachage MD5 128 bits encodée en Base64 de la clé de chiffrement conformément à la norme RFC 1321. Cet en-tête est utilisé pour vérifier l'intégrité du message et veiller à ce que la clé de chiffrement ait été transmise sans erreur. |
 
-### Création d'une clé de chiffrement
+### SSE-C - Chiffrement côté serveur avec clés de chiffrement client
+
+#### Création d'une clé de chiffrement
 
 Exemple de création d'une clé de chiffrement ( *--sse-customer-key* ) :
 
@@ -61,7 +78,7 @@ et de la clé MD5 ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Envoi d'un objet avec SSE-C
+#### Envoi d'un objet avec SSE-C
 
 Pour envoyer un objet avec SSE-C et aws-cli, procédez comme suit:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Réception d'un objet avec SSE-C
+#### Réception d'un objet avec SSE-C
 
 Pour recevoir un objet avec SSE-C et aws-cli, procédez comme suit:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Obtenir les métadonnées d'un objet avec SSE-C
+#### Obtenir les métadonnées d'un objet avec SSE-C
 
 Pour obtenir les métadonnées d'un objet avec SSE-C et aws-cli, procédez comme suit:
 
@@ -137,9 +154,9 @@ Pour supprimer un objet chiffré avec SSE-C et aws-cli, procédez comme suit:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### URLs présignées et SSE-C
+#### URLs présignées et SSE-C
 
-Les URL pré-signées, qui peuvent être utilisées pour des opérations telles que l'envoi d'un nouvel objet, la récupération d'un objet existant ou des métadonnées d'un objet, prennent en charge le SSE-C comme suit:
+Les URL pré-signées, qui peuvent être utilisées pour des opérations telles que l'envoi d'un nouvel objet, la récupération d'un objet existant ou des métadonnées d'un objet, prennent en charge le SSE-C comme suit :
 
 - Lorsque vous créez une URL pré-signée, vous devez spécifier l'algorithme en utilisant l'en-tête `x-amz-server-side-encryption-customer-algorithm` dans le calcul de la signature.
 
@@ -148,7 +165,251 @@ Les URL pré-signées, qui peuvent être utilisées pour des opérations telles 
 > [!primary]
 >
 > Vous pouvez donc utiliser l'URL pré-signée pour les objets SSE-C uniquement par programmation, car en plus de l'URL pré-signée, vous devez également inclure des en-têtes HTTP spécifiques aux objets SSE-C.
->
+
+### SSE-S3 - Chiffrement côté serveur avec clés gérées par OVHcloud
+
+L'utilisation du chiffrement côté serveur avec des clés gérées par OVHcloud (SSE-S3) permet de protéger vos données stockées sur OVHcloud en les chiffrant automatiquement au repos. SSE-S3 utilise des clés gérées et protégées par OVHcloud, éliminant ainsi le besoin pour l'utilisateur de gérer manuellement ces clés de chiffrement.
+
+#### Avantages
+
+- **Gestion des Clés Simplifiée**
+
+Avec OVHcloud prenant en charge la gestion sécurisée des clés de chiffrement, les utilisateurs bénéficient d'une gestion des clés simplifiée. Cette approche élimine les complexités liées à la rotation des clés tout en maintenant un niveau élevé de sécurité pour les données. Elle permet de concilier sécurité et efficacité opérationnelle, en éliminant la charge administrative de la gestion manuelle des clés de chiffrement.
+
+- **Sécurité Renforcée**
+
+Nous employons une stratégie de chiffrement avancée pour offrir une protection maximale de vos données. Chaque bucket bénéficie d'une clé unique, et pour chaque objet stocké, une clé de chiffrement distincte est générée. Cette clé est obtenue en combinant la clé unique du bucket avec un sel aléatoire, ce qui assure que chaque objet est chiffré avec sa propre clé. Cette méthode de dérivation de clés limite le risque associé à l'exposition d'une clé unique et garantit une sécurité renforcée pour vos données.
+
+- **Transparence**
+
+Le processus de chiffrement et de déchiffrement est entièrement transparent pour l'utilisateur, permettant d'accéder et de gérer les données chiffrées aussi aisément que s'il s'agissait de données non chiffrées.
+
+- **Sécurité renforcée grâce à OVHcloud Key Management Service (KMS)**
+
+Notre engagement envers la sécurité de vos données est renforcé par l'utilisation d'OVHcloud Key Management Service (KMS), une plateforme avancée pour le stockage sécurisé et la gestion des clés de chiffrement. Cette approche garantit une protection optimale de vos données, mettant en place une infrastructure de sécurité robuste sans les complexités liées à la gestion directe des clés de chiffrement.
+
+Pour approfondir votre compréhension du Key Management Service (KMS) d'OVHcloud et de ses applications dans divers contextes d'infrastructure cloud, nous vous recommandons de consulter les ressources suivantes :
+
+- **[Mise en route du KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)** : ce guide offre un aperçu détaillé de la mise en œuvre et de l'utilisation du KMS pour sécuriser vos données.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)** : guide pratique sur l'activation du chiffrement de machines virtuelles en utilisant les capacités de KMS.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)** : instructions détaillées sur l'utilisation de KMS en conjonction avec le fournisseur de clés natif vSphere pour le chiffrement de machines virtuelles.
+
+Ces documents fournissent des informations précieuses sur la manière dont le KMS peut être utilisé pour renforcer la sécurité dans différents scénarios d'infrastructure cloud.
+
+#### Mise en œuvre
+
+Pour renforcer la sécurité des données téléchargées sur OVHcloud, l'activation du chiffrement côté serveur (SSE-S3) a été conçue pour être à la fois facile et transparente. En configurant une méthode de chiffrement par défaut sur votre bucket via la requête `PutBucketEncryption`, tout objet téléchargé sera automatiquement chiffré sans nécessiter d'actions supplémentaires de votre part. Lors du téléchargement d'un objet, il suffit de spécifier l'option de chiffrement dans la requête d'API ou via la ligne de commande AWS CLI. OVHcloud prend en charge le reste, chiffrant vos données avant leur stockage en utilisant une clé unique générée automatiquement pour le bucket.
+
+#### Gestion sécurisée des clés de chiffrement avec SSE-S3 sur OVHcloud S3
+
+L'implémentation du chiffrement SSE-S3 sur OVHcloud S3 est conçue pour offrir une gestion des clés de chiffrement à la fois sécurisée et transparente pour l'utilisateur. Chaque bucket bénéficie d'une clé distincte, ce qui assure que les données y sont sécurisées de façon individuelle et isolée. Cette méthode de chiffrement, intégrée et gérée par la plateforme, élimine les complexités associées à la gestion manuelle des clés par les utilisateurs. Tout en rendant le processus utilisateur aussi fluide et intuitif que possible, elle maintient une sécurité robuste et conforme aux standards les plus stricts en matière de protection des données.
+
+#### Envoi d'un objet avec SSE-S3 sur OVHcloud S3
+
+##### Upload d'un objet sur OVHcloud S3 avec chiffrement SSE-S3
+
+Pour envoyer un objet dans votre bucket S3 sur OVHcloud avec chiffrement SSE-S3, utilisez la commande Bash suivante via l'AWS CLI. Cette commande intègre l'option de chiffrement côté serveur pour renforcer la sécurité de vos données stockées.
+
+```bash
+aws s3api put-object --bucket votre-bucket --key votre-objet --body chemin/vers/votre/fichier --server-side-encryption AES256 --endpoint-url https://s3.<region>.ovhcloud.com
+```
+Lorsque vous utilisez la commande AWS CLI pour uploader un objet avec chiffrement SSE-S3 sur OVHcloud S3, assurez-vous de remplacer les valeurs suivantes selon vos informations spécifiques :
+
+- `votre-bucket` : remplacez cette valeur par le nom de votre bucket S3 où vous souhaitez envoyer l'objet.
+- `votre-objet` : remplacez par la clé ou le nom sous lequel vous voulez que l'objet soit stocké dans le bucket.
+- `chemin/vers/votre/fichier` : indiquez le chemin d'accès complet au fichier que vous prévoyez d'envoyer.
+- `<region>` : remplacez par la région de votre service OVHcloud S3, qui héberge votre bucket.
+
+L'option `--server-side-encryption AES256` dans la commande indique que vous souhaitez appliquer le chiffrement SSE-S3. Cela garantit que l'objet envoyé est chiffré de manière sécurisée directement sur le serveur OVHcloud, offrant une couche supplémentaire de protection pour vos données.
+
+##### Téléchargement d'un Objet avec SSE-S3 sur OVHcloud S3
+
+Pour télécharger un objet qui a été chiffré avec SSE-S3 depuis OVHcloud S3, il n'est pas nécessaire de spécifier des headers du chiffrement dans la commande. En effet, l'objet peut être téléchargé directement sans manipulation supplémentaire liée au chiffrement, car le déchiffrement est géré automatiquement côté serveur. Voici un exemple de commande de téléchargement :
+
+```bash
+aws s3api get-object --bucket votre-bucket --key votre-objet chemin/vers/destination/fichier --endpoint-url https://s3.<region>.ovhcloud.com 
+```
+
+- Remplacez `votre-bucket` par le nom de votre bucket.
+- Remplacez `votre-objet` par la clé de l'objet que vous souhaitez télécharger.
+- Remplacez `chemin/vers/destination/fichier` par le chemin où vous souhaitez sauvegarder le fichier téléchargé.
+- Le paramètre `--endpoint-url https://s3.<region>.ovhcloud.com` doit être ajusté à la région de votre service OVHcloud S3.
+
+Attention de ne pas inclure de headers de chiffrement spécifiques lors du téléchargement d'un objet chiffré avec SSE-S3 pour éviter des erreurs, telles qu'une erreur 400 Bad Request. 
+
+#### Ajout du chiffrement à un bucket existant sur OVHcloud S3
+
+Pour ajouter le chiffrement SSE-S3 à un bucket S3 existant sur OVHcloud, vous devez utiliser la commande `put-bucket-encryption` de l'AWS CLI. Cette commande configure le chiffrement du bucket pour que tous les nouveaux objets ajoutés soient automatiquement chiffrés avec SSE-S3. Voici la commande spécifique que vous utiliseriez :
+
+```bash
+aws s3api put-bucket-encryption --bucket votre-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.<region>.ovhcloud.com
+```
+
+- Remplacez `votre-bucket` par le nom de votre bucket S3.
+- Remplacez `<region>` par la région de votre service OVHcloud S3 où votre bucket est situé.
+
+Cela va configurer le bucket pour utiliser le chiffrement SSE-S3 avec les clés gérées par S3 (AES256) pour tous les nouveaux objets. Les objets existants ne seront pas affectés. Si vous souhaitez également les chiffrer, vous devrez les copier ou les uploader à nouveau après avoir changé cette configuration.
+
+##### Affichage de la configuration du chiffrement du Bucket
+
+Après avoir configuré le chiffrement de votre bucket via `PutBucketEncryption` pour utiliser SSE-S3, assurez-vous que tout est correctement mis en place en utilisant la commande suivante avec l'AWS CLI :
+
+```bash
+aws s3api get-bucket-encryption --bucket votre-bucket --endpoint-url https://s3.<region>.ovhcloud.com
+```
+
+- Remplacez `votre-bucket` par le nom de votre bucket.
+- Et `<region>` par la région de votre service OVHcloud S3.
+
+Cette commande vous permet de vérifier la configuration actuelle du chiffrement de votre bucket pour vous assurer que le chiffrement SSE-S3 est bien activé.
+
+Dans cette commande, remplacez `votre-bucket` par le nom de votre bucket et `<region>` par la région de votre service OVHcloud S3. Cette commande vous renvoie les détails de la configuration du chiffrement actuelle de votre bucket, vous confirmant l'utilisation de SSE-S3 pour le chiffrement des données au repos.
+
+Cette étape supplémentaire garantit une transparence totale et vous permet de vous assurer que la sécurité de vos données est maintenue selon les normes les plus élevées, avec la simplicité et l'efficacité que propose le chiffrement SSE-S3 gérée par OVHcloud.
+
+##### Suppression d'un objet chiffré avec SSE-S3
+
+La suppression d'objets chiffrés avec SSE-S3 ne diffère pas de la suppression d'objets non chiffrés. Vous pouvez utiliser la commande suivante pour supprimer un objet :
+
+```bash
+aws s3 rm s3://mon-Bucket/mon-objet
+```
+
+- Remplacez `mon-Bucket` par le nom de votre bucket
+- `mon-objet` par le nom de l'objet que vous souhaitez supprimer.
+
+Cette commande permet de supprimer efficacement un objet, qu'il soit chiffré ou non, de votre bucket sur OVHcloud S3.
+
+### Considérations sur le Chiffrement SSE-S3
+
+Lors de l'utilisation du chiffrement SSE-S3 sur OVHcloud S3, il est important de prendre en compte les éléments suivants :
+
+#### Performances
+
+- **Surcharge** : le chiffrement SSE-S3 peut introduire une légère surcharge due au processus de chiffrement et de déchiffrement. Cependant, cette surcharge est généralement minime et n'affecte pas significativement les performances globales.
+
+#### Sécurité
+
+- **Gestion des clés** : SSE-S3 offre un haut niveau de sécurité en gérant automatiquement les clés de chiffrement. Cela simplifie la gestion de la sécurité pour les utilisateurs.
+- **Pratiques de sécurité supplémentaires** : il est crucial de combiner le chiffrement SSE-S3 avec d'autres pratiques de sécurité pour une protection optimale. Cela inclut l'utilisation de politiques IAM strictes et le suivi des accès aux logs pour surveiller et contrôler l'accès aux données.
+
+#### Comparaison des méthodes de chiffrement
+
+Il est essentiel de comparer les différentes méthodes de chiffrement disponibles pour choisir celle qui convient le mieux à vos besoins spécifiques. Les méthodes à considérer incluent le chiffrement côté client (CSE) et le chiffrement côté serveur (SSE), avec ses variantes SSE-C et SSE-S3.
+
+#### Avantages et inconvénients
+
+- **CSE vs SSE** : chaque méthode a ses propres avantages et inconvénients en termes de facilité de gestion, de sécurité et d'impact sur les performances.
+- **Cas d'usage recommandés** : selon votre situation spécifique, certaines méthodes peuvent être plus appropriées que d'autres. Il est important d'évaluer les cas d'usage recommandés pour chaque méthode de chiffrement.
+
+Un tableau comparatif peut être utile pour résumer ces éléments, offrant une vue d'ensemble claire qui facilite la prise de décision.
+
+| Méthode de Chiffrement | Avantages | Inconvénients | Cas d’Usage Recommandés |
+|------------------------|-----------|---------------|-------------------------|
+| **CSE (Client-Side Encryption)** | - Contrôle total sur les clés de chiffrement<br>- Sécurité maximisée car les clés ne quittent jamais le client | - Gestion complexe des clés<br>- Responsabilité complète de la sécurité des clés | - Scénarios nécessitant une conformité spécifique<br>- Haute sensibilité des données |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Maîtrise sur les clés de chiffrement<br>- Sécurité renforcée sans la complexité totale de CSE | - Nécessité de fournir les clés à chaque requête<br>- Gestion des clés plus complexe que SSE-S3 | - Conformité et contrôle sur les clés<br>- Besoins intermédiaires en sécurité |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simplicité de mise en œuvre<br>- Gestion des clés automatique par OVHcloud<br>- Transparence d'utilisation | - Moins de contrôle sur les clés de chiffrement par rapport à CSE et SSE-C | - Usage général où la facilité de gestion est prioritaire<br>- Données moins sensibles |
+
+Chaque méthode de chiffrement a ses propres forces et faiblesses. Le choix de la méthode dépend de plusieurs facteurs, notamment le niveau de sécurité requis, la complexité de la gestion des clés que vous êtes prêt à assumer, et les spécificités réglementaires ou de conformité auxquelles votre organisation doit adhérer.
+
+### Cas d'usage recommandés pour le chiffrement sur OVHcloud S3
+
+#### CSE (Client-Side Encryption)
+
+- **Idéal pour** : organisations avec des exigences de sécurité très élevées, nécessitant que les clés de chiffrement restent sous contrôle exclusif.
+- **Adapté pour** : environnements réglementés strictement, tels que les institutions financières ou les services de santé.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Convient aux** : organisations recherchant un équilibre entre le contrôle des clés et la facilité de gestion.
+- **Utile pour** : cas où les clients sont prêts à gérer les clés mais souhaitent déléguer le chiffrement et le déchiffrement.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Parfait pour**:  utilisateurs préférant une solution clé en main sans la charge de la gestion des clés.
+- **Méthode privilégiée pour** : entreprises cherchant à protéger leurs données sans nécessités spécifiques de conformité en matière de chiffrement.
+
+Le choix entre ces méthodes doit être guidé par les politiques de sécurité et exigences réglementaires, ainsi que la capacité à gérer les clés de chiffrement. Un équilibre entre facilité d'utilisation et sécurité est essentiel.
+
+### Exemples de scripts et commandes
+
+#### CSE (Client-Side Encryption):
+
+```bash
+# Génération d'une clé de chiffrement côté client
+client_key=$(openssl rand -base64 32)
+# Chiffrement d'un fichier avant l'envoi
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Envoi du fichier chiffré vers le bucket S3
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys):
+
+```bash
+# Création d'une clé de chiffrement et de son empreinte MD5
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Téléchargement d'un objet avec chiffrement SSE-C
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Récupération d'un objet avec chiffrement SSE-C
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Envoi d'un objet avec chiffrement SSE-S3
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Téléchargement d'un objet avec chiffrement SSE-S3
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Dépannage et Résolution d'erreurs communnes
+
+### Erreur lors de l'utilisation de SSE-C sans les en-têtes de chiffrement appropriés
+
+- **En-têtes nécessaires** : assurez-vous que les en-têtes `--sse-customer-algorithm`, `--sse-customer-key`, et `--sse-customer-key-md5` sont inclus correctement dans votre commande.
+- **Vérification de la clé**: Confirmez que la clé de chiffrement est exacte et n'a subi aucune modification ou altération depuis son utilisation pour chiffrer l'objet.
+
+### Erreur de requête incorrecte lors de l'utilisation de SSE-S3
+
+- **Sans en-têtes spécifiques** : pour SSE-S3, évitez de spécifier des en-têtes de chiffrement lors du téléchargement. L'option `--server-side-encryption AES256` suffit.
+- **Vérification de la méthode de chiffrement**: assurez-vous que l'objet n'a pas été chiffré initialement avec une méthode différente.
+
+### Problèmes de performance ou de latence lors du chiffrement/déchiffrement
+
+- **Surcharge potentielle** : le chiffrement et le déchiffrement peuvent causer une surcharge. Vérifiez que votre infrastructure réseau et système est capable de gérer cette charge additionnelle.
+- **Optimisation de performance** : pour améliorer les performances, réalisez le chiffrement et le déchiffrement dans une région géographique proche de votre localisation pour minimiser la latence.
+
+### En cas de perte de la clé de chiffrement SSE-C
+
+- **Récupération impossible**: si la clé de chiffrement est perdue, il est impossible de récupérer les données chiffrées avec SSE-C. Gardez vos clés dans un endroit sûr et envisagez l'utilisation de services de gestion des clés pour améliorer la sécurité.
+
+## Conclusion
+
+Cette documentation met en évidence notre engagement à fournir des solutions de sécurité des données avancées. Que vous optiez pour le chiffrement côté client (CSE) ou côté serveur (SSE-S3), notre objectif est de vous offrir une sécurité optimale sans surcharge opérationnelle.
+
+L'OVHcloud Key Management Service (KMS) témoigne de notre engagement dans la sécurisation de vos données, offrant une protection complète sans les complexités de gestion directe des clés. Nous encourageons l'adoption de ces pratiques de chiffrement pour sécuriser vos données au repos, vous fournissant les outils et les connaissances nécessaires pour une mise en œuvre efficace. OVHcloud est à votre disposition pour toute assistance supplémentaire concernant le chiffrement et la sécurité des données. N'hésitez pas à consulter nos ressources supplémentaires ou à contacter notre support technique pour toute clarification ou assistance.
 
 ## Aller plus loin
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
@@ -211,7 +211,7 @@ L'implémentation du chiffrement SSE-S3 sur OVHcloud S3 est conçue pour offrir 
 Pour envoyer un objet dans votre bucket S3 sur OVHcloud avec chiffrement SSE-S3, utilisez la commande Bash suivante via l'AWS CLI. Cette commande intègre l'option de chiffrement côté serveur pour renforcer la sécurité de vos données stockées.
 
 ```bash
-aws s3api put-object --bucket votre-bucket --key votre-objet --body chemin/vers/votre/fichier --server-side-encryption AES256 --endpoint-url https://s3.<region>.ovhcloud.com
+aws s3api put-object --bucket votre-bucket --key votre-objet --body chemin/vers/votre/fichier --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
 ```
 Lorsque vous utilisez la commande AWS CLI pour uploader un objet avec chiffrement SSE-S3 sur OVHcloud S3, assurez-vous de remplacer les valeurs suivantes selon vos informations spécifiques :
 
@@ -227,13 +227,13 @@ L'option `--server-side-encryption AES256` dans la commande indique que vous sou
 Pour télécharger un objet qui a été chiffré avec SSE-S3 depuis OVHcloud S3, il n'est pas nécessaire de spécifier des headers du chiffrement dans la commande. En effet, l'objet peut être téléchargé directement sans manipulation supplémentaire liée au chiffrement, car le déchiffrement est géré automatiquement côté serveur. Voici un exemple de commande de téléchargement :
 
 ```bash
-aws s3api get-object --bucket votre-bucket --key votre-objet chemin/vers/destination/fichier --endpoint-url https://s3.<region>.ovhcloud.com 
+aws s3api get-object --bucket votre-bucket --key votre-objet chemin/vers/destination/fichier --endpoint-url https://s3.io.cloud.ovh.net
 ```
 
 - Remplacez `votre-bucket` par le nom de votre bucket.
 - Remplacez `votre-objet` par la clé de l'objet que vous souhaitez télécharger.
 - Remplacez `chemin/vers/destination/fichier` par le chemin où vous souhaitez sauvegarder le fichier téléchargé.
-- Le paramètre `--endpoint-url https://s3.<region>.ovhcloud.com` doit être ajusté à la région de votre service OVHcloud S3.
+- Le paramètre `--endpoint-url https://s3.io.cloud.ovh.net` doit être ajusté à la région de votre service OVHcloud S3.
 
 Attention de ne pas inclure de headers de chiffrement spécifiques lors du téléchargement d'un objet chiffré avec SSE-S3 pour éviter des erreurs, telles qu'une erreur 400 Bad Request. 
 
@@ -242,7 +242,7 @@ Attention de ne pas inclure de headers de chiffrement spécifiques lors du tél�
 Pour ajouter le chiffrement SSE-S3 à un bucket S3 existant sur OVHcloud, vous devez utiliser la commande `put-bucket-encryption` de l'AWS CLI. Cette commande configure le chiffrement du bucket pour que tous les nouveaux objets ajoutés soient automatiquement chiffrés avec SSE-S3. Voici la commande spécifique que vous utiliseriez :
 
 ```bash
-aws s3api put-bucket-encryption --bucket votre-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.<region>.ovhcloud.com
+aws s3api put-bucket-encryption --bucket votre-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
 ```
 
 - Remplacez `votre-bucket` par le nom de votre bucket S3.
@@ -255,7 +255,7 @@ Cela va configurer le bucket pour utiliser le chiffrement SSE-S3 avec les clés 
 Après avoir configuré le chiffrement de votre bucket via `PutBucketEncryption` pour utiliser SSE-S3, assurez-vous que tout est correctement mis en place en utilisant la commande suivante avec l'AWS CLI :
 
 ```bash
-aws s3api get-bucket-encryption --bucket votre-bucket --endpoint-url https://s3.<region>.ovhcloud.com
+aws s3api get-bucket-encryption --bucket votre-bucket --endpoint-url https://s3.io.cloud.ovh.net
 ```
 
 - Remplacez `votre-bucket` par le nom de votre bucket.

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Chiffrez vos objets côté serveur avec SSE-C ou SSE-S3
-excerpt: Ce guide explique comment chiffrer vos objets côté serveur avec SSE-C
-updated: 2024-03-22
+excerpt: Ce guide explique comment chiffrer vos objets côté serveur avec SSE-C ou SSE-S3
+updated: 2024-04-08
 ---
 
 <style>
@@ -198,7 +198,7 @@ Ces documents fournissent des informations précieuses sur la manière dont le K
 
 #### Mise en œuvre
 
-Pour renforcer la sécurité des données téléchargées sur OVHcloud, l'activation du chiffrement côté serveur (SSE-S3) a été conçue pour être à la fois facile et transparente. En configurant une méthode de chiffrement par défaut sur votre bucket via la requête `PutBucketEncryption`, tout objet téléchargé sera automatiquement chiffré sans nécessiter d'actions supplémentaires de votre part. Lors du téléchargement d'un objet, il suffit de spécifier l'option de chiffrement dans la requête d'API ou via la ligne de commande AWS CLI. OVHcloud prend en charge le reste, chiffrant vos données avant leur stockage en utilisant une clé unique générée automatiquement pour le bucket.
+Pour renforcer la sécurité des données uploadées chez OVHcloud, l'activation du chiffrement côté serveur (SSE-S3) a été conçue pour être à la fois facile et transparente. En configurant une méthode de chiffrement par défaut sur votre bucket via la requête `PutBucketEncryption`, tout objet uploadé sera automatiquement chiffré sans nécessiter d'actions supplémentaires de votre part. Lors de l'upload d'un objet, il suffit de spécifier l'option de chiffrement dans la requête d'API ou via la ligne de commande AWS CLI. OVHcloud prend en charge le reste, chiffrant vos données avant leur stockage en utilisant une clé unique générée automatiquement pour le bucket.
 
 #### Gestion sécurisée des clés de chiffrement avec SSE-S3 sur OVHcloud S3
 
@@ -213,6 +213,7 @@ Pour envoyer un objet dans votre bucket S3 sur OVHcloud avec chiffrement SSE-S3,
 ```bash
 aws s3api put-object --bucket votre-bucket --key votre-objet --body chemin/vers/votre/fichier --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
 ```
+
 Lorsque vous utilisez la commande AWS CLI pour uploader un objet avec chiffrement SSE-S3 sur OVHcloud S3, assurez-vous de remplacer les valeurs suivantes selon vos informations spécifiques :
 
 - `votre-bucket` : remplacez cette valeur par le nom de votre bucket S3 où vous souhaitez envoyer l'objet.
@@ -276,7 +277,7 @@ aws s3 rm s3://mon-Bucket/mon-objet
 ```
 
 - Remplacez `mon-Bucket` par le nom de votre bucket
-- `mon-objet` par le nom de l'objet que vous souhaitez supprimer.
+- Remplacez `mon-objet` par le nom de l'objet que vous souhaitez supprimer.
 
 Cette commande permet de supprimer efficacement un objet, qu'il soit chiffré ou non, de votre bucket sur OVHcloud S3.
 
@@ -312,7 +313,7 @@ Un tableau comparatif peut être utile pour résumer ces éléments, offrant une
 
 Chaque méthode de chiffrement a ses propres forces et faiblesses. Le choix de la méthode dépend de plusieurs facteurs, notamment le niveau de sécurité requis, la complexité de la gestion des clés que vous êtes prêt à assumer, et les spécificités réglementaires ou de conformité auxquelles votre organisation doit adhérer.
 
-### Cas d'usage recommandés pour le chiffrement sur OVHcloud S3
+### Cas d'usage recommandés pour le chiffrement sur OVHcloud S3 Object Storage
 
 #### CSE (Client-Side Encryption)
 
@@ -333,7 +334,7 @@ Le choix entre ces méthodes doit être guidé par les politiques de sécurité 
 
 ### Exemples de scripts et commandes
 
-#### CSE (Client-Side Encryption):
+#### CSE (Client-Side Encryption)
 
 ```bash
 # Génération d'une clé de chiffrement côté client
@@ -344,7 +345,7 @@ openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file
 aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
 ```
 
-#### SSE-C (Server-Side Encryption with Customer Keys):
+#### SSE-C (Server-Side Encryption with Customer Keys)
 
 ```bash
 # Création d'une clé de chiffrement et de son empreinte MD5
@@ -368,7 +369,7 @@ aws s3api get-object \
   path/to/destination/file
 ```
 
-#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
 
 ```bash
 # Envoi d'un objet avec chiffrement SSE-S3

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
@@ -219,7 +219,6 @@ Lorsque vous utilisez la commande AWS CLI pour uploader un objet avec chiffremen
 - `votre-bucket` : remplacez cette valeur par le nom de votre bucket S3 où vous souhaitez envoyer l'objet.
 - `votre-objet` : remplacez par la clé ou le nom sous lequel vous voulez que l'objet soit stocké dans le bucket.
 - `chemin/vers/votre/fichier` : indiquez le chemin d'accès complet au fichier que vous prévoyez d'envoyer.
-- `<region>` : remplacez par la région de votre service OVHcloud S3, qui héberge votre bucket.
 
 L'option `--server-side-encryption AES256` dans la commande indique que vous souhaitez appliquer le chiffrement SSE-S3. Cela garantit que l'objet envoyé est chiffré de manière sécurisée directement sur le serveur OVHcloud, offrant une couche supplémentaire de protection pour vos données.
 
@@ -247,7 +246,6 @@ aws s3api put-bucket-encryption --bucket votre-bucket --server-side-encryption-c
 ```
 
 - Remplacez `votre-bucket` par le nom de votre bucket S3.
-- Remplacez `<region>` par la région de votre service OVHcloud S3 où votre bucket est situé.
 
 Cela va configurer le bucket pour utiliser le chiffrement SSE-S3 avec les clés gérées par S3 (AES256) pour tous les nouveaux objets. Les objets existants ne seront pas affectés. Si vous souhaitez également les chiffrer, vous devrez les copier ou les uploader à nouveau après avoir changé cette configuration.
 
@@ -260,11 +258,10 @@ aws s3api get-bucket-encryption --bucket votre-bucket --endpoint-url https://s3.
 ```
 
 - Remplacez `votre-bucket` par le nom de votre bucket.
-- Et `<region>` par la région de votre service OVHcloud S3.
 
 Cette commande vous permet de vérifier la configuration actuelle du chiffrement de votre bucket pour vous assurer que le chiffrement SSE-S3 est bien activé.
 
-Dans cette commande, remplacez `votre-bucket` par le nom de votre bucket et `<region>` par la région de votre service OVHcloud S3. Cette commande vous renvoie les détails de la configuration du chiffrement actuelle de votre bucket, vous confirmant l'utilisation de SSE-S3 pour le chiffrement des données au repos.
+Dans cette commande, remplacez `votre-bucket` par le nom de votre bucket. Cette commande vous renvoie les détails de la configuration du chiffrement actuelle de votre bucket, vous confirmant l'utilisation de SSE-S3 pour le chiffrement des données au repos.
 
 Cette étape supplémentaire garantit une transparence totale et vous permet de vous assurer que la sécurité de vos données est maintenue selon les normes les plus élevées, avec la simplicité et l'efficacité que propose le chiffrement SSE-S3 gérée par OVHcloud.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Chiffrez vos objets côté serveur avec SSE-C ou SSE-S3
 excerpt: Ce guide explique comment chiffrer vos objets côté serveur avec SSE-C ou SSE-S3
-updated: 2024-04-08
+updated: 2024-04-10
 ---
 
 <style>

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.it-it.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Crittografa i tuoi oggetti lato server con SSE-C (EN)
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C
-updated: 2022-04-15
+updated: 2024-04-10
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objective
 
-Using server-side encryption with customer-provided encryption keys (SSE-C) allows you to set your own encryption keys.  
+At OVHcloud, we understand the crucial importance of data protection in today’s digital ecosystem. In the face of ever-evolving security threats and increasingly stringent regulatory requirements, it’s essential to implement robust measures to secure data at all times. This includes not only data in transit, but also data at rest.
 
-When you upload an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you retrieve an object, you must provide the same encryption key as part of your request. S3 Object Storage first verifies that the encryption key you provided matches and then decrypts the object before returning the object data to you.
+Protecting *at rest* data, i.e. data stored on physical devices or in the cloud, is a crucial part of any organization’s IT security strategy. In this context, there are two main approaches to encrypting this data: client-side encryption (CSE) and server-side encryption (SSE).
 
-**This guide explains how to encrypt your server-side objects with SSE-C.**
+Client-Side Encryption (CSE) allows our customers to encrypt their data on their own device before sending it to our servers for storage. This ensures that data remains encrypted throughout its lifecycle, offering a high degree of security, as encryption keys are managed by the customer and never shared with OVHcloud or any other third party.
+
+While this approach requires the customer to strictly manage the keys, it is an ideal solution for those who require complete control over their data security.
+
+At the same time, server-side encryption (SSE) offers an alternative where data is encrypted when it arrives at our servers. This is the responsibility of OVHcloud, which greatly reduces the burden of security management for our customers. Two server-side encryption methods are available: 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)**: You can provide and manage your own encryption keys, giving you complete control over your data security. This option is particularly well-suited to organizations with specific compliance and data security needs, as it allows for exclusive management of encryption keys.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)**: Simplifies the encryption process by using keys managed by OVHcloud. This method is ideal for customers who want a robust encryption solution without the complexities of key management.
+
+Our goal is to help you choose the type of encryption that is best for you. This page gives you all the information you need to make an informed choice. Whether you prefer to manage yourself with SSE-C or opt for the ease of SSE-S3, we are committed to offering you flexible and secure solutions to protect your data when it is stored.
+
+**This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3.**
 
 > [!warning]
 >
@@ -31,13 +42,17 @@ When you upload an object, S3 Object Storage uses the encryption key you provide
 
 ## Requirements
 
-- A bucket
+- An S3 bucket
 - A user with the required access rights on the bucket
-- Have installed and configured aws-cli
+- Have installed and configured the AWS command line interface (aws-cli)
 
 See our [Getting started with S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) guide.
 
 ## Instructions
+
+Using server-side encryption with client-provided encryption keys (SSE-C) allows you to define your own encryption keys.
+
+When you download an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you check out an object, you must provide the same encryption key as part of your request. S3 Object Storage first checks that the encryption key you provided matches, then decrypts the object before returning the object data to you.
 
 When you use SSE-C, you must provide encryption key information using the following request headers.
 
@@ -47,7 +62,9 @@ When you use SSE-C, you must provide encryption key information using the follow
 | --sse-customer-key | Use this header to provide the 256-bit, base64-encoded encryption key for S3 Object Storage to use to encrypt or decrypt your data. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Use this header to provide the base64-encoded 128-bit MD5 digest of the encryption key according to RFC 1321. S3 Object Storage uses this header for a message integrity check to ensure that the encryption key was transmitted without error. |
 
-### Creating an encryption key
+### SSE-C - Server-Side Encryption with Client Encryption Keys
+
+#### Creating an encryption key
 
 Example of creating an encryption key ( *--sse-customer-key* ):
 
@@ -61,7 +78,7 @@ and the MD5 key ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Uploading an object with SSE-C
+#### Uploading an object with SSE-C
 
 To upload an object with SSE-C and aws-cli, proceed as follows:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Downloading an object with SSE-C
+#### Downloading an object with SSE-C
 
 To download an object with SSE-C and aws-cli, proceed as follows:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Getting object metadata with SSE-C
+#### Getting object metadata with SSE-C
 
 To get an object metadata with SSE-C and aws-cli, proceed as follows:
 
@@ -129,7 +146,7 @@ Output should look like:
 
 Without encryption headers, you will get a `Bad Request` error.
 
-### Deleting an encrypted object with SSE-C
+#### Deleting an encrypted object with SSE-C
 
 To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 
@@ -137,7 +154,7 @@ To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### Presigned URLs and SSE-C
+#### Presigned URLs and SSE-C
 
 Presigned URLs, that can be used for operations such as upload a new object, retrieve an existing object, or object metadata, support the SSE-C as follows:
 
@@ -149,6 +166,248 @@ Presigned URLs, that can be used for operations such as upload a new object, ret
 >
 > You can use the presigned URL for SSE-C objects only programmatically, because in addition to the presigned URL, you also need to include HTTP headers that are specific to SSE-C objects.
 >
+
+### SSE-S3 - Server-side encryption with keys managed by OVHcloud
+
+Using server-side encryption with keys managed by OVHcloud (SSE-S3) helps protect your data stored on OVHcloud by encrypting it automatically at rest. SSE-S3 uses keys managed and protected by OVHcloud, eliminating the need for the user to manually manage these encryption keys.
+
+#### Benefits
+
+- **Simplified Key Management**
+
+With OVHcloud supporting secure encryption key management, users benefit from simplified key management. This approach eliminates the complexities of key rotation while maintaining a high level of data security. It balances security with operational efficiency, eliminating the administrative burden of manually managing encryption keys.
+
+- **Enhanced Security**
+
+We use an advanced encryption strategy to offer maximum protection for your data. Each bucket has a unique key, and for each stored object, a separate encryption key is generated. This key is obtained by combining the unique key of the bucket with a random salt, which ensures that each object is encrypted with its own key. This key derivation method reduces the risk associated with exposing a single key and ensures enhanced security for your data.
+
+- **Transparency**
+
+The encryption and decryption process is completely transparent to the user, allowing encrypted data to be accessed and managed as easily as unencrypted data.
+
+- **Enhanced security with OVHcloud Key Management Service (KMS)**
+
+Our commitment to securing your data is reinforced through the use of OVHcloud Key Management Service (KMS), an advanced platform for secure storage and encryption key management. This approach ensures optimal data protection, setting up a robust security infrastructure without the complexities of directly managing encryption keys.
+
+To further your understanding of OVHcloud Key Management Service (KMS) and its applications in various cloud infrastructure contexts, we recommend reading the following resources:
+
+- **[Getting started with the KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)**: this guide provides a detailed overview of how to implement and use the KMS to secure your data.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)**: practical guide on enabling VM encryption using KMS capabilities.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)**: detailed instructions on using KMS in conjunction with the vSphere Native Key Provider for VM encryption.
+
+These documents provide valuable information on how the KMS can be used to enhance security in different cloud infrastructure scenarios.
+
+#### Implementation
+
+To enhance the security of data uploaded to OVHcloud, enabling server-side encryption (SSE-S3) has been designed to be both easy and transparent. By configuring a default encryption method on your bucket via the `PutBucketEncryption` request, any uploaded object will be automatically encrypted without requiring any additional actions on your side. When uploading an object, simply specify the encryption option in the API request or via the AWS CLI command line. OVHcloud takes care of the rest, encrypting your data before it is stored using an automatically generated unique key for the bucket.
+
+### Secure encryption key management with SSE-S3 on OVHcloud S3
+
+The implementation of SSE-S3 encryption on OVHcloud S3 is designed to provide encryption key management that is both secure and transparent for the user. Each bucket has a separate key, which ensures that data is secured individually and in isolation. This encryption method, integrated and managed by the platform, eliminates the complexities associated with manual key management by users. While making the user process as smooth and intuitive as possible, it maintains robust security and complies with the very strictest data protection standards.
+
+#### Sending an object with SSE-S3 on OVHcloud S3
+
+##### Uploading an object on OVHcloud S3 with SSE-S3 encryption
+
+To send an object in your S3 bucket on OVHcloud with SSE-S3 encryption, use the following Bash command via the AWS CLI. This command includes the server-side encryption option to enhance the security of your stored data.
+
+```bash
+aws s3api put-object --bucket your-bucket --key your-object --body path/to/your/file --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+When using the AWS CLI command to upload an object with SSE-S3 encryption to OVHcloud S3, make sure to replace the following values based on your specific information:
+
+- `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
+- `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
+- `path/to/your/file`: Specify the full path to the file you plan to send.
+
+The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
+
+##### Downloading an Object with SSE-S3 to OVHcloud S3
+
+To download an object that has been encrypted with SSE-S3 from OVHcloud S3, you do not need to specify encryption headers in the command. The object can be downloaded directly without any additional manipulation linked to the encryption, because the decryption is managed automatically on the server side. Here is an example of a download command:
+
+```bash
+aws s3api get-object --bucket your-bucket --key your-object path/to/destination/file --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- Replace `your-object` with the key of the object you want to download.
+- Replace `path/to/destination/file` with the path where you want to save the downloaded file.
+
+Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
+
+#### Adding encryption to an existing bucket on OVHcloud S3
+
+To add SSE-S3 encryption to an existing S3 bucket on OVHcloud, you must use the `put-bucket-encryption` command from the AWS CLI. This command configures bucket encryption so that all newly added objects are automatically encrypted with SSE-S3. Here is the specific command you would use:
+
+```bash
+aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your S3 bucket.
+
+This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
+
+##### Viewing bucket encryption configuration
+
+After configuring your bucket encryption via `PutBucketEncryption` to use SSE-S3, make sure everything is set up correctly using the following command with the AWS CLI:
+
+```bash
+aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+
+With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
+
+In this order, replace `your-bucket` with the name of your bucket. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+
+This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
+
+##### Deleting an encrypted object with SSE-S3
+
+Deleting objects encrypted with SSE-S3 is no different from deleting objects that are not encrypted. You can use the following command to delete an object:
+
+```bash
+aws s3 rm s3://my-Bucket/my-object
+```
+
+- Replace `my-Bucket` with the name of your bucket
+- Replace `my-object` by the name of the object you want to delete.
+
+With this command, you can effectively delete an object, whether it is encrypted or not, from your bucket on OVHcloud S3.
+
+### SSE-S3 Encryption considerations
+
+When using SSE-S3 encryption on OVHcloud S3, it is important to consider the following:
+
+#### Performance
+
+- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+
+#### Security
+
+- **Key Management**: SSE-S3 offers a high level of security by automatically managing encryption keys. This simplifies security management for users.
+- **Additional security practices**: Combining SSE-S3 encryption with other security practices is crucial for optimal protection. This includes the use of strict IAM policies and log access tracking to monitor and control data access.
+
+#### Comparison of encryption methods
+
+It’s essential to compare the different encryption methods available to choose the one that best suits your specific needs. Methods to consider include client-side encryption (CSE) and server-side encryption (SSE), with its SSE-C and SSE-S3 variants.
+
+#### Pros and cons
+
+- **CSE vs SSE**: Each method has its own advantages and disadvantages in terms of manageability, security and performance impact.
+- **Recommended use cases**: depending on your specific situation, some methods may be more appropriate than others. It is important to evaluate the recommended use cases for each encryption method.
+
+A comparative table may be useful for summarizing these elements, providing a clear overview that facilitates decision-making.
+
+| Encryption method | Benefits | Cons | Recommended Use Cases |
+|-------------------|----------|------|-----------------------|
+| **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+
+Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+### Recommended use cases for encryption on OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Ideal for**: Organizations with very high security requirements, requiring encryption keys to remain under exclusive control.
+- **Suitable for**: strictly regulated environments, such as financial institutions or healthcare services.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Suitable for**: Organizations seeking a balance between key control and manageability.
+- **Useful for**: when customers are ready to manage keys but want to delegate encryption and decryption.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Perfect for**: users who prefer a turnkey solution without the burden of key management.
+- **Preferred method for**: companies looking to protect their data without specific encryption compliance needs.
+
+The choice between these methods should be guided by security policies and regulatory requirements, as well as the ability to manage encryption keys. A balance between ease of use and security is essential.
+
+### Examples of scripts and commands
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Generating a client-side encryption key
+client_key=$(openssl rand -base64 32)
+# Encryption of a file before sending
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Sending encrypted file to S3 bucket
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Creating an encryption key and its MD5 fingerprint
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Uploading an object with SSE-C encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Retrieving an object with SSE-C encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Sending an object with SSE-S3 encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Uploading an object with SSE-S3 encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Troubleshooting and Common Error Resolution
+
+### Error using SSE-C without proper encryption headers
+
+- **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
+- **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
+
+### Bad query error when using SSE-S3
+
+- **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
+- **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
+
+### Performance or latency issues during encryption/decryption
+
+- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
+
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
+## Conclusion
+
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+
+The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 
 ## Go further
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.pl-pl.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Szyfruj obiekty po stronie serwera za pomocą SSE-C (EN)
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C
-updated: 2022-04-15
+updated: 2024-04-10
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objective
 
-Using server-side encryption with customer-provided encryption keys (SSE-C) allows you to set your own encryption keys.  
+At OVHcloud, we understand the crucial importance of data protection in today’s digital ecosystem. In the face of ever-evolving security threats and increasingly stringent regulatory requirements, it’s essential to implement robust measures to secure data at all times. This includes not only data in transit, but also data at rest.
 
-When you upload an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you retrieve an object, you must provide the same encryption key as part of your request. S3 Object Storage first verifies that the encryption key you provided matches and then decrypts the object before returning the object data to you.
+Protecting *at rest* data, i.e. data stored on physical devices or in the cloud, is a crucial part of any organization’s IT security strategy. In this context, there are two main approaches to encrypting this data: client-side encryption (CSE) and server-side encryption (SSE).
 
-**This guide explains how to encrypt your server-side objects with SSE-C.**
+Client-Side Encryption (CSE) allows our customers to encrypt their data on their own device before sending it to our servers for storage. This ensures that data remains encrypted throughout its lifecycle, offering a high degree of security, as encryption keys are managed by the customer and never shared with OVHcloud or any other third party.
+
+While this approach requires the customer to strictly manage the keys, it is an ideal solution for those who require complete control over their data security.
+
+At the same time, server-side encryption (SSE) offers an alternative where data is encrypted when it arrives at our servers. This is the responsibility of OVHcloud, which greatly reduces the burden of security management for our customers. Two server-side encryption methods are available: 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)**: You can provide and manage your own encryption keys, giving you complete control over your data security. This option is particularly well-suited to organizations with specific compliance and data security needs, as it allows for exclusive management of encryption keys.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)**: Simplifies the encryption process by using keys managed by OVHcloud. This method is ideal for customers who want a robust encryption solution without the complexities of key management.
+
+Our goal is to help you choose the type of encryption that is best for you. This page gives you all the information you need to make an informed choice. Whether you prefer to manage yourself with SSE-C or opt for the ease of SSE-S3, we are committed to offering you flexible and secure solutions to protect your data when it is stored.
+
+**This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3.**
 
 > [!warning]
 >
@@ -31,13 +42,17 @@ When you upload an object, S3 Object Storage uses the encryption key you provide
 
 ## Requirements
 
-- A bucket
+- An S3 bucket
 - A user with the required access rights on the bucket
-- Have installed and configured aws-cli
+- Have installed and configured the AWS command line interface (aws-cli)
 
 See our [Getting started with S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) guide.
 
 ## Instructions
+
+Using server-side encryption with client-provided encryption keys (SSE-C) allows you to define your own encryption keys.
+
+When you download an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you check out an object, you must provide the same encryption key as part of your request. S3 Object Storage first checks that the encryption key you provided matches, then decrypts the object before returning the object data to you.
 
 When you use SSE-C, you must provide encryption key information using the following request headers.
 
@@ -47,7 +62,9 @@ When you use SSE-C, you must provide encryption key information using the follow
 | --sse-customer-key | Use this header to provide the 256-bit, base64-encoded encryption key for S3 Object Storage to use to encrypt or decrypt your data. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Use this header to provide the base64-encoded 128-bit MD5 digest of the encryption key according to RFC 1321. S3 Object Storage uses this header for a message integrity check to ensure that the encryption key was transmitted without error. |
 
-### Creating an encryption key
+### SSE-C - Server-Side Encryption with Client Encryption Keys
+
+#### Creating an encryption key
 
 Example of creating an encryption key ( *--sse-customer-key* ):
 
@@ -61,7 +78,7 @@ and the MD5 key ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Uploading an object with SSE-C
+#### Uploading an object with SSE-C
 
 To upload an object with SSE-C and aws-cli, proceed as follows:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Downloading an object with SSE-C
+#### Downloading an object with SSE-C
 
 To download an object with SSE-C and aws-cli, proceed as follows:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Getting object metadata with SSE-C
+#### Getting object metadata with SSE-C
 
 To get an object metadata with SSE-C and aws-cli, proceed as follows:
 
@@ -129,7 +146,7 @@ Output should look like:
 
 Without encryption headers, you will get a `Bad Request` error.
 
-### Deleting an encrypted object with SSE-C
+#### Deleting an encrypted object with SSE-C
 
 To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 
@@ -137,7 +154,7 @@ To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### Presigned URLs and SSE-C
+#### Presigned URLs and SSE-C
 
 Presigned URLs, that can be used for operations such as upload a new object, retrieve an existing object, or object metadata, support the SSE-C as follows:
 
@@ -149,6 +166,248 @@ Presigned URLs, that can be used for operations such as upload a new object, ret
 >
 > You can use the presigned URL for SSE-C objects only programmatically, because in addition to the presigned URL, you also need to include HTTP headers that are specific to SSE-C objects.
 >
+
+### SSE-S3 - Server-side encryption with keys managed by OVHcloud
+
+Using server-side encryption with keys managed by OVHcloud (SSE-S3) helps protect your data stored on OVHcloud by encrypting it automatically at rest. SSE-S3 uses keys managed and protected by OVHcloud, eliminating the need for the user to manually manage these encryption keys.
+
+#### Benefits
+
+- **Simplified Key Management**
+
+With OVHcloud supporting secure encryption key management, users benefit from simplified key management. This approach eliminates the complexities of key rotation while maintaining a high level of data security. It balances security with operational efficiency, eliminating the administrative burden of manually managing encryption keys.
+
+- **Enhanced Security**
+
+We use an advanced encryption strategy to offer maximum protection for your data. Each bucket has a unique key, and for each stored object, a separate encryption key is generated. This key is obtained by combining the unique key of the bucket with a random salt, which ensures that each object is encrypted with its own key. This key derivation method reduces the risk associated with exposing a single key and ensures enhanced security for your data.
+
+- **Transparency**
+
+The encryption and decryption process is completely transparent to the user, allowing encrypted data to be accessed and managed as easily as unencrypted data.
+
+- **Enhanced security with OVHcloud Key Management Service (KMS)**
+
+Our commitment to securing your data is reinforced through the use of OVHcloud Key Management Service (KMS), an advanced platform for secure storage and encryption key management. This approach ensures optimal data protection, setting up a robust security infrastructure without the complexities of directly managing encryption keys.
+
+To further your understanding of OVHcloud Key Management Service (KMS) and its applications in various cloud infrastructure contexts, we recommend reading the following resources:
+
+- **[Getting started with the KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)**: this guide provides a detailed overview of how to implement and use the KMS to secure your data.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)**: practical guide on enabling VM encryption using KMS capabilities.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)**: detailed instructions on using KMS in conjunction with the vSphere Native Key Provider for VM encryption.
+
+These documents provide valuable information on how the KMS can be used to enhance security in different cloud infrastructure scenarios.
+
+#### Implementation
+
+To enhance the security of data uploaded to OVHcloud, enabling server-side encryption (SSE-S3) has been designed to be both easy and transparent. By configuring a default encryption method on your bucket via the `PutBucketEncryption` request, any uploaded object will be automatically encrypted without requiring any additional actions on your side. When uploading an object, simply specify the encryption option in the API request or via the AWS CLI command line. OVHcloud takes care of the rest, encrypting your data before it is stored using an automatically generated unique key for the bucket.
+
+### Secure encryption key management with SSE-S3 on OVHcloud S3
+
+The implementation of SSE-S3 encryption on OVHcloud S3 is designed to provide encryption key management that is both secure and transparent for the user. Each bucket has a separate key, which ensures that data is secured individually and in isolation. This encryption method, integrated and managed by the platform, eliminates the complexities associated with manual key management by users. While making the user process as smooth and intuitive as possible, it maintains robust security and complies with the very strictest data protection standards.
+
+#### Sending an object with SSE-S3 on OVHcloud S3
+
+##### Uploading an object on OVHcloud S3 with SSE-S3 encryption
+
+To send an object in your S3 bucket on OVHcloud with SSE-S3 encryption, use the following Bash command via the AWS CLI. This command includes the server-side encryption option to enhance the security of your stored data.
+
+```bash
+aws s3api put-object --bucket your-bucket --key your-object --body path/to/your/file --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+When using the AWS CLI command to upload an object with SSE-S3 encryption to OVHcloud S3, make sure to replace the following values based on your specific information:
+
+- `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
+- `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
+- `path/to/your/file`: Specify the full path to the file you plan to send.
+
+The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
+
+##### Downloading an Object with SSE-S3 to OVHcloud S3
+
+To download an object that has been encrypted with SSE-S3 from OVHcloud S3, you do not need to specify encryption headers in the command. The object can be downloaded directly without any additional manipulation linked to the encryption, because the decryption is managed automatically on the server side. Here is an example of a download command:
+
+```bash
+aws s3api get-object --bucket your-bucket --key your-object path/to/destination/file --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- Replace `your-object` with the key of the object you want to download.
+- Replace `path/to/destination/file` with the path where you want to save the downloaded file.
+
+Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
+
+#### Adding encryption to an existing bucket on OVHcloud S3
+
+To add SSE-S3 encryption to an existing S3 bucket on OVHcloud, you must use the `put-bucket-encryption` command from the AWS CLI. This command configures bucket encryption so that all newly added objects are automatically encrypted with SSE-S3. Here is the specific command you would use:
+
+```bash
+aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your S3 bucket.
+
+This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
+
+##### Viewing bucket encryption configuration
+
+After configuring your bucket encryption via `PutBucketEncryption` to use SSE-S3, make sure everything is set up correctly using the following command with the AWS CLI:
+
+```bash
+aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+
+With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
+
+In this order, replace `your-bucket` with the name of your bucket. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+
+This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
+
+##### Deleting an encrypted object with SSE-S3
+
+Deleting objects encrypted with SSE-S3 is no different from deleting objects that are not encrypted. You can use the following command to delete an object:
+
+```bash
+aws s3 rm s3://my-Bucket/my-object
+```
+
+- Replace `my-Bucket` with the name of your bucket
+- Replace `my-object` by the name of the object you want to delete.
+
+With this command, you can effectively delete an object, whether it is encrypted or not, from your bucket on OVHcloud S3.
+
+### SSE-S3 Encryption considerations
+
+When using SSE-S3 encryption on OVHcloud S3, it is important to consider the following:
+
+#### Performance
+
+- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+
+#### Security
+
+- **Key Management**: SSE-S3 offers a high level of security by automatically managing encryption keys. This simplifies security management for users.
+- **Additional security practices**: Combining SSE-S3 encryption with other security practices is crucial for optimal protection. This includes the use of strict IAM policies and log access tracking to monitor and control data access.
+
+#### Comparison of encryption methods
+
+It’s essential to compare the different encryption methods available to choose the one that best suits your specific needs. Methods to consider include client-side encryption (CSE) and server-side encryption (SSE), with its SSE-C and SSE-S3 variants.
+
+#### Pros and cons
+
+- **CSE vs SSE**: Each method has its own advantages and disadvantages in terms of manageability, security and performance impact.
+- **Recommended use cases**: depending on your specific situation, some methods may be more appropriate than others. It is important to evaluate the recommended use cases for each encryption method.
+
+A comparative table may be useful for summarizing these elements, providing a clear overview that facilitates decision-making.
+
+| Encryption method | Benefits | Cons | Recommended Use Cases |
+|-------------------|----------|------|-----------------------|
+| **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+
+Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+### Recommended use cases for encryption on OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Ideal for**: Organizations with very high security requirements, requiring encryption keys to remain under exclusive control.
+- **Suitable for**: strictly regulated environments, such as financial institutions or healthcare services.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Suitable for**: Organizations seeking a balance between key control and manageability.
+- **Useful for**: when customers are ready to manage keys but want to delegate encryption and decryption.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Perfect for**: users who prefer a turnkey solution without the burden of key management.
+- **Preferred method for**: companies looking to protect their data without specific encryption compliance needs.
+
+The choice between these methods should be guided by security policies and regulatory requirements, as well as the ability to manage encryption keys. A balance between ease of use and security is essential.
+
+### Examples of scripts and commands
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Generating a client-side encryption key
+client_key=$(openssl rand -base64 32)
+# Encryption of a file before sending
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Sending encrypted file to S3 bucket
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Creating an encryption key and its MD5 fingerprint
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Uploading an object with SSE-C encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Retrieving an object with SSE-C encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Sending an object with SSE-S3 encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Uploading an object with SSE-S3 encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Troubleshooting and Common Error Resolution
+
+### Error using SSE-C without proper encryption headers
+
+- **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
+- **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
+
+### Bad query error when using SSE-S3
+
+- **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
+- **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
+
+### Performance or latency issues during encryption/decryption
+
+- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
+
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
+## Conclusion
+
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+
+The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 
 ## Go further
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.pt-pt.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Criptografe seus objetos do lado do servidor com SSE-C (EN)
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C
-updated: 2022-04-15
+updated: 2024-04-10
 ---
 
 <style>
@@ -18,11 +18,22 @@ td:nth-of-type(1) {
 
 ## Objective
 
-Using server-side encryption with customer-provided encryption keys (SSE-C) allows you to set your own encryption keys.  
+At OVHcloud, we understand the crucial importance of data protection in today’s digital ecosystem. In the face of ever-evolving security threats and increasingly stringent regulatory requirements, it’s essential to implement robust measures to secure data at all times. This includes not only data in transit, but also data at rest.
 
-When you upload an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you retrieve an object, you must provide the same encryption key as part of your request. S3 Object Storage first verifies that the encryption key you provided matches and then decrypts the object before returning the object data to you.
+Protecting *at rest* data, i.e. data stored on physical devices or in the cloud, is a crucial part of any organization’s IT security strategy. In this context, there are two main approaches to encrypting this data: client-side encryption (CSE) and server-side encryption (SSE).
 
-**This guide explains how to encrypt your server-side objects with SSE-C.**
+Client-Side Encryption (CSE) allows our customers to encrypt their data on their own device before sending it to our servers for storage. This ensures that data remains encrypted throughout its lifecycle, offering a high degree of security, as encryption keys are managed by the customer and never shared with OVHcloud or any other third party.
+
+While this approach requires the customer to strictly manage the keys, it is an ideal solution for those who require complete control over their data security.
+
+At the same time, server-side encryption (SSE) offers an alternative where data is encrypted when it arrives at our servers. This is the responsibility of OVHcloud, which greatly reduces the burden of security management for our customers. Two server-side encryption methods are available: 
+
+- **SSE-C (Server-Side Encryption with Customer Keys)**: You can provide and manage your own encryption keys, giving you complete control over your data security. This option is particularly well-suited to organizations with specific compliance and data security needs, as it allows for exclusive management of encryption keys.
+- **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)**: Simplifies the encryption process by using keys managed by OVHcloud. This method is ideal for customers who want a robust encryption solution without the complexities of key management.
+
+Our goal is to help you choose the type of encryption that is best for you. This page gives you all the information you need to make an informed choice. Whether you prefer to manage yourself with SSE-C or opt for the ease of SSE-S3, we are committed to offering you flexible and secure solutions to protect your data when it is stored.
+
+**This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3.**
 
 > [!warning]
 >
@@ -31,13 +42,17 @@ When you upload an object, S3 Object Storage uses the encryption key you provide
 
 ## Requirements
 
-- A bucket
+- An S3 bucket
 - A user with the required access rights on the bucket
-- Have installed and configured aws-cli
+- Have installed and configured the AWS command line interface (aws-cli)
 
 See our [Getting started with S3 Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) guide.
 
 ## Instructions
+
+Using server-side encryption with client-provided encryption keys (SSE-C) allows you to define your own encryption keys.
+
+When you download an object, S3 Object Storage uses the encryption key you provide to apply AES-256 encryption to your data. When you check out an object, you must provide the same encryption key as part of your request. S3 Object Storage first checks that the encryption key you provided matches, then decrypts the object before returning the object data to you.
 
 When you use SSE-C, you must provide encryption key information using the following request headers.
 
@@ -47,7 +62,9 @@ When you use SSE-C, you must provide encryption key information using the follow
 | --sse-customer-key | Use this header to provide the 256-bit, base64-encoded encryption key for S3 Object Storage to use to encrypt or decrypt your data. |
 | --sse​-customer-key-md5<p class="optional">Optional</p>| Use this header to provide the base64-encoded 128-bit MD5 digest of the encryption key according to RFC 1321. S3 Object Storage uses this header for a message integrity check to ensure that the encryption key was transmitted without error. |
 
-### Creating an encryption key
+### SSE-C - Server-Side Encryption with Client Encryption Keys
+
+#### Creating an encryption key
 
 Example of creating an encryption key ( *--sse-customer-key* ):
 
@@ -61,7 +78,7 @@ and the MD5 key ( *--sse-customer-key-md5* ):
 $ md5Key=$(echo $encKey | md5sum | awk '{print $1}' | base64 -w0)
 ```
 
-### Uploading an object with SSE-C
+#### Uploading an object with SSE-C
 
 To upload an object with SSE-C and aws-cli, proceed as follows:
 
@@ -75,7 +92,7 @@ $ aws s3api put-object \
   --sse-customer-key-md5 $md5Key
 ```
 
-### Downloading an object with SSE-C
+#### Downloading an object with SSE-C
 
 To download an object with SSE-C and aws-cli, proceed as follows:
 
@@ -100,7 +117,7 @@ $ aws s3api get-object \
 $ An error occurred (400) when calling the HeadObject operation: Bad Request
 ```
 
-### Getting object metadata with SSE-C
+#### Getting object metadata with SSE-C
 
 To get an object metadata with SSE-C and aws-cli, proceed as follows:
 
@@ -129,7 +146,7 @@ Output should look like:
 
 Without encryption headers, you will get a `Bad Request` error.
 
-### Deleting an encrypted object with SSE-C
+#### Deleting an encrypted object with SSE-C
 
 To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 
@@ -137,7 +154,7 @@ To delete an encrypted object with SSE-C and aws-cli, proceed as follows:
 $ aws s3 rm s3://<bucket_name>/encrypt_magic
 ```
 
-### Presigned URLs and SSE-C
+#### Presigned URLs and SSE-C
 
 Presigned URLs, that can be used for operations such as upload a new object, retrieve an existing object, or object metadata, support the SSE-C as follows:
 
@@ -149,6 +166,248 @@ Presigned URLs, that can be used for operations such as upload a new object, ret
 >
 > You can use the presigned URL for SSE-C objects only programmatically, because in addition to the presigned URL, you also need to include HTTP headers that are specific to SSE-C objects.
 >
+
+### SSE-S3 - Server-side encryption with keys managed by OVHcloud
+
+Using server-side encryption with keys managed by OVHcloud (SSE-S3) helps protect your data stored on OVHcloud by encrypting it automatically at rest. SSE-S3 uses keys managed and protected by OVHcloud, eliminating the need for the user to manually manage these encryption keys.
+
+#### Benefits
+
+- **Simplified Key Management**
+
+With OVHcloud supporting secure encryption key management, users benefit from simplified key management. This approach eliminates the complexities of key rotation while maintaining a high level of data security. It balances security with operational efficiency, eliminating the administrative burden of manually managing encryption keys.
+
+- **Enhanced Security**
+
+We use an advanced encryption strategy to offer maximum protection for your data. Each bucket has a unique key, and for each stored object, a separate encryption key is generated. This key is obtained by combining the unique key of the bucket with a random salt, which ensures that each object is encrypted with its own key. This key derivation method reduces the risk associated with exposing a single key and ensures enhanced security for your data.
+
+- **Transparency**
+
+The encryption and decryption process is completely transparent to the user, allowing encrypted data to be accessed and managed as easily as unencrypted data.
+
+- **Enhanced security with OVHcloud Key Management Service (KMS)**
+
+Our commitment to securing your data is reinforced through the use of OVHcloud Key Management Service (KMS), an advanced platform for secure storage and encryption key management. This approach ensures optimal data protection, setting up a robust security infrastructure without the complexities of directly managing encryption keys.
+
+To further your understanding of OVHcloud Key Management Service (KMS) and its applications in various cloud infrastructure contexts, we recommend reading the following resources:
+
+- **[Getting started with the KMS CipherTrust Manager - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/kms_cipher_trust)**: this guide provides a detailed overview of how to implement and use the KMS to secure your data.
+- **[Enabling Virtual Machine Encryption (VM Encrypt) - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt)**: practical guide on enabling VM encryption using KMS capabilities.
+- **[Enabling virtual machine encryption with vSphere Native Key Provider - OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vm_encrypt-vnkp)**: detailed instructions on using KMS in conjunction with the vSphere Native Key Provider for VM encryption.
+
+These documents provide valuable information on how the KMS can be used to enhance security in different cloud infrastructure scenarios.
+
+#### Implementation
+
+To enhance the security of data uploaded to OVHcloud, enabling server-side encryption (SSE-S3) has been designed to be both easy and transparent. By configuring a default encryption method on your bucket via the `PutBucketEncryption` request, any uploaded object will be automatically encrypted without requiring any additional actions on your side. When uploading an object, simply specify the encryption option in the API request or via the AWS CLI command line. OVHcloud takes care of the rest, encrypting your data before it is stored using an automatically generated unique key for the bucket.
+
+### Secure encryption key management with SSE-S3 on OVHcloud S3
+
+The implementation of SSE-S3 encryption on OVHcloud S3 is designed to provide encryption key management that is both secure and transparent for the user. Each bucket has a separate key, which ensures that data is secured individually and in isolation. This encryption method, integrated and managed by the platform, eliminates the complexities associated with manual key management by users. While making the user process as smooth and intuitive as possible, it maintains robust security and complies with the very strictest data protection standards.
+
+#### Sending an object with SSE-S3 on OVHcloud S3
+
+##### Uploading an object on OVHcloud S3 with SSE-S3 encryption
+
+To send an object in your S3 bucket on OVHcloud with SSE-S3 encryption, use the following Bash command via the AWS CLI. This command includes the server-side encryption option to enhance the security of your stored data.
+
+```bash
+aws s3api put-object --bucket your-bucket --key your-object --body path/to/your/file --server-side-encryption AES256 --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+When using the AWS CLI command to upload an object with SSE-S3 encryption to OVHcloud S3, make sure to replace the following values based on your specific information:
+
+- `your-bucket`: replace this value with the name of your S3 bucket where you want to send the object.
+- `your-object`: replace with the key or name under which you want the object to be stored in the bucket.
+- `path/to/your/file`: Specify the full path to the file you plan to send.
+
+The option `--server-side-encryption AES256` in the command indicates that you want to apply SSE-S3 encryption. This ensures that the sent object is securely encrypted directly on the OVHcloud server, providing an additional layer of protection for your data.
+
+##### Downloading an Object with SSE-S3 to OVHcloud S3
+
+To download an object that has been encrypted with SSE-S3 from OVHcloud S3, you do not need to specify encryption headers in the command. The object can be downloaded directly without any additional manipulation linked to the encryption, because the decryption is managed automatically on the server side. Here is an example of a download command:
+
+```bash
+aws s3api get-object --bucket your-bucket --key your-object path/to/destination/file --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+- Replace `your-object` with the key of the object you want to download.
+- Replace `path/to/destination/file` with the path where you want to save the downloaded file.
+
+Be careful not to include specific encryption headers when downloading an encrypted object with SSE-S3 to avoid errors, such as a 400 Bad Request error. 
+
+#### Adding encryption to an existing bucket on OVHcloud S3
+
+To add SSE-S3 encryption to an existing S3 bucket on OVHcloud, you must use the `put-bucket-encryption` command from the AWS CLI. This command configures bucket encryption so that all newly added objects are automatically encrypted with SSE-S3. Here is the specific command you would use:
+
+```bash
+aws s3api put-bucket-encryption --bucket your-bucket --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your S3 bucket.
+
+This will configure the bucket to use SSE-S3 encryption with keys managed by S3 (AES256) for all new objects. Existing objects will not be affected. If you also want to encrypt them, you will need to copy or upload them again after changing this configuration.
+
+##### Viewing bucket encryption configuration
+
+After configuring your bucket encryption via `PutBucketEncryption` to use SSE-S3, make sure everything is set up correctly using the following command with the AWS CLI:
+
+```bash
+aws s3api get-bucket-encryption --bucket your-bucket --endpoint-url https://s3.io.cloud.ovh.net
+```
+
+- Replace `your-bucket` with the name of your bucket.
+
+With this command, you can check your bucket’s current encryption configuration to ensure that SSE-S3 encryption is enabled.
+
+In this order, replace `your-bucket` with the name of your bucket. This command returns the details of your bucket’s current encryption configuration, confirming the use of SSE-S3 for data encryption at rest.
+
+This extra step ensures full transparency and helps ensure your data is kept safe to the highest standards, with the simplicity and efficiency offered by SSE-S3 encryption managed by OVHcloud.
+
+##### Deleting an encrypted object with SSE-S3
+
+Deleting objects encrypted with SSE-S3 is no different from deleting objects that are not encrypted. You can use the following command to delete an object:
+
+```bash
+aws s3 rm s3://my-Bucket/my-object
+```
+
+- Replace `my-Bucket` with the name of your bucket
+- Replace `my-object` by the name of the object you want to delete.
+
+With this command, you can effectively delete an object, whether it is encrypted or not, from your bucket on OVHcloud S3.
+
+### SSE-S3 Encryption considerations
+
+When using SSE-S3 encryption on OVHcloud S3, it is important to consider the following:
+
+#### Performance
+
+- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+
+#### Security
+
+- **Key Management**: SSE-S3 offers a high level of security by automatically managing encryption keys. This simplifies security management for users.
+- **Additional security practices**: Combining SSE-S3 encryption with other security practices is crucial for optimal protection. This includes the use of strict IAM policies and log access tracking to monitor and control data access.
+
+#### Comparison of encryption methods
+
+It’s essential to compare the different encryption methods available to choose the one that best suits your specific needs. Methods to consider include client-side encryption (CSE) and server-side encryption (SSE), with its SSE-C and SSE-S3 variants.
+
+#### Pros and cons
+
+- **CSE vs SSE**: Each method has its own advantages and disadvantages in terms of manageability, security and performance impact.
+- **Recommended use cases**: depending on your specific situation, some methods may be more appropriate than others. It is important to evaluate the recommended use cases for each encryption method.
+
+A comparative table may be useful for summarizing these elements, providing a clear overview that facilitates decision-making.
+
+| Encryption method | Benefits | Cons | Recommended Use Cases |
+|-------------------|----------|------|-----------------------|
+| **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+
+Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+### Recommended use cases for encryption on OVHcloud S3 Object Storage
+
+#### CSE (Client-Side Encryption)
+
+- **Ideal for**: Organizations with very high security requirements, requiring encryption keys to remain under exclusive control.
+- **Suitable for**: strictly regulated environments, such as financial institutions or healthcare services.
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+- **Suitable for**: Organizations seeking a balance between key control and manageability.
+- **Useful for**: when customers are ready to manage keys but want to delegate encryption and decryption.
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)
+
+- **Perfect for**: users who prefer a turnkey solution without the burden of key management.
+- **Preferred method for**: companies looking to protect their data without specific encryption compliance needs.
+
+The choice between these methods should be guided by security policies and regulatory requirements, as well as the ability to manage encryption keys. A balance between ease of use and security is essential.
+
+### Examples of scripts and commands
+
+#### CSE (Client-Side Encryption)
+
+```bash
+# Generating a client-side encryption key
+client_key=$(openssl rand -base64 32)
+# Encryption of a file before sending
+openssl enc -aes-256-cbc -salt -in path/to/your/file -out path/to/encrypted/file -pass pass:$client_key
+# Sending encrypted file to S3 bucket
+aws s3 cp path/to/encrypted/file s3://your-bucket/your-encrypted-object
+```
+
+#### SSE-C (Server-Side Encryption with Customer Keys)
+
+```bash
+# Creating an encryption key and its MD5 fingerprint
+sse_c_key=$(openssl rand -base64 32)
+sse_c_key_md5=$(echo -n $sse_c_key | openssl md5 -binary | base64)
+# Uploading an object with SSE-C encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5
+# Retrieving an object with SSE-C encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  --sse-customer-algorithm AES256 \
+  --sse-customer-key $sse_c_key \
+  --sse-customer-key-md5 $sse_c_key_md5 \
+  path/to/destination/file
+```
+
+#### SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys):
+
+```bash
+# Sending an object with SSE-S3 encryption
+aws s3api put-object \
+  --bucket your-bucket \
+  --key your-object \
+  --body path/to/your/file \
+  --server-side-encryption AES256
+# Uploading an object with SSE-S3 encryption
+aws s3api get-object \
+  --bucket your-bucket \
+  --key your-object \
+  path/to/destination/file
+```
+
+## Troubleshooting and Common Error Resolution
+
+### Error using SSE-C without proper encryption headers
+
+- **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
+- **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
+
+### Bad query error when using SSE-S3
+
+- **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
+- **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
+
+### Performance or latency issues during encryption/decryption
+
+- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
+
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
+## Conclusion
+
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+
+The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 
 ## Go further
 


### PR DESCRIPTION
Replacing Pull Request #5950 from @KebirHakim 

This pull request updates the French documentation located at pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c_and_sse_s3/guide.fr-fr.md. The draft s3_encrypt_your_objects_with_sse_c has been finalized and is now available. 

The updated content provides detailed guidance on implementing server-side encryption with SSE-C (Server-Side Encryption with Customer Keys) and SSE-S3 (Server-Side Encryption with S3-Managed Keys) for object storage on OVHcloud S3.

This enhancement aims to improve security measures and user understanding of encryption options available on OVHcloud S3.