### PR TITLE
S3 Object Storage - Getting started - "aws --configure" does not exist 

### DIFF
--- a/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage/guide.fr-fr.md
+++ b/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage/guide.fr-fr.md
@@ -44,7 +44,7 @@ Vous pouvez utiliser la configuration interactive pour générer les fichiers de
 > [!primary]
 >
 > Pour utiliser la configuration interactive en exécutant la commande suivante :
-> `aws --configure`
+> `aws configure`
 >
 
 Le format du fichier de configuration dans le client aws est le suivant :


### PR DESCRIPTION
Update guide.fr-fr.md aws --configure not exist, change to aws configure
[AWS cli docs https://docs.aws.amazon.com/cli/latest/topic/s3-config.html?highlight=configure ](https://docs.aws.amazon.com/cli/latest/topic/s3-config.html?highlight=configure)