### PR TITLE
Updated docs for MKS with vRack and Nodeport usage

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.en-asia.md
@@ -62,6 +62,10 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 >
 > In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
+> [!warning]
+> If your OVHcloud Managed Kubernets is connected to a vRack the `NodePort` is only exposed on your private Subnet. So you have to check your private IPs on your nodes in your Nodepool and you can
+> connect via one of these private IPs.
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.en-ca.md
@@ -62,6 +62,10 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 >
 > In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
+> [!warning]
+> If your OVHcloud Managed Kubernets is connected to a vRack the `NodePort` is only exposed on your private Subnet. So you have to check your private IPs on your nodes in your Nodepool and you can
+> connect via one of these private IPs.
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.en-gb.md
@@ -62,6 +62,10 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 >
 > In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
+> [!warning]
+> If your OVHcloud Managed Kubernets is connected to a vRack the `NodePort` is only exposed on your private Subnet. So you have to check your private IPs on your nodes in your Nodepool and you can
+> connect via one of these private IPs.
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.en-ie.md
@@ -62,6 +62,10 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 >
 > In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
+> [!warning]
+> If your OVHcloud Managed Kubernets is connected to a vRack the `NodePort` is only exposed on your private Subnet. So you have to check your private IPs on your nodes in your Nodepool and you can
+> connect via one of these private IPs.
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.en-sg.md
@@ -62,6 +62,10 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 >
 > In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
+> [!warning]
+> If your OVHcloud Managed Kubernets is connected to a vRack the `NodePort` is only exposed on your private Subnet. So you have to check your private IPs on your nodes in your Nodepool and you can
+> connect via one of these private IPs.
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.en-us.md
@@ -62,6 +62,10 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 >
 > In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
+> [!warning]
+> If your OVHcloud Managed Kubernets is connected to a vRack the `NodePort` is only exposed on your private Subnet. So you have to check your private IPs on your nodes in your Nodepool and you can
+> connect via one of these private IPs.
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.es-es.md
@@ -62,6 +62,10 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 >
 > In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
+> [!warning]
+> If your OVHcloud Managed Kubernets is connected to a vRack the `NodePort` is only exposed on your private Subnet. So you have to check your private IPs on your nodes in your Nodepool and you can
+> connect via one of these private IPs.
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.fr-ca.md
@@ -62,6 +62,10 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 >
 > In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
+> [!warning]
+> If your OVHcloud Managed Kubernets is connected to a vRack the `NodePort` is only exposed on your private Subnet. So you have to check your private IPs on your nodes in your Nodepool and you can
+> connect via one of these private IPs.
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.fr-fr.md
@@ -62,6 +62,10 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 >
 > In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
+> [!warning]
+> If your OVHcloud Managed Kubernets is connected to a vRack the `NodePort` is only exposed on your private Subnet. So you have to check your private IPs on your nodes in your Nodepool and you can
+> connect via one of these private IPs.
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.it-it.md
@@ -62,6 +62,10 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 >
 > In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
+> [!warning]
+> If your OVHcloud Managed Kubernets is connected to a vRack the `NodePort` is only exposed on your private Subnet. So you have to check your private IPs on your nodes in your Nodepool and you can
+> connect via one of these private IPs.
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/using-lb/guide.pl-pl.md
@@ -62,6 +62,10 @@ It's rather cumbersome to use `NodePort` `Services` in production. As you are us
 >
 > In this case the *nodes* URL will be `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net` and a service deployed on NodePort 30123 can be accessed on `https://xxxxxx.nodes.c1.gra9.k8s.ovh.net:30123`.
 
+> [!warning]
+> If your OVHcloud Managed Kubernets is connected to a vRack the `NodePort` is only exposed on your private Subnet. So you have to check your private IPs on your nodes in your Nodepool and you can
+> connect via one of these private IPs.
+
 ### Exposing services as LoadBalancer
 
 Declaring a service of type `LoadBalancer` exposes it externally using a cloud provider’s load balancer. The cloud provider will provision a load balancer for the `Service`, and map it to its automatically assigned `NodePort`. How the traffic from that external load balancer is routed to the `Service` pods depends on the cluster provider.


### PR DESCRIPTION
I added the information, that a MKS with vRack doesn't expose the Nodeport on public interfaces.