### PR TITLE
EN: Update guide.en-gb.md

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/using_ipmi_on_dedicated_servers/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/using_ipmi_on_dedicated_servers/guide.en-gb.md
@@ -86,6 +86,7 @@ It will take several minutes for the IPMI to reboot.
 
 > [!warning]
 > OVHcloud does not guarantee the functionality of any operating systems installed via IPMI. This route should only be taken by an experienced server administrator.
+> 64bit versions of Java can prevent the Redirect ISO/Redirect CDROM menus from opening and cause JViewer to crash.
 >
 
 To begin, open [IPMI in a Java applet](./#applet-java) from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB). Then, click `Device`{.action} from the menu bar and select `Redirect ISO`{.action} from the drop-down menu.

--- a/pages/bare_metal_cloud/dedicated_servers/using_ipmi_on_dedicated_servers/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/using_ipmi_on_dedicated_servers/guide.en-gb.md
@@ -86,8 +86,8 @@ It will take several minutes for the IPMI to reboot.
 
 > [!warning]
 > OVHcloud does not guarantee the functionality of any operating systems installed via IPMI. This route should only be taken by an experienced server administrator.
-> 64bit versions of Java can prevent the Redirect ISO/Redirect CDROM menus from opening and cause JViewer to crash.
 >
+> 64-bit versions of Java can prevent the `Redirect ISO`/`Redirect CDROM` menus from opening and cause JViewer to crash.
 
 To begin, open [IPMI in a Java applet](./#applet-java) from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB). Then, click `Device`{.action} from the menu bar and select `Redirect ISO`{.action} from the drop-down menu.
 


### PR DESCRIPTION
Warn users about using 64bit Java with JViewer. In some instances attempting to Redirect CDROM or ISO causes JViewer to hard crash with no errors.