### PR TITLE
LDP Roles and Permissions fixes

### DIFF
--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.de-de.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.de-de.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-asia.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-asia.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-au.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-au.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-ca.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-gb.md
@@ -51,13 +51,13 @@ Select the items you want to share in the role and they will switch from the **a
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager in the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+ In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, This member will see in their manager on the relevant pages the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when cliecking the `...`{.action} menu on their button.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that has been shared with them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-gb.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+ In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager in the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
 
 Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-gb.md
@@ -51,13 +51,13 @@ Select the items you want to share in the role and they will switch from the **a
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, This member will see in their manager on the relevant pages the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when cliecking the `...`{.action} menu on their button.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that has been shared with them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-ie.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-ie.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-sg.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-sg.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.en-us.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.es-es.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.es-es.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.es-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.es-us.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.fr-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.fr-ca.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.fr-fr.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.fr-fr.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.it-it.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.it-it.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.pl-pl.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.pl-pl.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.pt-pt.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_roles_permission/guide.pt-pt.md
@@ -6,7 +6,7 @@ updated: 2022-07-28
 
 ## Overview
 
-Logs policies are often decisions taken by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone share data in a easy and secure manner.
+Logs policies are often decisions made by an entire team, not individuals. Collaboration remains an utmost priority for Logs Data Platform, following this strategy it shall enable everyone to share data in a easy and secure manner.
 Log policies also affect several teams regarding access rights, for instance the Product managers can access some data but be denied to access security logs. That's why we decided to provide a [Role Based Access Control](https://en.wikipedia.org/wiki/Role-based_access_control){.external} to users to configure access rights. This document will expose you how you can use this system to configure access rights.
 
 ## Creating a Role
@@ -19,7 +19,7 @@ Once created you will be able to configure the role details: the permissions and
 
 ## Managing Permissions
 
-Click on the `...`{.action} button on the right to display the menu and head to manage permissions
+Click on the `...`{.action} button on the right to display the menu and head to manage permissions.
 
 ![menu\_permission](images/menu_permissions.png){.thumbnail}
 
@@ -37,27 +37,27 @@ Some items can be shared in read-only whereas others can be shared with a write 
 
 - **Data Stream**: Graylog Data Streams can only be shared **read-only** since logs are fully immutable.
 - **Dashboards**: Graylog Dashboards can be shared **read-only or read-write**. With the read-write access, the users in the role can add, modify and remove widgets of a dashboard.
-- **Index **: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
+- **Index**: OpenSearch indices can be shared **read-only or read-write**. With the read-write access, users in the role can add, modify and delete documents in the index. They can also alter the mapping.
 - **Aliases**: OpenSearch Aliases are **read-only**. They can only be used to read the data attached to them.
 - **OpenSearch Dashboards**: OpenSearch Dashboards can be shared **read-only or read-write**. If OpenSearch Dashboards is read-only, users have access to the OpenSearch Dashboards but cannot modify it. If OpenSearch Dashboards is read-write, they can modify the dashboards or the visualizations or any other OpenSearch Dashboards feature or setting.
 
 > [!primary]
 > Note that to give access to data (index or aliases) explored through OpenSearch Dashboards to a user, you need to give at least **read** rights to **both** the instance and to the data explored.
 
-Select the items you want to share in the role and they will switch from the **avalaible** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
+Select the items you want to share in the role and they will switch from the **available** column to the **selected** column. Go back to the **roles** page to manage the users in the defined role.
 
 ![menu\_permission](images/permissions_page.png){.thumbnail}
 
 ## Managing members
 
 To manage the members of a role, use the same `...`{.action} menu to navigate to the **Manage members** page. Click on `Add a member`{.action} to add a new member for this role.
- In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your manager int the **General** section. Any person who have a Logs Data Platform service can be added to the role even if their primary cluster is different from yours.
+In the username box you must add a **Logs Data Platform username**. The ldp username can be found in the **Home** panel of your OVHcloud Control Panel, in the **General** section. Any Logs Data Platform user can be added to the role even if their assignated cluster is different from yours.
 
-Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the **Shared** column. The available actions will be displayed to him in the `...`{.action} menu.
+Once a member has been added, this member will see (on the relevant pages of the Control Panel) the items that have been shared to them with an indication present on the **Shared** column. Their available actions will also be displayed when clieking the `...`{.action} button menu.
 
 ![menu\_permission](images/shared_stream.png){.thumbnail}
 
-A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them.
+A user can use their usual Logs Data Platform account credentials on a different cluster to access a shared item if it is not on their assignated cluster. If one user has access to items on another cluster, they can create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud account can create one or several accounts and they don't have to pay for data that has been shared with them.
 
 ## Using API
 


### PR DESCRIPTION
Other issues:

- Documentation link in "Go further" leads to an empty page.
- In the "Managing members" section, I think two paragraphs are worded in a confusing way. They are also gendered as "he".

"Once a member has been added, he will see the relevant page the item that have been shared to him with an indication on the Shared column. The available actions will be displayed to him in the ... menu."

"A user can access the shared items with his usual credentials whatever the cluster is. If one has access to items on another cluster, it shall be possible to create tokens for this new cluster access. As a reminder, creating an account on Logs Data Platform is free, any OVHcloud nic-handle can create one or several accounts and they don't have to pay for data that have been shared to them."