### PR TITLE
fix: OAuth2: wrong URLs + wrong examples + typos

### DIFF
--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.de-de.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.de-de.md
@@ -1,6 +1,6 @@
 ---
 title: How to use service accounts to connect to OVHcloud APIs (EN)
-excerpt: "How to connect to APIs with OVHcloud service accounts using the Oauth2 protocol"
+excerpt: "How to connect to APIs with OVHcloud service accounts using the OAuth2 protocol"
 updated: 2023-08-24
 ---
 
@@ -19,9 +19,9 @@ This can allow you to:
 - provide your monitoring with information from our infrastructure
 - etc...
 
-The service accounts work with the Oauth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of Oauth2.
+The service accounts work with the OAuth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of OAuth2.
 
-Oauth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
+OAuth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
 
 ## Requirements
 
@@ -48,7 +48,7 @@ For example, for the */v1/hosting/web* call, the name of the action required is 
 
 You can also use the **\*** operator to designate a subset of rights. In our example, we would like to provide all rights to the APIs linked to the product **Web Hosting plans**. We will then use the **webHosting:** action
 
-As part of our example, we have created the following access policy: 
+As part of our example, we have created the following access policy:
 
 ```json
 {
@@ -86,7 +86,7 @@ curl --request POST \
   --data scope=all
 ```
 
-By modifying the following data: 
+By modifying the following data:
 
 - **client_id**: your service account ID
 - **client_secret**: token for your service account
@@ -94,7 +94,7 @@ By modifying the following data:
 Depending on the location of your API, you will need to use the following URL:
 
 - **EU API**: `https://www.ovh.com/auth/oauth2/token`
-- **CA API**: `https://www.ovh.ca/auth/oauth2/token`
+- **CA API**: `https://ca.ovh.com/auth/oauth2/token`
 
 Following this API call, you will receive a response in the following format:
 
@@ -113,15 +113,15 @@ To get information on your web hosting plan, you can now make a call on:
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 To do this, you will need to provide the token retrieved earlier in the header of your request, as follows:
 
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
-  -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Accept: application/json"\
+  -H "Authorization: Bearer your-api-token"
 ```
 
 With this access policy, you only have access to the webhosting APIs. The other APIs will return the following HTTP 403 error:

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-asia.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-asia.md
@@ -1,10 +1,10 @@
 ---
 title: How to use service accounts to connect to OVHcloud APIs
-excerpt: "How to connect to APIs with OVHcloud service accounts using the Oauth2 protocol"
+excerpt: "How to connect to APIs with OVHcloud service accounts using the OAuth2 protocol"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objective
 
@@ -20,9 +20,9 @@ This can allow you to:
 - provide your monitoring with information from our infrastructure
 - etc...
 
-The service accounts work with the Oauth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of Oauth2.
+The service accounts work with the OAuth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of OAuth2.
 
-Oauth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
+OAuth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
 
 ## Requirements
 
@@ -49,7 +49,7 @@ For example, for the */v1/hosting/web* call, the name of the action required is 
 
 You can also use the **\*** operator to designate a subset of rights. In our example, we would like to provide all rights to the APIs linked to the product **Web Hosting plans**. We will then use the **webHosting:** action
 
-As part of our example, we have created the following access policy: 
+As part of our example, we have created the following access policy:
 
 ```json
 {
@@ -87,7 +87,7 @@ curl --request POST \
   --data scope=all
 ```
 
-By modifying the following data: 
+By modifying the following data:
 
 - **client_id**: your service account ID
 - **client_secret**: token for your service account
@@ -95,7 +95,7 @@ By modifying the following data:
 Depending on the location of your API, you will need to use the following URL:
 
 - **EU API**: `https://www.ovh.com/auth/oauth2/token`
-- **CA API**: `https://www.ovh.ca/auth/oauth2/token`
+- **CA API**: `https://ca.ovh.com/auth/oauth2/token`
 
 Following this API call, you will receive a response in the following format:
 
@@ -114,7 +114,7 @@ To get information on your web hosting plan, you can now make a call on:
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 To do this, you will need to provide the token retrieved earlier in the header of your request, as follows:
@@ -122,7 +122,7 @@ To do this, you will need to provide the token retrieved earlier in the header o
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 With this access policy, you only have access to the webhosting APIs. The other APIs will return the following HTTP 403 error:

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-au.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-au.md
@@ -1,10 +1,10 @@
 ---
 title: How to use service accounts to connect to OVHcloud APIs
-excerpt: "How to connect to APIs with OVHcloud service accounts using the Oauth2 protocol"
+excerpt: "How to connect to APIs with OVHcloud service accounts using the OAuth2 protocol"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objective
 
@@ -20,9 +20,9 @@ This can allow you to:
 - provide your monitoring with information from our infrastructure
 - etc...
 
-The service accounts work with the Oauth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of Oauth2.
+The service accounts work with the OAuth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of OAuth2.
 
-Oauth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
+OAuth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
 
 ## Requirements
 
@@ -49,7 +49,7 @@ For example, for the */v1/hosting/web* call, the name of the action required is 
 
 You can also use the **\*** operator to designate a subset of rights. In our example, we would like to provide all rights to the APIs linked to the product **Web Hosting plans**. We will then use the **webHosting:** action
 
-As part of our example, we have created the following access policy: 
+As part of our example, we have created the following access policy:
 
 ```json
 {
@@ -87,7 +87,7 @@ curl --request POST \
   --data scope=all
 ```
 
-By modifying the following data: 
+By modifying the following data:
 
 - **client_id**: your service account ID
 - **client_secret**: token for your service account
@@ -95,7 +95,7 @@ By modifying the following data:
 Depending on the location of your API, you will need to use the following URL:
 
 - **EU API**: `https://www.ovh.com/auth/oauth2/token`
-- **CA API**: `https://www.ovh.ca/auth/oauth2/token`
+- **CA API**: `https://ca.ovh.com/auth/oauth2/token`
 
 Following this API call, you will receive a response in the following format:
 
@@ -114,7 +114,7 @@ To get information on your web hosting plan, you can now make a call on:
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 To do this, you will need to provide the token retrieved earlier in the header of your request, as follows:
@@ -122,7 +122,7 @@ To do this, you will need to provide the token retrieved earlier in the header o
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 With this access policy, you only have access to the webhosting APIs. The other APIs will return the following HTTP 403 error:

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-ca.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-ca.md
@@ -1,10 +1,10 @@
 ---
 title: How to use service accounts to connect to OVHcloud APIs
-excerpt: "How to connect to APIs with OVHcloud service accounts using the Oauth2 protocol"
+excerpt: "How to connect to APIs with OVHcloud service accounts using the OAuth2 protocol"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objective
 
@@ -20,9 +20,9 @@ This can allow you to:
 - provide your monitoring with information from our infrastructure
 - etc...
 
-The service accounts work with the Oauth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of Oauth2.
+The service accounts work with the OAuth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of OAuth2.
 
-Oauth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
+OAuth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
 
 ## Requirements
 
@@ -49,7 +49,7 @@ For example, for the */v1/hosting/web* call, the name of the action required is 
 
 You can also use the **\*** operator to designate a subset of rights. In our example, we would like to provide all rights to the APIs linked to the product **Web Hosting plans**. We will then use the **webHosting:** action
 
-As part of our example, we have created the following access policy: 
+As part of our example, we have created the following access policy:
 
 ```json
 {
@@ -87,7 +87,7 @@ curl --request POST \
   --data scope=all
 ```
 
-By modifying the following data: 
+By modifying the following data:
 
 - **client_id**: your service account ID
 - **client_secret**: token for your service account
@@ -95,7 +95,7 @@ By modifying the following data:
 Depending on the location of your API, you will need to use the following URL:
 
 - **EU API**: `https://www.ovh.com/auth/oauth2/token`
-- **CA API**: `https://www.ovh.ca/auth/oauth2/token`
+- **CA API**: `https://ca.ovh.com/auth/oauth2/token`
 
 Following this API call, you will receive a response in the following format:
 
@@ -114,7 +114,7 @@ To get information on your web hosting plan, you can now make a call on:
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 To do this, you will need to provide the token retrieved earlier in the header of your request, as follows:
@@ -122,7 +122,7 @@ To do this, you will need to provide the token retrieved earlier in the header o
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 With this access policy, you only have access to the webhosting APIs. The other APIs will return the following HTTP 403 error:

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-gb.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-gb.md
@@ -1,10 +1,10 @@
 ---
 title: How to use service accounts to connect to OVHcloud APIs
-excerpt: "How to connect to APIs with OVHcloud service accounts using the Oauth2 protocol"
+excerpt: "How to connect to APIs with OVHcloud service accounts using the OAuth2 protocol"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objective
 
@@ -20,9 +20,9 @@ This can allow you to:
 - provide your monitoring with information from our infrastructure
 - etc...
 
-The service accounts work with the Oauth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of Oauth2.
+The service accounts work with the OAuth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of OAuth2.
 
-Oauth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
+OAuth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
 
 ## Requirements
 
@@ -49,7 +49,7 @@ For example, for the */v1/hosting/web* call, the name of the action required is 
 
 You can also use the **\*** operator to designate a subset of rights. In our example, we would like to provide all rights to the APIs linked to the product **Web Hosting plans**. We will then use the **webHosting:** action
 
-As part of our example, we have created the following access policy: 
+As part of our example, we have created the following access policy:
 
 ```json
 {
@@ -87,7 +87,7 @@ curl --request POST \
   --data scope=all
 ```
 
-By modifying the following data: 
+By modifying the following data:
 
 - **client_id**: your service account ID
 - **client_secret**: token for your service account
@@ -95,7 +95,7 @@ By modifying the following data:
 Depending on the location of your API, you will need to use the following URL:
 
 - **EU API**: `https://www.ovh.com/auth/oauth2/token`
-- **CA API**: `https://www.ovh.ca/auth/oauth2/token`
+- **CA API**: `https://ca.ovh.com/auth/oauth2/token`
 
 Following this API call, you will receive a response in the following format:
 
@@ -114,7 +114,7 @@ To get information on your web hosting plan, you can now make a call on:
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 To do this, you will need to provide the token retrieved earlier in the header of your request, as follows:
@@ -122,7 +122,7 @@ To do this, you will need to provide the token retrieved earlier in the header o
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 With this access policy, you only have access to the webhosting APIs. The other APIs will return the following HTTP 403 error:

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-ie.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-ie.md
@@ -1,10 +1,10 @@
 ---
 title: How to use service accounts to connect to OVHcloud APIs
-excerpt: "How to connect to APIs with OVHcloud service accounts using the Oauth2 protocol"
+excerpt: "How to connect to APIs with OVHcloud service accounts using the OAuth2 protocol"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objective
 
@@ -20,9 +20,9 @@ This can allow you to:
 - provide your monitoring with information from our infrastructure
 - etc...
 
-The service accounts work with the Oauth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of Oauth2.
+The service accounts work with the OAuth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of OAuth2.
 
-Oauth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
+OAuth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
 
 ## Requirements
 
@@ -49,7 +49,7 @@ For example, for the */v1/hosting/web* call, the name of the action required is 
 
 You can also use the **\*** operator to designate a subset of rights. In our example, we would like to provide all rights to the APIs linked to the product **Web Hosting plans**. We will then use the **webHosting:** action
 
-As part of our example, we have created the following access policy: 
+As part of our example, we have created the following access policy:
 
 ```json
 {
@@ -87,7 +87,7 @@ curl --request POST \
   --data scope=all
 ```
 
-By modifying the following data: 
+By modifying the following data:
 
 - **client_id**: your service account ID
 - **client_secret**: token for your service account
@@ -95,7 +95,7 @@ By modifying the following data:
 Depending on the location of your API, you will need to use the following URL:
 
 - **EU API**: `https://www.ovh.com/auth/oauth2/token`
-- **CA API**: `https://www.ovh.ca/auth/oauth2/token`
+- **CA API**: `https://ca.ovh.com/auth/oauth2/token`
 
 Following this API call, you will receive a response in the following format:
 
@@ -114,7 +114,7 @@ To get information on your web hosting plan, you can now make a call on:
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 To do this, you will need to provide the token retrieved earlier in the header of your request, as follows:
@@ -122,7 +122,7 @@ To do this, you will need to provide the token retrieved earlier in the header o
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 With this access policy, you only have access to the webhosting APIs. The other APIs will return the following HTTP 403 error:

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-sg.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-sg.md
@@ -1,10 +1,10 @@
 ---
 title: How to use service accounts to connect to OVHcloud APIs
-excerpt: "How to connect to APIs with OVHcloud service accounts using the Oauth2 protocol"
+excerpt: "How to connect to APIs with OVHcloud service accounts using the OAuth2 protocol"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objective
 
@@ -20,9 +20,9 @@ This can allow you to:
 - provide your monitoring with information from our infrastructure
 - etc...
 
-The service accounts work with the Oauth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of Oauth2.
+The service accounts work with the OAuth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of OAuth2.
 
-Oauth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
+OAuth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
 
 ## Requirements
 
@@ -49,7 +49,7 @@ For example, for the */v1/hosting/web* call, the name of the action required is 
 
 You can also use the **\*** operator to designate a subset of rights. In our example, we would like to provide all rights to the APIs linked to the product **Web Hosting plans**. We will then use the **webHosting:** action
 
-As part of our example, we have created the following access policy: 
+As part of our example, we have created the following access policy:
 
 ```json
 {
@@ -87,7 +87,7 @@ curl --request POST \
   --data scope=all
 ```
 
-By modifying the following data: 
+By modifying the following data:
 
 - **client_id**: your service account ID
 - **client_secret**: token for your service account
@@ -95,7 +95,7 @@ By modifying the following data:
 Depending on the location of your API, you will need to use the following URL:
 
 - **EU API**: `https://www.ovh.com/auth/oauth2/token`
-- **CA API**: `https://www.ovh.ca/auth/oauth2/token`
+- **CA API**: `https://ca.ovh.com/auth/oauth2/token`
 
 Following this API call, you will receive a response in the following format:
 
@@ -114,7 +114,7 @@ To get information on your web hosting plan, you can now make a call on:
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 To do this, you will need to provide the token retrieved earlier in the header of your request, as follows:
@@ -122,7 +122,7 @@ To do this, you will need to provide the token retrieved earlier in the header o
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 With this access policy, you only have access to the webhosting APIs. The other APIs will return the following HTTP 403 error:

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-us.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.en-us.md
@@ -1,10 +1,10 @@
 ---
 title: How to use service accounts to connect to OVHcloud APIs
-excerpt: "How to connect to APIs with OVHcloud service accounts using the Oauth2 protocol"
+excerpt: "How to connect to APIs with OVHcloud service accounts using the OAuth2 protocol"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objective
 
@@ -20,9 +20,9 @@ This can allow you to:
 - provide your monitoring with information from our infrastructure
 - etc...
 
-The service accounts work with the Oauth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of Oauth2.
+The service accounts work with the OAuth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of OAuth2.
 
-Oauth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
+OAuth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
 
 ## Requirements
 
@@ -49,7 +49,7 @@ For example, for the */v1/hosting/web* call, the name of the action required is 
 
 You can also use the **\*** operator to designate a subset of rights. In our example, we would like to provide all rights to the APIs linked to the product **Web Hosting plans**. We will then use the **webHosting:** action
 
-As part of our example, we have created the following access policy: 
+As part of our example, we have created the following access policy:
 
 ```json
 {
@@ -87,7 +87,7 @@ curl --request POST \
   --data scope=all
 ```
 
-By modifying the following data: 
+By modifying the following data:
 
 - **client_id**: your service account ID
 - **client_secret**: token for your service account
@@ -95,7 +95,7 @@ By modifying the following data:
 Depending on the location of your API, you will need to use the following URL:
 
 - **EU API**: `https://www.ovh.com/auth/oauth2/token`
-- **CA API**: `https://www.ovh.ca/auth/oauth2/token`
+- **CA API**: `https://ca.ovh.com/auth/oauth2/token`
 
 Following this API call, you will receive a response in the following format:
 
@@ -114,7 +114,7 @@ To get information on your web hosting plan, you can now make a call on:
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 To do this, you will need to provide the token retrieved earlier in the header of your request, as follows:
@@ -122,7 +122,7 @@ To do this, you will need to provide the token retrieved earlier in the header o
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 With this access policy, you only have access to the webhosting APIs. The other APIs will return the following HTTP 403 error:

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.es-es.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.es-es.md
@@ -1,10 +1,10 @@
 ---
 title: How to use service accounts to connect to OVHcloud APIs (EN)
-excerpt: "How to connect to APIs with OVHcloud service accounts using the Oauth2 protocol"
+excerpt: "How to connect to APIs with OVHcloud service accounts using the OAuth2 protocol"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objective
 
@@ -20,9 +20,9 @@ This can allow you to:
 - provide your monitoring with information from our infrastructure
 - etc...
 
-The service accounts work with the Oauth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of Oauth2.
+The service accounts work with the OAuth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of OAuth2.
 
-Oauth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
+OAuth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
 
 ## Requirements
 
@@ -49,7 +49,7 @@ For example, for the */v1/hosting/web* call, the name of the action required is 
 
 You can also use the **\*** operator to designate a subset of rights. In our example, we would like to provide all rights to the APIs linked to the product **Web Hosting plans**. We will then use the **webHosting:** action
 
-As part of our example, we have created the following access policy: 
+As part of our example, we have created the following access policy:
 
 ```json
 {
@@ -87,7 +87,7 @@ curl --request POST \
   --data scope=all
 ```
 
-By modifying the following data: 
+By modifying the following data:
 
 - **client_id**: your service account ID
 - **client_secret**: token for your service account
@@ -95,7 +95,7 @@ By modifying the following data:
 Depending on the location of your API, you will need to use the following URL:
 
 - **EU API**: `https://www.ovh.com/auth/oauth2/token`
-- **CA API**: `https://www.ovh.ca/auth/oauth2/token`
+- **CA API**: `https://ca.ovh.com/auth/oauth2/token`
 
 Following this API call, you will receive a response in the following format:
 
@@ -114,7 +114,7 @@ To get information on your web hosting plan, you can now make a call on:
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 To do this, you will need to provide the token retrieved earlier in the header of your request, as follows:
@@ -122,7 +122,7 @@ To do this, you will need to provide the token retrieved earlier in the header o
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 With this access policy, you only have access to the webhosting APIs. The other APIs will return the following HTTP 403 error:

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.es-us.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.es-us.md
@@ -1,10 +1,10 @@
 ---
 title: How to use service accounts to connect to OVHcloud APIs (EN)
-excerpt: "How to connect to APIs with OVHcloud service accounts using the Oauth2 protocol"
+excerpt: "How to connect to APIs with OVHcloud service accounts using the OAuth2 protocol"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objective
 
@@ -20,9 +20,9 @@ This can allow you to:
 - provide your monitoring with information from our infrastructure
 - etc...
 
-The service accounts work with the Oauth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of Oauth2.
+The service accounts work with the OAuth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of OAuth2.
 
-Oauth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
+OAuth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
 
 ## Requirements
 
@@ -49,7 +49,7 @@ For example, for the */v1/hosting/web* call, the name of the action required is 
 
 You can also use the **\*** operator to designate a subset of rights. In our example, we would like to provide all rights to the APIs linked to the product **Web Hosting plans**. We will then use the **webHosting:** action
 
-As part of our example, we have created the following access policy: 
+As part of our example, we have created the following access policy:
 
 ```json
 {
@@ -87,7 +87,7 @@ curl --request POST \
   --data scope=all
 ```
 
-By modifying the following data: 
+By modifying the following data:
 
 - **client_id**: your service account ID
 - **client_secret**: token for your service account
@@ -95,7 +95,7 @@ By modifying the following data:
 Depending on the location of your API, you will need to use the following URL:
 
 - **EU API**: `https://www.ovh.com/auth/oauth2/token`
-- **CA API**: `https://www.ovh.ca/auth/oauth2/token`
+- **CA API**: `https://ca.ovh.com/auth/oauth2/token`
 
 Following this API call, you will receive a response in the following format:
 
@@ -114,7 +114,7 @@ To get information on your web hosting plan, you can now make a call on:
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 To do this, you will need to provide the token retrieved earlier in the header of your request, as follows:
@@ -122,7 +122,7 @@ To do this, you will need to provide the token retrieved earlier in the header o
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 With this access policy, you only have access to the webhosting APIs. The other APIs will return the following HTTP 403 error:

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.fr-ca.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.fr-ca.md
@@ -1,10 +1,10 @@
 ---
 title: Comment utiliser les comptes de service pour se connecter aux API de OVHcloud
-excerpt: "Comment se connecter aux API avec ses comptes de service OVHcloud grâce au protocole Oauth2"
+excerpt: "Comment se connecter aux API avec ses comptes de service OVHcloud grâce au protocole OAuth2"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objectif
 
@@ -20,9 +20,9 @@ Cela peut vous permettre de :
 - fournir à votre monitoring des informations issues de nos infrastructures ;
 - etc...
 
-Les comptes de service fonctionnent avec le flow *client credentials* de Oauth2. Cela vous permet donc d'intégrer l'utilisation de l'API OVHcloud avec tous les outils respectant ce protocole. Les versions v1 et v2 de l'API OVHcloud sont compatibles avec les flows *client credentials* et *authorization code* de Oauth2.
+Les comptes de service fonctionnent avec le flow *client credentials* de OAuth2. Cela vous permet donc d'intégrer l'utilisation de l'API OVHcloud avec tous les outils respectant ce protocole. Les versions v1 et v2 de l'API OVHcloud sont compatibles avec les flows *client credentials* et *authorization code* de OAuth2.
 
-Oauth2 permet aussi de développer des applications tierces se connectant aux API de OVHcloud, sans collecter les identifiants. Si vous souhaitez créer vos propres applications exploitant les informations de comptes OVHcloud, vous pouvez utiliser le flow *authorization code* qui n'est pas décrit dans ce guide.
+OAuth2 permet aussi de développer des applications tierces se connectant aux API de OVHcloud, sans collecter les identifiants. Si vous souhaitez créer vos propres applications exploitant les informations de comptes OVHcloud, vous pouvez utiliser le flow *authorization code* qui n'est pas décrit dans ce guide.
 
 ## Prérequis
 
@@ -49,7 +49,7 @@ Par exemple, pour l'appel */v1/hosting/web*, le nom de l'action nécessaire est 
 
 Vous pouvez aussi utiliser l'opérateur **\*** pour désigner un sous ensemble de droits. Dans notre exemple, nous souhaitons fournir tous les droits sur les API liées au produit **Hébergements Web**. Nous utiliserons ainsi l'action **webHosting:**
 
-Dans le cadre de notre exemple, nous avons créé la politique d'accès suivante : 
+Dans le cadre de notre exemple, nous avons créé la politique d'accès suivante :
 
 ```json
 {
@@ -87,15 +87,15 @@ curl --request POST \
   --data scope=all
 ```
 
-En modifiant les données suivantes: 
+En modifiant les données suivantes:
 
 - **client_id**: identifiant de votre compte de service
 - **client_secret**: token de votre compte de service
 
-En fonction de la localisation de votre API, vous devez utiliser l'URL suivante : 
+En fonction de la localisation de votre API, vous devez utiliser l'URL suivante :
 
 - **API EU**: `https://www.ovh.com/auth/oauth2/token`
-- **API CA**: `https://www.ovh.ca/auth/oauth2/token`
+- **API CA**: `https://ca.ovh.com/auth/oauth2/token`
 
 Lors de cet appel d'API, vous recevrez une réponse respectant le format suivant:
 
@@ -110,11 +110,11 @@ Lors de cet appel d'API, vous recevrez une réponse respectant le format suivant
 
 Conservez le token contenu dans le champ **access_token**. Il sera nécessaire pour authentifier vos appels d'API.
 
-Pour obtenir des informations sur votre hébergement web, vous pouvez désormais faire un appel sur 
+Pour obtenir des informations sur votre hébergement web, vous pouvez désormais faire un appel sur
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 Pour ce faire, vous devez fournir le token récupéré précédemment en header de votre requête de la façon suivante :
@@ -122,7 +122,7 @@ Pour ce faire, vous devez fournir le token récupéré précédemment en header 
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 Avec cette politique d'accès, vous n'avez accès qu'aux API de webhosting. Les autres API vous retourneront l'erreur HTTP 403 suivante :

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.fr-fr.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.fr-fr.md
@@ -1,10 +1,10 @@
 ---
 title: Comment utiliser les comptes de service pour se connecter aux API de OVHcloud
-excerpt: "Comment se connecter aux API avec ses comptes de service OVHcloud grâce au protocole Oauth2"
+excerpt: "Comment se connecter aux API avec ses comptes de service OVHcloud grâce au protocole OAuth2"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objectif
 
@@ -20,9 +20,9 @@ Cela peut vous permettre de :
 - fournir à votre monitoring des informations issues de nos infrastructures ;
 - etc...
 
-Les comptes de service fonctionnent avec le flow *client credentials* de Oauth2. Cela vous permet donc d'intégrer l'utilisation de l'API OVHcloud avec tous les outils respectant ce protocole. Les versions v1 et v2 de l'API OVHcloud sont compatibles avec les flows *client credentials* et *authorization code* de Oauth2.
+Les comptes de service fonctionnent avec le flow *client credentials* de OAuth2. Cela vous permet donc d'intégrer l'utilisation de l'API OVHcloud avec tous les outils respectant ce protocole. Les versions v1 et v2 de l'API OVHcloud sont compatibles avec les flows *client credentials* et *authorization code* de OAuth2.
 
-Oauth2 permet aussi de développer des applications tierces se connectant aux API de OVHcloud, sans collecter les identifiants. Si vous souhaitez créer vos propres applications exploitant les informations de comptes OVHcloud, vous pouvez utiliser le flow *authorization code* qui n'est pas décrit dans ce guide.
+OAuth2 permet aussi de développer des applications tierces se connectant aux API de OVHcloud, sans collecter les identifiants. Si vous souhaitez créer vos propres applications exploitant les informations de comptes OVHcloud, vous pouvez utiliser le flow *authorization code* qui n'est pas décrit dans ce guide.
 
 ## Prérequis
 
@@ -49,7 +49,7 @@ Par exemple, pour l'appel */v1/hosting/web*, le nom de l'action nécessaire est 
 
 Vous pouvez aussi utiliser l'opérateur **\*** pour désigner un sous ensemble de droits. Dans notre exemple, nous souhaitons fournir tous les droits sur les API liées au produit **Hébergements Web**. Nous utiliserons ainsi l'action **webHosting:**
 
-Dans le cadre de notre exemple, nous avons créé la politique d'accès suivante : 
+Dans le cadre de notre exemple, nous avons créé la politique d'accès suivante :
 
 ```json
 {
@@ -87,15 +87,15 @@ curl --request POST \
   --data scope=all
 ```
 
-En modifiant les données suivantes: 
+En modifiant les données suivantes:
 
 - **client_id**: identifiant de votre compte de service
 - **client_secret**: token de votre compte de service
 
-En fonction de la localisation de votre API, vous devez utiliser l'URL suivante : 
+En fonction de la localisation de votre API, vous devez utiliser l'URL suivante :
 
 - **API EU**: `https://www.ovh.com/auth/oauth2/token`
-- **API CA**: `https://www.ovh.ca/auth/oauth2/token`
+- **API CA**: `https://ca.ovh.com/auth/oauth2/token`
 
 Lors de cet appel d'API, vous recevrez une réponse respectant le format suivant:
 
@@ -110,11 +110,11 @@ Lors de cet appel d'API, vous recevrez une réponse respectant le format suivant
 
 Conservez le token contenu dans le champ **access_token**. Il sera nécessaire pour authentifier vos appels d'API.
 
-Pour obtenir des informations sur votre hébergement web, vous pouvez désormais faire un appel sur 
+Pour obtenir des informations sur votre hébergement web, vous pouvez désormais faire un appel sur
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 Pour ce faire, vous devez fournir le token récupéré précédemment en header de votre requête de la façon suivante :
@@ -122,7 +122,7 @@ Pour ce faire, vous devez fournir le token récupéré précédemment en header 
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 Avec cette politique d'accès, vous n'avez accès qu'aux API de webhosting. Les autres API vous retourneront l'erreur HTTP 403 suivante :

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.it-it.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.it-it.md
@@ -1,10 +1,10 @@
 ---
 title: How to use service accounts to connect to OVHcloud APIs (EN)
-excerpt: "How to connect to APIs with OVHcloud service accounts using the Oauth2 protocol"
+excerpt: "How to connect to APIs with OVHcloud service accounts using the OAuth2 protocol"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objective
 
@@ -20,9 +20,9 @@ This can allow you to:
 - provide your monitoring with information from our infrastructure
 - etc...
 
-The service accounts work with the Oauth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of Oauth2.
+The service accounts work with the OAuth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of OAuth2.
 
-Oauth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
+OAuth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
 
 ## Requirements
 
@@ -49,7 +49,7 @@ For example, for the */v1/hosting/web* call, the name of the action required is 
 
 You can also use the **\*** operator to designate a subset of rights. In our example, we would like to provide all rights to the APIs linked to the product **Web Hosting plans**. We will then use the **webHosting:** action
 
-As part of our example, we have created the following access policy: 
+As part of our example, we have created the following access policy:
 
 ```json
 {
@@ -87,7 +87,7 @@ curl --request POST \
   --data scope=all
 ```
 
-By modifying the following data: 
+By modifying the following data:
 
 - **client_id**: your service account ID
 - **client_secret**: token for your service account
@@ -95,7 +95,7 @@ By modifying the following data:
 Depending on the location of your API, you will need to use the following URL:
 
 - **EU API**: `https://www.ovh.com/auth/oauth2/token`
-- **CA API**: `https://www.ovh.ca/auth/oauth2/token`
+- **CA API**: `https://ca.ovh.com/auth/oauth2/token`
 
 Following this API call, you will receive a response in the following format:
 
@@ -114,7 +114,7 @@ To get information on your web hosting plan, you can now make a call on:
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 To do this, you will need to provide the token retrieved earlier in the header of your request, as follows:
@@ -122,7 +122,7 @@ To do this, you will need to provide the token retrieved earlier in the header o
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 With this access policy, you only have access to the webhosting APIs. The other APIs will return the following HTTP 403 error:

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.pl-pl.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.pl-pl.md
@@ -1,10 +1,10 @@
 ---
 title: How to use service accounts to connect to OVHcloud APIs (EN)
-excerpt: "How to connect to APIs with OVHcloud service accounts using the Oauth2 protocol"
+excerpt: "How to connect to APIs with OVHcloud service accounts using the OAuth2 protocol"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objective
 
@@ -20,9 +20,9 @@ This can allow you to:
 - provide your monitoring with information from our infrastructure
 - etc...
 
-The service accounts work with the Oauth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of Oauth2.
+The service accounts work with the OAuth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of OAuth2.
 
-Oauth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
+OAuth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
 
 ## Requirements
 
@@ -49,7 +49,7 @@ For example, for the */v1/hosting/web* call, the name of the action required is 
 
 You can also use the **\*** operator to designate a subset of rights. In our example, we would like to provide all rights to the APIs linked to the product **Web Hosting plans**. We will then use the **webHosting:** action
 
-As part of our example, we have created the following access policy: 
+As part of our example, we have created the following access policy:
 
 ```json
 {
@@ -87,7 +87,7 @@ curl --request POST \
   --data scope=all
 ```
 
-By modifying the following data: 
+By modifying the following data:
 
 - **client_id**: your service account ID
 - **client_secret**: token for your service account
@@ -95,7 +95,7 @@ By modifying the following data:
 Depending on the location of your API, you will need to use the following URL:
 
 - **EU API**: `https://www.ovh.com/auth/oauth2/token`
-- **CA API**: `https://www.ovh.ca/auth/oauth2/token`
+- **CA API**: `https://ca.ovh.com/auth/oauth2/token`
 
 Following this API call, you will receive a response in the following format:
 
@@ -114,7 +114,7 @@ To get information on your web hosting plan, you can now make a call on:
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 To do this, you will need to provide the token retrieved earlier in the header of your request, as follows:
@@ -122,7 +122,7 @@ To do this, you will need to provide the token retrieved earlier in the header o
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 With this access policy, you only have access to the webhosting APIs. The other APIs will return the following HTTP 403 error:

--- a/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.pt-pt.md
+++ b/pages/account_and_service_management/account_information/authenticate-api-with-service-account/guide.pt-pt.md
@@ -1,10 +1,10 @@
 ---
 title: How to use service accounts to connect to OVHcloud APIs (EN)
-excerpt: "How to connect to APIs with OVHcloud service accounts using the Oauth2 protocol"
+excerpt: "How to connect to APIs with OVHcloud service accounts using the OAuth2 protocol"
 updated: 2023-08-24
 ---
 
- 
+
 
 ## Objective
 
@@ -20,9 +20,9 @@ This can allow you to:
 - provide your monitoring with information from our infrastructure
 - etc...
 
-The service accounts work with the Oauth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of Oauth2.
+The service accounts work with the OAuth2 *client credentials* flow. This means you can integrate the use of the OVHcloud API with all the tools that follow this protocol. The v1 and v2 versions of the OVHcloud API are compatible with the *client credentials* and *authorization code* flows of OAuth2.
 
-Oauth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
+OAuth2 also allows you to develop third-party applications that connect to OVHcloud APIs, without collecting credentials. If you would like to create your own applications using OVHcloud account information, you can use the *authorization code* flow, which is not described in this guide.
 
 ## Requirements
 
@@ -49,7 +49,7 @@ For example, for the */v1/hosting/web* call, the name of the action required is 
 
 You can also use the **\*** operator to designate a subset of rights. In our example, we would like to provide all rights to the APIs linked to the product **Web Hosting plans**. We will then use the **webHosting:** action
 
-As part of our example, we have created the following access policy: 
+As part of our example, we have created the following access policy:
 
 ```json
 {
@@ -87,7 +87,7 @@ curl --request POST \
   --data scope=all
 ```
 
-By modifying the following data: 
+By modifying the following data:
 
 - **client_id**: your service account ID
 - **client_secret**: token for your service account
@@ -95,7 +95,7 @@ By modifying the following data:
 Depending on the location of your API, you will need to use the following URL:
 
 - **EU API**: `https://www.ovh.com/auth/oauth2/token`
-- **CA API**: `https://www.ovh.ca/auth/oauth2/token`
+- **CA API**: `https://ca.ovh.com/auth/oauth2/token`
 
 Following this API call, you will receive a response in the following format:
 
@@ -114,7 +114,7 @@ To get information on your web hosting plan, you can now make a call on:
 
 > [!api]
 >
-> @api {v1} /hosting/web GET /hosting/web/xxxxxxx.cluster001.hosting.ovh.net
+> @api {v1} /hosting/web GET /hosting/web/{serviceName}
 >
 
 To do this, you will need to provide the token retrieved earlier in the header of your request, as follows:
@@ -122,7 +122,7 @@ To do this, you will need to provide the token retrieved earlier in the header o
 ```bash
 curl -i -X GET "https://{eu|ca}.api.ovh.com/v1/hosting/web/xxxxxxx.cluster001.hosting.ovh.net" \
   -H "accept: application/json"\
-  -H "authorization: your-api-token" 
+  -H "Authorization: Bearer your-api-token"
 ```
 
 With this access policy, you only have access to the webhosting APIs. The other APIs will return the following HTTP 403 error:

--- a/pages/manage_and_operate/api/manage-service-account/guide.de-de.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.de-de.md
@@ -11,9 +11,9 @@ Access to OVHcloud products can be configured within **access policies**, which 
 When API access is required from applications or code, it is necessary to generate specific credentials in order not to link them to a user. You don't want to reset your scripts in production if your user changes their credentials or leaves your company.
 
 This guide will explain how to generate credentials to deploy within your code, as well as their use in OVHcloud access policies.
-These credentials can be used within the different APIs of our products: 
+These credentials can be used within the different APIs of our products:
 
-- OVHcloud API: [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- OVHcloud API: [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - OpenStack API: [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Requirements
@@ -30,7 +30,7 @@ Service accounts are one of the types of identities that can be set up on your O
 
 ### How service accounts work
 
-OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the Oauth2 protocol by following the **client credential** authentication mechanism.
+OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the OAuth2 protocol by following the **client credential** authentication mechanism.
 
 This identifier/token pair has no time limit. It is therefore ideal for use within a code deployed in production. Of course, you can revoke the access associated with this service account at any time by modifying the associated access policies or by deleting this service account.
 
@@ -51,12 +51,12 @@ To create a service account, use the following API call:
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-With this API call, you can create Oauth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
+With this API call, you can create OAuth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
 
 You must supply the following values:
 
 - **callbackUrls**: an empty array of callback urls `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: the name you would like to provide to your identifier
 - **description**: a description of your identifier. We recommend describing how you will use this identifier. If you audit your access in the future, it is easier to link it to your application name, so that you can easily find out where the identifier is deployed (and what the impact will be if you change your access).
 
@@ -77,7 +77,7 @@ In this call, you will have access to the **identity** value in the form of a UR
 
 This URN is of the following form:
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Delete a service account
 
@@ -91,7 +91,7 @@ If you no longer use a service account, or want to permanently delete this acces
 > [!warning]
 >
 > Warning: this action is permanent. If you would like to cancel it, you will need to create a new service account and deploy the username/token pair within your application.
-> 
+>
 > To delete access, we recommend detaching all access policies from this service account. This action is reversible, and allows you to cancel in case of an error. Once you have ensured that this service account is not used in production, you can delete it without fear.
 >
 
@@ -143,7 +143,7 @@ This example can be used directly within the following call to create a new poli
 
 Service accounts are available in several APIs of our products. For each API, there is a guide:
 
-- [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Go further

--- a/pages/manage_and_operate/api/manage-service-account/guide.en-asia.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.en-asia.md
@@ -11,9 +11,9 @@ Access to OVHcloud products can be configured within **access policies**, which 
 When API access is required from applications or code, it is necessary to generate specific credentials in order not to link them to a user. You don't want to reset your scripts in production if your user changes their credentials or leaves your company.
 
 This guide will explain how to generate credentials to deploy within your code, as well as their use in OVHcloud access policies.
-These credentials can be used within the different APIs of our products: 
+These credentials can be used within the different APIs of our products:
 
-- OVHcloud API: [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- OVHcloud API: [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - OpenStack API: [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Requirements
@@ -30,7 +30,7 @@ Service accounts are one of the types of identities that can be set up on your O
 
 ### How service accounts work
 
-OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the Oauth2 protocol by following the **client credential** authentication mechanism.
+OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the OAuth2 protocol by following the **client credential** authentication mechanism.
 
 This identifier/token pair has no time limit. It is therefore ideal for use within a code deployed in production. Of course, you can revoke the access associated with this service account at any time by modifying the associated access policies or by deleting this service account.
 
@@ -51,12 +51,12 @@ To create a service account, use the following API call:
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-With this API call, you can create Oauth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
+With this API call, you can create OAuth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
 
 You must supply the following values:
 
 - **callbackUrls**: an empty array of callback urls `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: the name you would like to provide to your identifier
 - **description**: a description of your identifier. We recommend describing how you will use this identifier. If you audit your access in the future, it is easier to link it to your application name, so that you can easily find out where the identifier is deployed (and what the impact will be if you change your access).
 
@@ -77,7 +77,7 @@ In this call, you will have access to the **identity** value in the form of a UR
 
 This URN is of the following form:
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Delete a service account
 
@@ -91,7 +91,7 @@ If you no longer use a service account, or want to permanently delete this acces
 > [!warning]
 >
 > Warning: this action is permanent. If you would like to cancel it, you will need to create a new service account and deploy the username/token pair within your application.
-> 
+>
 > To delete access, we recommend detaching all access policies from this service account. This action is reversible, and allows you to cancel in case of an error. Once you have ensured that this service account is not used in production, you can delete it without fear.
 >
 
@@ -143,7 +143,7 @@ This example can be used directly within the following call to create a new poli
 
 Service accounts are available in several APIs of our products. For each API, there is a guide:
 
-- [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Go further

--- a/pages/manage_and_operate/api/manage-service-account/guide.en-au.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.en-au.md
@@ -11,9 +11,9 @@ Access to OVHcloud products can be configured within **access policies**, which 
 When API access is required from applications or code, it is necessary to generate specific credentials in order not to link them to a user. You don't want to reset your scripts in production if your user changes their credentials or leaves your company.
 
 This guide will explain how to generate credentials to deploy within your code, as well as their use in OVHcloud access policies.
-These credentials can be used within the different APIs of our products: 
+These credentials can be used within the different APIs of our products:
 
-- OVHcloud API: [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- OVHcloud API: [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - OpenStack API: [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Requirements
@@ -30,7 +30,7 @@ Service accounts are one of the types of identities that can be set up on your O
 
 ### How service accounts work
 
-OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the Oauth2 protocol by following the **client credential** authentication mechanism.
+OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the OAuth2 protocol by following the **client credential** authentication mechanism.
 
 This identifier/token pair has no time limit. It is therefore ideal for use within a code deployed in production. Of course, you can revoke the access associated with this service account at any time by modifying the associated access policies or by deleting this service account.
 
@@ -51,12 +51,12 @@ To create a service account, use the following API call:
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-With this API call, you can create Oauth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
+With this API call, you can create OAuth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
 
 You must supply the following values:
 
 - **callbackUrls**: an empty array of callback urls `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: the name you would like to provide to your identifier
 - **description**: a description of your identifier. We recommend describing how you will use this identifier. If you audit your access in the future, it is easier to link it to your application name, so that you can easily find out where the identifier is deployed (and what the impact will be if you change your access).
 
@@ -77,7 +77,7 @@ In this call, you will have access to the **identity** value in the form of a UR
 
 This URN is of the following form:
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Delete a service account
 
@@ -91,7 +91,7 @@ If you no longer use a service account, or want to permanently delete this acces
 > [!warning]
 >
 > Warning: this action is permanent. If you would like to cancel it, you will need to create a new service account and deploy the username/token pair within your application.
-> 
+>
 > To delete access, we recommend detaching all access policies from this service account. This action is reversible, and allows you to cancel in case of an error. Once you have ensured that this service account is not used in production, you can delete it without fear.
 >
 
@@ -143,7 +143,7 @@ This example can be used directly within the following call to create a new poli
 
 Service accounts are available in several APIs of our products. For each API, there is a guide:
 
-- [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Go further

--- a/pages/manage_and_operate/api/manage-service-account/guide.en-ca.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.en-ca.md
@@ -11,9 +11,9 @@ Access to OVHcloud products can be configured within **access policies**, which 
 When API access is required from applications or code, it is necessary to generate specific credentials in order not to link them to a user. You don't want to reset your scripts in production if your user changes their credentials or leaves your company.
 
 This guide will explain how to generate credentials to deploy within your code, as well as their use in OVHcloud access policies.
-These credentials can be used within the different APIs of our products: 
+These credentials can be used within the different APIs of our products:
 
-- OVHcloud API: [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- OVHcloud API: [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - OpenStack API: [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Requirements
@@ -30,7 +30,7 @@ Service accounts are one of the types of identities that can be set up on your O
 
 ### How service accounts work
 
-OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the Oauth2 protocol by following the **client credential** authentication mechanism.
+OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the OAuth2 protocol by following the **client credential** authentication mechanism.
 
 This identifier/token pair has no time limit. It is therefore ideal for use within a code deployed in production. Of course, you can revoke the access associated with this service account at any time by modifying the associated access policies or by deleting this service account.
 
@@ -51,12 +51,12 @@ To create a service account, use the following API call:
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-With this API call, you can create Oauth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
+With this API call, you can create OAuth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
 
 You must supply the following values:
 
 - **callbackUrls**: an empty array of callback urls `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: the name you would like to provide to your identifier
 - **description**: a description of your identifier. We recommend describing how you will use this identifier. If you audit your access in the future, it is easier to link it to your application name, so that you can easily find out where the identifier is deployed (and what the impact will be if you change your access).
 
@@ -77,7 +77,7 @@ In this call, you will have access to the **identity** value in the form of a UR
 
 This URN is of the following form:
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Delete a service account
 
@@ -91,7 +91,7 @@ If you no longer use a service account, or want to permanently delete this acces
 > [!warning]
 >
 > Warning: this action is permanent. If you would like to cancel it, you will need to create a new service account and deploy the username/token pair within your application.
-> 
+>
 > To delete access, we recommend detaching all access policies from this service account. This action is reversible, and allows you to cancel in case of an error. Once you have ensured that this service account is not used in production, you can delete it without fear.
 >
 
@@ -143,7 +143,7 @@ This example can be used directly within the following call to create a new poli
 
 Service accounts are available in several APIs of our products. For each API, there is a guide:
 
-- [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Go further

--- a/pages/manage_and_operate/api/manage-service-account/guide.en-gb.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.en-gb.md
@@ -11,9 +11,9 @@ Access to OVHcloud products can be configured within **access policies**, which 
 When API access is required from applications or code, it is necessary to generate specific credentials in order not to link them to a user. You don't want to reset your scripts in production if your user changes their credentials or leaves your company.
 
 This guide will explain how to generate credentials to deploy within your code, as well as their use in OVHcloud access policies.
-These credentials can be used within the different APIs of our products: 
+These credentials can be used within the different APIs of our products:
 
-- OVHcloud API: [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- OVHcloud API: [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - OpenStack API: [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Requirements
@@ -30,7 +30,7 @@ Service accounts are one of the types of identities that can be set up on your O
 
 ### How service accounts work
 
-OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the Oauth2 protocol by following the **client credential** authentication mechanism.
+OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the OAuth2 protocol by following the **client credential** authentication mechanism.
 
 This identifier/token pair has no time limit. It is therefore ideal for use within a code deployed in production. Of course, you can revoke the access associated with this service account at any time by modifying the associated access policies or by deleting this service account.
 
@@ -51,12 +51,12 @@ To create a service account, use the following API call:
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-With this API call, you can create Oauth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
+With this API call, you can create OAuth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
 
 You must supply the following values:
 
 - **callbackUrls**: an empty array of callback urls `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: the name you would like to provide to your identifier
 - **description**: a description of your identifier. We recommend describing how you will use this identifier. If you audit your access in the future, it is easier to link it to your application name, so that you can easily find out where the identifier is deployed (and what the impact will be if you change your access).
 
@@ -77,7 +77,7 @@ In this call, you will have access to the **identity** value in the form of a UR
 
 This URN is of the following form:
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Delete a service account
 
@@ -91,7 +91,7 @@ If you no longer use a service account, or want to permanently delete this acces
 > [!warning]
 >
 > Warning: this action is permanent. If you would like to cancel it, you will need to create a new service account and deploy the username/token pair within your application.
-> 
+>
 > To delete access, we recommend detaching all access policies from this service account. This action is reversible, and allows you to cancel in case of an error. Once you have ensured that this service account is not used in production, you can delete it without fear.
 >
 
@@ -143,7 +143,7 @@ This example can be used directly within the following call to create a new poli
 
 Service accounts are available in several APIs of our products. For each API, there is a guide:
 
-- [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Go further

--- a/pages/manage_and_operate/api/manage-service-account/guide.en-ie.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.en-ie.md
@@ -11,9 +11,9 @@ Access to OVHcloud products can be configured within **access policies**, which 
 When API access is required from applications or code, it is necessary to generate specific credentials in order not to link them to a user. You don't want to reset your scripts in production if your user changes their credentials or leaves your company.
 
 This guide will explain how to generate credentials to deploy within your code, as well as their use in OVHcloud access policies.
-These credentials can be used within the different APIs of our products: 
+These credentials can be used within the different APIs of our products:
 
-- OVHcloud API: [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- OVHcloud API: [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - OpenStack API: [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Requirements
@@ -30,7 +30,7 @@ Service accounts are one of the types of identities that can be set up on your O
 
 ### How service accounts work
 
-OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the Oauth2 protocol by following the **client credential** authentication mechanism.
+OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the OAuth2 protocol by following the **client credential** authentication mechanism.
 
 This identifier/token pair has no time limit. It is therefore ideal for use within a code deployed in production. Of course, you can revoke the access associated with this service account at any time by modifying the associated access policies or by deleting this service account.
 
@@ -51,12 +51,12 @@ To create a service account, use the following API call:
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-With this API call, you can create Oauth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
+With this API call, you can create OAuth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
 
 You must supply the following values:
 
 - **callbackUrls**: an empty array of callback urls `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: the name you would like to provide to your identifier
 - **description**: a description of your identifier. We recommend describing how you will use this identifier. If you audit your access in the future, it is easier to link it to your application name, so that you can easily find out where the identifier is deployed (and what the impact will be if you change your access).
 
@@ -77,7 +77,7 @@ In this call, you will have access to the **identity** value in the form of a UR
 
 This URN is of the following form:
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Delete a service account
 
@@ -91,7 +91,7 @@ If you no longer use a service account, or want to permanently delete this acces
 > [!warning]
 >
 > Warning: this action is permanent. If you would like to cancel it, you will need to create a new service account and deploy the username/token pair within your application.
-> 
+>
 > To delete access, we recommend detaching all access policies from this service account. This action is reversible, and allows you to cancel in case of an error. Once you have ensured that this service account is not used in production, you can delete it without fear.
 >
 
@@ -143,7 +143,7 @@ This example can be used directly within the following call to create a new poli
 
 Service accounts are available in several APIs of our products. For each API, there is a guide:
 
-- [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Go further

--- a/pages/manage_and_operate/api/manage-service-account/guide.en-sg.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.en-sg.md
@@ -11,9 +11,9 @@ Access to OVHcloud products can be configured within **access policies**, which 
 When API access is required from applications or code, it is necessary to generate specific credentials in order not to link them to a user. You don't want to reset your scripts in production if your user changes their credentials or leaves your company.
 
 This guide will explain how to generate credentials to deploy within your code, as well as their use in OVHcloud access policies.
-These credentials can be used within the different APIs of our products: 
+These credentials can be used within the different APIs of our products:
 
-- OVHcloud API: [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- OVHcloud API: [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - OpenStack API: [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Requirements
@@ -30,7 +30,7 @@ Service accounts are one of the types of identities that can be set up on your O
 
 ### How service accounts work
 
-OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the Oauth2 protocol by following the **client credential** authentication mechanism.
+OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the OAuth2 protocol by following the **client credential** authentication mechanism.
 
 This identifier/token pair has no time limit. It is therefore ideal for use within a code deployed in production. Of course, you can revoke the access associated with this service account at any time by modifying the associated access policies or by deleting this service account.
 
@@ -51,12 +51,12 @@ To create a service account, use the following API call:
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-With this API call, you can create Oauth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
+With this API call, you can create OAuth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
 
 You must supply the following values:
 
 - **callbackUrls**: an empty array of callback urls `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: the name you would like to provide to your identifier
 - **description**: a description of your identifier. We recommend describing how you will use this identifier. If you audit your access in the future, it is easier to link it to your application name, so that you can easily find out where the identifier is deployed (and what the impact will be if you change your access).
 
@@ -77,7 +77,7 @@ In this call, you will have access to the **identity** value in the form of a UR
 
 This URN is of the following form:
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Delete a service account
 
@@ -91,7 +91,7 @@ If you no longer use a service account, or want to permanently delete this acces
 > [!warning]
 >
 > Warning: this action is permanent. If you would like to cancel it, you will need to create a new service account and deploy the username/token pair within your application.
-> 
+>
 > To delete access, we recommend detaching all access policies from this service account. This action is reversible, and allows you to cancel in case of an error. Once you have ensured that this service account is not used in production, you can delete it without fear.
 >
 
@@ -143,7 +143,7 @@ This example can be used directly within the following call to create a new poli
 
 Service accounts are available in several APIs of our products. For each API, there is a guide:
 
-- [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Go further

--- a/pages/manage_and_operate/api/manage-service-account/guide.en-us.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.en-us.md
@@ -11,9 +11,9 @@ Access to OVHcloud products can be configured within **access policies**, which 
 When API access is required from applications or code, it is necessary to generate specific credentials in order not to link them to a user. You don't want to reset your scripts in production if your user changes their credentials or leaves your company.
 
 This guide will explain how to generate credentials to deploy within your code, as well as their use in OVHcloud access policies.
-These credentials can be used within the different APIs of our products: 
+These credentials can be used within the different APIs of our products:
 
-- OVHcloud API: [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- OVHcloud API: [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - OpenStack API: [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Requirements
@@ -30,7 +30,7 @@ Service accounts are one of the types of identities that can be set up on your O
 
 ### How service accounts work
 
-OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the Oauth2 protocol by following the **client credential** authentication mechanism.
+OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the OAuth2 protocol by following the **client credential** authentication mechanism.
 
 This identifier/token pair has no time limit. It is therefore ideal for use within a code deployed in production. Of course, you can revoke the access associated with this service account at any time by modifying the associated access policies or by deleting this service account.
 
@@ -51,12 +51,12 @@ To create a service account, use the following API call:
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-With this API call, you can create Oauth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
+With this API call, you can create OAuth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
 
 You must supply the following values:
 
 - **callbackUrls**: an empty array of callback urls `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: the name you would like to provide to your identifier
 - **description**: a description of your identifier. We recommend describing how you will use this identifier. If you audit your access in the future, it is easier to link it to your application name, so that you can easily find out where the identifier is deployed (and what the impact will be if you change your access).
 
@@ -77,7 +77,7 @@ In this call, you will have access to the **identity** value in the form of a UR
 
 This URN is of the following form:
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Delete a service account
 
@@ -91,7 +91,7 @@ If you no longer use a service account, or want to permanently delete this acces
 > [!warning]
 >
 > Warning: this action is permanent. If you would like to cancel it, you will need to create a new service account and deploy the username/token pair within your application.
-> 
+>
 > To delete access, we recommend detaching all access policies from this service account. This action is reversible, and allows you to cancel in case of an error. Once you have ensured that this service account is not used in production, you can delete it without fear.
 >
 
@@ -143,7 +143,7 @@ This example can be used directly within the following call to create a new poli
 
 Service accounts are available in several APIs of our products. For each API, there is a guide:
 
-- [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Go further

--- a/pages/manage_and_operate/api/manage-service-account/guide.es-es.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.es-es.md
@@ -11,9 +11,9 @@ Access to OVHcloud products can be configured within **access policies**, which 
 When API access is required from applications or code, it is necessary to generate specific credentials in order not to link them to a user. You don't want to reset your scripts in production if your user changes their credentials or leaves your company.
 
 This guide will explain how to generate credentials to deploy within your code, as well as their use in OVHcloud access policies.
-These credentials can be used within the different APIs of our products: 
+These credentials can be used within the different APIs of our products:
 
-- OVHcloud API: [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- OVHcloud API: [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - OpenStack API: [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Requirements
@@ -30,7 +30,7 @@ Service accounts are one of the types of identities that can be set up on your O
 
 ### How service accounts work
 
-OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the Oauth2 protocol by following the **client credential** authentication mechanism.
+OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the OAuth2 protocol by following the **client credential** authentication mechanism.
 
 This identifier/token pair has no time limit. It is therefore ideal for use within a code deployed in production. Of course, you can revoke the access associated with this service account at any time by modifying the associated access policies or by deleting this service account.
 
@@ -51,12 +51,12 @@ To create a service account, use the following API call:
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-With this API call, you can create Oauth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
+With this API call, you can create OAuth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
 
 You must supply the following values:
 
 - **callbackUrls**: an empty array of callback urls `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: the name you would like to provide to your identifier
 - **description**: a description of your identifier. We recommend describing how you will use this identifier. If you audit your access in the future, it is easier to link it to your application name, so that you can easily find out where the identifier is deployed (and what the impact will be if you change your access).
 
@@ -77,7 +77,7 @@ In this call, you will have access to the **identity** value in the form of a UR
 
 This URN is of the following form:
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Delete a service account
 
@@ -91,7 +91,7 @@ If you no longer use a service account, or want to permanently delete this acces
 > [!warning]
 >
 > Warning: this action is permanent. If you would like to cancel it, you will need to create a new service account and deploy the username/token pair within your application.
-> 
+>
 > To delete access, we recommend detaching all access policies from this service account. This action is reversible, and allows you to cancel in case of an error. Once you have ensured that this service account is not used in production, you can delete it without fear.
 >
 
@@ -143,7 +143,7 @@ This example can be used directly within the following call to create a new poli
 
 Service accounts are available in several APIs of our products. For each API, there is a guide:
 
-- [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Go further

--- a/pages/manage_and_operate/api/manage-service-account/guide.es-us.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.es-us.md
@@ -11,9 +11,9 @@ Access to OVHcloud products can be configured within **access policies**, which 
 When API access is required from applications or code, it is necessary to generate specific credentials in order not to link them to a user. You don't want to reset your scripts in production if your user changes their credentials or leaves your company.
 
 This guide will explain how to generate credentials to deploy within your code, as well as their use in OVHcloud access policies.
-These credentials can be used within the different APIs of our products: 
+These credentials can be used within the different APIs of our products:
 
-- OVHcloud API: [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- OVHcloud API: [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - OpenStack API: [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Requirements
@@ -30,7 +30,7 @@ Service accounts are one of the types of identities that can be set up on your O
 
 ### How service accounts work
 
-OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the Oauth2 protocol by following the **client credential** authentication mechanism.
+OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the OAuth2 protocol by following the **client credential** authentication mechanism.
 
 This identifier/token pair has no time limit. It is therefore ideal for use within a code deployed in production. Of course, you can revoke the access associated with this service account at any time by modifying the associated access policies or by deleting this service account.
 
@@ -51,12 +51,12 @@ To create a service account, use the following API call:
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-With this API call, you can create Oauth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
+With this API call, you can create OAuth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
 
 You must supply the following values:
 
 - **callbackUrls**: an empty array of callback urls `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: the name you would like to provide to your identifier
 - **description**: a description of your identifier. We recommend describing how you will use this identifier. If you audit your access in the future, it is easier to link it to your application name, so that you can easily find out where the identifier is deployed (and what the impact will be if you change your access).
 
@@ -77,7 +77,7 @@ In this call, you will have access to the **identity** value in the form of a UR
 
 This URN is of the following form:
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Delete a service account
 
@@ -91,7 +91,7 @@ If you no longer use a service account, or want to permanently delete this acces
 > [!warning]
 >
 > Warning: this action is permanent. If you would like to cancel it, you will need to create a new service account and deploy the username/token pair within your application.
-> 
+>
 > To delete access, we recommend detaching all access policies from this service account. This action is reversible, and allows you to cancel in case of an error. Once you have ensured that this service account is not used in production, you can delete it without fear.
 >
 
@@ -143,7 +143,7 @@ This example can be used directly within the following call to create a new poli
 
 Service accounts are available in several APIs of our products. For each API, there is a guide:
 
-- [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Go further

--- a/pages/manage_and_operate/api/manage-service-account/guide.fr-ca.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.fr-ca.md
@@ -13,7 +13,7 @@ Lorsque des accès aux API sont nécessaires depuis des applications ou du code,
 Ce guide vous expliquera comment générer des identifiants pour les déployer au sein de votre code, ainsi que leur utilisation dans les politiques d'accès de OVHcloud.
 Ces identifiants peuvent être utilisés au sein des différentes API de nos produits :
 
-- API OVHcloud: [Comment s'authentifier sur l'API OVHcloud avec Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- API OVHcloud: [Comment s'authentifier sur l'API OVHcloud avec OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - API OpenStack: [Comment utiliser les comptes de service pour se connecter à OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Prérequis
@@ -30,7 +30,7 @@ Les comptes de services sont un des types d'identités pouvant être mis en plac
 
 ### Fonctionnement des comptes de services
 
-Les comptes de service OVHcloud sont un couple identifiant/token qui permettent à votre code de s'authentifier auprès des APIs de OVHcloud. Ces identifiants respectent le protocole Oauth2 en suivant le mécanisme d'authentification **client credential**.
+Les comptes de service OVHcloud sont un couple identifiant/token qui permettent à votre code de s'authentifier auprès des APIs de OVHcloud. Ces identifiants respectent le protocole OAuth2 en suivant le mécanisme d'authentification **client credential**.
 
 Ce couple identifiant/token n'a pas de limite d'utilisation dans le temps. Il est donc idéal pour l'utilisation au sein d'un code déployé en production. Vous pouvez bien entendu révoquer les accès associés à ce compte de service à tout moment en modifiant les politiques d'accès associées ou en supprimant ce compte de service.
 
@@ -51,12 +51,12 @@ Afin de créer un compte de service, utilisez l'appel API suivant :
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-Cet appel API permet de créer des identifiants Oauth2 pour plusieurs mécanismes d'authentification. Celui qui nous intéresse ici est **CLIENT_CREDENTIALS**. Ce mécanisme ne nécessite pas d'URL de callback.
+Cet appel API permet de créer des identifiants OAuth2 pour plusieurs mécanismes d'authentification. Celui qui nous intéresse ici est **CLIENT_CREDENTIALS**. Ce mécanisme ne nécessite pas d'URL de callback.
 
 Ainsi, vous devez fournir les valeurs suivantes :
 
 - **callbackUrls**: un tableau vide d'url de callback `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: le nom que vous souhaitez fournir à votre identifiant
 - **description**: une description de votre identifiant. Nous vous conseillons de décrire l'usage de cet identifiant. Si vous auditez vos accès dans le futur, il est plus simple de le rattacher au nommage de votre applicatif afin de retrouver facilement où cet identifiant est déployé (et quel est l'impact si on change ces accès).
 
@@ -77,7 +77,7 @@ Dans cet appel, vous aurez accès à la valeur **identity** sous forme d'une URN
 
 Cette URN est de la forme suivante :
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Supprimer un compte de service
 
@@ -91,7 +91,7 @@ Si vous n'utilisez plus un compte de service, ou bien que vous voulez supprimer 
 > [!warning]
 >
 > Attention, cette action est définitive. Si vous souhaitez faire un retour en arrière, vous serez contraint de créer un nouveau compte de service et de déployer le couple identifiant/token au sein de votre application.
-> 
+>
 > Afin de supprimer les accès, nous vous conseillons de dissocier toutes les politiques d'accès de ce compte de service. Cette action est réversible et permet de revenir en arrière en cas d'erreur. Une fois assuré que ce compte de service n'est pas utilisé en production, vous pourrez le supprimer sans crainte.
 >
 
@@ -143,7 +143,7 @@ Cet exemple peut être utilisé directement au sein de l'appel suivant pour cré
 
 Les comptes de services sont disponible dans plusieurs API de nos produits. Pour chaque API, un guide y est consacré :
 
-- [Comment s'authentifier sur l'API OVHcloud avec Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [Comment s'authentifier sur l'API OVHcloud avec OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [Comment utiliser les comptes de service pour se connecter à OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Aller plus loin

--- a/pages/manage_and_operate/api/manage-service-account/guide.fr-fr.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.fr-fr.md
@@ -13,7 +13,7 @@ Lorsque des accès aux API sont nécessaires depuis des applications ou du code,
 Ce guide vous expliquera comment générer des identifiants pour les déployer au sein de votre code, ainsi que leur utilisation dans les politiques d'accès de OVHcloud.
 Ces identifiants peuvent être utilisés au sein des différentes API de nos produits :
 
-- API OVHcloud: [Comment s'authentifier sur l'API OVHcloud avec Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- API OVHcloud: [Comment s'authentifier sur l'API OVHcloud avec OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - API OpenStack: [Comment utiliser les comptes de service pour se connecter à OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Prérequis
@@ -30,7 +30,7 @@ Les comptes de services sont un des types d'identités pouvant être mis en plac
 
 ### Fonctionnement des comptes de services
 
-Les comptes de service OVHcloud sont un couple identifiant/token qui permettent à votre code de s'authentifier auprès des APIs de OVHcloud. Ces identifiants respectent le protocole Oauth2 en suivant le mécanisme d'authentification **client credential**.
+Les comptes de service OVHcloud sont un couple identifiant/token qui permettent à votre code de s'authentifier auprès des APIs de OVHcloud. Ces identifiants respectent le protocole OAuth2 en suivant le mécanisme d'authentification **client credential**.
 
 Ce couple identifiant/token n'a pas de limite d'utilisation dans le temps. Il est donc idéal pour l'utilisation au sein d'un code déployé en production. Vous pouvez bien entendu révoquer les accès associés à ce compte de service à tout moment en modifiant les politiques d'accès associées ou en supprimant ce compte de service.
 
@@ -51,12 +51,12 @@ Afin de créer un compte de service, utilisez l'appel API suivant :
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-Cet appel API permet de créer des identifiants Oauth2 pour plusieurs mécanismes d'authentification. Celui qui nous intéresse ici est **CLIENT_CREDENTIALS**. Ce mécanisme ne nécessite pas d'URL de callback.
+Cet appel API permet de créer des identifiants OAuth2 pour plusieurs mécanismes d'authentification. Celui qui nous intéresse ici est **CLIENT_CREDENTIALS**. Ce mécanisme ne nécessite pas d'URL de callback.
 
 Ainsi, vous devez fournir les valeurs suivantes :
 
 - **callbackUrls**: un tableau vide d'url de callback `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: le nom que vous souhaitez fournir à votre identifiant
 - **description**: une description de votre identifiant. Nous vous conseillons de décrire l'usage de cet identifiant. Si vous auditez vos accès dans le futur, il est plus simple de le rattacher au nommage de votre applicatif afin de retrouver facilement où cet identifiant est déployé (et quel est l'impact si on change ces accès).
 
@@ -77,7 +77,7 @@ Dans cet appel, vous aurez accès à la valeur **identity** sous forme d'une URN
 
 Cette URN est de la forme suivante :
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Supprimer un compte de service
 
@@ -91,7 +91,7 @@ Si vous n'utilisez plus un compte de service, ou bien que vous voulez supprimer 
 > [!warning]
 >
 > Attention, cette action est définitive. Si vous souhaitez faire un retour en arrière, vous serez contraint de créer un nouveau compte de service et de déployer le couple identifiant/token au sein de votre application.
-> 
+>
 > Afin de supprimer les accès, nous vous conseillons de dissocier toutes les politiques d'accès de ce compte de service. Cette action est réversible et permet de revenir en arrière en cas d'erreur. Une fois assuré que ce compte de service n'est pas utilisé en production, vous pourrez le supprimer sans crainte.
 >
 
@@ -143,7 +143,7 @@ Cet exemple peut être utilisé directement au sein de l'appel suivant pour cré
 
 Les comptes de services sont disponible dans plusieurs API de nos produits. Pour chaque API, un guide y est consacré :
 
-- [Comment s'authentifier sur l'API OVHcloud avec Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [Comment s'authentifier sur l'API OVHcloud avec OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [Comment utiliser les comptes de service pour se connecter à OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Aller plus loin

--- a/pages/manage_and_operate/api/manage-service-account/guide.it-it.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.it-it.md
@@ -11,9 +11,9 @@ Access to OVHcloud products can be configured within **access policies**, which 
 When API access is required from applications or code, it is necessary to generate specific credentials in order not to link them to a user. You don't want to reset your scripts in production if your user changes their credentials or leaves your company.
 
 This guide will explain how to generate credentials to deploy within your code, as well as their use in OVHcloud access policies.
-These credentials can be used within the different APIs of our products: 
+These credentials can be used within the different APIs of our products:
 
-- OVHcloud API: [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- OVHcloud API: [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - OpenStack API: [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Requirements
@@ -30,7 +30,7 @@ Service accounts are one of the types of identities that can be set up on your O
 
 ### How service accounts work
 
-OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the Oauth2 protocol by following the **client credential** authentication mechanism.
+OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the OAuth2 protocol by following the **client credential** authentication mechanism.
 
 This identifier/token pair has no time limit. It is therefore ideal for use within a code deployed in production. Of course, you can revoke the access associated with this service account at any time by modifying the associated access policies or by deleting this service account.
 
@@ -51,12 +51,12 @@ To create a service account, use the following API call:
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-With this API call, you can create Oauth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
+With this API call, you can create OAuth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
 
 You must supply the following values:
 
 - **callbackUrls**: an empty array of callback urls `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: the name you would like to provide to your identifier
 - **description**: a description of your identifier. We recommend describing how you will use this identifier. If you audit your access in the future, it is easier to link it to your application name, so that you can easily find out where the identifier is deployed (and what the impact will be if you change your access).
 
@@ -77,7 +77,7 @@ In this call, you will have access to the **identity** value in the form of a UR
 
 This URN is of the following form:
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Delete a service account
 
@@ -91,7 +91,7 @@ If you no longer use a service account, or want to permanently delete this acces
 > [!warning]
 >
 > Warning: this action is permanent. If you would like to cancel it, you will need to create a new service account and deploy the username/token pair within your application.
-> 
+>
 > To delete access, we recommend detaching all access policies from this service account. This action is reversible, and allows you to cancel in case of an error. Once you have ensured that this service account is not used in production, you can delete it without fear.
 >
 
@@ -143,7 +143,7 @@ This example can be used directly within the following call to create a new poli
 
 Service accounts are available in several APIs of our products. For each API, there is a guide:
 
-- [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Go further

--- a/pages/manage_and_operate/api/manage-service-account/guide.pl-pl.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.pl-pl.md
@@ -11,9 +11,9 @@ Access to OVHcloud products can be configured within **access policies**, which 
 When API access is required from applications or code, it is necessary to generate specific credentials in order not to link them to a user. You don't want to reset your scripts in production if your user changes their credentials or leaves your company.
 
 This guide will explain how to generate credentials to deploy within your code, as well as their use in OVHcloud access policies.
-These credentials can be used within the different APIs of our products: 
+These credentials can be used within the different APIs of our products:
 
-- OVHcloud API: [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- OVHcloud API: [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - OpenStack API: [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Requirements
@@ -30,7 +30,7 @@ Service accounts are one of the types of identities that can be set up on your O
 
 ### How service accounts work
 
-OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the Oauth2 protocol by following the **client credential** authentication mechanism.
+OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the OAuth2 protocol by following the **client credential** authentication mechanism.
 
 This identifier/token pair has no time limit. It is therefore ideal for use within a code deployed in production. Of course, you can revoke the access associated with this service account at any time by modifying the associated access policies or by deleting this service account.
 
@@ -51,12 +51,12 @@ To create a service account, use the following API call:
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-With this API call, you can create Oauth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
+With this API call, you can create OAuth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
 
 You must supply the following values:
 
 - **callbackUrls**: an empty array of callback urls `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: the name you would like to provide to your identifier
 - **description**: a description of your identifier. We recommend describing how you will use this identifier. If you audit your access in the future, it is easier to link it to your application name, so that you can easily find out where the identifier is deployed (and what the impact will be if you change your access).
 
@@ -77,7 +77,7 @@ In this call, you will have access to the **identity** value in the form of a UR
 
 This URN is of the following form:
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Delete a service account
 
@@ -91,7 +91,7 @@ If you no longer use a service account, or want to permanently delete this acces
 > [!warning]
 >
 > Warning: this action is permanent. If you would like to cancel it, you will need to create a new service account and deploy the username/token pair within your application.
-> 
+>
 > To delete access, we recommend detaching all access policies from this service account. This action is reversible, and allows you to cancel in case of an error. Once you have ensured that this service account is not used in production, you can delete it without fear.
 >
 
@@ -143,7 +143,7 @@ This example can be used directly within the following call to create a new poli
 
 Service accounts are available in several APIs of our products. For each API, there is a guide:
 
-- [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Go further

--- a/pages/manage_and_operate/api/manage-service-account/guide.pt-pt.md
+++ b/pages/manage_and_operate/api/manage-service-account/guide.pt-pt.md
@@ -11,9 +11,9 @@ Access to OVHcloud products can be configured within **access policies**, which 
 When API access is required from applications or code, it is necessary to generate specific credentials in order not to link them to a user. You don't want to reset your scripts in production if your user changes their credentials or leaves your company.
 
 This guide will explain how to generate credentials to deploy within your code, as well as their use in OVHcloud access policies.
-These credentials can be used within the different APIs of our products: 
+These credentials can be used within the different APIs of our products:
 
-- OVHcloud API: [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
+- OVHcloud API: [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account).
 - OpenStack API: [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account).
 
 ## Requirements
@@ -30,7 +30,7 @@ Service accounts are one of the types of identities that can be set up on your O
 
 ### How service accounts work
 
-OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the Oauth2 protocol by following the **client credential** authentication mechanism.
+OVHcloud service accounts are a username/token couple that allow your code to authenticate with OVHcloud APIs. These credentials follow the OAuth2 protocol by following the **client credential** authentication mechanism.
 
 This identifier/token pair has no time limit. It is therefore ideal for use within a code deployed in production. Of course, you can revoke the access associated with this service account at any time by modifying the associated access policies or by deleting this service account.
 
@@ -51,12 +51,12 @@ To create a service account, use the following API call:
 > @api {v1} /me POST /me/api/oauth2/client
 >
 
-With this API call, you can create Oauth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
+With this API call, you can create OAuth2 credentials for several authentication mechanisms. The one we are interested in here is **CLIENT_CREDENTIALS**. This mechanism does not require a callback URL.
 
 You must supply the following values:
 
 - **callbackUrls**: an empty array of callback urls `[]`
-- **flow**: "CLIENT_CREDENTIALS"
+- **flow**: `CLIENT_CREDENTIALS`
 - **name**: the name you would like to provide to your identifier
 - **description**: a description of your identifier. We recommend describing how you will use this identifier. If you audit your access in the future, it is easier to link it to your application name, so that you can easily find out where the identifier is deployed (and what the impact will be if you change your access).
 
@@ -77,7 +77,7 @@ In this call, you will have access to the **identity** value in the form of a UR
 
 This URN is of the following form:
 
-urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*
+`urn:v1:*<eu|ca>*:identity:credential:*<xx11111-ovh>*/oauth2-*<clientId>*`
 
 #### Delete a service account
 
@@ -91,7 +91,7 @@ If you no longer use a service account, or want to permanently delete this acces
 > [!warning]
 >
 > Warning: this action is permanent. If you would like to cancel it, you will need to create a new service account and deploy the username/token pair within your application.
-> 
+>
 > To delete access, we recommend detaching all access policies from this service account. This action is reversible, and allows you to cancel in case of an error. Once you have ensured that this service account is not used in production, you can delete it without fear.
 >
 
@@ -143,7 +143,7 @@ This example can be used directly within the following call to create a new poli
 
 Service accounts are available in several APIs of our products. For each API, there is a guide:
 
-- [How to authenticate on the OVHcloud API with Oauth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
+- [How to authenticate on the OVHcloud API with OAuth2](/pages/account_and_service_management/account_information/authenticate-api-with-service-account)
 - [How to use service accounts to connect to OpenStack](/pages/manage_and_operate/iam/authenticate-api-openstack-with-service-account)
 
 ## Go further


### PR DESCRIPTION
Hello,

Here a few fixes for OAuth2 documentation pages.

Ready to be merged as soon as you like.
Thanks
Romain

cc @Alkorin 