### PR TITLE
VCD Docs fix - naming / missing section

### DIFF
--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.de-de.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.de-de.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ (EN)"
-excerpt: "Frequently asked questions on vCD"
+excerpt: "Frequently asked questions on VCD"
 updated: 2024-04-16
 ---
 
@@ -10,13 +10,13 @@ updated: 2024-04-16
 
 ### What is VMware Cloud Director by OVHcloud ?
 
-This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.   
+This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.
 
 VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 - VCD Standard, providing the standard VMware stack virtualization capabilities.
-- VCD Advanced, including advanced networking & security capabilities on top of the standard tier. 
-- VCD Premium, adding high-performance vSAN storage to the Advanced tier. 
+- VCD Advanced, including advanced networking & security capabilities on top of the standard tier.
+- VCD Premium, adding high-performance vSAN storage to the Advanced tier.
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
@@ -24,7 +24,7 @@ Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cl
 
 ### How migration will be done by OVHcloud ?
 
-If you choose to migrate to VCD, OVHcloud will be handling the migration for you. 
+If you choose to migrate to VCD, OVHcloud will be handling the migration for you.
 
 As an exception, we won’t be charging the new current server/host prices during the migration process. We’ll absorb the costs of the license price increase while the migration is ongoing. Whether or not you choose to continue using the current solution, you will still benefit from the new VCD prices right away, starting on May 1st 2024.
 
@@ -63,9 +63,9 @@ With VMware Cloud Director, you are able to set group affinity for Virtual Machi
 
 ### Which certifications apply to the new VCD service ?
 
-At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service. 
+At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service.
 
-However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives. 
+However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.de-de.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.de-de.md
@@ -6,7 +6,7 @@ updated: 2024-04-16
 
 ## FAQ
 
-<a name="vDConOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### What is VMware Cloud Director by OVHcloud ?
 
@@ -20,7 +20,7 @@ VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### How migration will be done by OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-asia.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-asia.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ"
-excerpt: "Frequently asked questions on vCD"
+excerpt: "Frequently asked questions on VCD"
 updated: 2024-04-16
 ---
 
@@ -10,13 +10,13 @@ updated: 2024-04-16
 
 ### What is VMware Cloud Director by OVHcloud ?
 
-This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.   
+This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.
 
 VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 - VCD Standard, providing the standard VMware stack virtualization capabilities.
-- VCD Advanced, including advanced networking & security capabilities on top of the standard tier. 
-- VCD Premium, adding high-performance vSAN storage to the Advanced tier. 
+- VCD Advanced, including advanced networking & security capabilities on top of the standard tier.
+- VCD Premium, adding high-performance vSAN storage to the Advanced tier.
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
@@ -24,7 +24,7 @@ Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cl
 
 ### How migration will be done by OVHcloud ?
 
-If you choose to migrate to VCD, OVHcloud will be handling the migration for you. 
+If you choose to migrate to VCD, OVHcloud will be handling the migration for you.
 
 As an exception, we won’t be charging the new current server/host prices during the migration process. We’ll absorb the costs of the license price increase while the migration is ongoing. Whether or not you choose to continue using the current solution, you will still benefit from the new VCD prices right away, starting on May 1st 2024.
 
@@ -63,9 +63,9 @@ With VMware Cloud Director, you are able to set group affinity for Virtual Machi
 
 ### Which certifications apply to the new VCD service ?
 
-At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service. 
+At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service.
 
-However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives. 
+However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-asia.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-asia.md
@@ -6,7 +6,7 @@ updated: 2024-04-16
 
 ## FAQ
 
-<a name="vDConOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### What is VMware Cloud Director by OVHcloud ?
 
@@ -20,7 +20,7 @@ VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### How migration will be done by OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-au.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-au.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ"
-excerpt: "Frequently asked questions on vCD"
+excerpt: "Frequently asked questions on VCD"
 updated: 2024-04-16
 ---
 
@@ -10,13 +10,13 @@ updated: 2024-04-16
 
 ### What is VMware Cloud Director by OVHcloud ?
 
-This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.   
+This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.
 
 VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 - VCD Standard, providing the standard VMware stack virtualization capabilities.
-- VCD Advanced, including advanced networking & security capabilities on top of the standard tier. 
-- VCD Premium, adding high-performance vSAN storage to the Advanced tier. 
+- VCD Advanced, including advanced networking & security capabilities on top of the standard tier.
+- VCD Premium, adding high-performance vSAN storage to the Advanced tier.
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
@@ -24,7 +24,7 @@ Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cl
 
 ### How migration will be done by OVHcloud ?
 
-If you choose to migrate to VCD, OVHcloud will be handling the migration for you. 
+If you choose to migrate to VCD, OVHcloud will be handling the migration for you.
 
 As an exception, we won’t be charging the new current server/host prices during the migration process. We’ll absorb the costs of the license price increase while the migration is ongoing. Whether or not you choose to continue using the current solution, you will still benefit from the new VCD prices right away, starting on May 1st 2024.
 
@@ -63,9 +63,9 @@ With VMware Cloud Director, you are able to set group affinity for Virtual Machi
 
 ### Which certifications apply to the new VCD service ?
 
-At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service. 
+At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service.
 
-However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives. 
+However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-au.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-au.md
@@ -6,7 +6,7 @@ updated: 2024-04-16
 
 ## FAQ
 
-<a name="vDConOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### What is VMware Cloud Director by OVHcloud ?
 
@@ -20,7 +20,7 @@ VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### How migration will be done by OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-ca.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ"
-excerpt: "Frequently asked questions on vCD"
+excerpt: "Frequently asked questions on VCD"
 updated: 2024-04-16
 ---
 
@@ -10,13 +10,13 @@ updated: 2024-04-16
 
 ### What is VMware Cloud Director by OVHcloud ?
 
-This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.   
+This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.
 
 VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 - VCD Standard, providing the standard VMware stack virtualization capabilities.
-- VCD Advanced, including advanced networking & security capabilities on top of the standard tier. 
-- VCD Premium, adding high-performance vSAN storage to the Advanced tier. 
+- VCD Advanced, including advanced networking & security capabilities on top of the standard tier.
+- VCD Premium, adding high-performance vSAN storage to the Advanced tier.
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
@@ -24,7 +24,7 @@ Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cl
 
 ### How migration will be done by OVHcloud ?
 
-If you choose to migrate to VCD, OVHcloud will be handling the migration for you. 
+If you choose to migrate to VCD, OVHcloud will be handling the migration for you.
 
 As an exception, we won’t be charging the new current server/host prices during the migration process. We’ll absorb the costs of the license price increase while the migration is ongoing. Whether or not you choose to continue using the current solution, you will still benefit from the new VCD prices right away, starting on May 1st 2024.
 
@@ -63,9 +63,9 @@ With VMware Cloud Director, you are able to set group affinity for Virtual Machi
 
 ### Which certifications apply to the new VCD service ?
 
-At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service. 
+At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service.
 
-However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives. 
+However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-ca.md
@@ -6,7 +6,7 @@ updated: 2024-04-16
 
 ## FAQ
 
-<a name="vDConOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### What is VMware Cloud Director by OVHcloud ?
 
@@ -20,7 +20,7 @@ VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### How migration will be done by OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-gb.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-gb.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ"
-excerpt: "Frequently asked questions on vCD"
+excerpt: "Frequently asked questions on VCD"
 updated: 2024-04-16
 ---
 
@@ -10,13 +10,13 @@ updated: 2024-04-16
 
 ### What is VMware Cloud Director by OVHcloud ?
 
-This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.   
+This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.
 
 VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 - VCD Standard, providing the standard VMware stack virtualization capabilities.
-- VCD Advanced, including advanced networking & security capabilities on top of the standard tier. 
-- VCD Premium, adding high-performance vSAN storage to the Advanced tier. 
+- VCD Advanced, including advanced networking & security capabilities on top of the standard tier.
+- VCD Premium, adding high-performance vSAN storage to the Advanced tier.
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
@@ -24,7 +24,7 @@ Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cl
 
 ### How migration will be done by OVHcloud ?
 
-If you choose to migrate to VCD, OVHcloud will be handling the migration for you. 
+If you choose to migrate to VCD, OVHcloud will be handling the migration for you.
 
 As an exception, we won’t be charging the new current server/host prices during the migration process. We’ll absorb the costs of the license price increase while the migration is ongoing. Whether or not you choose to continue using the current solution, you will still benefit from the new VCD prices right away, starting on May 1st 2024.
 
@@ -63,9 +63,9 @@ With VMware Cloud Director, you are able to set group affinity for Virtual Machi
 
 ### Which certifications apply to the new VCD service ?
 
-At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service. 
+At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service.
 
-However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives. 
+However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-gb.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-gb.md
@@ -6,7 +6,7 @@ updated: 2024-04-16
 
 ## FAQ
 
-<a name="vDConOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### What is VMware Cloud Director by OVHcloud ?
 
@@ -20,7 +20,7 @@ VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### How migration will be done by OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-ie.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-ie.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ"
-excerpt: "Frequently asked questions on vCD"
+excerpt: "Frequently asked questions on VCD"
 updated: 2024-04-16
 ---
 
@@ -10,13 +10,13 @@ updated: 2024-04-16
 
 ### What is VMware Cloud Director by OVHcloud ?
 
-This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.   
+This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.
 
 VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 - VCD Standard, providing the standard VMware stack virtualization capabilities.
-- VCD Advanced, including advanced networking & security capabilities on top of the standard tier. 
-- VCD Premium, adding high-performance vSAN storage to the Advanced tier. 
+- VCD Advanced, including advanced networking & security capabilities on top of the standard tier.
+- VCD Premium, adding high-performance vSAN storage to the Advanced tier.
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
@@ -24,7 +24,7 @@ Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cl
 
 ### How migration will be done by OVHcloud ?
 
-If you choose to migrate to VCD, OVHcloud will be handling the migration for you. 
+If you choose to migrate to VCD, OVHcloud will be handling the migration for you.
 
 As an exception, we won’t be charging the new current server/host prices during the migration process. We’ll absorb the costs of the license price increase while the migration is ongoing. Whether or not you choose to continue using the current solution, you will still benefit from the new VCD prices right away, starting on May 1st 2024.
 
@@ -63,9 +63,9 @@ With VMware Cloud Director, you are able to set group affinity for Virtual Machi
 
 ### Which certifications apply to the new VCD service ?
 
-At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service. 
+At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service.
 
-However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives. 
+However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-ie.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-ie.md
@@ -6,7 +6,7 @@ updated: 2024-04-16
 
 ## FAQ
 
-<a name="vDConOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### What is VMware Cloud Director by OVHcloud ?
 
@@ -20,7 +20,7 @@ VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### How migration will be done by OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-sg.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-sg.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ"
-excerpt: "Frequently asked questions on vCD"
+excerpt: "Frequently asked questions on VCD"
 updated: 2024-04-16
 ---
 
@@ -10,13 +10,13 @@ updated: 2024-04-16
 
 ### What is VMware Cloud Director by OVHcloud ?
 
-This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.   
+This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.
 
 VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 - VCD Standard, providing the standard VMware stack virtualization capabilities.
-- VCD Advanced, including advanced networking & security capabilities on top of the standard tier. 
-- VCD Premium, adding high-performance vSAN storage to the Advanced tier. 
+- VCD Advanced, including advanced networking & security capabilities on top of the standard tier.
+- VCD Premium, adding high-performance vSAN storage to the Advanced tier.
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
@@ -24,7 +24,7 @@ Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cl
 
 ### How migration will be done by OVHcloud ?
 
-If you choose to migrate to VCD, OVHcloud will be handling the migration for you. 
+If you choose to migrate to VCD, OVHcloud will be handling the migration for you.
 
 As an exception, we won’t be charging the new current server/host prices during the migration process. We’ll absorb the costs of the license price increase while the migration is ongoing. Whether or not you choose to continue using the current solution, you will still benefit from the new VCD prices right away, starting on May 1st 2024.
 
@@ -63,9 +63,9 @@ With VMware Cloud Director, you are able to set group affinity for Virtual Machi
 
 ### Which certifications apply to the new VCD service ?
 
-At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service. 
+At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service.
 
-However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives. 
+However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-sg.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-sg.md
@@ -6,7 +6,7 @@ updated: 2024-04-16
 
 ## FAQ
 
-<a name="vDConOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### What is VMware Cloud Director by OVHcloud ?
 
@@ -20,7 +20,7 @@ VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### How migration will be done by OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-us.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ"
-excerpt: "Frequently asked questions on vCD"
+excerpt: "Frequently asked questions on VCD"
 updated: 2024-04-16
 ---
 
@@ -10,13 +10,13 @@ updated: 2024-04-16
 
 ### What is VMware Cloud Director by OVHcloud ?
 
-This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.   
+This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.
 
 VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 - VCD Standard, providing the standard VMware stack virtualization capabilities.
-- VCD Advanced, including advanced networking & security capabilities on top of the standard tier. 
-- VCD Premium, adding high-performance vSAN storage to the Advanced tier. 
+- VCD Advanced, including advanced networking & security capabilities on top of the standard tier.
+- VCD Premium, adding high-performance vSAN storage to the Advanced tier.
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
@@ -24,7 +24,7 @@ Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cl
 
 ### How migration will be done by OVHcloud ?
 
-If you choose to migrate to VCD, OVHcloud will be handling the migration for you. 
+If you choose to migrate to VCD, OVHcloud will be handling the migration for you.
 
 As an exception, we won’t be charging the new current server/host prices during the migration process. We’ll absorb the costs of the license price increase while the migration is ongoing. Whether or not you choose to continue using the current solution, you will still benefit from the new VCD prices right away, starting on May 1st 2024.
 
@@ -63,9 +63,9 @@ With VMware Cloud Director, you are able to set group affinity for Virtual Machi
 
 ### Which certifications apply to the new VCD service ?
 
-At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service. 
+At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service.
 
-However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives. 
+However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.en-us.md
@@ -6,7 +6,7 @@ updated: 2024-04-16
 
 ## FAQ
 
-<a name="vDConOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### What is VMware Cloud Director by OVHcloud ?
 
@@ -20,7 +20,7 @@ VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### How migration will be done by OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.es-es.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.es-es.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ (EN)"
-excerpt: "Frequently asked questions on vCD"
+excerpt: "Frequently asked questions on VCD"
 updated: 2024-04-16
 ---
 
@@ -10,13 +10,13 @@ updated: 2024-04-16
 
 ### What is VMware Cloud Director by OVHcloud ?
 
-This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.   
+This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.
 
 VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 - VCD Standard, providing the standard VMware stack virtualization capabilities.
-- VCD Advanced, including advanced networking & security capabilities on top of the standard tier. 
-- VCD Premium, adding high-performance vSAN storage to the Advanced tier. 
+- VCD Advanced, including advanced networking & security capabilities on top of the standard tier.
+- VCD Premium, adding high-performance vSAN storage to the Advanced tier.
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
@@ -24,7 +24,7 @@ Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cl
 
 ### How migration will be done by OVHcloud ?
 
-If you choose to migrate to VCD, OVHcloud will be handling the migration for you. 
+If you choose to migrate to VCD, OVHcloud will be handling the migration for you.
 
 As an exception, we won’t be charging the new current server/host prices during the migration process. We’ll absorb the costs of the license price increase while the migration is ongoing. Whether or not you choose to continue using the current solution, you will still benefit from the new VCD prices right away, starting on May 1st 2024.
 
@@ -63,9 +63,9 @@ With VMware Cloud Director, you are able to set group affinity for Virtual Machi
 
 ### Which certifications apply to the new VCD service ?
 
-At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service. 
+At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service.
 
-However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives. 
+However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.es-es.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.es-es.md
@@ -6,7 +6,7 @@ updated: 2024-04-16
 
 ## FAQ
 
-<a name="vDConOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### What is VMware Cloud Director by OVHcloud ?
 
@@ -20,7 +20,7 @@ VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### How migration will be done by OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.es-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.es-us.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ (EN)"
-excerpt: "Frequently asked questions on vCD"
+excerpt: "Frequently asked questions on VCD"
 updated: 2024-04-16
 ---
 
@@ -10,13 +10,13 @@ updated: 2024-04-16
 
 ### What is VMware Cloud Director by OVHcloud ?
 
-This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.   
+This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.
 
 VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 - VCD Standard, providing the standard VMware stack virtualization capabilities.
-- VCD Advanced, including advanced networking & security capabilities on top of the standard tier. 
-- VCD Premium, adding high-performance vSAN storage to the Advanced tier. 
+- VCD Advanced, including advanced networking & security capabilities on top of the standard tier.
+- VCD Premium, adding high-performance vSAN storage to the Advanced tier.
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
@@ -24,7 +24,7 @@ Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cl
 
 ### How migration will be done by OVHcloud ?
 
-If you choose to migrate to VCD, OVHcloud will be handling the migration for you. 
+If you choose to migrate to VCD, OVHcloud will be handling the migration for you.
 
 As an exception, we won’t be charging the new current server/host prices during the migration process. We’ll absorb the costs of the license price increase while the migration is ongoing. Whether or not you choose to continue using the current solution, you will still benefit from the new VCD prices right away, starting on May 1st 2024.
 
@@ -63,9 +63,9 @@ With VMware Cloud Director, you are able to set group affinity for Virtual Machi
 
 ### Which certifications apply to the new VCD service ?
 
-At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service. 
+At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service.
 
-However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives. 
+However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.es-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.es-us.md
@@ -6,7 +6,7 @@ updated: 2024-04-16
 
 ## FAQ
 
-<a name="vDConOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### What is VMware Cloud Director by OVHcloud ?
 
@@ -20,7 +20,7 @@ VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### How migration will be done by OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.fr-ca.md
@@ -8,7 +8,7 @@ updated: 2024-04-16
 
 **Retrouvez ci-dessous les questions les plus fréquentes concernant VMWare Cloud Director par OVHcloud**
 
-<a name="vCDonOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### Qu’est-ce que VMware Cloud Director par OVHcloud ?
 
@@ -22,7 +22,7 @@ VMware Cloud Director par OVHcloud sera disponible en 3 niveaux :
 
 Pour plus d'informations, voir la page [les principes clés de VCD sur OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features).
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### Comment la migration sera-t-elle effectuée par OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.fr-ca.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ"
-excerpt: "Retrouvez les questions les plus fréquentes concernant vCD"
+excerpt: "Retrouvez les questions les plus fréquentes concernant VCD"
 updated: 2024-04-16
 ---
 
@@ -17,16 +17,16 @@ Il s’agit d’un nouveau produit disponible dans l’offre VMware on OVHcloud 
 VMware Cloud Director par OVHcloud sera disponible en 3 niveaux :
 
 - VCD Standard, fournissant les capacités standard de virtualisation de la pile VMware.
-- VCD Advanced, qui comprend vCD standard ainsi que des capacités avancées de mise en réseau et de sécurité.
+- VCD Advanced, qui comprend VCD standard ainsi que des capacités avancées de mise en réseau et de sécurité.
 - VCD Premium, qui comprend les fonctionnalités des niveaux précédents ainsi qu'un stockage vSAN haute performance au niveau Advanced.
 
-Pour plus d'informations, voir la page [les principes clés de vCD sur OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features).
+Pour plus d'informations, voir la page [les principes clés de VCD sur OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features).
 
 <a name="migrationvCD"></a>
 
 ### Comment la migration sera-t-elle effectuée par OVHcloud ?
 
-Si vous choisissez de migrer vers VCD, OVHcloud se chargera de la migration pour vous. 
+Si vous choisissez de migrer vers VCD, OVHcloud se chargera de la migration pour vous.
 
 Par exception, nous ne facturerons pas les nouveaux prix actuels du serveur/hôte pendant le processus de migration. Nous absorberons les coûts liés à l’augmentation du prix des licences pendant la migration. Que vous choisissiez ou non de continuer à utiliser la solution actuelle, vous bénéficierez tout de suite des nouveaux tarifs VCD à compter du 1er mai 2024.
 
@@ -40,7 +40,7 @@ Vos données restent sur les *filers* Leclerc v3, nous allons exposer à VCD le 
 
 <a name="accessAPI"></a>
 
-### Puis-je toujours avoir accès à vSphere ESXi et à l’API vCenter avec VMware Cloud Director ?	
+### Puis-je toujours avoir accès à vSphere ESXi et à l’API vCenter avec VMware Cloud Director ?
 
 Avec VMware Cloud Director, vous ne pouvez pas accéder aux API vSphere ESXi et vCenter. Vous aurez accès à l’API de Cloud Director et pourrez utiliser des outils comme [Terraform](https://registry.terraform.io/providers/vmware/vcd/latest/docs).
 
@@ -65,7 +65,7 @@ Avec VMware Cloud Director, vous pouvez définir l’affinité de groupe pour le
 
 ### Quelles certifications s'appliquent au nouveau service VCD ?
 
-Lors du lancement du service, aucune certification spécifique ne sera applicable au service VMware Cloud Director par OVHcloud. 
+Lors du lancement du service, aucune certification spécifique ne sera applicable au service VMware Cloud Director par OVHcloud.
 
 Cependant, la prise en charge des certifications HDS, ISO27001, SOC2 ou PCI-DSS est un des objectifs de notre feuille de route.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.fr-fr.md
@@ -8,7 +8,7 @@ updated: 2024-04-16
 
 **Retrouvez ci-dessous les questions les plus fréquentes concernant VMWare Cloud Director par OVHcloud**
 
-<a name="vCDonOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### Qu’est-ce que VMware Cloud Director par OVHcloud ?
 
@@ -22,7 +22,7 @@ VMware Cloud Director par OVHcloud sera disponible en 3 niveaux :
 
 Pour plus d'informations, voir la page [les principes clés de VCD sur OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features).
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### Comment la migration sera-t-elle effectuée par OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.fr-fr.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ"
-excerpt: "Retrouvez les questions les plus fréquentes concernant vCD"
+excerpt: "Retrouvez les questions les plus fréquentes concernant VCD"
 updated: 2024-04-16
 ---
 
@@ -17,16 +17,16 @@ Il s’agit d’un nouveau produit disponible dans l’offre VMware on OVHcloud 
 VMware Cloud Director par OVHcloud sera disponible en 3 niveaux :
 
 - VCD Standard, fournissant les capacités standard de virtualisation de la pile VMware.
-- VCD Advanced, qui comprend vCD standard ainsi que des capacités avancées de mise en réseau et de sécurité.
+- VCD Advanced, qui comprend VCD standard ainsi que des capacités avancées de mise en réseau et de sécurité.
 - VCD Premium, qui comprend les fonctionnalités des niveaux précédents ainsi qu'un stockage vSAN haute performance au niveau Advanced.
 
-Pour plus d'informations, voir la page [les principes clés de vCD sur OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features).
+Pour plus d'informations, voir la page [les principes clés de VCD sur OVHcloud](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features).
 
 <a name="migrationvCD"></a>
 
 ### Comment la migration sera-t-elle effectuée par OVHcloud ?
 
-Si vous choisissez de migrer vers VCD, OVHcloud se chargera de la migration pour vous. 
+Si vous choisissez de migrer vers VCD, OVHcloud se chargera de la migration pour vous.
 
 Par exception, nous ne facturerons pas les nouveaux prix actuels du serveur/hôte pendant le processus de migration. Nous absorberons les coûts liés à l’augmentation du prix des licences pendant la migration. Que vous choisissiez ou non de continuer à utiliser la solution actuelle, vous bénéficierez tout de suite des nouveaux tarifs VCD à compter du 1er mai 2024.
 
@@ -40,7 +40,7 @@ Vos données restent sur les *filers* Leclerc v3, nous allons exposer à VCD le 
 
 <a name="accessAPI"></a>
 
-### Puis-je toujours avoir accès à vSphere ESXi et à l’API vCenter avec VMware Cloud Director ?	
+### Puis-je toujours avoir accès à vSphere ESXi et à l’API vCenter avec VMware Cloud Director ?
 
 Avec VMware Cloud Director, vous ne pouvez pas accéder aux API vSphere ESXi et vCenter. Vous aurez accès à l’API de Cloud Director et pourrez utiliser des outils comme [Terraform](https://registry.terraform.io/providers/vmware/vcd/latest/docs).
 
@@ -65,7 +65,7 @@ Avec VMware Cloud Director, vous pouvez définir l’affinité de groupe pour le
 
 ### Quelles certifications s'appliquent au nouveau service VCD ?
 
-Lors du lancement du service, aucune certification spécifique ne sera applicable au service VMware Cloud Director par OVHcloud. 
+Lors du lancement du service, aucune certification spécifique ne sera applicable au service VMware Cloud Director par OVHcloud.
 
 Cependant, la prise en charge des certifications HDS, ISO27001, SOC2 ou PCI-DSS est un des objectifs de notre feuille de route.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.it-it.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.it-it.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ (EN)"
-excerpt: "Frequently asked questions on vCD"
+excerpt: "Frequently asked questions on VCD"
 updated: 2024-04-16
 ---
 
@@ -10,13 +10,13 @@ updated: 2024-04-16
 
 ### What is VMware Cloud Director by OVHcloud ?
 
-This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.   
+This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.
 
 VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 - VCD Standard, providing the standard VMware stack virtualization capabilities.
-- VCD Advanced, including advanced networking & security capabilities on top of the standard tier. 
-- VCD Premium, adding high-performance vSAN storage to the Advanced tier. 
+- VCD Advanced, including advanced networking & security capabilities on top of the standard tier.
+- VCD Premium, adding high-performance vSAN storage to the Advanced tier.
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
@@ -24,7 +24,7 @@ Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cl
 
 ### How migration will be done by OVHcloud ?
 
-If you choose to migrate to VCD, OVHcloud will be handling the migration for you. 
+If you choose to migrate to VCD, OVHcloud will be handling the migration for you.
 
 As an exception, we won’t be charging the new current server/host prices during the migration process. We’ll absorb the costs of the license price increase while the migration is ongoing. Whether or not you choose to continue using the current solution, you will still benefit from the new VCD prices right away, starting on May 1st 2024.
 
@@ -63,9 +63,9 @@ With VMware Cloud Director, you are able to set group affinity for Virtual Machi
 
 ### Which certifications apply to the new VCD service ?
 
-At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service. 
+At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service.
 
-However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives. 
+However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.it-it.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.it-it.md
@@ -6,7 +6,7 @@ updated: 2024-04-16
 
 ## FAQ
 
-<a name="vDConOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### What is VMware Cloud Director by OVHcloud ?
 
@@ -20,7 +20,7 @@ VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### How migration will be done by OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.pl-pl.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ (EN)"
-excerpt: "Frequently asked questions on vCD"
+excerpt: "Frequently asked questions on VCD"
 updated: 2024-04-16
 ---
 
@@ -10,13 +10,13 @@ updated: 2024-04-16
 
 ### What is VMware Cloud Director by OVHcloud ?
 
-This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.   
+This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.
 
 VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 - VCD Standard, providing the standard VMware stack virtualization capabilities.
-- VCD Advanced, including advanced networking & security capabilities on top of the standard tier. 
-- VCD Premium, adding high-performance vSAN storage to the Advanced tier. 
+- VCD Advanced, including advanced networking & security capabilities on top of the standard tier.
+- VCD Premium, adding high-performance vSAN storage to the Advanced tier.
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
@@ -24,7 +24,7 @@ Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cl
 
 ### How migration will be done by OVHcloud ?
 
-If you choose to migrate to VCD, OVHcloud will be handling the migration for you. 
+If you choose to migrate to VCD, OVHcloud will be handling the migration for you.
 
 As an exception, we won’t be charging the new current server/host prices during the migration process. We’ll absorb the costs of the license price increase while the migration is ongoing. Whether or not you choose to continue using the current solution, you will still benefit from the new VCD prices right away, starting on May 1st 2024.
 
@@ -63,9 +63,9 @@ With VMware Cloud Director, you are able to set group affinity for Virtual Machi
 
 ### Which certifications apply to the new VCD service ?
 
-At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service. 
+At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service.
 
-However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives. 
+However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.pl-pl.md
@@ -6,7 +6,7 @@ updated: 2024-04-16
 
 ## FAQ
 
-<a name="vDConOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### What is VMware Cloud Director by OVHcloud ?
 
@@ -20,7 +20,7 @@ VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### How migration will be done by OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.pt-pt.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - FAQ (EN)"
-excerpt: "Frequently asked questions on vCD"
+excerpt: "Frequently asked questions on VCD"
 updated: 2024-04-16
 ---
 
@@ -10,13 +10,13 @@ updated: 2024-04-16
 
 ### What is VMware Cloud Director by OVHcloud ?
 
-This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.   
+This is a new product available in the VMware on OVHcloud offering that provides you with a virtual Datacenter powered by VMware technology, on top of a mutualized infrastructure hosted and operated by OVHcloud.
 
 VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 - VCD Standard, providing the standard VMware stack virtualization capabilities.
-- VCD Advanced, including advanced networking & security capabilities on top of the standard tier. 
-- VCD Premium, adding high-performance vSAN storage to the Advanced tier. 
+- VCD Advanced, including advanced networking & security capabilities on top of the standard tier.
+- VCD Premium, adding high-performance vSAN storage to the Advanced tier.
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
@@ -24,7 +24,7 @@ Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cl
 
 ### How migration will be done by OVHcloud ?
 
-If you choose to migrate to VCD, OVHcloud will be handling the migration for you. 
+If you choose to migrate to VCD, OVHcloud will be handling the migration for you.
 
 As an exception, we won’t be charging the new current server/host prices during the migration process. We’ll absorb the costs of the license price increase while the migration is ongoing. Whether or not you choose to continue using the current solution, you will still benefit from the new VCD prices right away, starting on May 1st 2024.
 
@@ -63,9 +63,9 @@ With VMware Cloud Director, you are able to set group affinity for Virtual Machi
 
 ### Which certifications apply to the new VCD service ?
 
-At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service. 
+At the service launch, no specific certification will be applicable to the VMware Cloud Director by OVHcloud service.
 
-However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives. 
+However, supporting HDS, ISO27001, SOC2 or PCI-DSS certifications are clearly our roadmap objectives.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-faq/guide.pt-pt.md
@@ -6,7 +6,7 @@ updated: 2024-04-16
 
 ## FAQ
 
-<a name="vDConOVH"></a>
+<a name="VCDonOVH"></a>
 
 ### What is VMware Cloud Director by OVHcloud ?
 
@@ -20,7 +20,7 @@ VMware Cloud Director by OVHcloud will be available in 3 tiers:
 
 Please see [our key features page](/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts#key-features) for more information.
 
-<a name="migrationvCD"></a>
+<a name="migrationVCD"></a>
 
 ### How migration will be done by OVHcloud ?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.de-de.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.de-de.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Creating a new virtual machine (EN)"
-excerpt: "How to create a new Virtual Machine in vCD"
+excerpt: "How to create a new Virtual Machine in VCD"
 updated: 2024-04-16
 ---
 
@@ -13,12 +13,12 @@ This guide details how to create your first virtual machine using two methods:
 
 ## Requirements
 
-- A VMware Cloud Director 
+- A VMware Cloud Director
 - An ISO of an operating system
 
 ## Instructions
 
-### Creating a virtual machine 
+### Creating a virtual machine
 
 To create your virtual machine, first go to the datacentre where you plan to deploy it. Next, navigate to the `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action} section.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-asia.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-asia.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Creating a new virtual machine"
-excerpt: "How to create a new Virtual Machine in vCD"
+excerpt: "How to create a new Virtual Machine in VCD"
 updated: 2024-04-16
 ---
 
@@ -13,12 +13,12 @@ This guide details how to create your first virtual machine using two methods:
 
 ## Requirements
 
-- A VMware Cloud Director 
+- A VMware Cloud Director
 - An ISO of an operating system
 
 ## Instructions
 
-### Creating a virtual machine 
+### Creating a virtual machine
 
 To create your virtual machine, first go to the datacentre where you plan to deploy it. Next, navigate to the `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action} section.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-au.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-au.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Creating a new virtual machine"
-excerpt: "How to create a new Virtual Machine in vCD"
+excerpt: "How to create a new Virtual Machine in VCD"
 updated: 2024-04-16
 ---
 
@@ -13,12 +13,12 @@ This guide details how to create your first virtual machine using two methods:
 
 ## Requirements
 
-- A VMware Cloud Director 
+- A VMware Cloud Director
 - An ISO of an operating system
 
 ## Instructions
 
-### Creating a virtual machine 
+### Creating a virtual machine
 
 To create your virtual machine, first go to the datacentre where you plan to deploy it. Next, navigate to the `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action} section.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-ca.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Creating a new virtual machine"
-excerpt: "How to create a new Virtual Machine in vCD"
+excerpt: "How to create a new Virtual Machine in VCD"
 updated: 2024-04-16
 ---
 
@@ -13,12 +13,12 @@ This guide details how to create your first virtual machine using two methods:
 
 ## Requirements
 
-- A VMware Cloud Director 
+- A VMware Cloud Director
 - An ISO of an operating system
 
 ## Instructions
 
-### Creating a virtual machine 
+### Creating a virtual machine
 
 To create your virtual machine, first go to the datacentre where you plan to deploy it. Next, navigate to the `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action} section.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-gb.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-gb.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Creating a new virtual machine"
-excerpt: "How to create a new Virtual Machine in vCD"
+excerpt: "How to create a new Virtual Machine in VCD"
 updated: 2024-04-16
 ---
 
@@ -13,12 +13,12 @@ This guide details how to create your first virtual machine using two methods:
 
 ## Requirements
 
-- A VMware Cloud Director 
+- A VMware Cloud Director
 - An ISO of an operating system
 
 ## Instructions
 
-### Creating a virtual machine 
+### Creating a virtual machine
 
 To create your virtual machine, first go to the datacentre where you plan to deploy it. Next, navigate to the `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action} section.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-ie.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-ie.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Creating a new virtual machine"
-excerpt: "How to create a new Virtual Machine in vCD"
+excerpt: "How to create a new Virtual Machine in VCD"
 updated: 2024-04-16
 ---
 
@@ -13,12 +13,12 @@ This guide details how to create your first virtual machine using two methods:
 
 ## Requirements
 
-- A VMware Cloud Director 
+- A VMware Cloud Director
 - An ISO of an operating system
 
 ## Instructions
 
-### Creating a virtual machine 
+### Creating a virtual machine
 
 To create your virtual machine, first go to the datacentre where you plan to deploy it. Next, navigate to the `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action} section.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-sg.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-sg.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Creating a new virtual machine"
-excerpt: "How to create a new Virtual Machine in vCD"
+excerpt: "How to create a new Virtual Machine in VCD"
 updated: 2024-04-16
 ---
 
@@ -13,12 +13,12 @@ This guide details how to create your first virtual machine using two methods:
 
 ## Requirements
 
-- A VMware Cloud Director 
+- A VMware Cloud Director
 - An ISO of an operating system
 
 ## Instructions
 
-### Creating a virtual machine 
+### Creating a virtual machine
 
 To create your virtual machine, first go to the datacentre where you plan to deploy it. Next, navigate to the `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action} section.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.en-us.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Creating a new virtual machine"
-excerpt: "How to create a new Virtual Machine in vCD"
+excerpt: "How to create a new Virtual Machine in VCD"
 updated: 2024-04-16
 ---
 
@@ -13,12 +13,12 @@ This guide details how to create your first virtual machine using two methods:
 
 ## Requirements
 
-- A VMware Cloud Director 
+- A VMware Cloud Director
 - An ISO of an operating system
 
 ## Instructions
 
-### Creating a virtual machine 
+### Creating a virtual machine
 
 To create your virtual machine, first go to the datacentre where you plan to deploy it. Next, navigate to the `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action} section.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.es-es.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.es-es.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Creating a new virtual machine (EN)"
-excerpt: "How to create a new Virtual Machine in vCD"
+excerpt: "How to create a new Virtual Machine in VCD"
 updated: 2024-04-16
 ---
 
@@ -13,12 +13,12 @@ This guide details how to create your first virtual machine using two methods:
 
 ## Requirements
 
-- A VMware Cloud Director 
+- A VMware Cloud Director
 - An ISO of an operating system
 
 ## Instructions
 
-### Creating a virtual machine 
+### Creating a virtual machine
 
 To create your virtual machine, first go to the datacentre where you plan to deploy it. Next, navigate to the `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action} section.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.es-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.es-us.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Creating a new virtual machine (EN)"
-excerpt: "How to create a new Virtual Machine in vCD"
+excerpt: "How to create a new Virtual Machine in VCD"
 updated: 2024-04-16
 ---
 
@@ -13,12 +13,12 @@ This guide details how to create your first virtual machine using two methods:
 
 ## Requirements
 
-- A VMware Cloud Director 
+- A VMware Cloud Director
 - An ISO of an operating system
 
 ## Instructions
 
-### Creating a virtual machine 
+### Creating a virtual machine
 
 To create your virtual machine, first go to the datacentre where you plan to deploy it. Next, navigate to the `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action} section.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.fr-ca.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Création d'une nouvelle machine virtuelle"
-excerpt: "Comment créer une nouvelle machine virtuelle dans vCD"
+excerpt: "Comment créer une nouvelle machine virtuelle dans VCD"
 updated: 2024-04-16
 ---
 
@@ -18,7 +18,7 @@ Ce guide vous détaille comment créer votre première machine virtuelle de deux
 
 ## En pratique
 
-### Création d'une machine virtuelle 
+### Création d'une machine virtuelle
 
 Pour créer votre machine virtuelle, accédez d'abord au datacenter où vous prévoyez de la déployer. Ensuite, naviguez vers la section `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action}.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.fr-fr.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Création d'une nouvelle machine virtuelle"
-excerpt: "Comment créer une nouvelle machine virtuelle dans vCD"
+excerpt: "Comment créer une nouvelle machine virtuelle dans VCD"
 updated: 2024-04-16
 ---
 
@@ -18,7 +18,7 @@ Ce guide vous détaille comment créer votre première machine virtuelle de deux
 
 ## En pratique
 
-### Création d'une machine virtuelle 
+### Création d'une machine virtuelle
 
 Pour créer votre machine virtuelle, accédez d'abord au datacenter où vous prévoyez de la déployer. Ensuite, naviguez vers la section `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action}.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.it-it.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.it-it.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Creating a new virtual machine (EN)"
-excerpt: "How to create a new Virtual Machine in vCD"
+excerpt: "How to create a new Virtual Machine in VCD"
 updated: 2024-04-16
 ---
 
@@ -13,12 +13,12 @@ This guide details how to create your first virtual machine using two methods:
 
 ## Requirements
 
-- A VMware Cloud Director 
+- A VMware Cloud Director
 - An ISO of an operating system
 
 ## Instructions
 
-### Creating a virtual machine 
+### Creating a virtual machine
 
 To create your virtual machine, first go to the datacentre where you plan to deploy it. Next, navigate to the `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action} section.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.pl-pl.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Creating a new virtual machine (EN)"
-excerpt: "How to create a new Virtual Machine in vCD"
+excerpt: "How to create a new Virtual Machine in VCD"
 updated: 2024-04-16
 ---
 
@@ -13,12 +13,12 @@ This guide details how to create your first virtual machine using two methods:
 
 ## Requirements
 
-- A VMware Cloud Director 
+- A VMware Cloud Director
 - An ISO of an operating system
 
 ## Instructions
 
-### Creating a virtual machine 
+### Creating a virtual machine
 
 To create your virtual machine, first go to the datacentre where you plan to deploy it. Next, navigate to the `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action} section.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-first-vm-creation/guide.pt-pt.md
@@ -1,6 +1,6 @@
 ---
 title: "VMware Cloud Director - Creating a new virtual machine (EN)"
-excerpt: "How to create a new Virtual Machine in vCD"
+excerpt: "How to create a new Virtual Machine in VCD"
 updated: 2024-04-16
 ---
 
@@ -13,12 +13,12 @@ This guide details how to create your first virtual machine using two methods:
 
 ## Requirements
 
-- A VMware Cloud Director 
+- A VMware Cloud Director
 - An ISO of an operating system
 
 ## Instructions
 
-### Creating a virtual machine 
+### Creating a virtual machine
 
 To create your virtual machine, first go to the datacentre where you plan to deploy it. Next, navigate to the `Compute`{.action} > `Virtual Machine`{.action} > `NEW VM`{.action} section.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.de-de.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.de-de.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - The fundamentals of vCD (EN)"
-excerpt: "Discover the basic concepts of vCD"
+title: "VMware Cloud Director - The fundamentals of VCD (EN)"
+excerpt: "Discover the basic concepts of VCD"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide details the fundamentals of vCD at OVHcloud.**
+**This guide details the fundamentals of VCD at OVHcloud.**
 
 ## Fundamental concepts
 
-In this section, we will detail the essential foundations of VMware Cloud Director (VCD). 
+In this section, we will detail the essential foundations of VMware Cloud Director (VCD).
 
 By defining these principles in a clear and concise way, we will provide the necessary foundation for effective and successful VCD use. Whether it’s for administrators looking to deploy complex infrastructures, or for users looking to access resources seamlessly, this exploration of VCD basics is a vital starting point.
 
 ### Organizations
 
-An organization is an administrative entity that groups together specific users, groups, and IT resources. 
+An organization is an administrative entity that groups together specific users, groups, and IT resources.
 
-Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported. 
+Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported.
 
 System administrators are responsible for creating and provisioning organizations, while organization administrators are responsible for managing users, groups, and catalogs specific to the organization.
 
@@ -42,17 +42,17 @@ Only system administrators have the privilege to create such networks, but organ
 
 ### vApp Networks
 
-A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines. 
+A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines.
 
-It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization. 
+It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization.
 
 Furthermore, if the organization’s virtual datacentre network is connected to an external network, this allows the vApp to communicate outside the organization as well.
 
 ### Catalogs
 
-Organizations use catalogs to store vApp templates and media files. 
+Organizations use catalogs to store vApp templates and media files.
 
-Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps. 
+Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps.
 
 In addition, organization administrators have the ability to copy items from public catalogs into their organization-specific catalog.
 
@@ -64,9 +64,9 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅              |       -      |
-| vCD Prenium  |              ✅              |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅              |       -      |
+| VCD Prenium  |              ✅              |       ✅      |
 
 #### Cluster Management
 
@@ -77,7 +77,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
 
@@ -89,7 +89,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
 |      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
 |   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
-|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions (OpenSource Only !) 	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
 |    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-asia.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-asia.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - The fundamentals of vCD"
-excerpt: "Discover the basic concepts of vCD"
+title: "VMware Cloud Director - The fundamentals of VCD"
+excerpt: "Discover the basic concepts of VCD"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide details the fundamentals of vCD at OVHcloud.**
+**This guide details the fundamentals of VCD at OVHcloud.**
 
 ## Fundamental concepts
 
-In this section, we will detail the essential foundations of VMware Cloud Director (VCD). 
+In this section, we will detail the essential foundations of VMware Cloud Director (VCD).
 
 By defining these principles in a clear and concise way, we will provide the necessary foundation for effective and successful VCD use. Whether it’s for administrators looking to deploy complex infrastructures, or for users looking to access resources seamlessly, this exploration of VCD basics is a vital starting point.
 
 ### Organizations
 
-An organization is an administrative entity that groups together specific users, groups, and IT resources. 
+An organization is an administrative entity that groups together specific users, groups, and IT resources.
 
-Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported. 
+Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported.
 
 System administrators are responsible for creating and provisioning organizations, while organization administrators are responsible for managing users, groups, and catalogs specific to the organization.
 
@@ -42,17 +42,17 @@ Only system administrators have the privilege to create such networks, but organ
 
 ### vApp Networks
 
-A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines. 
+A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines.
 
-It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization. 
+It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization.
 
 Furthermore, if the organization’s virtual datacentre network is connected to an external network, this allows the vApp to communicate outside the organization as well.
 
 ### Catalogs
 
-Organizations use catalogs to store vApp templates and media files. 
+Organizations use catalogs to store vApp templates and media files.
 
-Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps. 
+Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps.
 
 In addition, organization administrators have the ability to copy items from public catalogs into their organization-specific catalog.
 
@@ -64,9 +64,9 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅              |       -      |
-| vCD Prenium  |              ✅              |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅              |       -      |
+| VCD Prenium  |              ✅              |       ✅      |
 
 #### Cluster Management
 
@@ -77,7 +77,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
 
@@ -89,7 +89,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
 |      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
 |   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
-|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions (OpenSource Only !) 	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
 |    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-au.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-au.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - The fundamentals of vCD"
-excerpt: "Discover the basic concepts of vCD"
+title: "VMware Cloud Director - The fundamentals of VCD"
+excerpt: "Discover the basic concepts of VCD"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide details the fundamentals of vCD at OVHcloud.**
+**This guide details the fundamentals of VCD at OVHcloud.**
 
 ## Fundamental concepts
 
-In this section, we will detail the essential foundations of VMware Cloud Director (VCD). 
+In this section, we will detail the essential foundations of VMware Cloud Director (VCD).
 
 By defining these principles in a clear and concise way, we will provide the necessary foundation for effective and successful VCD use. Whether it’s for administrators looking to deploy complex infrastructures, or for users looking to access resources seamlessly, this exploration of VCD basics is a vital starting point.
 
 ### Organizations
 
-An organization is an administrative entity that groups together specific users, groups, and IT resources. 
+An organization is an administrative entity that groups together specific users, groups, and IT resources.
 
-Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported. 
+Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported.
 
 System administrators are responsible for creating and provisioning organizations, while organization administrators are responsible for managing users, groups, and catalogs specific to the organization.
 
@@ -42,17 +42,17 @@ Only system administrators have the privilege to create such networks, but organ
 
 ### vApp Networks
 
-A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines. 
+A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines.
 
-It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization. 
+It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization.
 
 Furthermore, if the organization’s virtual datacentre network is connected to an external network, this allows the vApp to communicate outside the organization as well.
 
 ### Catalogs
 
-Organizations use catalogs to store vApp templates and media files. 
+Organizations use catalogs to store vApp templates and media files.
 
-Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps. 
+Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps.
 
 In addition, organization administrators have the ability to copy items from public catalogs into their organization-specific catalog.
 
@@ -64,9 +64,9 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅              |       -      |
-| vCD Prenium  |              ✅              |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅              |       -      |
+| VCD Prenium  |              ✅              |       ✅      |
 
 #### Cluster Management
 
@@ -77,9 +77,20 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
+
+##### Virtual Machine Management
+
+|         Features        	| Standard 	| Advanced 	| Prenium 	|                                    Comments                                   	|
+|:-----------------------:	|:--------:	|:--------:	|:-------:	|:-----------------------------------------------------------------------------:	|
+|        Create VM        	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
+| Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
+|      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
+|   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
+|    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-ca.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - The fundamentals of vCD"
-excerpt: "Discover the basic concepts of vCD"
+title: "VMware Cloud Director - The fundamentals of VCD"
+excerpt: "Discover the basic concepts of VCD"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide details the fundamentals of vCD at OVHcloud.**
+**This guide details the fundamentals of VCD at OVHcloud.**
 
 ## Fundamental concepts
 
-In this section, we will detail the essential foundations of VMware Cloud Director (VCD). 
+In this section, we will detail the essential foundations of VMware Cloud Director (VCD).
 
 By defining these principles in a clear and concise way, we will provide the necessary foundation for effective and successful VCD use. Whether it’s for administrators looking to deploy complex infrastructures, or for users looking to access resources seamlessly, this exploration of VCD basics is a vital starting point.
 
 ### Organizations
 
-An organization is an administrative entity that groups together specific users, groups, and IT resources. 
+An organization is an administrative entity that groups together specific users, groups, and IT resources.
 
-Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported. 
+Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported.
 
 System administrators are responsible for creating and provisioning organizations, while organization administrators are responsible for managing users, groups, and catalogs specific to the organization.
 
@@ -42,17 +42,17 @@ Only system administrators have the privilege to create such networks, but organ
 
 ### vApp Networks
 
-A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines. 
+A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines.
 
-It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization. 
+It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization.
 
 Furthermore, if the organization’s virtual datacentre network is connected to an external network, this allows the vApp to communicate outside the organization as well.
 
 ### Catalogs
 
-Organizations use catalogs to store vApp templates and media files. 
+Organizations use catalogs to store vApp templates and media files.
 
-Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps. 
+Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps.
 
 In addition, organization administrators have the ability to copy items from public catalogs into their organization-specific catalog.
 
@@ -64,9 +64,9 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅              |       -      |
-| vCD Prenium  |              ✅              |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅              |       -      |
+| VCD Prenium  |              ✅              |       ✅      |
 
 #### Cluster Management
 
@@ -77,7 +77,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
 
@@ -89,7 +89,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
 |      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
 |   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
-|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions (OpenSource Only !) 	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
 |    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-gb.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-gb.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - The fundamentals of vCD"
-excerpt: "Discover the basic concepts of vCD"
+title: "VMware Cloud Director - The fundamentals of VCD"
+excerpt: "Discover the basic concepts of VCD"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide details the fundamentals of vCD at OVHcloud.**
+**This guide details the fundamentals of VCD at OVHcloud.**
 
 ## Fundamental concepts
 
-In this section, we will detail the essential foundations of VMware Cloud Director (VCD). 
+In this section, we will detail the essential foundations of VMware Cloud Director (VCD).
 
 By defining these principles in a clear and concise way, we will provide the necessary foundation for effective and successful VCD use. Whether it’s for administrators looking to deploy complex infrastructures, or for users looking to access resources seamlessly, this exploration of VCD basics is a vital starting point.
 
 ### Organizations
 
-An organization is an administrative entity that groups together specific users, groups, and IT resources. 
+An organization is an administrative entity that groups together specific users, groups, and IT resources.
 
-Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported. 
+Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported.
 
 System administrators are responsible for creating and provisioning organizations, while organization administrators are responsible for managing users, groups, and catalogs specific to the organization.
 
@@ -42,17 +42,17 @@ Only system administrators have the privilege to create such networks, but organ
 
 ### vApp Networks
 
-A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines. 
+A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines.
 
-It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization. 
+It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization.
 
 Furthermore, if the organization’s virtual datacentre network is connected to an external network, this allows the vApp to communicate outside the organization as well.
 
 ### Catalogs
 
-Organizations use catalogs to store vApp templates and media files. 
+Organizations use catalogs to store vApp templates and media files.
 
-Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps. 
+Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps.
 
 In addition, organization administrators have the ability to copy items from public catalogs into their organization-specific catalog.
 
@@ -64,9 +64,9 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅              |       -      |
-| vCD Prenium  |              ✅              |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅              |       -      |
+| VCD Prenium  |              ✅              |       ✅      |
 
 #### Cluster Management
 
@@ -77,7 +77,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
 
@@ -89,7 +89,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
 |      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
 |   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
-|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions (OpenSource Only !) 	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
 |    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-ie.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-ie.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - The fundamentals of vCD"
-excerpt: "Discover the basic concepts of vCD"
+title: "VMware Cloud Director - The fundamentals of VCD"
+excerpt: "Discover the basic concepts of VCD"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide details the fundamentals of vCD at OVHcloud.**
+**This guide details the fundamentals of VCD at OVHcloud.**
 
 ## Fundamental concepts
 
-In this section, we will detail the essential foundations of VMware Cloud Director (VCD). 
+In this section, we will detail the essential foundations of VMware Cloud Director (VCD).
 
 By defining these principles in a clear and concise way, we will provide the necessary foundation for effective and successful VCD use. Whether it’s for administrators looking to deploy complex infrastructures, or for users looking to access resources seamlessly, this exploration of VCD basics is a vital starting point.
 
 ### Organizations
 
-An organization is an administrative entity that groups together specific users, groups, and IT resources. 
+An organization is an administrative entity that groups together specific users, groups, and IT resources.
 
-Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported. 
+Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported.
 
 System administrators are responsible for creating and provisioning organizations, while organization administrators are responsible for managing users, groups, and catalogs specific to the organization.
 
@@ -42,17 +42,17 @@ Only system administrators have the privilege to create such networks, but organ
 
 ### vApp Networks
 
-A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines. 
+A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines.
 
-It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization. 
+It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization.
 
 Furthermore, if the organization’s virtual datacentre network is connected to an external network, this allows the vApp to communicate outside the organization as well.
 
 ### Catalogs
 
-Organizations use catalogs to store vApp templates and media files. 
+Organizations use catalogs to store vApp templates and media files.
 
-Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps. 
+Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps.
 
 In addition, organization administrators have the ability to copy items from public catalogs into their organization-specific catalog.
 
@@ -64,9 +64,9 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅              |       -      |
-| vCD Prenium  |              ✅              |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅              |       -      |
+| VCD Prenium  |              ✅              |       ✅      |
 
 #### Cluster Management
 
@@ -77,7 +77,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
 
@@ -89,7 +89,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
 |      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
 |   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
-|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions (OpenSource Only !) 	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
 |    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-sg.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-sg.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - The fundamentals of vCD"
-excerpt: "Discover the basic concepts of vCD"
+title: "VMware Cloud Director - The fundamentals of VCD"
+excerpt: "Discover the basic concepts of VCD"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide details the fundamentals of vCD at OVHcloud.**
+**This guide details the fundamentals of VCD at OVHcloud.**
 
 ## Fundamental concepts
 
-In this section, we will detail the essential foundations of VMware Cloud Director (VCD). 
+In this section, we will detail the essential foundations of VMware Cloud Director (VCD).
 
 By defining these principles in a clear and concise way, we will provide the necessary foundation for effective and successful VCD use. Whether it’s for administrators looking to deploy complex infrastructures, or for users looking to access resources seamlessly, this exploration of VCD basics is a vital starting point.
 
 ### Organizations
 
-An organization is an administrative entity that groups together specific users, groups, and IT resources. 
+An organization is an administrative entity that groups together specific users, groups, and IT resources.
 
-Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported. 
+Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported.
 
 System administrators are responsible for creating and provisioning organizations, while organization administrators are responsible for managing users, groups, and catalogs specific to the organization.
 
@@ -42,17 +42,17 @@ Only system administrators have the privilege to create such networks, but organ
 
 ### vApp Networks
 
-A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines. 
+A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines.
 
-It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization. 
+It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization.
 
 Furthermore, if the organization’s virtual datacentre network is connected to an external network, this allows the vApp to communicate outside the organization as well.
 
 ### Catalogs
 
-Organizations use catalogs to store vApp templates and media files. 
+Organizations use catalogs to store vApp templates and media files.
 
-Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps. 
+Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps.
 
 In addition, organization administrators have the ability to copy items from public catalogs into their organization-specific catalog.
 
@@ -64,9 +64,9 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅              |       -      |
-| vCD Prenium  |              ✅              |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅              |       -      |
+| VCD Prenium  |              ✅              |       ✅      |
 
 #### Cluster Management
 
@@ -77,7 +77,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
 
@@ -89,7 +89,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
 |      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
 |   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
-|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions (OpenSource Only !) 	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
 |    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.en-us.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - The fundamentals of vCD"
-excerpt: "Discover the basic concepts of vCD"
+title: "VMware Cloud Director - The fundamentals of VCD"
+excerpt: "Discover the basic concepts of VCD"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide details the fundamentals of vCD at OVHcloud.**
+**This guide details the fundamentals of VCD at OVHcloud.**
 
 ## Fundamental concepts
 
-In this section, we will detail the essential foundations of VMware Cloud Director (VCD). 
+In this section, we will detail the essential foundations of VMware Cloud Director (VCD).
 
 By defining these principles in a clear and concise way, we will provide the necessary foundation for effective and successful VCD use. Whether it’s for administrators looking to deploy complex infrastructures, or for users looking to access resources seamlessly, this exploration of VCD basics is a vital starting point.
 
 ### Organizations
 
-An organization is an administrative entity that groups together specific users, groups, and IT resources. 
+An organization is an administrative entity that groups together specific users, groups, and IT resources.
 
-Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported. 
+Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported.
 
 System administrators are responsible for creating and provisioning organizations, while organization administrators are responsible for managing users, groups, and catalogs specific to the organization.
 
@@ -42,17 +42,17 @@ Only system administrators have the privilege to create such networks, but organ
 
 ### vApp Networks
 
-A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines. 
+A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines.
 
-It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization. 
+It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization.
 
 Furthermore, if the organization’s virtual datacentre network is connected to an external network, this allows the vApp to communicate outside the organization as well.
 
 ### Catalogs
 
-Organizations use catalogs to store vApp templates and media files. 
+Organizations use catalogs to store vApp templates and media files.
 
-Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps. 
+Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps.
 
 In addition, organization administrators have the ability to copy items from public catalogs into their organization-specific catalog.
 
@@ -64,9 +64,9 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅              |       -      |
-| vCD Prenium  |              ✅              |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅              |       -      |
+| VCD Prenium  |              ✅              |       ✅      |
 
 #### Cluster Management
 
@@ -77,7 +77,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
 
@@ -89,7 +89,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
 |      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
 |   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
-|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions (OpenSource Only !) 	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
 |    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.es-es.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.es-es.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - The fundamentals of vCD (EN)"
-excerpt: "Discover the basic concepts of vCD"
+title: "VMware Cloud Director - The fundamentals of VCD (EN)"
+excerpt: "Discover the basic concepts of VCD"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide details the fundamentals of vCD at OVHcloud.**
+**This guide details the fundamentals of VCD at OVHcloud.**
 
 ## Fundamental concepts
 
-In this section, we will detail the essential foundations of VMware Cloud Director (VCD). 
+In this section, we will detail the essential foundations of VMware Cloud Director (VCD).
 
 By defining these principles in a clear and concise way, we will provide the necessary foundation for effective and successful VCD use. Whether it’s for administrators looking to deploy complex infrastructures, or for users looking to access resources seamlessly, this exploration of VCD basics is a vital starting point.
 
 ### Organizations
 
-An organization is an administrative entity that groups together specific users, groups, and IT resources. 
+An organization is an administrative entity that groups together specific users, groups, and IT resources.
 
-Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported. 
+Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported.
 
 System administrators are responsible for creating and provisioning organizations, while organization administrators are responsible for managing users, groups, and catalogs specific to the organization.
 
@@ -42,17 +42,17 @@ Only system administrators have the privilege to create such networks, but organ
 
 ### vApp Networks
 
-A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines. 
+A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines.
 
-It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization. 
+It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization.
 
 Furthermore, if the organization’s virtual datacentre network is connected to an external network, this allows the vApp to communicate outside the organization as well.
 
 ### Catalogs
 
-Organizations use catalogs to store vApp templates and media files. 
+Organizations use catalogs to store vApp templates and media files.
 
-Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps. 
+Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps.
 
 In addition, organization administrators have the ability to copy items from public catalogs into their organization-specific catalog.
 
@@ -64,9 +64,9 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅              |       -      |
-| vCD Prenium  |              ✅              |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅              |       -      |
+| VCD Prenium  |              ✅              |       ✅      |
 
 #### Cluster Management
 
@@ -77,7 +77,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
 
@@ -89,7 +89,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
 |      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
 |   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
-|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions (OpenSource Only !) 	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
 |    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.es-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.es-us.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - The fundamentals of vCD (EN)"
-excerpt: "Discover the basic concepts of vCD"
+title: "VMware Cloud Director - The fundamentals of VCD (EN)"
+excerpt: "Discover the basic concepts of VCD"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide details the fundamentals of vCD at OVHcloud.**
+**This guide details the fundamentals of VCD at OVHcloud.**
 
 ## Fundamental concepts
 
-In this section, we will detail the essential foundations of VMware Cloud Director (VCD). 
+In this section, we will detail the essential foundations of VMware Cloud Director (VCD).
 
 By defining these principles in a clear and concise way, we will provide the necessary foundation for effective and successful VCD use. Whether it’s for administrators looking to deploy complex infrastructures, or for users looking to access resources seamlessly, this exploration of VCD basics is a vital starting point.
 
 ### Organizations
 
-An organization is an administrative entity that groups together specific users, groups, and IT resources. 
+An organization is an administrative entity that groups together specific users, groups, and IT resources.
 
-Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported. 
+Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported.
 
 System administrators are responsible for creating and provisioning organizations, while organization administrators are responsible for managing users, groups, and catalogs specific to the organization.
 
@@ -42,17 +42,17 @@ Only system administrators have the privilege to create such networks, but organ
 
 ### vApp Networks
 
-A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines. 
+A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines.
 
-It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization. 
+It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization.
 
 Furthermore, if the organization’s virtual datacentre network is connected to an external network, this allows the vApp to communicate outside the organization as well.
 
 ### Catalogs
 
-Organizations use catalogs to store vApp templates and media files. 
+Organizations use catalogs to store vApp templates and media files.
 
-Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps. 
+Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps.
 
 In addition, organization administrators have the ability to copy items from public catalogs into their organization-specific catalog.
 
@@ -64,9 +64,9 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅              |       -      |
-| vCD Prenium  |              ✅              |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅              |       -      |
+| VCD Prenium  |              ✅              |       ✅      |
 
 #### Cluster Management
 
@@ -77,9 +77,20 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
+
+##### Virtual Machine Management
+
+|         Features        	| Standard 	| Advanced 	| Prenium 	|                                    Comments                                   	|
+|:-----------------------:	|:--------:	|:--------:	|:-------:	|:-----------------------------------------------------------------------------:	|
+|        Create VM        	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
+| Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
+|      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
+|   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
+|    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.fr-ca.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - Les concepts fondamentaux de vCD"
-excerpt: "Decouvrez les concepts fondamentaux de vCD"
+title: "VMware Cloud Director - Les concepts fondamentaux de VCD"
+excerpt: "Decouvrez les concepts fondamentaux de VCD"
 updated: 2024-04-16
 ---
 
 ## Objectif
 
-**Ce guide vous détaille les fondamentaux de vCD chez OVHcloud.**
+**Ce guide vous détaille les fondamentaux de VCD chez OVHcloud.**
 
 ## Concept fondamentaux
 
-Dans cette section, nous allons établir les bases essentielles de VMware Cloud Director (VCD). 
+Dans cette section, nous allons établir les bases essentielles de VMware Cloud Director (VCD).
 
 En définissant ces principes de manière claire et concise, nous allons fournir les bases nécessaires pour une utilisation efficace et réussie de VCD. Que ce soit pour les administrateurs cherchant à déployer des infrastructures complexes ou pour les utilisateurs souhaitant accéder aux ressources de manière transparente, cette exploration des concepts de base de VCD constitue un point de départ essentiel.
 
 ### Organisations
 
-Une organisation représente une entité administrative regroupant des utilisateurs, des groupes et des ressources informatiques spécifiques. 
+Une organisation représente une entité administrative regroupant des utilisateurs, des groupes et des ressources informatiques spécifiques.
 
-Les utilisateurs s'authentifient au niveau de l'organisation en fournissant des informations d'identification établies par un administrateur d'organisation lors de leur création ou de leur importation. 
+Les utilisateurs s'authentifient au niveau de l'organisation en fournissant des informations d'identification établies par un administrateur d'organisation lors de leur création ou de leur importation.
 
 Les administrateurs système sont responsables de la création et du provisionnement des organisations, tandis que les administrateurs d'organisation prennent en charge la gestion des utilisateurs, des groupes et des catalogues propres à l'organisation.
 
@@ -44,13 +44,13 @@ Seuls les administrateurs système ont le privilège de créer de tels réseaux,
 
 Un réseau vApp est inclus dans une vApp et facilite la communication entre les différentes machines virtuelles de cette vApp.
 
-Il est possible de connecter un réseau vApp à un réseau de datacenter virtuel d'organisation, ce qui permet à la vApp de communiquer avec d'autres vApps au sein de l'organisation. 
+Il est possible de connecter un réseau vApp à un réseau de datacenter virtuel d'organisation, ce qui permet à la vApp de communiquer avec d'autres vApps au sein de l'organisation.
 
 De plus, si le réseau de datacenter virtuel d'organisation est connecté à un réseau externe, cela offre la possibilité à la vApp de communiquer également en dehors de l'organisation.
 
 ### Catalogue
 
-Les organisations exploitent des catalogues pour stocker des modèles vApp ainsi que des fichiers multimédia. 
+Les organisations exploitent des catalogues pour stocker des modèles vApp ainsi que des fichiers multimédia.
 
 Les membres autorisés au sein d'une organisation peuvent accéder à ces catalogues pour utiliser les modèles vApp et les fichiers multimédia qui y sont contenus afin de créer leurs propres vApps.
 
@@ -60,13 +60,13 @@ De plus, les administrateurs d'organisation ont la capacité de copier des élé
 
 ### Fonctionnalités de VMware Cloud Director chez OVHcloud
 
-Retrouvez ci-dessous une comparaison des fonctionnalités fournies par OVHcloud sur ses 3 offres de VMware Cloud Director. 
+Retrouvez ci-dessous une comparaison des fonctionnalités fournies par OVHcloud sur ses 3 offres de VMware Cloud Director.
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅             |       -     |
-| vCD Prenium  |              ✅             |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅             |       -     |
+| VCD Prenium  |              ✅             |       ✅      |
 
 #### Cluster Management
 
@@ -77,7 +77,7 @@ Retrouvez ci-dessous une comparaison des fonctionnalités fournies par OVHcloud 
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
 
@@ -89,7 +89,7 @@ Retrouvez ci-dessous une comparaison des fonctionnalités fournies par OVHcloud 
 | Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
 |      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
 |   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
-|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions (OpenSource Only !) 	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
 |    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.fr-fr.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - Les concepts fondamentaux de vCD"
-excerpt: "Decouvrez les concepts fondamentaux de vCD"
+title: "VMware Cloud Director - Les concepts fondamentaux de VCD"
+excerpt: "Decouvrez les concepts fondamentaux de VCD"
 updated: 2024-04-16
 ---
 
 ## Objectif
 
-**Ce guide vous détaille les fondamentaux de vCD chez OVHcloud.**
+**Ce guide vous détaille les fondamentaux de VCD chez OVHcloud.**
 
 ## Concept fondamentaux
 
-Dans cette section, nous allons établir les bases essentielles de VMware Cloud Director (VCD). 
+Dans cette section, nous allons établir les bases essentielles de VMware Cloud Director (VCD).
 
 En définissant ces principes de manière claire et concise, nous allons fournir les bases nécessaires pour une utilisation efficace et réussie de VCD. Que ce soit pour les administrateurs cherchant à déployer des infrastructures complexes ou pour les utilisateurs souhaitant accéder aux ressources de manière transparente, cette exploration des concepts de base de VCD constitue un point de départ essentiel.
 
 ### Organisations
 
-Une organisation représente une entité administrative regroupant des utilisateurs, des groupes et des ressources informatiques spécifiques. 
+Une organisation représente une entité administrative regroupant des utilisateurs, des groupes et des ressources informatiques spécifiques.
 
-Les utilisateurs s'authentifient au niveau de l'organisation en fournissant des informations d'identification établies par un administrateur d'organisation lors de leur création ou de leur importation. 
+Les utilisateurs s'authentifient au niveau de l'organisation en fournissant des informations d'identification établies par un administrateur d'organisation lors de leur création ou de leur importation.
 
 Les administrateurs système sont responsables de la création et du provisionnement des organisations, tandis que les administrateurs d'organisation prennent en charge la gestion des utilisateurs, des groupes et des catalogues propres à l'organisation.
 
@@ -44,13 +44,13 @@ Seuls les administrateurs système ont le privilège de créer de tels réseaux,
 
 Un réseau vApp est inclus dans une vApp et facilite la communication entre les différentes machines virtuelles de cette vApp.
 
-Il est possible de connecter un réseau vApp à un réseau de datacenter virtuel d'organisation, ce qui permet à la vApp de communiquer avec d'autres vApps au sein de l'organisation. 
+Il est possible de connecter un réseau vApp à un réseau de datacenter virtuel d'organisation, ce qui permet à la vApp de communiquer avec d'autres vApps au sein de l'organisation.
 
 De plus, si le réseau de datacenter virtuel d'organisation est connecté à un réseau externe, cela offre la possibilité à la vApp de communiquer également en dehors de l'organisation.
 
 ### Catalogue
 
-Les organisations exploitent des catalogues pour stocker des modèles vApp ainsi que des fichiers multimédia. 
+Les organisations exploitent des catalogues pour stocker des modèles vApp ainsi que des fichiers multimédia.
 
 Les membres autorisés au sein d'une organisation peuvent accéder à ces catalogues pour utiliser les modèles vApp et les fichiers multimédia qui y sont contenus afin de créer leurs propres vApps.
 
@@ -60,13 +60,13 @@ De plus, les administrateurs d'organisation ont la capacité de copier des élé
 
 ### Fonctionnalités de VMware Cloud Director chez OVHcloud
 
-Retrouvez ci-dessous une comparaison des fonctionnalités fournies par OVHcloud sur ses 3 offres de VMware Cloud Director. 
+Retrouvez ci-dessous une comparaison des fonctionnalités fournies par OVHcloud sur ses 3 offres de VMware Cloud Director.
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅             |       -     |
-| vCD Prenium  |              ✅             |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅             |       -     |
+| VCD Prenium  |              ✅             |       ✅      |
 
 #### Cluster Management
 
@@ -77,7 +77,7 @@ Retrouvez ci-dessous une comparaison des fonctionnalités fournies par OVHcloud 
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
 
@@ -89,7 +89,7 @@ Retrouvez ci-dessous une comparaison des fonctionnalités fournies par OVHcloud 
 | Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
 |      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
 |   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
-|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions (OpenSource Only !) 	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
 |    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.it-it.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.it-it.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - The fundamentals of vCD (EN)"
-excerpt: "Discover the basic concepts of vCD"
+title: "VMware Cloud Director - The fundamentals of VCD (EN)"
+excerpt: "Discover the basic concepts of VCD"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide details the fundamentals of vCD at OVHcloud.**
+**This guide details the fundamentals of VCD at OVHcloud.**
 
 ## Fundamental concepts
 
-In this section, we will detail the essential foundations of VMware Cloud Director (VCD). 
+In this section, we will detail the essential foundations of VMware Cloud Director (VCD).
 
 By defining these principles in a clear and concise way, we will provide the necessary foundation for effective and successful VCD use. Whether it’s for administrators looking to deploy complex infrastructures, or for users looking to access resources seamlessly, this exploration of VCD basics is a vital starting point.
 
 ### Organizations
 
-An organization is an administrative entity that groups together specific users, groups, and IT resources. 
+An organization is an administrative entity that groups together specific users, groups, and IT resources.
 
-Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported. 
+Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported.
 
 System administrators are responsible for creating and provisioning organizations, while organization administrators are responsible for managing users, groups, and catalogs specific to the organization.
 
@@ -42,17 +42,17 @@ Only system administrators have the privilege to create such networks, but organ
 
 ### vApp Networks
 
-A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines. 
+A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines.
 
-It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization. 
+It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization.
 
 Furthermore, if the organization’s virtual datacentre network is connected to an external network, this allows the vApp to communicate outside the organization as well.
 
 ### Catalogs
 
-Organizations use catalogs to store vApp templates and media files. 
+Organizations use catalogs to store vApp templates and media files.
 
-Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps. 
+Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps.
 
 In addition, organization administrators have the ability to copy items from public catalogs into their organization-specific catalog.
 
@@ -64,9 +64,9 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅              |       -      |
-| vCD Prenium  |              ✅              |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅              |       -      |
+| VCD Prenium  |              ✅              |       ✅      |
 
 #### Cluster Management
 
@@ -77,7 +77,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
 
@@ -89,7 +89,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
 |      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
 |   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
-|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions (OpenSource Only !) 	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
 |    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.pl-pl.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - The fundamentals of vCD (EN)"
-excerpt: "Discover the basic concepts of vCD"
+title: "VMware Cloud Director - The fundamentals of VCD (EN)"
+excerpt: "Discover the basic concepts of VCD"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide details the fundamentals of vCD at OVHcloud.**
+**This guide details the fundamentals of VCD at OVHcloud.**
 
 ## Fundamental concepts
 
-In this section, we will detail the essential foundations of VMware Cloud Director (VCD). 
+In this section, we will detail the essential foundations of VMware Cloud Director (VCD).
 
 By defining these principles in a clear and concise way, we will provide the necessary foundation for effective and successful VCD use. Whether it’s for administrators looking to deploy complex infrastructures, or for users looking to access resources seamlessly, this exploration of VCD basics is a vital starting point.
 
 ### Organizations
 
-An organization is an administrative entity that groups together specific users, groups, and IT resources. 
+An organization is an administrative entity that groups together specific users, groups, and IT resources.
 
-Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported. 
+Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported.
 
 System administrators are responsible for creating and provisioning organizations, while organization administrators are responsible for managing users, groups, and catalogs specific to the organization.
 
@@ -42,17 +42,17 @@ Only system administrators have the privilege to create such networks, but organ
 
 ### vApp Networks
 
-A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines. 
+A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines.
 
-It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization. 
+It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization.
 
 Furthermore, if the organization’s virtual datacentre network is connected to an external network, this allows the vApp to communicate outside the organization as well.
 
 ### Catalogs
 
-Organizations use catalogs to store vApp templates and media files. 
+Organizations use catalogs to store vApp templates and media files.
 
-Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps. 
+Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps.
 
 In addition, organization administrators have the ability to copy items from public catalogs into their organization-specific catalog.
 
@@ -64,9 +64,9 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅              |       -      |
-| vCD Prenium  |              ✅              |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅              |       -      |
+| VCD Prenium  |              ✅              |       ✅      |
 
 #### Cluster Management
 
@@ -77,7 +77,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
 
@@ -89,7 +89,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
 |      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
 |   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
-|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions (OpenSource Only !) 	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
 |    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-get-concepts/guide.pt-pt.md
@@ -1,24 +1,24 @@
 ---
-title: "VMware Cloud Director - The fundamentals of vCD (EN)"
-excerpt: "Discover the basic concepts of vCD"
+title: "VMware Cloud Director - The fundamentals of VCD (EN)"
+excerpt: "Discover the basic concepts of VCD"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide details the fundamentals of vCD at OVHcloud.**
+**This guide details the fundamentals of VCD at OVHcloud.**
 
 ## Fundamental concepts
 
-In this section, we will detail the essential foundations of VMware Cloud Director (VCD). 
+In this section, we will detail the essential foundations of VMware Cloud Director (VCD).
 
 By defining these principles in a clear and concise way, we will provide the necessary foundation for effective and successful VCD use. Whether it’s for administrators looking to deploy complex infrastructures, or for users looking to access resources seamlessly, this exploration of VCD basics is a vital starting point.
 
 ### Organizations
 
-An organization is an administrative entity that groups together specific users, groups, and IT resources. 
+An organization is an administrative entity that groups together specific users, groups, and IT resources.
 
-Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported. 
+Users authenticate at the organization level by providing credentials established by an organization administrator when they are created or imported.
 
 System administrators are responsible for creating and provisioning organizations, while organization administrators are responsible for managing users, groups, and catalogs specific to the organization.
 
@@ -42,17 +42,17 @@ Only system administrators have the privilege to create such networks, but organ
 
 ### vApp Networks
 
-A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines. 
+A vApp network is included in a vApp, and facilitates communication between the vApp’s various virtual machines.
 
-It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization. 
+It is possible to connect a vApp network to an organization's virtual datacentre network, which allows the vApp to communicate with other vApps within the organization.
 
 Furthermore, if the organization’s virtual datacentre network is connected to an external network, this allows the vApp to communicate outside the organization as well.
 
 ### Catalogs
 
-Organizations use catalogs to store vApp templates and media files. 
+Organizations use catalogs to store vApp templates and media files.
 
-Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps. 
+Authorized members within an organization can access these catalogs to use the vApp templates and the media files contained within them to create their own vApps.
 
 In addition, organization administrators have the ability to copy items from public catalogs into their organization-specific catalog.
 
@@ -64,9 +64,9 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 
 |              | Advanced Network & Security | vSAN Storage |
 |:------------:|:---------------------------:|:------------:|
-| vCD Standard |              -              |       -      |
-| vCD Advanced |              ✅              |       -      |
-| vCD Prenium  |              ✅              |       ✅      |
+| VCD Standard |              -              |       -      |
+| VCD Advanced |              ✅              |       -      |
+| VCD Prenium  |              ✅              |       ✅      |
 
 #### Cluster Management
 
@@ -77,7 +77,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Features |
 | :-: |
 | ESXi management / capacity planning |
-| Hosts Failover / Proactive HA       |  
+| Hosts Failover / Proactive HA       |
 | DRS / Storage DRS                   |
 | vMotion / Storage vMotion           |
 
@@ -89,7 +89,7 @@ Below is a comparison of the features provided by OVHcloud on its 3 VMware Cloud
 | Manage Virtual Machines 	|     ✅    	|     ✅    	|    ✅    	|                  Start, Stop, Suspend, Delete, Copy/clone...                  	|
 |      Affinity Rules     	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
 |   Anti-Affinity Rules   	|     ✅    	|     ✅    	|    ✅    	|                                                                               	|
-|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions (OpenSource Only !) 	|
+|    VMware Marketplace   	|     ✅    	|     ✅     |    ✅     	| Allowed to deploy VMs with pre-packaged sofware solutions  	                    |
 |    Create VM catalogs   	|     ✅    	|     ✅     |    ✅     	|                     Build your own catalog of VM templates                    	|
 
 #### Organisation / Virtual Datacenter Management

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.de-de.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.de-de.md
@@ -1,12 +1,12 @@
 ---
-title: "VMware Cloud Director - Find out how to use the vCD user interface (EN)"
-excerpt: "Discover the vCD user interface"
+title: "VMware Cloud Director - Find out how to use the VCD user interface (EN)"
+excerpt: "Discover the VCD user interface"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide will walk you through the different sections of the vCD interface.**
+**This guide will walk you through the different sections of the VCD interface.**
 
 ## Requirements
 
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## Instructions
 
-VMware vCloud Director (vCD) is a cloud computing management platform. vCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments. 
+VMware vCloud Director (VCD) is a cloud computing management platform. VCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments.
 
 This solution enables you to provision and efficiently manage virtual machines, virtual networks, and other resources, providing increased operational agility and flexibility to meet changing business needs.
 
 >[!primary]
-> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (vCD).
+> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ In this section, get a comprehensive overview of all your vApps and virtual mach
 
 ![Network Overview](images/vcd-networking-overview.png){.thumbnail}
 
-In this section, you can find all the network components of your vCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
+In this section, you can find all the network components of your VCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-asia.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-asia.md
@@ -1,12 +1,12 @@
 ---
-title: "VMware Cloud Director - Find out how to use the vCD user interface"
-excerpt: "Discover the vCD user interface"
+title: "VMware Cloud Director - Find out how to use the VCD user interface"
+excerpt: "Discover the VCD user interface"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide will walk you through the different sections of the vCD interface.**
+**This guide will walk you through the different sections of the VCD interface.**
 
 ## Requirements
 
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## Instructions
 
-VMware vCloud Director (vCD) is a cloud computing management platform. vCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments. 
+VMware vCloud Director (VCD) is a cloud computing management platform. VCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments.
 
 This solution enables you to provision and efficiently manage virtual machines, virtual networks, and other resources, providing increased operational agility and flexibility to meet changing business needs.
 
 >[!primary]
-> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (vCD).
+> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ In this section, get a comprehensive overview of all your vApps and virtual mach
 
 ![Network Overview](images/vcd-networking-overview.png){.thumbnail}
 
-In this section, you can find all the network components of your vCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
+In this section, you can find all the network components of your VCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-au.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-au.md
@@ -1,12 +1,12 @@
 ---
-title: "VMware Cloud Director - Find out how to use the vCD user interface"
-excerpt: "Discover the vCD user interface"
+title: "VMware Cloud Director - Find out how to use the VCD user interface"
+excerpt: "Discover the VCD user interface"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide will walk you through the different sections of the vCD interface.**
+**This guide will walk you through the different sections of the VCD interface.**
 
 ## Requirements
 
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## Instructions
 
-VMware vCloud Director (vCD) is a cloud computing management platform. vCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments. 
+VMware vCloud Director (VCD) is a cloud computing management platform. VCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments.
 
 This solution enables you to provision and efficiently manage virtual machines, virtual networks, and other resources, providing increased operational agility and flexibility to meet changing business needs.
 
 >[!primary]
-> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (vCD).
+> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ In this section, get a comprehensive overview of all your vApps and virtual mach
 
 ![Network Overview](images/vcd-networking-overview.png){.thumbnail}
 
-In this section, you can find all the network components of your vCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
+In this section, you can find all the network components of your VCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-ca.md
@@ -1,12 +1,12 @@
 ---
-title: "VMware Cloud Director - Find out how to use the vCD user interface"
-excerpt: "Discover the vCD user interface"
+title: "VMware Cloud Director - Find out how to use the VCD user interface"
+excerpt: "Discover the VCD user interface"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide will walk you through the different sections of the vCD interface.**
+**This guide will walk you through the different sections of the VCD interface.**
 
 ## Requirements
 
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## Instructions
 
-VMware vCloud Director (vCD) is a cloud computing management platform. vCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments. 
+VMware vCloud Director (VCD) is a cloud computing management platform. VCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments.
 
 This solution enables you to provision and efficiently manage virtual machines, virtual networks, and other resources, providing increased operational agility and flexibility to meet changing business needs.
 
 >[!primary]
-> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (vCD).
+> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ In this section, get a comprehensive overview of all your vApps and virtual mach
 
 ![Network Overview](images/vcd-networking-overview.png){.thumbnail}
 
-In this section, you can find all the network components of your vCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
+In this section, you can find all the network components of your VCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-gb.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-gb.md
@@ -1,12 +1,12 @@
 ---
-title: "VMware Cloud Director - Find out how to use the vCD user interface"
-excerpt: "Discover the vCD user interface"
+title: "VMware Cloud Director - Find out how to use the VCD user interface"
+excerpt: "Discover the VCD user interface"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide will walk you through the different sections of the vCD interface.**
+**This guide will walk you through the different sections of the VCD interface.**
 
 ## Requirements
 
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## Instructions
 
-VMware vCloud Director (vCD) is a cloud computing management platform. vCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments. 
+VMware vCloud Director (VCD) is a cloud computing management platform. VCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments.
 
 This solution enables you to provision and efficiently manage virtual machines, virtual networks, and other resources, providing increased operational agility and flexibility to meet changing business needs.
 
 >[!primary]
-> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (vCD).
+> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ In this section, get a comprehensive overview of all your vApps and virtual mach
 
 ![Network Overview](images/vcd-networking-overview.png){.thumbnail}
 
-In this section, you can find all the network components of your vCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
+In this section, you can find all the network components of your VCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-ie.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-ie.md
@@ -1,12 +1,12 @@
 ---
-title: "VMware Cloud Director - Find out how to use the vCD user interface"
-excerpt: "Discover the vCD user interface"
+title: "VMware Cloud Director - Find out how to use the VCD user interface"
+excerpt: "Discover the VCD user interface"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide will walk you through the different sections of the vCD interface.**
+**This guide will walk you through the different sections of the VCD interface.**
 
 ## Requirements
 
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## Instructions
 
-VMware vCloud Director (vCD) is a cloud computing management platform. vCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments. 
+VMware vCloud Director (VCD) is a cloud computing management platform. VCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments.
 
 This solution enables you to provision and efficiently manage virtual machines, virtual networks, and other resources, providing increased operational agility and flexibility to meet changing business needs.
 
 >[!primary]
-> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (vCD).
+> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ In this section, get a comprehensive overview of all your vApps and virtual mach
 
 ![Network Overview](images/vcd-networking-overview.png){.thumbnail}
 
-In this section, you can find all the network components of your vCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
+In this section, you can find all the network components of your VCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-sg.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-sg.md
@@ -1,12 +1,12 @@
 ---
-title: "VMware Cloud Director - Find out how to use the vCD user interface"
-excerpt: "Discover the vCD user interface"
+title: "VMware Cloud Director - Find out how to use the VCD user interface"
+excerpt: "Discover the VCD user interface"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide will walk you through the different sections of the vCD interface.**
+**This guide will walk you through the different sections of the VCD interface.**
 
 ## Requirements
 
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## Instructions
 
-VMware vCloud Director (vCD) is a cloud computing management platform. vCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments. 
+VMware vCloud Director (VCD) is a cloud computing management platform. VCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments.
 
 This solution enables you to provision and efficiently manage virtual machines, virtual networks, and other resources, providing increased operational agility and flexibility to meet changing business needs.
 
 >[!primary]
-> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (vCD).
+> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ In this section, get a comprehensive overview of all your vApps and virtual mach
 
 ![Network Overview](images/vcd-networking-overview.png){.thumbnail}
 
-In this section, you can find all the network components of your vCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
+In this section, you can find all the network components of your VCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.en-us.md
@@ -1,12 +1,12 @@
 ---
-title: "VMware Cloud Director - Find out how to use the vCD user interface"
-excerpt: "Discover the vCD user interface"
+title: "VMware Cloud Director - Find out how to use the VCD user interface"
+excerpt: "Discover the VCD user interface"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide will walk you through the different sections of the vCD interface.**
+**This guide will walk you through the different sections of the VCD interface.**
 
 ## Requirements
 
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## Instructions
 
-VMware vCloud Director (vCD) is a cloud computing management platform. vCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments. 
+VMware vCloud Director (VCD) is a cloud computing management platform. VCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments.
 
 This solution enables you to provision and efficiently manage virtual machines, virtual networks, and other resources, providing increased operational agility and flexibility to meet changing business needs.
 
 >[!primary]
-> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (vCD).
+> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ In this section, get a comprehensive overview of all your vApps and virtual mach
 
 ![Network Overview](images/vcd-networking-overview.png){.thumbnail}
 
-In this section, you can find all the network components of your vCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
+In this section, you can find all the network components of your VCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.es-es.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.es-es.md
@@ -1,12 +1,12 @@
 ---
-title: "VMware Cloud Director - Find out how to use the vCD user interface (EN)"
-excerpt: "Discover the vCD user interface"
+title: "VMware Cloud Director - Find out how to use the VCD user interface (EN)"
+excerpt: "Discover the VCD user interface"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide will walk you through the different sections of the vCD interface.**
+**This guide will walk you through the different sections of the VCD interface.**
 
 ## Requirements
 
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## Instructions
 
-VMware vCloud Director (vCD) is a cloud computing management platform. vCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments. 
+VMware vCloud Director (VCD) is a cloud computing management platform. VCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments.
 
 This solution enables you to provision and efficiently manage virtual machines, virtual networks, and other resources, providing increased operational agility and flexibility to meet changing business needs.
 
 >[!primary]
-> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (vCD).
+> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ In this section, get a comprehensive overview of all your vApps and virtual mach
 
 ![Network Overview](images/vcd-networking-overview.png){.thumbnail}
 
-In this section, you can find all the network components of your vCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
+In this section, you can find all the network components of your VCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.es-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.es-us.md
@@ -1,12 +1,12 @@
 ---
-title: "VMware Cloud Director - Find out how to use the vCD user interface (EN)"
-excerpt: "Discover the vCD user interface"
+title: "VMware Cloud Director - Find out how to use the VCD user interface (EN)"
+excerpt: "Discover the VCD user interface"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide will walk you through the different sections of the vCD interface.**
+**This guide will walk you through the different sections of the VCD interface.**
 
 ## Requirements
 
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## Instructions
 
-VMware vCloud Director (vCD) is a cloud computing management platform. vCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments. 
+VMware vCloud Director (VCD) is a cloud computing management platform. VCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments.
 
 This solution enables you to provision and efficiently manage virtual machines, virtual networks, and other resources, providing increased operational agility and flexibility to meet changing business needs.
 
 >[!primary]
-> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (vCD).
+> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ In this section, get a comprehensive overview of all your vApps and virtual mach
 
 ![Network Overview](images/vcd-networking-overview.png){.thumbnail}
 
-In this section, you can find all the network components of your vCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
+In this section, you can find all the network components of your VCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.fr-ca.md
@@ -1,5 +1,5 @@
 ---
-title: "VMware Cloud Director - Découvrez comment utiliser l'interface utilisateur de vCD"
+title: "VMware Cloud Director - Découvrez comment utiliser l'interface utilisateur de VCD"
 excerpt: "Découvrez l'interface utilisateur de VMware Cloud Director"
 updated: 2024-04-16
 ---
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## En pratique
 
-VMware vCloud Director (vCD) est une plateforme de gestion de cloud computing. Celle-ci permet la création, la gestion et le déploiement de ressources informatiques virtualisées à grande échelle. vCD offre une infrastructure agile et évolutive. Grâce à son interface utilisateur conviviale et à ses fonctionnalités avancées telles que la gestion des ressources, la facturation automatisée et la sécurité renforcée, vCloud Director simplifie la gestion des environnements cloud complexes.
+VMware vCloud Director (VCD) est une plateforme de gestion de cloud computing. Celle-ci permet la création, la gestion et le déploiement de ressources informatiques virtualisées à grande échelle. VCD offre une infrastructure agile et évolutive. Grâce à son interface utilisateur conviviale et à ses fonctionnalités avancées telles que la gestion des ressources, la facturation automatisée et la sécurité renforcée, vCloud Director simplifie la gestion des environnements cloud complexes.
 
 Cette solution vous permet de provisionner et de gérer efficacement des machines virtuelles, des réseaux virtuels et d'autres ressources, offrant ainsi une agilité opérationnelle et une flexibilité accrues pour répondre aux besoins changeants des entreprises.
 
 >[!primary]
-> Une fois connecté à votre interface web, vous serez accueilli par un tableau de bord affichant vos **vDC**, ainsi qu'un résumé détaillé de votre utilisation des ressources (10). En haut de l'écran, vous trouverez également une barre de navigation regroupant les différentes options de paramétrage disponibles pour vCloud Director (vCD).
+> Une fois connecté à votre interface web, vous serez accueilli par un tableau de bord affichant vos **vDC**, ainsi qu'un résumé détaillé de votre utilisation des ressources (10). En haut de l'écran, vous trouverez également une barre de navigation regroupant les différentes options de paramétrage disponibles pour vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ Cette section vous permet de profiter d'une vision d'ensemble complète de tous 
 
 ![Réseau Overview](images/vcd-networking-overview.png){.thumbnail}
 
-Dans cette section, retrouvez tous les composants réseau de vos environnements vCD : réseaux, passerelles Edge, passerelles fournisseur, plages d'adresses IP, groupes de centres de données et balises de sécurité.
+Dans cette section, retrouvez tous les composants réseau de vos environnements VCD : réseaux, passerelles Edge, passerelles fournisseur, plages d'adresses IP, groupes de centres de données et balises de sécurité.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.fr-fr.md
@@ -1,5 +1,5 @@
 ---
-title: "VMware Cloud Director - Découvrez comment utiliser l'interface utilisateur de vCD"
+title: "VMware Cloud Director - Découvrez comment utiliser l'interface utilisateur de VCD"
 excerpt: "Découvrez l'interface utilisateur de VMware Cloud Director"
 updated: 2024-04-16
 ---
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## En pratique
 
-VMware vCloud Director (vCD) est une plateforme de gestion de cloud computing. Celle-ci permet la création, la gestion et le déploiement de ressources informatiques virtualisées à grande échelle. vCD offre une infrastructure agile et évolutive. Grâce à son interface utilisateur conviviale et à ses fonctionnalités avancées telles que la gestion des ressources, la facturation automatisée et la sécurité renforcée, vCloud Director simplifie la gestion des environnements cloud complexes.
+VMware vCloud Director (VCD) est une plateforme de gestion de cloud computing. Celle-ci permet la création, la gestion et le déploiement de ressources informatiques virtualisées à grande échelle. VCD offre une infrastructure agile et évolutive. Grâce à son interface utilisateur conviviale et à ses fonctionnalités avancées telles que la gestion des ressources, la facturation automatisée et la sécurité renforcée, vCloud Director simplifie la gestion des environnements cloud complexes.
 
 Cette solution vous permet de provisionner et de gérer efficacement des machines virtuelles, des réseaux virtuels et d'autres ressources, offrant ainsi une agilité opérationnelle et une flexibilité accrues pour répondre aux besoins changeants des entreprises.
 
 >[!primary]
-> Une fois connecté à votre interface web, vous serez accueilli par un tableau de bord affichant vos **vDC**, ainsi qu'un résumé détaillé de votre utilisation des ressources (10). En haut de l'écran, vous trouverez également une barre de navigation regroupant les différentes options de paramétrage disponibles pour vCloud Director (vCD).
+> Une fois connecté à votre interface web, vous serez accueilli par un tableau de bord affichant vos **vDC**, ainsi qu'un résumé détaillé de votre utilisation des ressources (10). En haut de l'écran, vous trouverez également une barre de navigation regroupant les différentes options de paramétrage disponibles pour vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ Cette section vous permet de profiter d'une vision d'ensemble complète de tous 
 
 ![Réseau Overview](images/vcd-networking-overview.png){.thumbnail}
 
-Dans cette section, retrouvez tous les composants réseau de vos environnements vCD : réseaux, passerelles Edge, passerelles fournisseur, plages d'adresses IP, groupes de centres de données et balises de sécurité.
+Dans cette section, retrouvez tous les composants réseau de vos environnements VCD : réseaux, passerelles Edge, passerelles fournisseur, plages d'adresses IP, groupes de centres de données et balises de sécurité.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.it-it.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.it-it.md
@@ -1,12 +1,12 @@
 ---
-title: "VMware Cloud Director - Find out how to use the vCD user interface (EN)"
-excerpt: "Discover the vCD user interface"
+title: "VMware Cloud Director - Find out how to use the VCD user interface (EN)"
+excerpt: "Discover the VCD user interface"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide will walk you through the different sections of the vCD interface.**
+**This guide will walk you through the different sections of the VCD interface.**
 
 ## Requirements
 
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## Instructions
 
-VMware vCloud Director (vCD) is a cloud computing management platform. vCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments. 
+VMware vCloud Director (VCD) is a cloud computing management platform. VCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments.
 
 This solution enables you to provision and efficiently manage virtual machines, virtual networks, and other resources, providing increased operational agility and flexibility to meet changing business needs.
 
 >[!primary]
-> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (vCD).
+> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ In this section, get a comprehensive overview of all your vApps and virtual mach
 
 ![Network Overview](images/vcd-networking-overview.png){.thumbnail}
 
-In this section, you can find all the network components of your vCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
+In this section, you can find all the network components of your VCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.pl-pl.md
@@ -1,12 +1,12 @@
 ---
-title: "VMware Cloud Director - Find out how to use the vCD user interface (EN)"
-excerpt: "Discover the vCD user interface"
+title: "VMware Cloud Director - Find out how to use the VCD user interface (EN)"
+excerpt: "Discover the VCD user interface"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide will walk you through the different sections of the vCD interface.**
+**This guide will walk you through the different sections of the VCD interface.**
 
 ## Requirements
 
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## Instructions
 
-VMware vCloud Director (vCD) is a cloud computing management platform. vCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments. 
+VMware vCloud Director (VCD) is a cloud computing management platform. VCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments.
 
 This solution enables you to provision and efficiently manage virtual machines, virtual networks, and other resources, providing increased operational agility and flexibility to meet changing business needs.
 
 >[!primary]
-> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (vCD).
+> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ In this section, get a comprehensive overview of all your vApps and virtual mach
 
 ![Network Overview](images/vcd-networking-overview.png){.thumbnail}
 
-In this section, you can find all the network components of your vCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
+In this section, you can find all the network components of your VCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-getting-started/guide.pt-pt.md
@@ -1,12 +1,12 @@
 ---
-title: "VMware Cloud Director - Find out how to use the vCD user interface (EN)"
-excerpt: "Discover the vCD user interface"
+title: "VMware Cloud Director - Find out how to use the VCD user interface (EN)"
+excerpt: "Discover the VCD user interface"
 updated: 2024-04-16
 ---
 
 ## Objective
 
-**This guide will walk you through the different sections of the vCD interface.**
+**This guide will walk you through the different sections of the VCD interface.**
 
 ## Requirements
 
@@ -17,12 +17,12 @@ updated: 2024-04-16
 
 ## Instructions
 
-VMware vCloud Director (vCD) is a cloud computing management platform. vCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments. 
+VMware vCloud Director (VCD) is a cloud computing management platform. VCD enables the creation, management and deployment of virtualized computing resources on a large scale, and offers an agile and scalable infrastructure. With an easy-to-use user interface and advanced features such as resource management, automated billing, and enhanced security, vCloud Director simplifies the management of complex cloud environments.
 
 This solution enables you to provision and efficiently manage virtual machines, virtual networks, and other resources, providing increased operational agility and flexibility to meet changing business needs.
 
 >[!primary]
-> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (vCD).
+> Once you have logged in to your web interface, you will be greeted by a dashboard displaying your **vDC**, as well as a detailed summary of your resource usage (10). At the top of the screen, you will also find a navigation bar with the different settings options available for vCloud Director (VCD).
 
 ![Dashboard Overview](images/vcd-dashboard-overview.png){.thumbnail}
 
@@ -55,7 +55,7 @@ In this section, get a comprehensive overview of all your vApps and virtual mach
 
 ![Network Overview](images/vcd-networking-overview.png){.thumbnail}
 
-In this section, you can find all the network components of your vCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
+In this section, you can find all the network components of your VCD environments: networks, Edge Gateways, Provider Gateways, IP address ranges, datacentre groups, and security tags.
 
 ### Content Hub
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.de-de.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.de-de.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### First login
 
-Open your web browser and go to the vCD login page. Enter your organization name (provided in the account creation email).
+Open your web browser and go to the VCD login page. Enter your organization name (provided in the account creation email).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-asia.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-asia.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### First login
 
-Open your web browser and go to the vCD login page. Enter your organization name (provided in the account creation email).
+Open your web browser and go to the VCD login page. Enter your organization name (provided in the account creation email).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-au.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-au.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### First login
 
-Open your web browser and go to the vCD login page. Enter your organization name (provided in the account creation email).
+Open your web browser and go to the VCD login page. Enter your organization name (provided in the account creation email).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-ca.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### First login
 
-Open your web browser and go to the vCD login page. Enter your organization name (provided in the account creation email).
+Open your web browser and go to the VCD login page. Enter your organization name (provided in the account creation email).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-gb.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-gb.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### First login
 
-Open your web browser and go to the vCD login page. Enter your organization name (provided in the account creation email).
+Open your web browser and go to the VCD login page. Enter your organization name (provided in the account creation email).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-ie.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-ie.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### First login
 
-Open your web browser and go to the vCD login page. Enter your organization name (provided in the account creation email).
+Open your web browser and go to the VCD login page. Enter your organization name (provided in the account creation email).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-sg.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-sg.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### First login
 
-Open your web browser and go to vCD login page. Enter your organization name (provided in the account creation email).
+Open your web browser and go to VCD login page. Enter your organization name (provided in the account creation email).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.en-us.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### First login
 
-Open your web browser and go to the vCD login page. Enter your organization name (provided in the account creation email).
+Open your web browser and go to the VCD login page. Enter your organization name (provided in the account creation email).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.es-es.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.es-es.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### First login
 
-Open your web browser and go to the vCD login page. Enter your organization name (provided in the account creation email).
+Open your web browser and go to the VCD login page. Enter your organization name (provided in the account creation email).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.es-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.es-us.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### First login
 
-Open your web browser and go to the vCD login page. Enter your organization name (provided in the account creation email).
+Open your web browser and go to the VCD login page. Enter your organization name (provided in the account creation email).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.fr-ca.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### Premiere connexion
 
-Ouvrez votre navigateur web et rendez-vous sur la page de connexion du vCD. Renseignez votre nom d'organisation (celui-ci est fourni dans l'e-mail de création de compte).
+Ouvrez votre navigateur web et rendez-vous sur la page de connexion du VCD. Renseignez votre nom d'organisation (celui-ci est fourni dans l'e-mail de création de compte).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.fr-fr.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### Premiere connexion
 
-Ouvrez votre navigateur web et rendez-vous sur la page de connexion du vCD. Renseignez votre nom d'organisation (celui-ci est fourni dans l'e-mail de création de compte).
+Ouvrez votre navigateur web et rendez-vous sur la page de connexion du VCD. Renseignez votre nom d'organisation (celui-ci est fourni dans l'e-mail de création de compte).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.it-it.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.it-it.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### First login
 
-Open your web browser and go to the vCD login page. Enter your organization name (provided in the account creation email).
+Open your web browser and go to the VCD login page. Enter your organization name (provided in the account creation email).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.pl-pl.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### First login
 
-Open your web browser and go to the vCD login page. Enter your organization name (provided in the account creation email).
+Open your web browser and go to the VCD login page. Enter your organization name (provided in the account creation email).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-logging/guide.pt-pt.md
@@ -17,7 +17,7 @@ updated: 2024-04-16
 
 ### First login
 
-Open your web browser and go to the vCD login page. Enter your organization name (provided in the account creation email).
+Open your web browser and go to the VCD login page. Enter your organization name (provided in the account creation email).
 
 ![First page connection](images/vcd-organization-connection.png){.thumbnail}
 


### PR DESCRIPTION
Change "vCD" to "VCD" according to VMware Cloud Director official doc: https://docs.vmware.com/en/VMware-Cloud-Director/index.html the official abbreviation is "VCD".

Fixed some doc lang that have `<a name="vDConOVH"></a>` instead of `<a name="VCDonOVH"></a>`.

Remove the "(OpenSource Only!)" mention in the VMware Marketplace comment, as there is some pre-packaged software available there that is not open source, but simply does not require a license.

Add missing "Virtual Machine Management" section for es-us lang.
