### PR TITLE
wrong wording: overhead instead of overload on SSE-S3 doc

### DIFF
--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.de-de.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Verschlüsseln Ihrer serverseitigen Objekte mit SSE-C oder SSE-S3 (EN)
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -283,7 +283,7 @@ When using SSE-S3 encryption on OVHcloud S3, it is important to consider the fol
 
 #### Performance
 
-- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+- **Overhead**: SSE-S3 encryption can introduce a slight overhead due to the encryption and decryption process. However, this overhead is usually minimal and does not significantly affect overall performance.
 
 #### Security
 
@@ -304,10 +304,15 @@ A comparative table may be useful for summarizing these elements, providing a cl
 | Encryption method | Benefits | Cons | Recommended Use Cases |
 |-------------------|----------|------|-----------------------|
 | **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE<br>- No additonal cost | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage<br>- No additonal cost | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
 
 Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+> [!primary]
+>
+> There are no additional fees for using server-side encryption with SSE-C or SSE-S3.
+>
 
 ### Recommended use cases for encryption on OVHcloud S3 Object Storage
 
@@ -388,23 +393,23 @@ aws s3api get-object \
 - **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
 - **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
 
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
 ### Bad query error when using SSE-S3
 
 - **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
 - **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
 
-### Performance or latency issues during encryption/decryption
+### Performance or latency issues during encryption/decryption with SSE-S3
 
-- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
-
-### In case of a loss of the SSE-C encryption key
-
-- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
 
 ## Conclusion
 
-This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with minimal operational overhead.
 
 The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-asia.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C or SSE-S3
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -283,7 +283,7 @@ When using SSE-S3 encryption on OVHcloud S3, it is important to consider the fol
 
 #### Performance
 
-- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+- **Overhead**: SSE-S3 encryption can introduce a slight overhead due to the encryption and decryption process. However, this overhead is usually minimal and does not significantly affect overall performance.
 
 #### Security
 
@@ -304,10 +304,15 @@ A comparative table may be useful for summarizing these elements, providing a cl
 | Encryption method | Benefits | Cons | Recommended Use Cases |
 |-------------------|----------|------|-----------------------|
 | **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE<br>- No additonal cost | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage<br>- No additonal cost | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
 
 Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+> [!primary]
+>
+> There are no additional fees for using server-side encryption with SSE-C or SSE-S3.
+>
 
 ### Recommended use cases for encryption on OVHcloud S3 Object Storage
 
@@ -388,23 +393,23 @@ aws s3api get-object \
 - **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
 - **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
 
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
 ### Bad query error when using SSE-S3
 
 - **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
 - **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
 
-### Performance or latency issues during encryption/decryption
+### Performance or latency issues during encryption/decryption with SSE-S3
 
-- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
-
-### In case of a loss of the SSE-C encryption key
-
-- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
 
 ## Conclusion
 
-This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with minimal operational overhead.
 
 The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-au.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C or SSE-S3
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -283,7 +283,7 @@ When using SSE-S3 encryption on OVHcloud S3, it is important to consider the fol
 
 #### Performance
 
-- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+- **Overhead**: SSE-S3 encryption can introduce a slight overhead due to the encryption and decryption process. However, this overhead is usually minimal and does not significantly affect overall performance.
 
 #### Security
 
@@ -304,10 +304,15 @@ A comparative table may be useful for summarizing these elements, providing a cl
 | Encryption method | Benefits | Cons | Recommended Use Cases |
 |-------------------|----------|------|-----------------------|
 | **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE<br>- No additonal cost | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage<br>- No additonal cost | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
 
 Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+> [!primary]
+>
+> There are no additional fees for using server-side encryption with SSE-C or SSE-S3.
+>
 
 ### Recommended use cases for encryption on OVHcloud S3 Object Storage
 
@@ -388,23 +393,23 @@ aws s3api get-object \
 - **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
 - **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
 
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
 ### Bad query error when using SSE-S3
 
 - **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
 - **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
 
-### Performance or latency issues during encryption/decryption
+### Performance or latency issues during encryption/decryption with SSE-S3
 
-- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
-
-### In case of a loss of the SSE-C encryption key
-
-- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
 
 ## Conclusion
 
-This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with minimal operational overhead.
 
 The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-ca.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C or SSE-S3
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -283,7 +283,7 @@ When using SSE-S3 encryption on OVHcloud S3, it is important to consider the fol
 
 #### Performance
 
-- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+- **Overhead**: SSE-S3 encryption can introduce a slight overhead due to the encryption and decryption process. However, this overhead is usually minimal and does not significantly affect overall performance.
 
 #### Security
 
@@ -304,10 +304,15 @@ A comparative table may be useful for summarizing these elements, providing a cl
 | Encryption method | Benefits | Cons | Recommended Use Cases |
 |-------------------|----------|------|-----------------------|
 | **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE<br>- No additonal cost | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage<br>- No additonal cost | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
 
 Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+> [!primary]
+>
+> There are no additional fees for using server-side encryption with SSE-C or SSE-S3.
+>
 
 ### Recommended use cases for encryption on OVHcloud S3 Object Storage
 
@@ -388,23 +393,23 @@ aws s3api get-object \
 - **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
 - **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
 
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
 ### Bad query error when using SSE-S3
 
 - **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
 - **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
 
-### Performance or latency issues during encryption/decryption
+### Performance or latency issues during encryption/decryption with SSE-S3
 
-- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
-
-### In case of a loss of the SSE-C encryption key
-
-- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
 
 ## Conclusion
 
-This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with minimal operational overhead.
 
 The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-gb.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C or SSE-S3
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -283,7 +283,7 @@ When using SSE-S3 encryption on OVHcloud S3, it is important to consider the fol
 
 #### Performance
 
-- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+- **Overhead**: SSE-S3 encryption can introduce a slight overhead due to the encryption and decryption process. However, this overhead is usually minimal and does not significantly affect overall performance.
 
 #### Security
 
@@ -304,10 +304,15 @@ A comparative table may be useful for summarizing these elements, providing a cl
 | Encryption method | Benefits | Cons | Recommended Use Cases |
 |-------------------|----------|------|-----------------------|
 | **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE<br>- No additonal cost | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage<br>- No additonal cost | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
 
 Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+> [!primary]
+>
+> There are no additional fees for using server-side encryption with SSE-C or SSE-S3.
+>
 
 ### Recommended use cases for encryption on OVHcloud S3 Object Storage
 
@@ -388,23 +393,23 @@ aws s3api get-object \
 - **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
 - **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
 
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
 ### Bad query error when using SSE-S3
 
 - **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
 - **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
 
-### Performance or latency issues during encryption/decryption
+### Performance or latency issues during encryption/decryption with SSE-S3
 
-- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
-
-### In case of a loss of the SSE-C encryption key
-
-- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
 
 ## Conclusion
 
-This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with minimal operational overhead.
 
 The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-ie.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-ie.md
@@ -283,7 +283,7 @@ When using SSE-S3 encryption on OVHcloud S3, it is important to consider the fol
 
 #### Performance
 
-- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+- **Overhead**: SSE-S3 encryption can introduce a slight overhead due to the encryption and decryption process. However, this overhead is usually minimal and does not significantly affect overall performance.
 
 #### Security
 
@@ -304,10 +304,15 @@ A comparative table may be useful for summarizing these elements, providing a cl
 | Encryption method | Benefits | Cons | Recommended Use Cases |
 |-------------------|----------|------|-----------------------|
 | **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE<br>- No additonal cost | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage<br>- No additonal cost | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
 
 Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+> [!primary]
+>
+> There are no additional fees for using server-side encryption with SSE-C or SSE-S3.
+>
 
 ### Recommended use cases for encryption on OVHcloud S3 Object Storage
 
@@ -388,23 +393,24 @@ aws s3api get-object \
 - **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
 - **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
 
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
 ### Bad query error when using SSE-S3
 
 - **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
 - **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
 
-### Performance or latency issues during encryption/decryption
+### Performance or latency issues during encryption/decryption with SSE-S3
 
-- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
 
-### In case of a loss of the SSE-C encryption key
-
-- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
 
 ## Conclusion
 
-This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with minimal operational overhead.
 
 The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-ie.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C or SSE-S3
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -406,7 +406,6 @@ aws s3api get-object \
 
 - **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
-
 
 ## Conclusion
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-sg.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C or SSE-S3
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -283,7 +283,7 @@ When using SSE-S3 encryption on OVHcloud S3, it is important to consider the fol
 
 #### Performance
 
-- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+- **Overhead**: SSE-S3 encryption can introduce a slight overhead due to the encryption and decryption process. However, this overhead is usually minimal and does not significantly affect overall performance.
 
 #### Security
 
@@ -304,10 +304,15 @@ A comparative table may be useful for summarizing these elements, providing a cl
 | Encryption method | Benefits | Cons | Recommended Use Cases |
 |-------------------|----------|------|-----------------------|
 | **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE<br>- No additonal cost | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage<br>- No additonal cost | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
 
 Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+> [!primary]
+>
+> There are no additional fees for using server-side encryption with SSE-C or SSE-S3.
+>
 
 ### Recommended use cases for encryption on OVHcloud S3 Object Storage
 
@@ -388,23 +393,23 @@ aws s3api get-object \
 - **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
 - **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
 
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
 ### Bad query error when using SSE-S3
 
 - **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
 - **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
 
-### Performance or latency issues during encryption/decryption
+### Performance or latency issues during encryption/decryption with SSE-S3
 
-- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
-
-### In case of a loss of the SSE-C encryption key
-
-- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
 
 ## Conclusion
 
-This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with minimal operational overhead.
 
 The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-us.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Encrypt your server-side objects with SSE-C or SSE-S3
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -283,7 +283,7 @@ When using SSE-S3 encryption on OVHcloud S3, it is important to consider the fol
 
 #### Performance
 
-- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+- **Overhead**: SSE-S3 encryption can introduce a slight overhead due to the encryption and decryption process. However, this overhead is usually minimal and does not significantly affect overall performance.
 
 #### Security
 
@@ -304,10 +304,15 @@ A comparative table may be useful for summarizing these elements, providing a cl
 | Encryption method | Benefits | Cons | Recommended Use Cases |
 |-------------------|----------|------|-----------------------|
 | **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE<br>- No additonal cost | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage<br>- No additonal cost | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
 
 Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+> [!primary]
+>
+> There are no additional fees for using server-side encryption with SSE-C or SSE-S3.
+>
 
 ### Recommended use cases for encryption on OVHcloud S3 Object Storage
 
@@ -388,23 +393,23 @@ aws s3api get-object \
 - **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
 - **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
 
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
 ### Bad query error when using SSE-S3
 
 - **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
 - **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
 
-### Performance or latency issues during encryption/decryption
+### Performance or latency issues during encryption/decryption with SSE-S3
 
-- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
-
-### In case of a loss of the SSE-C encryption key
-
-- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
 
 ## Conclusion
 
-This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with minimal operational overhead.
 
 The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.es-es.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Cifre sus objetos del lado del servidor con SSE-C o SSE-S3 (EN)
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -283,7 +283,7 @@ When using SSE-S3 encryption on OVHcloud S3, it is important to consider the fol
 
 #### Performance
 
-- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+- **Overhead**: SSE-S3 encryption can introduce a slight overhead due to the encryption and decryption process. However, this overhead is usually minimal and does not significantly affect overall performance.
 
 #### Security
 
@@ -304,10 +304,15 @@ A comparative table may be useful for summarizing these elements, providing a cl
 | Encryption method | Benefits | Cons | Recommended Use Cases |
 |-------------------|----------|------|-----------------------|
 | **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE<br>- No additonal cost | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage<br>- No additonal cost | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
 
 Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+> [!primary]
+>
+> There are no additional fees for using server-side encryption with SSE-C or SSE-S3.
+>
 
 ### Recommended use cases for encryption on OVHcloud S3 Object Storage
 
@@ -388,23 +393,23 @@ aws s3api get-object \
 - **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
 - **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
 
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
 ### Bad query error when using SSE-S3
 
 - **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
 - **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
 
-### Performance or latency issues during encryption/decryption
+### Performance or latency issues during encryption/decryption with SSE-S3
 
-- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
-
-### In case of a loss of the SSE-C encryption key
-
-- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
 
 ## Conclusion
 
-This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with minimal operational overhead.
 
 The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.es-us.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Cifre sus objetos del lado del servidor con SSE-C o SSE-S3 (EN)
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -283,7 +283,7 @@ When using SSE-S3 encryption on OVHcloud S3, it is important to consider the fol
 
 #### Performance
 
-- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+- **Overhead**: SSE-S3 encryption can introduce a slight overhead due to the encryption and decryption process. However, this overhead is usually minimal and does not significantly affect overall performance.
 
 #### Security
 
@@ -304,10 +304,15 @@ A comparative table may be useful for summarizing these elements, providing a cl
 | Encryption method | Benefits | Cons | Recommended Use Cases |
 |-------------------|----------|------|-----------------------|
 | **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE<br>- No additonal cost | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage<br>- No additonal cost | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
 
 Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+> [!primary]
+>
+> There are no additional fees for using server-side encryption with SSE-C or SSE-S3.
+>
 
 ### Recommended use cases for encryption on OVHcloud S3 Object Storage
 
@@ -388,23 +393,23 @@ aws s3api get-object \
 - **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
 - **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
 
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
 ### Bad query error when using SSE-S3
 
 - **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
 - **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
 
-### Performance or latency issues during encryption/decryption
+### Performance or latency issues during encryption/decryption with SSE-S3
 
-- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
-
-### In case of a loss of the SSE-C encryption key
-
-- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
 
 ## Conclusion
 
-This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with minimal operational overhead.
 
 The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-ca.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Chiffrez vos objets côté serveur avec SSE-C ou SSE-S3
 excerpt: Ce guide explique comment chiffrer vos objets côté serveur avec SSE-C ou SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -304,10 +304,15 @@ Un tableau comparatif peut être utile pour résumer ces éléments, offrant une
 | Méthode de Chiffrement | Avantages | Inconvénients | Cas d’Usage Recommandés |
 |------------------------|-----------|---------------|-------------------------|
 | **CSE (Client-Side Encryption)** | - Contrôle total sur les clés de chiffrement<br>- Sécurité maximisée car les clés ne quittent jamais le client | - Gestion complexe des clés<br>- Responsabilité complète de la sécurité des clés | - Scénarios nécessitant une conformité spécifique<br>- Haute sensibilité des données |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Maîtrise sur les clés de chiffrement<br>- Sécurité renforcée sans la complexité totale de CSE | - Nécessité de fournir les clés à chaque requête<br>- Gestion des clés plus complexe que SSE-S3 | - Conformité et contrôle sur les clés<br>- Besoins intermédiaires en sécurité |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simplicité de mise en œuvre<br>- Gestion des clés automatique par OVHcloud<br>- Transparence d'utilisation | - Moins de contrôle sur les clés de chiffrement par rapport à CSE et SSE-C | - Usage général où la facilité de gestion est prioritaire<br>- Données moins sensibles |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Maîtrise sur les clés de chiffrement<br>- Sécurité renforcée sans la complexité totale de CSE<br>- Aucun coût supplémentaire | - Nécessité de fournir les clés à chaque requête<br>- Gestion des clés plus complexe que SSE-S3 | - Conformité et contrôle sur les clés<br>- Besoins intermédiaires en sécurité |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simplicité de mise en œuvre<br>- Gestion des clés automatique par OVHcloud<br>- Transparence d'utilisation<br>- Aucun coût supplémentaire | - Moins de contrôle sur les clés de chiffrement par rapport à CSE et SSE-C | - Usage général où la facilité de gestion est prioritaire<br>- Données moins sensibles |
 
 Chaque méthode de chiffrement a ses propres forces et faiblesses. Le choix de la méthode dépend de plusieurs facteurs, notamment le niveau de sécurité requis, la complexité de la gestion des clés que vous êtes prêt à assumer, et les spécificités réglementaires ou de conformité auxquelles votre organisation doit adhérer.
+
+> [!primary]
+>
+> Il n’y a pas de frais supplémentaires pour l’utilisation du chiffrement côté serveur avec SSE-C ou SSE-S3.
+>
 
 ### Cas d'usage recommandés pour le chiffrement sur OVHcloud S3 Object Storage
 
@@ -388,14 +393,18 @@ aws s3api get-object \
 - **En-têtes nécessaires** : assurez-vous que les en-têtes `--sse-customer-algorithm`, `--sse-customer-key`, et `--sse-customer-key-md5` sont inclus correctement dans votre commande.
 - **Vérification de la clé**: Confirmez que la clé de chiffrement est exacte et n'a subi aucune modification ou altération depuis son utilisation pour chiffrer l'objet.
 
+### En cas de perte de la clé de chiffrement SSE-C
+
+- **Récupération impossible** : Si la clé de chiffrement est perdue, il n'est pas possible de récupérer les données chiffrées avec SSE-C. Conservez vos clés en lieu sûr et envisagez d'utiliser des services de gestion des clés pour améliorer la sécurité.
+
 ### Erreur de requête incorrecte lors de l'utilisation de SSE-S3
 
 - **Sans en-têtes spécifiques** : pour SSE-S3, évitez de spécifier des en-têtes de chiffrement lors du téléchargement. L'option `--server-side-encryption AES256` suffit.
 - **Vérification de la méthode de chiffrement**: assurez-vous que l'objet n'a pas été chiffré initialement avec une méthode différente.
 
-### Problèmes de performance ou de latence lors du chiffrement/déchiffrement
+### Problèmes de performance ou de latence lors du chiffrement/déchiffrement avec SSE-S3
 
-- **Surcharge potentielle** : le chiffrement et le déchiffrement peuvent causer une surcharge. Vérifiez que votre infrastructure réseau et système est capable de gérer cette charge additionnelle.
+- **Surcharge potentielle** : le chiffrement et le déchiffrement peuvent causer une surcharge.
 - **Optimisation de performance** : pour améliorer les performances, réalisez le chiffrement et le déchiffrement dans une région géographique proche de votre localisation pour minimiser la latence.
 
 ### En cas de perte de la clé de chiffrement SSE-C
@@ -404,7 +413,7 @@ aws s3api get-object \
 
 ## Conclusion
 
-Cette documentation met en évidence notre engagement à fournir des solutions de sécurité des données avancées. Que vous optiez pour le chiffrement côté client (CSE) ou côté serveur (SSE-S3), notre objectif est de vous offrir une sécurité optimale sans surcharge opérationnelle.
+Cette documentation met en évidence notre engagement à fournir des solutions de sécurité des données avancées. Que vous optiez pour le chiffrement côté client (CSE) ou côté serveur (SSE-S3), notre objectif est de vous offrir une sécurité optimale avec une surcharge opérationnell minimale.
 
 L'OVHcloud Key Management Service (KMS) témoigne de notre engagement dans la sécurisation de vos données, offrant une protection complète sans les complexités de gestion directe des clés. Nous encourageons l'adoption de ces pratiques de chiffrement pour sécuriser vos données au repos, vous fournissant les outils et les connaissances nécessaires pour une mise en œuvre efficace. OVHcloud est à votre disposition pour toute assistance supplémentaire concernant le chiffrement et la sécurité des données. N'hésitez pas à consulter nos ressources supplémentaires ou à contacter notre support technique pour toute clarification ou assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-ca.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-ca.md
@@ -283,7 +283,7 @@ Lors de l'utilisation du chiffrement SSE-S3 sur OVHcloud S3, il est important de
 
 #### Performances
 
-- **Surcharge** : le chiffrement SSE-S3 peut introduire une légère surcharge due au processus de chiffrement et de déchiffrement. Cependant, cette surcharge est généralement minime et n'affecte pas significativement les performances globales.
+- ***Overhead*** : le chiffrement SSE-S3 peut introduire un léger *overhead* dû au processus de chiffrement et de déchiffrement. Cependant, cet *overhead* est généralement minime et n'affecte pas significativement les performances globales.
 
 #### Sécurité
 
@@ -404,7 +404,7 @@ aws s3api get-object \
 
 ### Problèmes de performance ou de latence lors du chiffrement/déchiffrement avec SSE-S3
 
-- **Surcharge potentielle** : le chiffrement et le déchiffrement peuvent causer une surcharge.
+- ***Overhead* potentiel** : le chiffrement et le déchiffrement peuvent causer un *overhead*.
 - **Optimisation de performance** : pour améliorer les performances, réalisez le chiffrement et le déchiffrement dans une région géographique proche de votre localisation pour minimiser la latence.
 
 ### En cas de perte de la clé de chiffrement SSE-C
@@ -413,7 +413,7 @@ aws s3api get-object \
 
 ## Conclusion
 
-Cette documentation met en évidence notre engagement à fournir des solutions de sécurité des données avancées. Que vous optiez pour le chiffrement côté client (CSE) ou côté serveur (SSE-S3), notre objectif est de vous offrir une sécurité optimale avec une surcharge opérationnell minimale.
+Cette documentation met en évidence notre engagement à fournir des solutions de sécurité des données avancées. Que vous optiez pour le chiffrement côté client (CSE) ou côté serveur (SSE-S3), notre objectif est de vous offrir une sécurité optimale avec un *overhead* opérationnel minimal.
 
 L'OVHcloud Key Management Service (KMS) témoigne de notre engagement dans la sécurisation de vos données, offrant une protection complète sans les complexités de gestion directe des clés. Nous encourageons l'adoption de ces pratiques de chiffrement pour sécuriser vos données au repos, vous fournissant les outils et les connaissances nécessaires pour une mise en œuvre efficace. OVHcloud est à votre disposition pour toute assistance supplémentaire concernant le chiffrement et la sécurité des données. N'hésitez pas à consulter nos ressources supplémentaires ou à contacter notre support technique pour toute clarification ou assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
@@ -284,7 +284,7 @@ Lors de l'utilisation du chiffrement SSE-S3 sur OVHcloud S3, il est important de
 
 #### Performances
 
-- **Surcharge** : le chiffrement SSE-S3 peut introduire une légère surcharge due au processus de chiffrement et de déchiffrement. Cependant, cette surcharge est généralement minime et n'affecte pas significativement les performances globales.
+- ***Overhead*** : le chiffrement SSE-S3 peut introduire un léger *overhead* dû au processus de chiffrement et de déchiffrement. Cependant, cet *overhead* est généralement minime et n'affecte pas significativement les performances globales.
 
 #### Sécurité
 
@@ -405,7 +405,7 @@ aws s3api get-object \
 
 ### Problèmes de performance ou de latence lors du chiffrement/déchiffrement avec SSE-S3
 
-- **Surcharge potentielle** : le chiffrement et le déchiffrement peuvent causer une surcharge.
+- ***Overhead* potentiel** : le chiffrement et le déchiffrement peuvent causer un *overhead*.
 - **Optimisation de performance** : pour améliorer les performances, réalisez le chiffrement et le déchiffrement dans une région géographique proche de votre localisation pour minimiser la latence.
 
 ### En cas de perte de la clé de chiffrement SSE-C
@@ -414,7 +414,7 @@ aws s3api get-object \
 
 ## Conclusion
 
-Cette documentation met en évidence notre engagement à fournir des solutions de sécurité des données avancées. Que vous optiez pour le chiffrement côté client (CSE) ou côté serveur (SSE-S3), notre objectif est de vous offrir une sécurité optimale avec une surcharge opérationnell minimale.
+Cette documentation met en évidence notre engagement à fournir des solutions de sécurité des données avancées. Que vous optiez pour le chiffrement côté client (CSE) ou côté serveur (SSE-S3), notre objectif est de vous offrir une sécurité optimale avec un *overhead* opérationnel minimal.
 
 L'OVHcloud Key Management Service (KMS) témoigne de notre engagement dans la sécurisation de vos données, offrant une protection complète sans les complexités de gestion directe des clés. Nous encourageons l'adoption de ces pratiques de chiffrement pour sécuriser vos données au repos, vous fournissant les outils et les connaissances nécessaires pour une mise en œuvre efficace. OVHcloud est à votre disposition pour toute assistance supplémentaire concernant le chiffrement et la sécurité des données. N'hésitez pas à consulter nos ressources supplémentaires ou à contacter notre support technique pour toute clarification ou assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Chiffrez vos objets côté serveur avec SSE-C ou SSE-S3
 excerpt: Ce guide explique comment chiffrer vos objets côté serveur avec SSE-C ou SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -305,10 +305,15 @@ Un tableau comparatif peut être utile pour résumer ces éléments, offrant une
 | Méthode de Chiffrement | Avantages | Inconvénients | Cas d’Usage Recommandés |
 |------------------------|-----------|---------------|-------------------------|
 | **CSE (Client-Side Encryption)** | - Contrôle total sur les clés de chiffrement<br>- Sécurité maximisée car les clés ne quittent jamais le client | - Gestion complexe des clés<br>- Responsabilité complète de la sécurité des clés | - Scénarios nécessitant une conformité spécifique<br>- Haute sensibilité des données |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Maîtrise sur les clés de chiffrement<br>- Sécurité renforcée sans la complexité totale de CSE | - Nécessité de fournir les clés à chaque requête<br>- Gestion des clés plus complexe que SSE-S3 | - Conformité et contrôle sur les clés<br>- Besoins intermédiaires en sécurité |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simplicité de mise en œuvre<br>- Gestion des clés automatique par OVHcloud<br>- Transparence d'utilisation | - Moins de contrôle sur les clés de chiffrement par rapport à CSE et SSE-C | - Usage général où la facilité de gestion est prioritaire<br>- Données moins sensibles |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Maîtrise sur les clés de chiffrement<br>- Sécurité renforcée sans la complexité totale de CSE<br>- Aucun coût supplémentaire | - Nécessité de fournir les clés à chaque requête<br>- Gestion des clés plus complexe que SSE-S3 | - Conformité et contrôle sur les clés<br>- Besoins intermédiaires en sécurité |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simplicité de mise en œuvre<br>- Gestion des clés automatique par OVHcloud<br>- Transparence d'utilisation<br>- Aucun coût supplémentaire | - Moins de contrôle sur les clés de chiffrement par rapport à CSE et SSE-C | - Usage général où la facilité de gestion est prioritaire<br>- Données moins sensibles |
 
 Chaque méthode de chiffrement a ses propres forces et faiblesses. Le choix de la méthode dépend de plusieurs facteurs, notamment le niveau de sécurité requis, la complexité de la gestion des clés que vous êtes prêt à assumer, et les spécificités réglementaires ou de conformité auxquelles votre organisation doit adhérer.
+
+> [!primary]
+>
+> Il n’y a pas de frais supplémentaires pour l’utilisation du chiffrement côté serveur avec SSE-C ou SSE-S3.
+>
 
 ### Cas d'usage recommandés pour le chiffrement sur OVHcloud S3 Object Storage
 
@@ -389,14 +394,18 @@ aws s3api get-object \
 - **En-têtes nécessaires** : assurez-vous que les en-têtes `--sse-customer-algorithm`, `--sse-customer-key`, et `--sse-customer-key-md5` sont inclus correctement dans votre commande.
 - **Vérification de la clé**: Confirmez que la clé de chiffrement est exacte et n'a subi aucune modification ou altération depuis son utilisation pour chiffrer l'objet.
 
+### En cas de perte de la clé de chiffrement SSE-C
+
+- **Récupération impossible** : Si la clé de chiffrement est perdue, il n'est pas possible de récupérer les données chiffrées avec SSE-C. Conservez vos clés en lieu sûr et envisagez d'utiliser des services de gestion des clés pour améliorer la sécurité.
+
 ### Erreur de requête incorrecte lors de l'utilisation de SSE-S3
 
 - **Sans en-têtes spécifiques** : pour SSE-S3, évitez de spécifier des en-têtes de chiffrement lors du téléchargement. L'option `--server-side-encryption AES256` suffit.
 - **Vérification de la méthode de chiffrement**: assurez-vous que l'objet n'a pas été chiffré initialement avec une méthode différente.
 
-### Problèmes de performance ou de latence lors du chiffrement/déchiffrement
+### Problèmes de performance ou de latence lors du chiffrement/déchiffrement avec SSE-S3
 
-- **Surcharge potentielle** : le chiffrement et le déchiffrement peuvent causer une surcharge. Vérifiez que votre infrastructure réseau et système est capable de gérer cette charge additionnelle.
+- **Surcharge potentielle** : le chiffrement et le déchiffrement peuvent causer une surcharge.
 - **Optimisation de performance** : pour améliorer les performances, réalisez le chiffrement et le déchiffrement dans une région géographique proche de votre localisation pour minimiser la latence.
 
 ### En cas de perte de la clé de chiffrement SSE-C
@@ -405,7 +414,7 @@ aws s3api get-object \
 
 ## Conclusion
 
-Cette documentation met en évidence notre engagement à fournir des solutions de sécurité des données avancées. Que vous optiez pour le chiffrement côté client (CSE) ou côté serveur (SSE-S3), notre objectif est de vous offrir une sécurité optimale sans surcharge opérationnelle.
+Cette documentation met en évidence notre engagement à fournir des solutions de sécurité des données avancées. Que vous optiez pour le chiffrement côté client (CSE) ou côté serveur (SSE-S3), notre objectif est de vous offrir une sécurité optimale avec une surcharge opérationnell minimale.
 
 L'OVHcloud Key Management Service (KMS) témoigne de notre engagement dans la sécurisation de vos données, offrant une protection complète sans les complexités de gestion directe des clés. Nous encourageons l'adoption de ces pratiques de chiffrement pour sécuriser vos données au repos, vous fournissant les outils et les connaissances nécessaires pour une mise en œuvre efficace. OVHcloud est à votre disposition pour toute assistance supplémentaire concernant le chiffrement et la sécurité des données. N'hésitez pas à consulter nos ressources supplémentaires ou à contacter notre support technique pour toute clarification ou assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.it-it.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Crittografa i tuoi oggetti lato server con SSE-C o SSE-S3 (EN)
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -283,7 +283,7 @@ When using SSE-S3 encryption on OVHcloud S3, it is important to consider the fol
 
 #### Performance
 
-- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+- **Overhead**: SSE-S3 encryption can introduce a slight overhead due to the encryption and decryption process. However, this overhead is usually minimal and does not significantly affect overall performance.
 
 #### Security
 
@@ -304,10 +304,15 @@ A comparative table may be useful for summarizing these elements, providing a cl
 | Encryption method | Benefits | Cons | Recommended Use Cases |
 |-------------------|----------|------|-----------------------|
 | **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE<br>- No additonal cost | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage<br>- No additonal cost | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
 
 Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+> [!primary]
+>
+> There are no additional fees for using server-side encryption with SSE-C or SSE-S3.
+>
 
 ### Recommended use cases for encryption on OVHcloud S3 Object Storage
 
@@ -388,23 +393,23 @@ aws s3api get-object \
 - **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
 - **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
 
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
 ### Bad query error when using SSE-S3
 
 - **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
 - **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
 
-### Performance or latency issues during encryption/decryption
+### Performance or latency issues during encryption/decryption with SSE-S3
 
-- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
-
-### In case of a loss of the SSE-C encryption key
-
-- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
 
 ## Conclusion
 
-This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with minimal operational overhead.
 
 The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.pl-pl.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Szyfruj obiekty po stronie serwera za pomocą SSE-C lub SSE-S3 (EN)
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -283,7 +283,7 @@ When using SSE-S3 encryption on OVHcloud S3, it is important to consider the fol
 
 #### Performance
 
-- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+- **Overhead**: SSE-S3 encryption can introduce a slight overhead due to the encryption and decryption process. However, this overhead is usually minimal and does not significantly affect overall performance.
 
 #### Security
 
@@ -304,10 +304,15 @@ A comparative table may be useful for summarizing these elements, providing a cl
 | Encryption method | Benefits | Cons | Recommended Use Cases |
 |-------------------|----------|------|-----------------------|
 | **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE<br>- No additonal cost | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage<br>- No additonal cost | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
 
 Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+> [!primary]
+>
+> There are no additional fees for using server-side encryption with SSE-C or SSE-S3.
+>
 
 ### Recommended use cases for encryption on OVHcloud S3 Object Storage
 
@@ -388,23 +393,23 @@ aws s3api get-object \
 - **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
 - **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
 
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
 ### Bad query error when using SSE-S3
 
 - **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
 - **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
 
-### Performance or latency issues during encryption/decryption
+### Performance or latency issues during encryption/decryption with SSE-S3
 
-- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
-
-### In case of a loss of the SSE-C encryption key
-
-- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
 
 ## Conclusion
 
-This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with minimal operational overhead.
 
 The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 

--- a/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.pt-pt.md
+++ b/pages/storage_and_backup/object_storage/s3_encrypt_your_objects_with_sse_c/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Criptografe seus objetos do lado do servidor com SSE-C ou SSE-S3 (EN)
 excerpt: This guide explains how to encrypt your server-side objects with SSE-C or SSE-S3
-updated: 2024-04-10
+updated: 2024-04-17
 ---
 
 <style>
@@ -283,7 +283,7 @@ When using SSE-S3 encryption on OVHcloud S3, it is important to consider the fol
 
 #### Performance
 
-- **Overload**: SSE-S3 encryption can introduce a slight overload due to the encryption and decryption process. However, this overload is usually minimal and does not significantly affect overall performance.
+- **Overhead**: SSE-S3 encryption can introduce a slight overhead due to the encryption and decryption process. However, this overhead is usually minimal and does not significantly affect overall performance.
 
 #### Security
 
@@ -304,10 +304,15 @@ A comparative table may be useful for summarizing these elements, providing a cl
 | Encryption method | Benefits | Cons | Recommended Use Cases |
 |-------------------|----------|------|-----------------------|
 | **CSE (Client-Side Encryption)** | - Full control over encryption keys<br>- Maximized security because keys never leave the client | - Complex key management<br>- Full responsibility for key security | - Scenarios requiring specific compliance<br>- High data sensitivity |
-| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
-| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
+| **SSE-C (Server-Side Encryption with Customer Keys)** | - Control over encryption keys<br>- Enhanced security without the total complexity of CSE<br>- No additonal cost | - Need to provide keys at each request<br>- More complex key management than SSE-S3 | - Compliance and key control<br>- Intermediate security needs |
+| **SSE-S3 (Server-Side Encryption with OVHcloud-Managed Keys)** | - Simple to implement<br>- Automatic key management by OVHcloud<br>- Transparent usage<br>- No additonal cost | - Less control over encryption keys compared to CSE and SSE-C | - General purpose where manageability is paramount<br>- Less sensitive data |
 
 Each encryption method has its own strengths and weaknesses. The choice of method depends on several factors, including the level of security required, the complexity of managing the keys you are willing to assume, and the regulatory or compliance specifics your organization must adhere to.
+
+> [!primary]
+>
+> There are no additional fees for using server-side encryption with SSE-C or SSE-S3.
+>
 
 ### Recommended use cases for encryption on OVHcloud S3 Object Storage
 
@@ -388,23 +393,23 @@ aws s3api get-object \
 - **Required headers**: ensure that the headers `--sse-customer-algorithm`, `--sse-customer-key`, and `--sse-customer-key-md5` are correctly included in your order.
 - **Key verification**: Confirm that the encryption key is correct and has not been modified or altered since it was used to encrypt the object.
 
+### In case of a loss of the SSE-C encryption key
+
+- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
+
 ### Bad query error when using SSE-S3
 
 - **Without specific headers**: For SSE-S3, avoid specifying encryption headers during download. The `--server-side-encryption AES256` option is sufficient.
 - **Verifying encryption method**: Make sure the object was not originally encrypted with a different method.
 
-### Performance or latency issues during encryption/decryption
+### Performance or latency issues during encryption/decryption with SSE-S3
 
-- **Potential overload**: Encryption and decryption may cause overload. Verify that your network and system infrastructure is capable of handling this additional load.
+- **Potential overhead**: Encryption and decryption may cause a slight overhead.
 - **Performance Optimization**: To improve performance, perform encryption and decryption in a geographical region close to your location to minimize latency.
-
-### In case of a loss of the SSE-C encryption key
-
-- **Cannot Recover**: If the encryption key is lost, it is not possible to recover data encrypted with SSE-C. Keep your keys in a safe place and consider using key management services to improve security.
 
 ## Conclusion
 
-This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with no operational overload.
+This documentation highlights our commitment to providing advanced data security solutions. Whether you opt for client-side (CSE) or server-side (SSE-S3) encryption, our goal is to offer you optimal security with minimal operational overhead.
 
 The OVHcloud Key Management Service (KMS) is a testament to our commitment to securing your data, offering comprehensive protection without the complexities of direct key management. We encourage the adoption of these encryption practices to secure your data at rest, providing you with the tools and knowledge necessary for effective implementation. OVHcloud is here to help with any additional support regarding data encryption and security. Please refer to our additional resources or contact our technical support team for any clarification or assistance.
 


### PR DESCRIPTION
- wrong wording: overhead instead of overload
- additonal info about pricing: SSE-C and SSE-S3 enquires no additional feed