### PR TITLE
Public Cloud Databases - Lifecyle Policy - Title update + Kafka versions update

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -651,7 +651,7 @@
     + [Public Cloud Databases](products/public-cloud-databases)
         + [General information](public-cloud-databases-general-information)
             + [Concepts - Security overview](public_cloud/public_cloud_databases/information_01_security_overview)
-            + [DBMS lifecycle policy](public_cloud/public_cloud_databases/information_02_lifecycle_policy)
+            + [Public Cloud Databases - Lifecycle policy](public_cloud/public_cloud_databases/information_02_lifecycle_policy)
             + [Responsibility model](public_cloud/public_cloud_databases/information_03_shared_responsibility)
             + [FAQ Public Cloud databases](public_cloud/public_cloud_databases/information_04_faq)
             + [Public Cloud Databases - Capabilities and Limitations](public_cloud/public_cloud_databases/information_05_capabilities)

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.de-de.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-asia.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-au.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-ca.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-gb.md
@@ -1,5 +1,5 @@
 ---
-title: DBMS lifecycle policy
+title: Public Cloud Databases - Lifecycle policy
 excerpt: Lifecycle policy for Public Cloud Databases engines
 updated: 2021-09-15
 ---
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-ie.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-sg.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.en-us.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.es-es.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.es-us.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.fr-ca.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 
@@ -96,4 +98,4 @@ Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask question
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr-ca/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on <https://community.ovh.com/>.
+Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.fr-fr.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 
@@ -96,4 +98,4 @@ Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask question
 
 If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
-Join our community of users on <https://community.ovh.com/>.
+Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.it-it.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.pl-pl.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/guide.pt-pt.md
@@ -26,7 +26,7 @@ Continued use of outdated services means that they no longer offer our customers
 This lifecycle policy is applicable to :
 
 - All Public Cloud Databases services;
-- Including all the service plans (Essential, Business, Enterprise);
+- Including all the service plans (Essential, Business, Enterprise, Production, Advanced);
 - And all proposed DBMS, such as MySQL, PostgreSQL, MongoDB, Redis, Kafka, ...
 - Whatever state; if they are **up and running** or in a **sleeping state** (powered off, waiting for payment).
 
@@ -70,9 +70,11 @@ To perform a fork, navigate to the "Overview" page of your service, and scroll d
 Public Cloud Databases for Kafka *major.minor* version will reach EOL approximately one year after it's made available on Public Cloud Databases.
 
 | **Kafka Version** | **OVHcloud EOL** | **Availability on Public Cloud Databases** |
-|-------|------------|------------|
-| 2.7.x | 2022-01-24 | 2021-01-21 |
-| 2.8.x | 2022-06-26 | 2021-04-26 |
+|-------------------|------------------|-------------------------------------------|
+| 3.4.x             | 2024-05-13       | 2023-05-09                                |
+| 3.5.x             | 2024-07-31       | 2023-07-31                                |
+| 3.6.x             | 2024-10-18       | 2023-10-18                                |
+| 3.7.x             | 2025-04-17       | 2024-04-17                                |
 
 ### MongoDB
 


### PR DESCRIPTION
   Update title: "Public Cloud Databases - Lifecycle policy"
    ¶ Lifecycle policy - Service coverage: update the service plans bullet point to include "Production" and "Advanced" plans.
    ¶ EOL Announcements for major versions - Kafka: remove 2.7.x and 2.8.x version already end of life, and add the following rows
        3.4.x / EOL at 2024-05-13 / Availability 2023-05-09
        3.5.x / EOL at 2024-07-31 / Availability 2023-07-31
        3.6.x / EOL at 2024-10-18 / Availability 2023-10-18
        3.7.x / EOL at 2025-04-17 / Availability 2024-04-17
