### PR TITLE
fix(mks): update s3 client configuration in velero docs

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.de-de.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-asia.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-au.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-ca.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-gb.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-ie.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-sg.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-us.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.es-es.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.es-us.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.fr-ca.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.fr-fr.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.it-it.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.pl-pl.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.pt-pt.md
@@ -90,6 +90,8 @@ Complete and write down the configuration into `~/.aws/config`:
 endpoint = awscli_plugin_endpoint
 
 [profile default]
+aws_access_key_id=<access_key>
+aws_secret_access_key=<secret_key>
 # region = <public_cloud_region_without_digit>
 region = gra #for example
 s3 =


### PR DESCRIPTION
The step to configure s3 credentials doesn't seem to appear in the current docs, so when trying to create the bucket the following error occurs:

```
$ aws --profile default s3 mb s3://velero-s3                                                                                
make_bucket failed: s3://velero-s3 Unable to locate credentials
```