### PR TITLE
feat(dedicated/api-os-installation): add api call to share anchored link

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.de-de.md
@@ -82,6 +82,11 @@ You can find interesting information such as the following:
 
 Some OSs can have a list of specific questions. If that is the case, the `inputs` key contains a list of questions.
 
+> [!api]
+>
+> @api {v1} /dedicated/installationTemplate GET  /dedicated/installationTemplate/{templateName}
+>
+
 Example of specific questions for Debian 12 (Bookworm):
 
 ```json

--- a/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-asia.md
@@ -82,6 +82,11 @@ You can find interesting information such as the following:
 
 Some OSs can have a list of specific questions. If that is the case, the `inputs` key contains a list of questions.
 
+> [!api]
+>
+> @api {v1} /dedicated/installationTemplate GET  /dedicated/installationTemplate/{templateName}
+>
+
 Example of specific questions for Debian 12 (Bookworm):
 
 ```json

--- a/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-au.md
@@ -82,6 +82,11 @@ You can find interesting information such as the following:
 
 Some OSs can have a list of specific questions. If that is the case, the `inputs` key contains a list of questions.
 
+> [!api]
+>
+> @api {v1} /dedicated/installationTemplate GET  /dedicated/installationTemplate/{templateName}
+>
+
 Example of specific questions for Debian 12 (Bookworm):
 
 ```json

--- a/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-ca.md
@@ -82,6 +82,11 @@ You can find interesting information such as the following:
 
 Some OSs can have a list of specific questions. If that is the case, the `inputs` key contains a list of questions.
 
+> [!api]
+>
+> @api {v1} /dedicated/installationTemplate GET  /dedicated/installationTemplate/{templateName}
+>
+
 Example of specific questions for Debian 12 (Bookworm):
 
 ```json

--- a/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-gb.md
@@ -82,6 +82,11 @@ You can find interesting information such as the following:
 
 Some OSs can have a list of specific questions. If that is the case, the `inputs` key contains a list of questions.
 
+> [!api]
+>
+> @api {v1} /dedicated/installationTemplate GET  /dedicated/installationTemplate/{templateName}
+>
+
 Example of specific questions for Debian 12 (Bookworm):
 
 ```json

--- a/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-ie.md
@@ -82,6 +82,11 @@ You can find interesting information such as the following:
 
 Some OSs can have a list of specific questions. If that is the case, the `inputs` key contains a list of questions.
 
+> [!api]
+>
+> @api {v1} /dedicated/installationTemplate GET  /dedicated/installationTemplate/{templateName}
+>
+
 Example of specific questions for Debian 12 (Bookworm):
 
 ```json

--- a/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-sg.md
@@ -82,6 +82,11 @@ You can find interesting information such as the following:
 
 Some OSs can have a list of specific questions. If that is the case, the `inputs` key contains a list of questions.
 
+> [!api]
+>
+> @api {v1} /dedicated/installationTemplate GET  /dedicated/installationTemplate/{templateName}
+>
+
 Example of specific questions for Debian 12 (Bookworm):
 
 ```json

--- a/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.en-us.md
@@ -82,6 +82,11 @@ You can find interesting information such as the following:
 
 Some OSs can have a list of specific questions. If that is the case, the `inputs` key contains a list of questions.
 
+> [!api]
+>
+> @api {v1} /dedicated/installationTemplate GET  /dedicated/installationTemplate/{templateName}
+>
+
 Example of specific questions for Debian 12 (Bookworm):
 
 ```json

--- a/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.es-es.md
@@ -82,6 +82,11 @@ You can find interesting information such as the following:
 
 Some OSs can have a list of specific questions. If that is the case, the `inputs` key contains a list of questions.
 
+> [!api]
+>
+> @api {v1} /dedicated/installationTemplate GET  /dedicated/installationTemplate/{templateName}
+>
+
 Example of specific questions for Debian 12 (Bookworm):
 
 ```json

--- a/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.es-us.md
@@ -82,6 +82,11 @@ You can find interesting information such as the following:
 
 Some OSs can have a list of specific questions. If that is the case, the `inputs` key contains a list of questions.
 
+> [!api]
+>
+> @api {v1} /dedicated/installationTemplate GET  /dedicated/installationTemplate/{templateName}
+>
+
 Example of specific questions for Debian 12 (Bookworm):
 
 ```json

--- a/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.it-it.md
@@ -82,6 +82,11 @@ You can find interesting information such as the following:
 
 Some OSs can have a list of specific questions. If that is the case, the `inputs` key contains a list of questions.
 
+> [!api]
+>
+> @api {v1} /dedicated/installationTemplate GET  /dedicated/installationTemplate/{templateName}
+>
+
 Example of specific questions for Debian 12 (Bookworm):
 
 ```json

--- a/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.pl-pl.md
@@ -82,6 +82,11 @@ You can find interesting information such as the following:
 
 Some OSs can have a list of specific questions. If that is the case, the `inputs` key contains a list of questions.
 
+> [!api]
+>
+> @api {v1} /dedicated/installationTemplate GET  /dedicated/installationTemplate/{templateName}
+>
+
 Example of specific questions for Debian 12 (Bookworm):
 
 ```json

--- a/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/api-os-installation/guide.pt-pt.md
@@ -82,6 +82,11 @@ You can find interesting information such as the following:
 
 Some OSs can have a list of specific questions. If that is the case, the `inputs` key contains a list of questions.
 
+> [!api]
+>
+> @api {v1} /dedicated/installationTemplate GET  /dedicated/installationTemplate/{templateName}
+>
+
 Example of specific questions for Debian 12 (Bookworm):
 
 ```json


### PR DESCRIPTION
ref: PUBM-36345

We want to share https://help.ovhcloud.com/csm/en-dedicated-servers-api-os-installation?id=kb_article_view&sysparm_article=KB0061951#os-questions in terraform provider doc, but as you can see, customer arrives at this part of the page and doesn't know where this data comes from