### PR TITLE
KevS-BankOfScreens-github-link-deletion

### DIFF
--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.de-de.md
@@ -249,7 +249,7 @@ Nachdem Sie die Dateien in Ihrem Ordner "**CMS**" dekomprimiert haben, stellen S
 
 Hier ein Beispiel für *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 >[!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-asia.md
@@ -246,7 +246,7 @@ Once you have unpacked the files in your **CMS** folder, [log in to your storage
 
 Below is an example with the CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 >[!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-au.md
@@ -246,7 +246,7 @@ Once you have unpacked the files in your **CMS** folder, [log in to your storage
 
 Below is an example with the CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 >[!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-ca.md
@@ -246,7 +246,7 @@ Once you have unpacked the files in your **CMS** folder, [log in to your storage
 
 Below is an example with the CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 >[!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-gb.md
@@ -246,7 +246,7 @@ Once you have unpacked the files in your **CMS** folder, [log in to your storage
 
 Below is an example with the CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 >[!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-ie.md
@@ -246,7 +246,7 @@ Once you have unpacked the files in your **CMS** folder, [log in to your storage
 
 Below is an example with the CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 >[!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-sg.md
@@ -246,7 +246,7 @@ Once you have unpacked the files in your **CMS** folder, [log in to your storage
 
 Below is an example with the CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 >[!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-us.md
@@ -246,7 +246,7 @@ Once you have unpacked the files in your **CMS** folder, [log in to your storage
 
 Below is an example with the CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 >[!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.es-es.md
@@ -250,7 +250,7 @@ Una vez descomprimidos los archivos en su carpeta "**CMS**", [conéctese por FTP
 
 A continuación, un ejemplo con el CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.es-us.md
@@ -250,7 +250,7 @@ Una vez descomprimidos los archivos en su carpeta "**CMS**", [conéctese por FTP
 
 A continuación, un ejemplo con el CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 > [!warning]
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-ca.md
@@ -248,7 +248,7 @@ Une fois les fichiers décompressés dans votre dossier « **CMS** », [connecte
 
 Ci-dessous, un exemple avec le CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 >[!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-fr.md
@@ -252,7 +252,7 @@ Une fois les fichiers décompressés dans votre dossier « **CMS** », [connecte
 
 Ci-dessous, un exemple avec le CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 >[!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.it-it.md
@@ -250,7 +250,7 @@ Una volta che i file decomprimono la cartella "**CMS**", [collegati in FTP al tu
 
 Di seguito, un esempio con il CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.pl-pl.md
@@ -250,7 +250,7 @@ Po rozpakowaniu plików w Twoim katalogu "**CMS**", [zaloguj się przez FTP do p
 
 Przykład systemu CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.pt-pt.md
@@ -250,7 +250,7 @@ Depois de descomprimir os ficheiros na pasta "**CMS**", [ligue-se ao espaço de 
 
 Abaixo, um exemplo com o CMS *WordPress*:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/web-hosting-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
+![hosting](/pages/assets/screens/other/web-tools/filezilla/ftp-upload-wordpress.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.de-de.md
@@ -57,7 +57,7 @@ Geben Sie Ihren Domainnamen in die Suchleiste Ihres Webbrowsers ein.
 
 Wenn die Quelldateien korrekt im Wurzelverzeichnis platziert wurden, erscheint die Seite zur Auswahl der Sprache für Drupal:
 
-![Drupal installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal installation step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Wählen Sie die Sprache der Website aus und klicken Sie auf `Save and Continue`{.action}.
 
@@ -69,7 +69,7 @@ Drupal bietet mehrere Installationsebenen an:
 - Minimale Version
 - Präsentationsversion
 
-![Drupal installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal installation step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 Wir empfehlen, die **Standard**-Installation durchzuführen. Klicken Sie dann auf `Save and Continue`{.action}.
 
@@ -77,7 +77,7 @@ Wir empfehlen, die **Standard**-Installation durchzuführen. Klicken Sie dann au
 
 Geben Sie die angeforderten Informationen zur Datenbank ein:
 
-![Drupal installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal installation step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Halten Sie die Zugangsdaten für Ihre Datenbank bereit. (Sie können bei Bedarf **Schritt 1.4** des Tutorials zur [manuellen Installation eines CMS](/pages/web_cloud/web_hosting/cms_manual_installation) verwenden).
 
@@ -108,7 +108,7 @@ Klicken Sie auf `Save and Continue`{.action}.
 
 Wenn alles korrekt eingegeben wurde, startet die Drupal-Installation:
 
-![Drupal installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal installation step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 Die Informationen der Website und den Administrator-Zugang konfigurieren
 
@@ -128,7 +128,7 @@ Geben Sie die angeforderten Informationen ein:
 
 Gehen Sie dann zum Ende der Seite:
 
-![Drupal installation step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal installation step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Email address*: Geben Sie Ihre E-Mail-Adresse ein. Nutzen Sie idealerweise die gleiche Adresse wie zuvor für *Site email address*.
 
@@ -140,7 +140,7 @@ Klicken Sie auf `Save and Continue`{.action}.
 
 Wenn alle Eingaben korrekt waren, erscheint folgende Seite:
 
-![Drupal installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal installation step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-asia.md
@@ -53,7 +53,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![Drupal installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal installation step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Select the site language and click `Save and Continue`{.action}.
 
@@ -65,7 +65,7 @@ Drupal offers several levels of installation:
 - Minimum version
 - Presentation version
 
-![Drupal installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal installation step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 We recommend choosing the **Standard** installation. Then click `Save and continue`{.action}.
 
@@ -73,7 +73,7 @@ We recommend choosing the **Standard** installation. Then click `Save and contin
 
 Enter the information requested for the database:
 
-![Drupal installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal installation step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -104,7 +104,7 @@ Click `Save and Continue`{.action}.
 
 If everything has been done correctly, Drupal will be installed:
 
-![Drupal installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal installation step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 Configure your website information and administrator access
 
@@ -124,7 +124,7 @@ Enter the information requested:
 
 Then continue to the bottom of the page:
 
-![Drupal installation step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal installation step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Email address*: Enter your email address. Ideally, enter the same address you entered earlier in the form *Site email address*.
 
@@ -136,7 +136,7 @@ Click `Save and Continue`{.action}.
 
 If everything went well, the following page appears:
 
-![Drupal installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal installation step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-au.md
@@ -53,7 +53,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![Drupal installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal installation step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Select the site language and click `Save and Continue`{.action}.
 
@@ -65,7 +65,7 @@ Drupal offers several levels of installation:
 - Minimum version
 - Presentation version
 
-![Drupal installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal installation step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 We recommend choosing the **Standard** installation. Then click `Save and continue`{.action}.
 
@@ -73,7 +73,7 @@ We recommend choosing the **Standard** installation. Then click `Save and contin
 
 Enter the information requested for the database:
 
-![Drupal installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal installation step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -104,7 +104,7 @@ Click `Save and Continue`{.action}.
 
 If everything has been done correctly, Drupal will be installed:
 
-![Drupal installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal installation step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 Configure your website information and administrator access
 
@@ -124,7 +124,7 @@ Enter the information requested:
 
 Then continue to the bottom of the page:
 
-![Drupal installation step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal installation step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Email address*: Enter your email address. Ideally, enter the same address you entered earlier in the form *Site email address*.
 
@@ -136,7 +136,7 @@ Click `Save and Continue`{.action}.
 
 If everything went well, the following page appears:
 
-![Drupal installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal installation step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-ca.md
@@ -53,7 +53,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![Drupal installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal installation step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Select the site language and click `Save and Continue`{.action}.
 
@@ -65,7 +65,7 @@ Drupal offers several levels of installation:
 - Minimum version
 - Presentation version
 
-![Drupal installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal installation step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 We recommend choosing the **Standard** installation. Then click `Save and continue`{.action}.
 
@@ -73,7 +73,7 @@ We recommend choosing the **Standard** installation. Then click `Save and contin
 
 Enter the information requested for the database:
 
-![Drupal installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal installation step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -104,7 +104,7 @@ Click `Save and Continue`{.action}.
 
 If everything has been done correctly, Drupal will be installed:
 
-![Drupal installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal installation step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 Configure your website information and administrator access
 
@@ -124,7 +124,7 @@ Enter the information requested:
 
 Then continue to the bottom of the page:
 
-![Drupal installation step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal installation step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Email address*: Enter your email address. Ideally, enter the same address you entered earlier in the form *Site email address*.
 
@@ -136,7 +136,7 @@ Click `Save and Continue`{.action}.
 
 If everything went well, the following page appears:
 
-![Drupal installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal installation step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-gb.md
@@ -53,7 +53,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![Drupal installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal installation step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Select the site language and click `Save and Continue`{.action}.
 
@@ -65,7 +65,7 @@ Drupal offers several levels of installation:
 - Minimum version
 - Presentation version
 
-![Drupal installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal installation step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 We recommend choosing the **Standard** installation. Then click `Save and continue`{.action}.
 
@@ -73,7 +73,7 @@ We recommend choosing the **Standard** installation. Then click `Save and contin
 
 Enter the information requested for the database:
 
-![Drupal installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal installation step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -104,7 +104,7 @@ Click `Save and Continue`{.action}.
 
 If everything has been done correctly, Drupal will be installed:
 
-![Drupal installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal installation step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 Configure your website information and administrator access
 
@@ -124,7 +124,7 @@ Enter the information requested:
 
 Then continue to the bottom of the page:
 
-![Drupal installation step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal installation step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Email address*: Enter your email address. Ideally, enter the same address you entered earlier in the form *Site email address*.
 
@@ -136,7 +136,7 @@ Click `Save and Continue`{.action}.
 
 If everything went well, the following page appears:
 
-![Drupal installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal installation step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-ie.md
@@ -53,7 +53,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![Drupal installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal installation step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Select the site language and click `Save and Continue`{.action}.
 
@@ -65,7 +65,7 @@ Drupal offers several levels of installation:
 - Minimum version
 - Presentation version
 
-![Drupal installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal installation step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 We recommend choosing the **Standard** installation. Then click `Save and continue`{.action}.
 
@@ -73,7 +73,7 @@ We recommend choosing the **Standard** installation. Then click `Save and contin
 
 Enter the information requested for the database:
 
-![Drupal installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal installation step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -104,7 +104,7 @@ Click `Save and Continue`{.action}.
 
 If everything has been done correctly, Drupal will be installed:
 
-![Drupal installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal installation step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 Configure your website information and administrator access
 
@@ -124,7 +124,7 @@ Enter the information requested:
 
 Then continue to the bottom of the page:
 
-![Drupal installation step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal installation step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Email address*: Enter your email address. Ideally, enter the same address you entered earlier in the form *Site email address*.
 
@@ -136,7 +136,7 @@ Click `Save and Continue`{.action}.
 
 If everything went well, the following page appears:
 
-![Drupal installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal installation step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-sg.md
@@ -53,7 +53,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![Drupal installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal installation step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Select the site language and click `Save and Continue`{.action}.
 
@@ -65,7 +65,7 @@ Drupal offers several levels of installation:
 - Minimum version
 - Presentation version
 
-![Drupal installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal installation step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 We recommend choosing the **Standard** installation. Then click `Save and continue`{.action}.
 
@@ -73,7 +73,7 @@ We recommend choosing the **Standard** installation. Then click `Save and contin
 
 Enter the information requested for the database:
 
-![Drupal installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal installation step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -104,7 +104,7 @@ Click `Save and Continue`{.action}.
 
 If everything has been done correctly, Drupal will be installed:
 
-![Drupal installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal installation step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 Configure your website information and administrator access
 
@@ -124,7 +124,7 @@ Enter the information requested:
 
 Then continue to the bottom of the page:
 
-![Drupal installation step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal installation step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Email address*: Enter your email address. Ideally, enter the same address you entered earlier in the form *Site email address*.
 
@@ -136,7 +136,7 @@ Click `Save and Continue`{.action}.
 
 If everything went well, the following page appears:
 
-![Drupal installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal installation step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.en-us.md
@@ -53,7 +53,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![Drupal installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal installation step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Select the site language and click `Save and Continue`{.action}.
 
@@ -65,7 +65,7 @@ Drupal offers several levels of installation:
 - Minimum version
 - Presentation version
 
-![Drupal installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal installation step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 We recommend choosing the **Standard** installation. Then click `Save and continue`{.action}.
 
@@ -73,7 +73,7 @@ We recommend choosing the **Standard** installation. Then click `Save and contin
 
 Enter the information requested for the database:
 
-![Drupal installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal installation step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -104,7 +104,7 @@ Click `Save and Continue`{.action}.
 
 If everything has been done correctly, Drupal will be installed:
 
-![Drupal installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal installation step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 Configure your website information and administrator access
 
@@ -124,7 +124,7 @@ Enter the information requested:
 
 Then continue to the bottom of the page:
 
-![Drupal installation step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal installation step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Email address*: Enter your email address. Ideally, enter the same address you entered earlier in the form *Site email address*.
 
@@ -136,7 +136,7 @@ Click `Save and Continue`{.action}.
 
 If everything went well, the following page appears:
 
-![Drupal installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal installation step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.es-es.md
@@ -57,7 +57,7 @@ Escriba su dominio en la barra de búsqueda de su navegador de Internet.
 
 Si los archivos fuente de Drupal se han colocado correctamente en la carpeta raíz, aparecerá la página de selección del idioma para Drupal:
 
-![Drupal instalation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal instalation step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Seleccione el idioma del sitio web y haga clic en `Save and Continue`{.action}.
 
@@ -69,7 +69,7 @@ Drupal ofrece varios niveles de instalación:
 - versión mínima
 - una versión de presentación 
 
-![Drupal instalation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal instalation step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 Le recomendamos que realice una instalación **Standard**. Haga clic en `Save and Continue`{.action}.
 
@@ -77,7 +77,7 @@ Le recomendamos que realice una instalación **Standard**. Haga clic en `Save an
 
 Introduzca la información solicitada para la base de datos:
 
-![Drupal instalation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal instalation step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Si lo necesita, consulte la guía sobre la [instalación manual de un CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -108,7 +108,7 @@ Haga clic en `Save and Continue`{.action}.
 
 Si todo se ha realizado correctamente, se inicia la instalación de Drupal:
 
-![Drupal instalation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal instalation step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 - Configurar la información del sitio y el acceso "Administrador"
 
@@ -128,7 +128,7 @@ Introduzca los datos solicitados:
 
 Continúe en el apartado:
 
-![Drupal instalation step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal instalation step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Email address*: introduzca su dirección de correo electrónico. Es el lugar ideal para introducir la misma dirección que la que se ha elegido en el formulario *Dirección de correo electrónico del sitio web*.
 
@@ -140,7 +140,7 @@ Haga clic en `Save and Continue`{.action}.
 
 Si todo ha ido bien, aparecerá la siguiente página:
 
-![Drupal instalation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal instalation step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.es-us.md
@@ -57,7 +57,7 @@ Escriba su dominio en la barra de búsqueda de su navegador de Internet.
 
 Si los archivos fuente de Drupal se han colocado correctamente en la carpeta raíz, aparecerá la página de selección del idioma para Drupal:
 
-![Drupal instalation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal instalation step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Seleccione el idioma del sitio web y haga clic en `Save and Continue`{.action}.
 
@@ -69,7 +69,7 @@ Drupal ofrece varios niveles de instalación:
 - versión mínima
 - una versión de presentación 
 
-![Drupal instalation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal instalation step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 Le recomendamos que realice una instalación **Standard**. Haga clic en `Save and Continue`{.action}.
 
@@ -77,7 +77,7 @@ Le recomendamos que realice una instalación **Standard**. Haga clic en `Save an
 
 Introduzca la información solicitada para la base de datos:
 
-![Drupal instalation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal instalation step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Si lo necesita, consulte la guía sobre la [instalación manual de un CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -108,7 +108,7 @@ Haga clic en `Save and Continue`{.action}.
 
 Si todo se ha realizado correctamente, se inicia la instalación de Drupal:
 
-![Drupal instalation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal instalation step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 - Configurar la información del sitio y el acceso "Administrador"
 
@@ -128,7 +128,7 @@ Introduzca los datos solicitados:
 
 Continúe en el apartado:
 
-![Drupal instalation step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal instalation step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Email address*: introduzca su dirección de correo electrónico. Es el lugar ideal para introducir la misma dirección que la que se ha elegido en el formulario *Dirección de correo electrónico del sitio web*.
 
@@ -140,7 +140,7 @@ Haga clic en `Save and Continue`{.action}.
 
 Si todo ha ido bien, aparecerá la siguiente página:
 
-![Drupal instalation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal instalation step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.fr-ca.md
@@ -53,7 +53,7 @@ Saisissez votre nom de domaine dans la barre de recherche de votre navigateur In
 
 Si les fichiers sources de Drupal ont été placés correctement dans votre dossier racine, la page de sélection de la langue pour Drupal apparaît :
 
-![Drupal installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal installation step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Sélectionnez la langue du site puis cliquez sur `Enregistrer et continuer`{.action}.
 
@@ -65,7 +65,7 @@ Drupal propose plusieurs niveaux d'installation :
 - une version minimale
 - une version de présentation 
 
-![Drupal installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal installation step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 Nous vous recommandons d'effectuer une installation **Standard**. Cliquez ensuite sur `Enregistrer et continuer`{.action}.
 
@@ -73,7 +73,7 @@ Nous vous recommandons d'effectuer une installation **Standard**. Cliquez ensuit
 
 Renseignez les informations demandées concernant la base de données :
 
-![Drupal installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal installation step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Munissez-vous des identifiants de votre base de données (au besoin, consultez **l'étape 1.4** du tutoriel sur l'[installation manuelle d'un CMS](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -104,7 +104,7 @@ Cliquez sur `Enregistrer et continuer`{.action}.
 
 Si tout a été réalisé correctement, l'installation de Drupal se lance :
 
-![Drupal installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal installation step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 - Configurer les informations du site et l'accès « Administrateur »
 
@@ -124,7 +124,7 @@ Renseignez les éléments demandés :
 
 Poursuivez ensuite vers le bas de la page :
 
-![Drupal installation step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal installation step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Adresse e-mail* : saisissez votre adresse e-mail. Idéalement, renseignez la même adresse que celle choisie plus haut dans le formulaire *Adresse e-mail du site*.
 
@@ -136,7 +136,7 @@ Cliquez sur `Enregistrer et continuer`{.action}.
 
 Si tout s'est bien passé, la page suivante apparaît :
 
-![Drupal installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal installation step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.fr-fr.md
@@ -53,7 +53,7 @@ Saisissez votre nom de domaine dans la barre de recherche de votre navigateur In
 
 Si les fichiers sources de Drupal ont été placés correctement dans votre dossier racine, la page de sélection de la langue pour Drupal apparaît :
 
-![Drupal installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal installation step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Sélectionnez la langue du site puis cliquez sur `Enregistrer et continuer`{.action}.
 
@@ -65,7 +65,7 @@ Drupal propose plusieurs niveaux d'installation :
 - une version minimale
 - une version de présentation 
 
-![Drupal installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal installation step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 Nous vous recommandons d'effectuer une installation **Standard**. Cliquez ensuite sur `Enregistrer et continuer`{.action}.
 
@@ -73,7 +73,7 @@ Nous vous recommandons d'effectuer une installation **Standard**. Cliquez ensuit
 
 Renseignez les informations demandées concernant la base de données :
 
-![Drupal installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal installation step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Munissez-vous des identifiants de votre base de données (au besoin, consultez **l'étape 1.4** du guide sur l'[installation manuelle d'un CMS](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -104,7 +104,7 @@ Cliquez sur `Enregistrer et continuer`{.action}.
 
 Si tout a été réalisé correctement, l'installation de Drupal se lance :
 
-![Drupal installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal installation step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 - Configurer les informations du site et l'accès « Administrateur »
 
@@ -124,7 +124,7 @@ Renseignez les éléments demandés :
 
 Poursuivez ensuite vers le bas de la page :
 
-![Drupal installation step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal installation step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Adresse e-mail* : saisissez votre adresse e-mail. Idéalement, renseignez la même adresse que celle choisie plus haut dans le formulaire *Adresse e-mail du site*.
 
@@ -136,7 +136,7 @@ Cliquez sur `Enregistrer et continuer`{.action}.
 
 Si tout s'est bien passé, la page suivante apparaît :
 
-![Drupal installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal installation step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.it-it.md
@@ -57,7 +57,7 @@ Inserisci il dominio nella barra di ricerca del browser
 
 Se i file sorgente di Drupal sono stati inseriti correttamente nella cartella root, la pagina di selezione della lingua per Drupal appare:
 
-![Drupal Installstep 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal Installstep 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Seleziona la lingua del sito e clicca su `Save and Continue`{.action}.
 
@@ -69,7 +69,7 @@ Drupal propone diversi livelli di installazione:
 - una versione minima
 - una versione di presentazione 
 
-![Drupal Installstep 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal Installstep 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 Ti consigliamo di installare questi strumenti **Standard**. Clicca su `Save and Continue`{.action}.
 
@@ -77,7 +77,7 @@ Ti consigliamo di installare questi strumenti **Standard**. Clicca su `Save and 
 
 Inserisci le informazioni richieste relative al database:
 
-![Drupal Installstep 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal Installstep 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Recupera le credenziali del tuo database (se necessario, consulta **lo Step 1.4** della guida sull'[installazione manuale di un CMS](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -108,7 +108,7 @@ Clicca su `Save and Continue`{.action}.
 
 Se tutto è stato realizzato correttamente, l'installazione di Drupal si avvia:
 
-![Drupal Installstep 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal Installstep 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 - Configura le informazioni del sito e l'accesso "Amministratore"
 
@@ -128,7 +128,7 @@ Inserisci gli elementi richiesti:
 
 Prosegui nella lettura di questa guida in basso:
 
-![Drupal Installstep 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal Installstep 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Email address*: inserisci il tuo indirizzo email. Idealmente inserisci lo stesso indirizzo indicato sopra nel form *Indirizzo email del sito*.
 
@@ -140,7 +140,7 @@ Clicca su `Save and Continue`{.action}.
 
 Se tutto è andato a buon fine, visualizzi la pagina seguente:
 
-![Drupal Installstep 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal Installstep 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.pl-pl.md
@@ -57,7 +57,7 @@ Wpisz nazwę domeny na pasku wyszukiwania przeglądarki internetowej.
 
 Jeśli pliki źródłowe Drupal zostały poprawnie umieszczone w katalogu głównym, wyświetli się strona z listą wyboru języka dla Drupal:
 
-![Drupal instalacja step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal instalacja step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Wybierz język strony i kliknij na `Save and Continue`{.action}.
 
@@ -69,7 +69,7 @@ Drupal oferuje kilka poziomów instalacji:
 - wersja minimalna
 - wersja prezentacji 
 
-![Drupal instalacja step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal instalacja step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 Zalecamy przeprowadzenie instalacji **Standard**. Następnie kliknij polecenie `Save and Continue`{.action}.
 
@@ -77,7 +77,7 @@ Zalecamy przeprowadzenie instalacji **Standard**. Następnie kliknij polecenie `
 
 Wpisz wymagane informacje dotyczące bazy danych:
 
-![Drupal instalacja step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal instalacja step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Przygotuj dane dostępowe do bazy danych (w razie potrzeby sprawdź **etap 1.4** w przewodniku dotyczącym [ręczna instalacja CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -108,7 +108,7 @@ Kliknij polecenie `Save and Continue`{.action}.
 
 Jeśli wszystko zostało poprawnie zrealizowane, Drupal zostanie uruchomiony:
 
-![Drupal instalacja step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal instalacja step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 - Skonfiguruj informacje o stronie WWW i dostęp "Administrator"
 
@@ -128,7 +128,7 @@ Wpisz wymagane elementy:
 
 Następnie przejdź do dołu strony:
 
-![Drupal instalacja step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal instalacja step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Email address*: wprowadź Twój adres e-mail. W idealnym przypadku wprowadź ten sam adres, który został wskazany powyżej w formularzu *Adres e-mail strony*.
 
@@ -140,7 +140,7 @@ Kliknij polecenie `Save and Continue`{.action}.
 
 Jeśli wszystko przebiegło pomyślnie, wyświetli się następna strona:
 
-![Drupal instalacja step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal instalacja step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_drupal/guide.pt-pt.md
@@ -57,7 +57,7 @@ Introduza o seu domínio na barra de pesquisa do seu browser.
 
 Se os ficheiros de origem do Drupal foram corretamente colocados na sua pasta raiz, a página de seleção da língua para o Drupal aparece:
 
-![Drupal instalação step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-language-1.png){.thumbnail}
+![Drupal instalação step 1](/pages/assets/screens/other/cms/drupal/install-language-1.png){.thumbnail}
 
 Selecione a língua do site e clique em `Save and Continue`{.action}.
 
@@ -69,7 +69,7 @@ O Drupal oferece vários níveis de instalação:
 - uma versão mínima
 - uma versão de apresentação 
 
-![Drupal instalação step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-profil-2.png){.thumbnail}
+![Drupal instalação step 2](/pages/assets/screens/other/cms/drupal/install-profil-2.png){.thumbnail}
 
 Recomendamos que efetue uma instalação **Standard**. A seguir, clique em `Save and Continue`{.action}.
 
@@ -77,7 +77,7 @@ Recomendamos que efetue uma instalação **Standard**. A seguir, clique em `Save
 
 Insira as informações solicitadas relativas à base de dados:
 
-![Drupal instalação step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-db-config-3.png){.thumbnail}
+![Drupal instalação step 3](/pages/assets/screens/other/cms/drupal/install-db-config-3.png){.thumbnail}
 
 Tenha consigo os dados de acesso à sua base de dados (se necessário, consulte **a etapa 1.4** do guia sobre a [instalação manual de um CMS](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -108,7 +108,7 @@ Clique em `Save and Continue`{.action}.
 
 Se tudo foi feito corretamente, a instalação do Drupal é iniciada:
 
-![Drupal instalação step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-4.png){.thumbnail}
+![Drupal instalação step 4](/pages/assets/screens/other/cms/drupal/install-4.png){.thumbnail}
 
 #### 2.4 - Configurar as informações do site e o acesso "Administrador"
 
@@ -128,7 +128,7 @@ Introduza os elementos solicitados:
 
 De seguida, clique no final da página:
 
-![Drupal instalação step 5-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-configure-site-5-2.png){.thumbnail}
+![Drupal instalação step 5-1](/pages/assets/screens/other/cms/drupal/install-configure-site-5-2.png){.thumbnail}
 
 - *Email address*: introduza o seu endereço de e-mail. Idealmente, introduza o mesmo endereço que o escolhido acima no formulário *Endereço de e-mail do site*.
 
@@ -140,7 +140,7 @@ Clique em `Save and Continue`{.action}.
 
 Se tudo correr bem, aparecerá a seguinte página:
 
-![Drupal instalação step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/drupal/install-ending-6.png){.thumbnail}
+![Drupal instalação step 6](/pages/assets/screens/other/cms/drupal/install-ending-6.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.de-de.md
@@ -54,7 +54,7 @@ Geben Sie Ihren Domainnamen in die Suchleiste Ihres Webbrowsers ein.
 
 Wenn die Quelldateien korrekt im Wurzelverzeichnis platziert wurden, erscheint die Seite zur Auswahl der Sprache für Joomla!.
 
-![Joomla installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla installation step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Wählen Sie die Sprache aus, geben Sie den Namen Ihrer Website ein und klicken Sie dann auf `Setup Login Data`{.action}.
 
@@ -62,7 +62,7 @@ Wählen Sie die Sprache aus, geben Sie den Namen Ihrer Website ein und klicken S
 
 Geben Sie die Daten zum Zugriff auf den Verwaltungsbereich (Backend) von Joomla! ein:
 
-![Joomla installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla installation step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -79,7 +79,7 @@ Geben Sie die Daten zum Zugriff auf den Verwaltungsbereich (Backend) von Joomla!
 
 Geben Sie die angeforderten Informationen zur Datenbank ein:
 
-![Joomla installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla installation step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Halten Sie die Zugangsdaten für Ihre Datenbank bereit. (Sie können bei Bedarf **Schritt 1.4** des Tutorials zur [manuellen Installation eines CMS](/pages/web_cloud/web_hosting/cms_manual_installation) verwenden).
 
@@ -108,7 +108,7 @@ Klicken Sie auf `Install Joomla`{.action}.
 
 Folgende Nachricht erscheint:
 
-![Joomla installation step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla installation step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Da Sie eine Datenbank außerhalb des lokalen Webservers verwenden, muss der *Token* gelöscht werden, der bei der Installation Ihres Joomla! zufallsgeneriert wurde.
 
@@ -122,7 +122,7 @@ Anschließend klicken Sie in Ihrem Webbrowser erneut auf `Install Joomla`{.actio
 
 Nach Abschluss der Installation erscheint folgende Seite:
 
-![Joomla installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla installation step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 Die Installation ist abgeschlossen. Sie können Ihrem CMS jedoch bei Bedarf weitere Sprachen hinzufügen.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-asia.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Joomla! source files have been correctly placed in your root folder, the Joomla! page for selecting the language appears:
 
-![Joomla installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla installation step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Select the language, enter the name of your website, and click `Setup Login Data`{.action}.
 
@@ -59,7 +59,7 @@ Select the language, enter the name of your website, and click `Setup Login Data
 
 Set access to your Joomla! back office:
 
-![Joomla installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla installation step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -76,7 +76,7 @@ Check the information entered, then click on `Setup Database Connection`{.action
 
 Enter the information requested for the database:
 
-![Joomla installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla installation step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -105,7 +105,7 @@ Click `Install Joomla`{.action}.
 
 The following message appears:
 
-![Joomla installation step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla installation step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Since you are using a database that exists outside of a local hosting plan, you will need to delete the *token* generated randomly when you set up your Joomla!.
 
@@ -119,7 +119,7 @@ Then go back to your web browser and click again on `Install Joomla`{.action}.
 
 Once the installation is complete, the following page appears:
 
-![Joomla installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla installation step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 The installation is complete, but you can add additional languages to your CMS if you need to.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-au.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Joomla! source files have been correctly placed in your root folder, the Joomla! page for selecting the language appears:
 
-![Joomla installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla installation step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Select the language, enter the name of your website, and click `Setup Login Data`{.action}.
 
@@ -59,7 +59,7 @@ Select the language, enter the name of your website, and click `Setup Login Data
 
 Set access to your Joomla! back office:
 
-![Joomla installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla installation step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -76,7 +76,7 @@ Check the information entered, then click on `Setup Database Connection`{.action
 
 Enter the information requested for the database:
 
-![Joomla installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla installation step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -105,7 +105,7 @@ Click `Install Joomla`{.action}.
 
 The following message appears:
 
-![Joomla installation step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla installation step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Since you are using a database that exists outside of a local hosting plan, you will need to delete the *token* generated randomly when you set up your Joomla!.
 
@@ -119,7 +119,7 @@ Then go back to your web browser and click again on `Install Joomla`{.action}.
 
 Once the installation is complete, the following page appears:
 
-![Joomla installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla installation step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 The installation is complete, but you can add additional languages to your CMS if you need to.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-ca.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Joomla! source files have been correctly placed in your root folder, the Joomla! page for selecting the language appears:
 
-![Joomla installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla installation step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Select the language, enter the name of your website, and click `Setup Login Data`{.action}.
 
@@ -59,7 +59,7 @@ Select the language, enter the name of your website, and click `Setup Login Data
 
 Set access to your Joomla! back office:
 
-![Joomla installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla installation step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -76,7 +76,7 @@ Check the information entered, then click on `Setup Database Connection`{.action
 
 Enter the information requested for the database:
 
-![Joomla installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla installation step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -105,7 +105,7 @@ Click `Install Joomla`{.action}.
 
 The following message appears:
 
-![Joomla installation step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla installation step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Since you are using a database that exists outside of a local hosting plan, you will need to delete the *token* generated randomly when you set up your Joomla!.
 
@@ -119,7 +119,7 @@ Then go back to your web browser and click again on `Install Joomla`{.action}.
 
 Once the installation is complete, the following page appears:
 
-![Joomla installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla installation step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 The installation is complete, but you can add additional languages to your CMS if you need to.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-gb.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Joomla! source files have been correctly placed in your root folder, the Joomla! page for selecting the language appears:
 
-![Joomla installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla installation step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Select the language, enter the name of your website, and click `Setup Login Data`{.action}.
 
@@ -59,7 +59,7 @@ Select the language, enter the name of your website, and click `Setup Login Data
 
 Set access to your Joomla! back office:
 
-![Joomla installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla installation step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -76,7 +76,7 @@ Check the information entered, then click on `Setup Database Connection`{.action
 
 Enter the information requested for the database:
 
-![Joomla installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla installation step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -105,7 +105,7 @@ Click `Install Joomla`{.action}.
 
 The following message appears:
 
-![Joomla installation step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla installation step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Since you are using a database that exists outside of a local hosting plan, you will need to delete the *token* generated randomly when you set up your Joomla!.
 
@@ -119,7 +119,7 @@ Then go back to your web browser and click again on `Install Joomla`{.action}.
 
 Once the installation is complete, the following page appears:
 
-![Joomla installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla installation step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 The installation is complete, but you can add additional languages to your CMS if you need to.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-ie.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Joomla! source files have been correctly placed in your root folder, the Joomla! page for selecting the language appears:
 
-![Joomla installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla installation step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Select the language, enter the name of your website, and click `Setup Login Data`{.action}.
 
@@ -59,7 +59,7 @@ Select the language, enter the name of your website, and click `Setup Login Data
 
 Set access to your Joomla! back office:
 
-![Joomla installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla installation step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -76,7 +76,7 @@ Check the information entered, then click on `Setup Database Connection`{.action
 
 Enter the information requested for the database:
 
-![Joomla installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla installation step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -105,7 +105,7 @@ Click `Install Joomla`{.action}.
 
 The following message appears:
 
-![Joomla installation step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla installation step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Since you are using a database that exists outside of a local hosting plan, you will need to delete the *token* generated randomly when you set up your Joomla!.
 
@@ -119,7 +119,7 @@ Then go back to your web browser and click again on `Install Joomla`{.action}.
 
 Once the installation is complete, the following page appears:
 
-![Joomla installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla installation step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 The installation is complete, but you can add additional languages to your CMS if you need to.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-sg.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Joomla! source files have been correctly placed in your root folder, the Joomla! page for selecting the language appears:
 
-![Joomla installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla installation step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Select the language, enter the name of your website, and click `Setup Login Data`{.action}.
 
@@ -59,7 +59,7 @@ Select the language, enter the name of your website, and click `Setup Login Data
 
 Set access to your Joomla! back office:
 
-![Joomla installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla installation step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -76,7 +76,7 @@ Check the information entered, then click on `Setup Database Connection`{.action
 
 Enter the information requested for the database:
 
-![Joomla installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla installation step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -105,7 +105,7 @@ Click `Install Joomla`{.action}.
 
 The following message appears:
 
-![Joomla installation step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla installation step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Since you are using a database that exists outside of a local hosting plan, you will need to delete the *token* generated randomly when you set up your Joomla!.
 
@@ -119,7 +119,7 @@ Then go back to your web browser and click again on `Install Joomla`{.action}.
 
 Once the installation is complete, the following page appears:
 
-![Joomla installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla installation step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 The installation is complete, but you can add additional languages to your CMS if you need to.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.en-us.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Joomla! source files have been correctly placed in your root folder, the Joomla! page for selecting the language appears:
 
-![Joomla installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla installation step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Select the language, enter the name of your website, and click `Setup Login Data`{.action}.
 
@@ -59,7 +59,7 @@ Select the language, enter the name of your website, and click `Setup Login Data
 
 Set access to your Joomla! back office:
 
-![Joomla installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla installation step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -76,7 +76,7 @@ Check the information entered, then click on `Setup Database Connection`{.action
 
 Enter the information requested for the database:
 
-![Joomla installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla installation step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -105,7 +105,7 @@ Click `Install Joomla`{.action}.
 
 The following message appears:
 
-![Joomla installation step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla installation step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Since you are using a database that exists outside of a local hosting plan, you will need to delete the *token* generated randomly when you set up your Joomla!.
 
@@ -119,7 +119,7 @@ Then go back to your web browser and click again on `Install Joomla`{.action}.
 
 Once the installation is complete, the following page appears:
 
-![Joomla installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla installation step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 The installation is complete, but you can add additional languages to your CMS if you need to.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.es-es.md
@@ -55,7 +55,7 @@ Escriba su dominio en la barra de búsqueda de su navegador de Internet.
 
 Si los archivos fuente de Joomla! se han colocado correctamente en la carpeta raíz, la página de selección del idioma para Joomla. aparece:
 
-![Joomla instalando step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla instalando step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Seleccione el idioma, introduzca el nombre de su sitio web y haga clic en `Setup Login Data`{.action}.
 
@@ -63,7 +63,7 @@ Seleccione el idioma, introduzca el nombre de su sitio web y haga clic en `Setup
 
 Defina los accesos a su espacio de administración (*Back Office*) Joomla! :
 
-![Joomla instalando step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla instalando step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -80,7 +80,7 @@ Compruebe los datos introducidos y haga clic en `Setup Database Connection`{.act
 
 Introduzca la información solicitada para la base de datos:
 
-![Joomla instalando step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla instalando step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Para completar los siguientes campos, consulte la información indicada en el **etapa 1.4** del tutorial sobre la [instalación manual de un CMS](/pages/web_cloud/web_hosting/cms_manual_installation):
 
@@ -110,7 +110,7 @@ Haga clic en `Install Joomla`{.action}.
 
 Aparecerá el siguiente mensaje:
 
-![Joomla instalando step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla instalando step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Si utiliza una base de datos externa al alojamiento local, deberá eliminar el *token* generado aleatoriamente al instalar el Joomla.
 
@@ -124,7 +124,7 @@ Vuelva al navegador de internet y vuelva a hacer clic en `Install Joomla`{.actio
 
 Una vez finalizada la instalación, se abrirá la siguiente página:
 
-![Joomla instalando step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla instalando step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 La instalación ha finalizado, pero puede añadir más idiomas al CMS si es necesario.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.es-us.md
@@ -55,7 +55,7 @@ Escriba su dominio en la barra de búsqueda de su navegador de Internet.
 
 Si los archivos fuente de Joomla! se han colocado correctamente en la carpeta raíz, la página de selección del idioma para Joomla. aparece:
 
-![Joomla instalando step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla instalando step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Seleccione el idioma, introduzca el nombre de su sitio web y haga clic en `Setup Login Data`{.action}.
 
@@ -63,7 +63,7 @@ Seleccione el idioma, introduzca el nombre de su sitio web y haga clic en `Setup
 
 Defina los accesos a su espacio de administración (*Back Office*) Joomla! :
 
-![Joomla instalando step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla instalando step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -80,7 +80,7 @@ Compruebe los datos introducidos y haga clic en `Setup Database Connection`{.act
 
 Introduzca la información solicitada para la base de datos:
 
-![Joomla instalando step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla instalando step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Para completar los siguientes campos, consulte la información indicada en el **etapa 1.4** del tutorial sobre la [instalación manual de un CMS](/pages/web_cloud/web_hosting/cms_manual_installation):
 
@@ -110,7 +110,7 @@ Haga clic en `Install Joomla`{.action}.
 
 Aparecerá el siguiente mensaje:
 
-![Joomla instalando step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla instalando step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Si utiliza una base de datos externa al alojamiento local, deberá eliminar el *token* generado aleatoriamente al instalar el Joomla.
 
@@ -124,7 +124,7 @@ Vuelva al navegador de internet y vuelva a hacer clic en `Install Joomla`{.actio
 
 Una vez finalizada la instalación, se abrirá la siguiente página:
 
-![Joomla instalando step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla instalando step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 La instalación ha finalizado, pero puede añadir más idiomas al CMS si es necesario.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.fr-ca.md
@@ -51,7 +51,7 @@ Saisissez votre nom de domaine dans la barre de recherche de votre navigateur In
 
 Si les fichiers sources de Joomla! ont été placés correctement dans votre dossier racine, la page de sélection de la langue pour Joomla! apparaît :
 
-![Joomla installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla installation step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Sélectionnez la langue, saisissez le nom de votre site web puis cliquez sur `Configuration des données de connexion`{.action}.
 
@@ -59,7 +59,7 @@ Sélectionnez la langue, saisissez le nom de votre site web puis cliquez sur `Co
 
 Définissez les accès à votre espace d'administration (*Back Office*) Joomla! :
 
-![Joomla installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla installation step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -76,7 +76,7 @@ Vérifiez les éléments renseignés puis cliquez sur `Configuration de la conne
 
 Renseignez les informations demandées concernant la base de données :
 
-![Joomla installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla installation step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Référez-vous aux informations indiquées dans **l'étape 1.4** du tutoriel sur l'[installation manuelle d'un CMS](/pages/web_cloud/web_hosting/cms_manual_installation) pour compléter les champs suivants :
 
@@ -106,7 +106,7 @@ Cliquez sur `Installer Joomla`{.action}.
 
 Le message suivant apparaît :
 
-![Joomla installation step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla installation step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Du fait que vous utilisez une base de données présente en dehors d'un hébergement local, vous devrez supprimer le *token* généré aléatoirement lors de l'installation de votre Joomla!.
 
@@ -120,7 +120,7 @@ Retournez ensuite dans votre navigateur internet puis cliquez de nouveau sur `In
 
 Une fois l'installation terminée, la page suivante apparaît :
 
-![Joomla installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla installation step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 L'installation est terminée mais vous pouvez ajouter des langues supplémentaires à votre CMS si besoin.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.fr-fr.md
@@ -51,7 +51,7 @@ Saisissez votre nom de domaine dans la barre de recherche de votre navigateur In
 
 Si les fichiers sources de Joomla! ont été placés correctement dans votre dossier racine, la page de sélection de la langue pour Joomla! apparaît :
 
-![Joomla installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla installation step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Sélectionnez la langue, saisissez le nom de votre site web puis cliquez sur `Configuration des données de connexion`{.action}.
 
@@ -59,7 +59,7 @@ Sélectionnez la langue, saisissez le nom de votre site web puis cliquez sur `Co
 
 Définissez les accès à votre espace d'administration (*Back Office*) Joomla! :
 
-![Joomla installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla installation step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -76,7 +76,7 @@ Vérifiez les éléments renseignés puis cliquez sur `Configuration de la conne
 
 Renseignez les informations demandées concernant la base de données :
 
-![Joomla installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla installation step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Référez-vous aux informations indiquées dans **l'étape 1.4** du tutoriel sur l'[installation manuelle d'un CMS](/pages/web_cloud/web_hosting/cms_manual_installation) pour compléter les champs suivants :
 
@@ -106,7 +106,7 @@ Cliquez sur `Installer Joomla`{.action}.
 
 Le message suivant apparaît :
 
-![Joomla installation step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla installation step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Du fait que vous utilisez une base de données présente en dehors d'un hébergement local, vous devrez supprimer le *token* généré aléatoirement lors de l'installation de votre Joomla!.
 
@@ -120,7 +120,7 @@ Retournez ensuite dans votre navigateur internet puis cliquez de nouveau sur `In
 
 Une fois l'installation terminée, la page suivante apparaît :
 
-![Joomla installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla installation step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 L'installation est terminée mais vous pouvez ajouter des langues supplémentaires à votre CMS si besoin.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.it-it.md
@@ -55,7 +55,7 @@ Inserisci il dominio nella barra di ricerca del browser
 
 Se i file sorgente di Joomla! sono stati inseriti correttamente nella cartella root, la pagina di selezione della lingua per Joomla! compare:
 
-![Joomla Installstep 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla Installstep 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Seleziona la lingua, inserisci il nome del tuo sito Web e clicca su `Setup Login Data`{.action}.
 
@@ -63,7 +63,7 @@ Seleziona la lingua, inserisci il nome del tuo sito Web e clicca su `Setup Login
 
 Definisci gli accessi al tuo spazio di amministrazione (*Back Office*) Joomla! :
 
-![Joomla Installstep 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla Installstep 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -80,7 +80,7 @@ Verifica le informazioni inserite e clicca su `Setup Database Connection`{.actio
 
 Inserisci le informazioni richieste relative al database:
 
-![Joomla Installstep 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla Installstep 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Per completare i campi seguenti, consulta le informazioni indicate nello **Step 1.4** del tutorial sull'[installazione manuale di un CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -110,7 +110,7 @@ Clicca su `Install Joomla`{.action}.
 
 Visualizzi questo messaggio:
 
-![Joomla Installstep 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla Installstep 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Se utilizzi un database presente al di fuori di un hosting locale, dovrai eliminare il *token* generato casualmente durante l'installazione del tuo Joomla!.
 
@@ -124,7 +124,7 @@ Clicca su `Install Joomla`{.action}. e poi torna al browser.
 
 Una volta completata l'installazione, visualizzi la pagina seguente:
 
-![Joomla Installstep 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla Installstep 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 L'installazione è completata ma, se necessario, è possibile aggiungere altre lingue al CMS.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.pl-pl.md
@@ -55,7 +55,7 @@ Wpisz nazwę domeny na pasku wyszukiwania przeglądarki internetowej.
 
 Jeśli pliki źródłowe Joomla! zostały poprawnie umieszczone w katalogu głównym, na stronie wyboru języka dla Joomla! pojawia się:
 
-![Joomla instalacja step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla instalacja step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Wybierz język, wpisz nazwę swojej strony www i kliknij `Setup Login Data`{.action}.
 
@@ -63,7 +63,7 @@ Wybierz język, wpisz nazwę swojej strony www i kliknij `Setup Login Data`{.act
 
 Zdefiniuj dostęp do swojej przestrzeni administracyjnej (*Back Office*) Joomla! :
 
-![Joomla instalacja step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla instalacja step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -80,7 +80,7 @@ Sprawdź podane elementy i kliknij `Setup Database Connection`{.action}.
 
 Wpisz wymagane informacje dotyczące bazy danych:
 
-![Joomla instalacja step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla instalacja step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 W celu uzupełnienia poniższych pól należy zapoznać się z informacjami podanymi w **przewodniku nr 1.4** w przewodniku dotyczącym [ręczna instalacja CMS](/pages/web_cloud/web_hosting/cms_manual_installation):
 
@@ -110,7 +110,7 @@ Kliknij polecenie `Install Joomla`{.action}.
 
 Pojawi się następujący komunikat:
 
-![Joomla instalacja step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla instalacja step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Jeśli używasz bazy danych poza hostingiem lokalnym, usuń losowo wygenerowany token* podczas instalacji modułu Joomla!.
 
@@ -124,7 +124,7 @@ Następnie przejdź do przeglądarki internetowej i kliknij ponownie przycisk `I
 
 Po zakończeniu instalacji pojawi się następująca strona:
 
-![Joomla instalacja step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla instalacja step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 Instalacja została zakończona, ale w razie potrzeby możesz dodać dodatkowe języki do CMS-a.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_joomla/guide.pt-pt.md
@@ -55,7 +55,7 @@ Introduza o seu domínio na barra de pesquisa do seu browser.
 
 Se os ficheiros são do Joomla! foram corretamente colocados na sua pasta raiz, a página de seleção da língua para o Joomla! aparece:
 
-![Joomla instalação step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-select-language-1.png){.thumbnail}
+![Joomla instalação step 1](/pages/assets/screens/other/cms/joomla/install-select-language-1.png){.thumbnail}
 
 Selecione o idioma, introduza o nome do seu website e clique em `Setup Login Data`{.action}.
 
@@ -63,7 +63,7 @@ Selecione o idioma, introduza o nome do seu website e clique em `Setup Login Dat
 
 Defina os acessos ao seu espaço de administração (*Back Office*) Joomla! :
 
-![Joomla instalação step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-define-admin-2.png){.thumbnail}
+![Joomla instalação step 2](/pages/assets/screens/other/cms/joomla/install-define-admin-2.png){.thumbnail}
 
 > [!primary]
 >
@@ -80,7 +80,7 @@ Verifique os elementos inseridos e clique em `Setup Database Connection`{.action
 
 Insira as informações solicitadas relativas à base de dados:
 
-![Joomla instalação step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3.png){.thumbnail}
+![Joomla instalação step 3](/pages/assets/screens/other/cms/joomla/install-db-connect-3.png){.thumbnail}
 
 Para preencher os campos abaixo, consulte o **etapa 1.4** do tutorial para a [instalação manual de um CMS](/pages/web_cloud/web_hosting/cms_manual_installation), e consulte as seguintes informações:
 
@@ -110,7 +110,7 @@ Clique em `Install Joomla`{.action}.
 
 Surge a seguinte mensagem:
 
-![Joomla instalação step 3-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-db-connect-3-1.png){.thumbnail}
+![Joomla instalação step 3-1](/pages/assets/screens/other/cms/joomla/install-db-connect-3-1.png){.thumbnail}
 
 Uma vez que utiliza uma base de dados presente fora de um alojamento local, deverá eliminar o * token* gerado automaticamente aquando da instalação do seu Joomla!
 
@@ -124,7 +124,7 @@ De seguida, volte ao seu browser e clique novamente em `Install Joomla`{.action}
 
 Uma vez terminada a instalação, surgirá a seguinte página:
 
-![Joomla instalação step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/joomla/install-ending-4.png){.thumbnail}
+![Joomla instalação step 4](/pages/assets/screens/other/cms/joomla/install-ending-4.png){.thumbnail}
 
 A instalação está terminada, mas pode adicionar línguas adicionais ao seu CMS caso seja necessário.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.de-de.md
@@ -50,7 +50,7 @@ Führen Sie zunächst **alle Schritte** in unserer Anleitung zur [manuellen Inst
 
 Wenn Sie nicht die neueste verfügbare PrestaShop-Version heruntergeladen haben, erscheint folgende Seite:
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Klicken Sie auf `No thanks`{.action}, wenn Sie die heruntergeladene PrestaShop-Version verwenden möchten, andernfalls auf `Yes please!`{.action} um die neueste Version zu erhalten.
 
@@ -60,7 +60,7 @@ Geben Sie Ihren Domainnamen in die Suchleiste Ihres Webbrowsers ein.
 
 Wenn die Quelldateien korrekt im Wurzelverzeichnis platziert wurden, erscheint die Seite zur Auswahl der Sprache für PrestaShop.
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Wählen Sie die Sprache der Website aus und klicken Sie auf `Next`{.action}.
 
@@ -68,13 +68,13 @@ Wählen Sie die Sprache der Website aus und klicken Sie auf `Next`{.action}.
 
 Lesen Sie die Nutzungsbedingungen, setzen Sie einen Haken bei `I agree to the above terms and conditions`{.action} und klicken Sie dann auf `Next`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 Die Informationen Ihres Webshops eingeben
 
 PrestaShop fordert Sie auf, einige Informationen zu Ihrem zukünftigen Onlineshop einzugeben:
 
-![PrestaShop installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop installation step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Information about your Store**
 
@@ -97,13 +97,13 @@ PrestaShop fordert Sie auf, einige Informationen zu Ihrem zukünftigen Onlinesho
 
 PrestaShop bietet Ihnen die Möglichkeit, Inhalte und Module für Ihre E-Commerce-Seite zu installieren:
 
-![PrestaShop installation step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop installation step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Treffen Sie Ihre Wahl und klicken Sie auf `Next`{.action}.
 
 #### 2.5 PrestaShop mit Ihrer OVHcloud Datenbank verbinden
 
-![PrestaShop installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop installation step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Halten Sie die Zugangsdaten für Ihre Datenbank bereit. (Sie können bei Bedarf **Schritt 1.4** des Tutorials zur [manuellen Installation eines CMS](/pages/web_cloud/web_hosting/cms_manual_installation) verwenden).
 
@@ -135,7 +135,7 @@ Geben Sie die angeforderten Informationen zur Datenbank ein:
 
 Klicken Sie auf `Test your database connection now!`{.action}, um die verwendeten Einstellungen zu überprüfen:
 
-![PrestaShop installation step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop installation step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 Wenn die Nachricht "Your database is connected" erscheint, klicken Sie auf `Next`{.action}. Wenn nicht, überprüfen Sie die eingegebenen Daten und korrigieren Sie ggf. die Angaben. Bei Bedarf lesen Sie die Informationen in **Schritt 1.4** des Tutorials zur [manuellen Installation eines CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -143,7 +143,7 @@ Wenn die Nachricht "Your database is connected" erscheint, klicken Sie auf `Next
 
 Im letzten Schritt erhalten Sie eine Zusammenfassung der soeben durchgeführten Installation:
 
-![PrestaShop installation step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop installation step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Speichern Sie Ihre Login-Daten zu PrestaShop, bevor Sie die Seite verlassen.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-asia.md
@@ -47,7 +47,7 @@ Follow **all steps** described in our tutorial on [installing a CMS manually](/p
 
 If you have not downloaded the latest available version of PrestaShop, the following page will appear:
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Click `No thanks`{.action} if you want to keep the version of PrestaShop you just downloaded or `Yes please!`{.action} if you want to use the latest version of the CMS.
 
@@ -57,7 +57,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Select the site language and click `Next`{.action}.
 
@@ -65,13 +65,13 @@ Select the site language and click `Next`{.action}.
 
 Review the *license agreements*, check the `I agree to the above terms and conditions`{.action} box, then click `Next`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 Enter your online store details
 
 PrestaShop will request a series of information about your future online store:
 
-![PrestaShop installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop installation step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Store information**
 
@@ -94,13 +94,13 @@ Review the information entered, then click `Next`{.action}.
 
 PrestaShop allows you to install content and modules for your future e-commerce site:
 
-![PrestaShop installation step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop installation step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Make your choices and click `Next`{.action}.
 
 ### 2.5 Link your PrestaShop to your OVHcloud database
 
-![PrestaShop installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop installation step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -132,7 +132,7 @@ Enter the information requested for the database:
 
 Click `Test your database connection now!`{.action} to verify the entered settings:
 
-![PrestaShop installation step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop installation step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 If the message "Your database is connected" appears, click `Next`{.action}. Otherwise, check the settings you entered until the connection is working. If required, please refer to **Step 1.4** in the tutorial on [manually installing a CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -140,7 +140,7 @@ If the message "Your database is connected" appears, click `Next`{.action}. Othe
 
 The final step is a summary of the installation you have just carried out:
 
-![PrestaShop installation step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop installation step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Retrieve your PrestaShop login details before you leave the page.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-au.md
@@ -47,7 +47,7 @@ Follow **all steps** described in our tutorial on [installing a CMS manually](/p
 
 If you have not downloaded the latest available version of PrestaShop, the following page will appear:
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Click `No thanks`{.action} if you want to keep the version of PrestaShop you just downloaded or `Yes please!`{.action} if you want to use the latest version of the CMS.
 
@@ -57,7 +57,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Select the site language and click `Next`{.action}.
 
@@ -65,13 +65,13 @@ Select the site language and click `Next`{.action}.
 
 Review the *license agreements*, check the `I agree to the above terms and conditions`{.action} box, then click `Next`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 Enter your online store details
 
 PrestaShop will request a series of information about your future online store:
 
-![PrestaShop installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop installation step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Store information**
 
@@ -94,13 +94,13 @@ Review the information entered, then click `Next`{.action}.
 
 PrestaShop allows you to install content and modules for your future e-commerce site:
 
-![PrestaShop installation step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop installation step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Make your choices and click `Next`{.action}.
 
 ### 2.5 Link your PrestaShop to your OVHcloud database
 
-![PrestaShop installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop installation step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -132,7 +132,7 @@ Enter the information requested for the database:
 
 Click `Test your database connection now!`{.action} to verify the entered settings:
 
-![PrestaShop installation step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop installation step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 If the message "Your database is connected" appears, click `Next`{.action}. Otherwise, check the settings you entered until the connection is working. If required, please refer to **Step 1.4** in the tutorial on [manually installing a CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -140,7 +140,7 @@ If the message "Your database is connected" appears, click `Next`{.action}. Othe
 
 The final step is a summary of the installation you have just carried out:
 
-![PrestaShop installation step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop installation step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Retrieve your PrestaShop login details before you leave the page.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-ca.md
@@ -47,7 +47,7 @@ Follow **all steps** described in our tutorial on [installing a CMS manually](/p
 
 If you have not downloaded the latest available version of PrestaShop, the following page will appear:
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Click `No thanks`{.action} if you want to keep the version of PrestaShop you just downloaded or `Yes please!`{.action} if you want to use the latest version of the CMS.
 
@@ -57,7 +57,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Select the site language and click `Next`{.action}.
 
@@ -65,13 +65,13 @@ Select the site language and click `Next`{.action}.
 
 Review the *license agreements*, check the `I agree to the above terms and conditions`{.action} box, then click `Next`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 Enter your online store details
 
 PrestaShop will request a series of information about your future online store:
 
-![PrestaShop installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop installation step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Store information**
 
@@ -94,13 +94,13 @@ Review the information entered, then click `Next`{.action}.
 
 PrestaShop allows you to install content and modules for your future e-commerce site:
 
-![PrestaShop installation step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop installation step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Make your choices and click `Next`{.action}.
 
 ### 2.5 Link your PrestaShop to your OVHcloud database
 
-![PrestaShop installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop installation step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -132,7 +132,7 @@ Enter the information requested for the database:
 
 Click `Test your database connection now!`{.action} to verify the entered settings:
 
-![PrestaShop installation step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop installation step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 If the message "Your database is connected" appears, click `Next`{.action}. Otherwise, check the settings you entered until the connection is working. If required, please refer to **Step 1.4** in the tutorial on [manually installing a CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -140,7 +140,7 @@ If the message "Your database is connected" appears, click `Next`{.action}. Othe
 
 The final step is a summary of the installation you have just carried out:
 
-![PrestaShop installation step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop installation step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Retrieve your PrestaShop login details before you leave the page.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-gb.md
@@ -47,7 +47,7 @@ Follow **all steps** described in our tutorial on [installing a CMS manually](/p
 
 If you have not downloaded the latest available version of PrestaShop, the following page will appear:
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Click `No thanks`{.action} if you want to keep the version of PrestaShop you just downloaded or `Yes please!`{.action} if you want to use the latest version of the CMS.
 
@@ -57,7 +57,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Select the site language and click `Next`{.action}.
 
@@ -65,13 +65,13 @@ Select the site language and click `Next`{.action}.
 
 Review the *license agreements*, check the `I agree to the above terms and conditions`{.action} box, then click `Next`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 Enter your online store details
 
 PrestaShop will request a series of information about your future online store:
 
-![PrestaShop installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop installation step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Store information**
 
@@ -94,13 +94,13 @@ Review the information entered, then click `Next`{.action}.
 
 PrestaShop allows you to install content and modules for your future e-commerce site:
 
-![PrestaShop installation step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop installation step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Make your choices and click `Next`{.action}.
 
 ### 2.5 Link your PrestaShop to your OVHcloud database
 
-![PrestaShop installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop installation step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -132,7 +132,7 @@ Enter the information requested for the database:
 
 Click `Test your database connection now!`{.action} to verify the entered settings:
 
-![PrestaShop installation step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop installation step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 If the message "Your database is connected" appears, click `Next`{.action}. Otherwise, check the settings you entered until the connection is working. If required, please refer to **Step 1.4** in the tutorial on [manually installing a CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -140,7 +140,7 @@ If the message "Your database is connected" appears, click `Next`{.action}. Othe
 
 The final step is a summary of the installation you have just carried out:
 
-![PrestaShop installation step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop installation step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Retrieve your PrestaShop login details before you leave the page.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-ie.md
@@ -47,7 +47,7 @@ Follow **all steps** described in our tutorial on [installing a CMS manually](/p
 
 If you have not downloaded the latest available version of PrestaShop, the following page will appear:
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Click `No thanks`{.action} if you want to keep the version of PrestaShop you just downloaded or `Yes please!`{.action} if you want to use the latest version of the CMS.
 
@@ -57,7 +57,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Select the site language and click `Next`{.action}.
 
@@ -65,13 +65,13 @@ Select the site language and click `Next`{.action}.
 
 Review the *license agreements*, check the `I agree to the above terms and conditions`{.action} box, then click `Next`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 Enter your online store details
 
 PrestaShop will request a series of information about your future online store:
 
-![PrestaShop installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop installation step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Store information**
 
@@ -94,13 +94,13 @@ Review the information entered, then click `Next`{.action}.
 
 PrestaShop allows you to install content and modules for your future e-commerce site:
 
-![PrestaShop installation step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop installation step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Make your choices and click `Next`{.action}.
 
 ### 2.5 Link your PrestaShop to your OVHcloud database
 
-![PrestaShop installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop installation step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -132,7 +132,7 @@ Enter the information requested for the database:
 
 Click `Test your database connection now!`{.action} to verify the entered settings:
 
-![PrestaShop installation step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop installation step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 If the message "Your database is connected" appears, click `Next`{.action}. Otherwise, check the settings you entered until the connection is working. If required, please refer to **Step 1.4** in the tutorial on [manually installing a CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -140,7 +140,7 @@ If the message "Your database is connected" appears, click `Next`{.action}. Othe
 
 The final step is a summary of the installation you have just carried out:
 
-![PrestaShop installation step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop installation step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Retrieve your PrestaShop login details before you leave the page.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-sg.md
@@ -47,7 +47,7 @@ Follow **all steps** described in our tutorial on [installing a CMS manually](/p
 
 If you have not downloaded the latest available version of PrestaShop, the following page will appear:
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Click `No thanks`{.action} if you want to keep the version of PrestaShop you just downloaded or `Yes please!`{.action} if you want to use the latest version of the CMS.
 
@@ -57,7 +57,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Select the site language and click `Next`{.action}.
 
@@ -65,13 +65,13 @@ Select the site language and click `Next`{.action}.
 
 Review the *license agreements*, check the `I agree to the above terms and conditions`{.action} box, then click `Next`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 Enter your online store details
 
 PrestaShop will request a series of information about your future online store:
 
-![PrestaShop installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop installation step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Store information**
 
@@ -94,13 +94,13 @@ Review the information entered, then click `Next`{.action}.
 
 PrestaShop allows you to install content and modules for your future e-commerce site:
 
-![PrestaShop installation step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop installation step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Make your choices and click `Next`{.action}.
 
 ### 2.5 Link your PrestaShop to your OVHcloud database
 
-![PrestaShop installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop installation step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -132,7 +132,7 @@ Enter the information requested for the database:
 
 Click `Test your database connection now!`{.action} to verify the entered settings:
 
-![PrestaShop installation step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop installation step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 If the message "Your database is connected" appears, click `Next`{.action}. Otherwise, check the settings you entered until the connection is working. If required, please refer to **Step 1.4** in the tutorial on [manually installing a CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -140,7 +140,7 @@ If the message "Your database is connected" appears, click `Next`{.action}. Othe
 
 The final step is a summary of the installation you have just carried out:
 
-![PrestaShop installation step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop installation step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Retrieve your PrestaShop login details before you leave the page.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.en-us.md
@@ -47,7 +47,7 @@ Follow **all steps** described in our tutorial on [installing a CMS manually](/p
 
 If you have not downloaded the latest available version of PrestaShop, the following page will appear:
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Click `No thanks`{.action} if you want to keep the version of PrestaShop you just downloaded or `Yes please!`{.action} if you want to use the latest version of the CMS.
 
@@ -57,7 +57,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the Drupal source files have been correctly placed in your root folder, the Drupal page for selecting the language appears:
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Select the site language and click `Next`{.action}.
 
@@ -65,13 +65,13 @@ Select the site language and click `Next`{.action}.
 
 Review the *license agreements*, check the `I agree to the above terms and conditions`{.action} box, then click `Next`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 Enter your online store details
 
 PrestaShop will request a series of information about your future online store:
 
-![PrestaShop installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop installation step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Store information**
 
@@ -94,13 +94,13 @@ Review the information entered, then click `Next`{.action}.
 
 PrestaShop allows you to install content and modules for your future e-commerce site:
 
-![PrestaShop installation step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop installation step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Make your choices and click `Next`{.action}.
 
 ### 2.5 Link your PrestaShop to your OVHcloud database
 
-![PrestaShop installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop installation step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -132,7 +132,7 @@ Enter the information requested for the database:
 
 Click `Test your database connection now!`{.action} to verify the entered settings:
 
-![PrestaShop installation step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop installation step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 If the message "Your database is connected" appears, click `Next`{.action}. Otherwise, check the settings you entered until the connection is working. If required, please refer to **Step 1.4** in the tutorial on [manually installing a CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -140,7 +140,7 @@ If the message "Your database is connected" appears, click `Next`{.action}. Othe
 
 The final step is a summary of the installation you have just carried out:
 
-![PrestaShop installation step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop installation step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Retrieve your PrestaShop login details before you leave the page.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.es-es.md
@@ -51,7 +51,7 @@ Siga el **conjunto de etapas** descritos en nuestro tutorial sobre la [instalaci
 
 Si no ha descargado la última versión disponible de PrestaShop, aparecerá la siguiente página:
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Haga clic en `No thanks`{.action} si desea conservar la versión de PrestaShop que acaba de descargar o en `Yes please!`{.action} si quiere utilizar la versión más reciente del CMS.
 
@@ -61,7 +61,7 @@ Escriba su dominio en la barra de búsqueda de su navegador de Internet.
 
 Si los archivos de origen de su PrestaShop se han colocado correctamente en la carpeta raíz, aparecerá la página de PrestaShop, en la que podrá seleccionar el idioma.
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Seleccione el idioma del sitio web y haga clic en `Next`{.action}.
 
@@ -69,13 +69,13 @@ Seleccione el idioma del sitio web y haga clic en `Next`{.action}.
 
 Lea atentamente las condiciones de uso, marque la casilla `I agree to the above terms and conditions`{.action} y haga clic en `Next`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 - Introduzca la información de su tienda online
 
 PrestaShop le pedirá una serie de información sobre su futura tienda online:
 
-![PrestaShop instalation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop instalation step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Información sobre su tienda**
 
@@ -98,13 +98,13 @@ Compruebe que la información introducida es correcta y haga clic en `Next`{.act
 
 PrestaShop le permite instalar contenidos y módulos en su sitio web de e-commerce:
 
-![PrestaShop instalación step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop instalación step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Elija y haga clic en `Next`{.action}.
 
 #### 2.5 - Asociar su PrestaShop con su base de datos de OVHcloud
 
-![PrestaShop instalación step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop instalación step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Si lo necesita, consulte la guía sobre la [instalación manual de un CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -137,7 +137,7 @@ Si marca la casilla **Drop existing tables**, se eliminarán todas las tablas qu
 
 Haga clic en `Test your database connection now!`{.action} para comprobar los parámetros introducidos:
 
-![PrestaShop instalación step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop instalación step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 Si aparece el mensaje "Su base de datos está conectada", haga clic en `Next`{.action}. En caso contrario, compruebe la configuración que haya introducido hasta que la conexión funcione. Si lo necesita, puede consultar el **etapa 1.4** del tutorial en el apartado ["Instalación manual de un CMS"](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -145,7 +145,7 @@ Si aparece el mensaje "Su base de datos está conectada", haga clic en `Next`{.a
 
 El último paso consiste en un resumen de la instalación que acaba de realizar:
 
-![PrestaShop instalación step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop instalación step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Consulte las claves de conexión de su PrestaShop antes de abandonar la página.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.es-us.md
@@ -51,7 +51,7 @@ Siga el **conjunto de etapas** descritos en nuestro tutorial sobre la [instalaci
 
 Si no ha descargado la última versión disponible de PrestaShop, aparecerá la siguiente página:
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Haga clic en `No thanks`{.action} si desea conservar la versión de PrestaShop que acaba de descargar o en `Yes please!`{.action} si quiere utilizar la versión más reciente del CMS.
 
@@ -61,7 +61,7 @@ Escriba su dominio en la barra de búsqueda de su navegador de Internet.
 
 Si los archivos de origen de su PrestaShop se han colocado correctamente en la carpeta raíz, aparecerá la página de PrestaShop, en la que podrá seleccionar el idioma.
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Seleccione el idioma del sitio web y haga clic en `Next`{.action}.
 
@@ -69,13 +69,13 @@ Seleccione el idioma del sitio web y haga clic en `Next`{.action}.
 
 Lea atentamente las condiciones de uso, marque la casilla `I agree to the above terms and conditions`{.action} y haga clic en `Next`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 - Introduzca la información de su tienda online
 
 PrestaShop le pedirá una serie de información sobre su futura tienda online:
 
-![PrestaShop instalation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop instalation step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Información sobre su tienda**
 
@@ -98,13 +98,13 @@ Compruebe que la información introducida es correcta y haga clic en `Next`{.act
 
 PrestaShop le permite instalar contenidos y módulos en su sitio web de e-commerce:
 
-![PrestaShop instalación step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop instalación step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Elija y haga clic en `Next`{.action}.
 
 #### 2.5 - Asociar su PrestaShop con su base de datos de OVHcloud
 
-![PrestaShop instalación step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop instalación step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Si lo necesita, consulte la guía sobre la [instalación manual de un CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -137,7 +137,7 @@ Si marca la casilla **Drop existing tables**, se eliminarán todas las tablas qu
 
 Haga clic en `Test your database connection now!`{.action} para comprobar los parámetros introducidos:
 
-![PrestaShop instalación step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop instalación step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 Si aparece el mensaje "Su base de datos está conectada", haga clic en `Next`{.action}. En caso contrario, compruebe la configuración que haya introducido hasta que la conexión funcione. Si lo necesita, puede consultar el **etapa 1.4** del tutorial en el apartado ["Instalación manual de un CMS"](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -145,7 +145,7 @@ Si aparece el mensaje "Su base de datos está conectada", haga clic en `Next`{.a
 
 El último paso consiste en un resumen de la instalación que acaba de realizar:
 
-![PrestaShop instalación step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop instalación step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Consulte las claves de conexión de su PrestaShop antes de abandonar la página.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.fr-ca.md
@@ -47,7 +47,7 @@ Suivez l'**ensemble des étapes** décrites dans notre tutoriel sur l'[installat
 
 Si vous n'avez pas téléchargé la dernière version disponible de PrestaShop, la page suivante apparaît :
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Cliquez sur `No thanks`{.action} si vous souhaitez conserver la version de PrestaShop que vous venez de télécharger ou sur `Yes please!`{.action} si vous souhaitez utilisez la version la plus récente du CMS.
 
@@ -57,7 +57,7 @@ Saisissez votre domaine dans la barre de recherche de votre navigateur Internet.
 
 Si les fichiers sources de votre PrestaShop ont été placés correctement dans votre dossier racine, la page de PrestaShop permettant de sélectionner la langue apparaît :
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Sélectionnez la langue du site puis cliquez sur `Suivant`{.action}.
 
@@ -65,13 +65,13 @@ Sélectionnez la langue du site puis cliquez sur `Suivant`{.action}.
 
 Prenez connaissance des conditions d'utilisation, cochez la case `J'accepte les termes et conditions ci-dessus`{.action} puis cliquez sur `Suivant`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 - Renseigner les informations de votre boutique en ligne
 
 PrestaShop vous demandera une série d'informations sur votre future boutique en ligne :
 
-![PrestaShop installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop installation step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Informations à propos de votre boutique**
 
@@ -94,13 +94,13 @@ Vérifiez les informations saisies puis cliquez sur `Suivant`{.action}.
 
 PrestaShop vous propose d'installer du contenu et des modules pour votre futur site de E-commerce :
 
-![PrestaShop installation step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop installation step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Faites vos choix puis cliquez sur `Suivant`{.action}.
 
 #### 2.5 - Lier votre PrestaShop avec votre base de données OVHcloud
 
-![PrestaShop installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop installation step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Munissez-vous des identifiants de votre base de données (au besoin, consultez **l'étape 1.4** du guide sur l'[installation manuelle d'un CMS](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -133,7 +133,7 @@ Pour les bases de données créées sur un service Web Cloud Databases, référe
 
 Cliquez sur `Testez dès maintenant la connexion à votre base de données!`{.action} pour vérifier les paramètres saisis :
 
-![PrestaShop installation step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop installation step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 Si le message « Votre base de données est connectée » apparaît, cliquez sur `Suivant`{.action}. Sinon, vérifiez les paramètres que vous avez saisis jusqu'à ce que la connexion fonctionne. Si besoin, référez-vous à **l'étape 1.4** du tutoriel sur l'[installation manuelle d'un CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -141,7 +141,7 @@ Si le message « Votre base de données est connectée » apparaît, cliquez sur
 
 La dernière étape correspond à un résumé de l'installation que vous venez de réaliser :
 
-![PrestaShop installation step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop installation step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Récupérez les identifiants de connexion de votre PrestaShop avant de quitter la page.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.fr-fr.md
@@ -47,7 +47,7 @@ Suivez l'**ensemble des étapes** décrites dans notre tutoriel sur l'[installat
 
 Si vous n'avez pas téléchargé la dernière version disponible de PrestaShop, la page suivante apparaît :
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Cliquez sur `No thanks`{.action} si vous souhaitez conserver la version de PrestaShop que vous venez de télécharger ou sur `Yes please!`{.action} si vous souhaitez utilisez la version la plus récente du CMS.
 
@@ -57,7 +57,7 @@ Saisissez votre domaine dans la barre de recherche de votre navigateur Internet.
 
 Si les fichiers sources de votre PrestaShop ont été placés correctement dans votre dossier racine, la page de PrestaShop permettant de sélectionner la langue apparaît :
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Sélectionnez la langue du site puis cliquez sur `Suivant`{.action}.
 
@@ -65,13 +65,13 @@ Sélectionnez la langue du site puis cliquez sur `Suivant`{.action}.
 
 Prenez connaissance des conditions d'utilisation, cochez la case `J'accepte les termes et conditions ci-dessus`{.action} puis cliquez sur `Suivant`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 - Renseigner les informations de votre boutique en ligne
 
 PrestaShop vous demandera une série d'informations sur votre future boutique en ligne :
 
-![PrestaShop installation step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop installation step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Informations à propos de votre boutique**
 
@@ -94,13 +94,13 @@ Vérifiez les informations saisies puis cliquez sur `Suivant`{.action}.
 
 PrestaShop vous propose d'installer du contenu et des modules pour votre futur site de E-commerce :
 
-![PrestaShop installation step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop installation step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Faites vos choix puis cliquez sur `Suivant`{.action}.
 
 #### 2.5 - Lier votre PrestaShop avec votre base de données OVHcloud
 
-![PrestaShop installation step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop installation step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Munissez-vous des identifiants de votre base de données (au besoin, consultez **l'étape 1.4** du guide sur l'[installation manuelle d'un CMS](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -133,7 +133,7 @@ Pour les bases de données créées sur un service Web Cloud Databases, référe
 
 Cliquez sur `Testez dès maintenant la connexion à votre base de données!`{.action} pour vérifier les paramètres saisis :
 
-![PrestaShop installation step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop installation step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 Si le message « Votre base de données est connectée » apparaît, cliquez sur `Suivant`{.action}. Sinon, vérifiez les paramètres que vous avez saisis jusqu'à ce que la connexion fonctionne. Si besoin, référez-vous à **l'étape 1.4** du tutoriel sur l'[installation manuelle d'un CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -141,7 +141,7 @@ Si le message « Votre base de données est connectée » apparaît, cliquez sur
 
 La dernière étape correspond à un résumé de l'installation que vous venez de réaliser :
 
-![PrestaShop installation step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop installation step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Récupérez les identifiants de connexion de votre PrestaShop avant de quitter la page.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.it-it.md
@@ -51,7 +51,7 @@ Segui **gli step** descritti nel nostro tutorial sull'[installazione manuale di 
 
 Se non hai scaricato l'ultima versione disponibile di PrestaShop, visualizzi la pagina seguente:
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Clicca su `No thanks`{.action} per conservare la versione di PrestaShop appena caricata o su `Yes please!`{.action} per utilizzare la versione più recente del CMS.
 
@@ -61,7 +61,7 @@ Inserisci il tuo dominio nella barra di ricerca del tuo browser Internet.
 
 Se i file sorgente del tuo PrestaShop sono stati inseriti correttamente nella cartella root, la pagina di PrestaShop che permette di selezionare la lingua apparirà:
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Seleziona la lingua del sito e clicca su `Next`{.action}.
 
@@ -69,13 +69,13 @@ Seleziona la lingua del sito e clicca su `Next`{.action}.
 
 Verifica le condizioni di utilizzo, seleziona la casella `I agree to the above terms and conditions`{.action} e clicca su `Next`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 - Inserisci le informazioni del tuo e-commerce
 
 PrestaShop ti chiederà una serie di informazioni sul tuo futuro negozio online:
 
-![PrestaShop Installstep 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop Installstep 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Informazioni sul tuo ecommerce**
 
@@ -98,13 +98,13 @@ Verifica le informazioni inserite e clicca su `Next`{.action}.
 
 PrestaShop ti permette di installare contenuti e moduli per il tuo futuro sito di e-commerce:
 
-![PrestaShop Installstep 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop Installstep 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Scegli e clicca su `Next`{.action}.
 
 #### 2.5 - Associa PrestaShop al tuo database OVHcloud
 
-![PrestaShop Installstep 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop Installstep 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Recupera le credenziali del tuo database (se necessario, consulta **lo Step 1.4** della guida sull'[installazione manuale di un CMS](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -138,7 +138,7 @@ Per i database creati su un servizio Web Cloud Databases, consulta le informazio
 
 Clicca su `Test your database connection now!`{.action} per verificare le impostazioni inserite:
 
-![PrestaShop Installstep 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop Installstep 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 Se visualizzi il messaggio "Il tuo database è connesso", clicca su `Next`{.action}. Altrimenti, verifica le impostazioni fino al completamento dell'accesso. Se necessario, fai riferimento allo **Step 1.4** del tutorial sull'[installazione manuale di un CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -146,7 +146,7 @@ Se visualizzi il messaggio "Il tuo database è connesso", clicca su `Next`{.acti
 
 L'ultimo step corrisponde al riepilogo dell'installazione che hai appena realizzato:
 
-![PrestaShop Installstep 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop Installstep 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Recupera le credenziali di accesso del tuo PrestaShop prima di lasciare la pagina.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.pl-pl.md
@@ -51,7 +51,7 @@ Postępuj zgodnie z **wszystkie etapy** opisane w tutorialu dotyczącym[Ręczna 
 
 Jeśli nie pobrałeś najnowszej dostępnej wersji PrestaShop, pojawi się następująca strona:
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Kliknij `No thanks`{.action}, jeśli chcesz zachować wersję PrestaShop, którą właśnie przesłałeś lub na `Yes please!`{.action}, jeśli chcesz korzystać z najnowszej wersji CMS-a.
 
@@ -61,7 +61,7 @@ Wpisz swoją domenę na pasku wyszukiwania przeglądarki internetowej.
 
 Jeśli pliki źródłowe Twojego PrestaShop zostały poprawnie umieszczone w katalogu głównym, wyświetli się strona PrestaShop, na której można wybrać język:
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Wybierz język strony i kliknij na `Next`{.action}.
 
@@ -69,13 +69,13 @@ Wybierz język strony i kliknij na `Next`{.action}.
 
 Zapoznaj się z warunkami korzystania, zaznacz kratkę `I agree to the above terms and conditions`{.action} i kliknij `Next`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 - Wpisz dane dotyczące sklepu online
 
 PrestaShop poprosi Cię o zestaw informacji dotyczących Twojego przyszłego sklepu internetowego:
 
-![PrestaShop instalacja step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop instalacja step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Informacje o sklepie**
 
@@ -98,13 +98,13 @@ Sprawdź wprowadzone informacje i kliknij na `Next`{.action}.
 
 PrestaShop proponuje zainstalowanie treści i modułów dla przyszłej strony e-commerce:
 
-![PrestaShop instalacja step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop instalacja step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Dokonaj wyboru i kliknij na `Next`{.action}.
 
 #### 2.5 - Powiązanie PrestaShop z bazą danych OVHcloud
 
-![PrestaShop instalacja step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop instalacja step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Przygotuj dane dostępowe do bazy danych (w razie potrzeby sprawdź **etap 1.4** w przewodniku dotyczącym [ręczna instalacja CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -138,7 +138,7 @@ W przypadku baz danych utworzonych w ramach usługi WWW Cloud Databases, zapozna
 
 Kliknij polecenie `Test your database connection now!`{.action} w celu sprawdzenia wprowadzonych parametrów:
 
-![PrestaShop instalacja step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop instalacja step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 Jeśli pojawi się komunikat "Twoja baza danych", kliknij przycisk `Next`{.action}. W przeciwnym razie sprawdź ustawienia, które wprowadziłeś, aż połączenie zacznie działać. W razie potrzeby sprawdź **etap 1.4** tutoriala w sprawie [ręczna instalacja CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -146,7 +146,7 @@ Jeśli pojawi się komunikat "Twoja baza danych", kliknij przycisk `Next`{.actio
 
 Ostatni etap to podsumowanie instalacji, którą właśnie przeprowadziłeś:
 
-![PrestaShop instalacja step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop instalacja step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Pobierz dane do logowania modułu PrestaShop przed opuszczeniem strony.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_prestashop/guide.pt-pt.md
@@ -51,7 +51,7 @@ Siga **os passos indicados** no nosso manual sobre a [instalação manual de um 
 
 Se não descarregou a última versão disponível do PrestaShop, aparecerá a seguinte página:
 
-![PrestaShop installation step 1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-update-version.png){.thumbnail}
+![PrestaShop installation step 1](/pages/assets/screens/other/cms/prestashop/install-update-version.png){.thumbnail}
 
 Clique em `No thanks`{.action} se deseja conservar a versão do PrestaShop que acabou de descarregar ou em `Yes please!`{.action} se deseja utilizar a versão mais recente do CMS.
 
@@ -61,7 +61,7 @@ Introduza o seu domínio na barra de pesquisa do seu browser.
 
 Se os ficheiros de origem do seu PrestaShop foram corretamente colocados na sua pasta raiz, a página do PrestaShop que permite selecionar o idioma aparece:
 
-![PrestaShop installation step 2](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-select-language.png){.thumbnail}
+![PrestaShop installation step 2](/pages/assets/screens/other/cms/prestashop/install-select-language.png){.thumbnail}
 
 Selecione a língua do site e clique em `Next`{.action}.
 
@@ -69,13 +69,13 @@ Selecione a língua do site e clique em `Next`{.action}.
 
 Leia atentamente as condições de utilização, selecione a opção `I agree to the above terms and conditions`{.action} e clique em `Next`{.action}.
 
-![PrestaShop installation step 3](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
+![PrestaShop installation step 3](/pages/assets/screens/other/cms/prestashop/install-licence-agreement-3.png){.thumbnail}
 
 #### 2.3 - Insira as informações da sua loja online
 
 O PrestaShop irá pedir-lhe uma série de informações sobre a sua futura loja online:
 
-![PrestaShop instalação step 4](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-infos-4.png){.thumbnail}
+![PrestaShop instalação step 4](/pages/assets/screens/other/cms/prestashop/install-store-infos-4.png){.thumbnail}
 
 **Informações sobre a sua loja**
 
@@ -98,13 +98,13 @@ Verifique as informações introduzidas e clique em `Next`{.action}.
 
 O PrestaShop propõe-lhe instalar conteúdos e módulos para o seu futuro site de E-commerce:
 
-![PrestaShop instalação step 5](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-store-content-5.png){.thumbnail}
+![PrestaShop instalação step 5](/pages/assets/screens/other/cms/prestashop/install-store-content-5.png){.thumbnail}
 
 Faça as suas escolhas e clique em `Next`{.action}.
 
 #### 2.5 - Associar o seu PrestaShop com a sua base de dados OVHcloud
 
-![PrestaShop instalação step 6](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6.png){.thumbnail}
+![PrestaShop instalação step 6](/pages/assets/screens/other/cms/prestashop/install-db-config-6.png){.thumbnail}
 
 Tenha consigo os dados de acesso à sua base de dados (se necessário, consulte **a etapa 1.4** do guia sobre a [instalação manual de um CMS](/pages/web_cloud/web_hosting/cms_manual_installation)).
 
@@ -137,7 +137,7 @@ Para as bases de dados criadas num serviço Web Cloud Databases, consulte as inf
 
 Clique em `Test your database connection now!`{.action} para verificar os parâmetros introduzidos:
 
-![PrestaShop instalação step 6-1](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-db-config-6-1.png){.thumbnail}
+![PrestaShop instalação step 6-1](/pages/assets/screens/other/cms/prestashop/install-db-config-6-1.png){.thumbnail}
 
 Se aparecer a mensagem "A sua base de dados está ligada", clique em `Next`{.action}. Caso contrário, verifique os parâmetros que introduziu até que a ligação funcione. Caso seja necessário, consulte o **etapa 1.4** do tutorial para a [instalação manual de um CMS](/pages/web_cloud/web_hosting/cms_manual_installation).
 
@@ -145,7 +145,7 @@ Se aparecer a mensagem "A sua base de dados está ligada", clique em `Next`{.act
 
 A última etapa corresponde a um resumo da instalação que acabou de realizar:
 
-![PrestaShop instalação step 7](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/prestashop/install-resume-7.png){.thumbnail}
+![PrestaShop instalação step 7](/pages/assets/screens/other/cms/prestashop/install-resume-7.png){.thumbnail}
 
 Obtenha as credenciais de acesso do PrestaShop antes de sair da página.
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.de-de.md
@@ -54,7 +54,7 @@ Geben Sie Ihren Domainnamen in die Adresszeile Ihres Webbrowsers ein.
 
 Wenn die Quelldateien korrekt im Wurzelverzeichnis platziert wurden, erscheint die Seite zur Auswahl der Sprache für WordPress.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Wählen Sie die Sprache für die Website aus und klicken Sie auf `Weiter`{.action}.
 
@@ -62,13 +62,13 @@ Wählen Sie die Sprache für die Website aus und klicken Sie auf `Weiter`{.actio
 
 WordPress fragt nun nach den Login-Daten für Ihre Datenbank.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Halten Sie die Zugangsdaten für Ihre Datenbank bereit. (Sie können bei Bedarf **Schritt 1.4** des Tutorials zur [manuellen Installation eines CMS](/pages/web_cloud/web_hosting/cms_manual_installation) verwenden). Klicken Sie auf `Let's go!`{.action}, um fortzufahren.
 
 Folgende Seite wird angezeigt:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Geben Sie die angeforderten Informationen zur Datenbank ein:
 
@@ -93,7 +93,7 @@ Klicken Sie auf `Submit`{.action}, um die Verbindungsinformationen zur Datenbank
 
 Wenn alle Eingaben korrekt waren, erscheint folgende Seite:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Klicken Sie auf `Run the installation`{.action}.
 
@@ -103,7 +103,7 @@ Nach der Installation fragt WordPress nach Informationen zu Ihrer künftigen Web
 
 Dieser ermöglicht Ihnen den Zugriff auf den Verwaltungsbereich Ihres WordPress CMS (Backend).
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Geben Sie die angeforderten Informationen ein:
 
@@ -119,7 +119,7 @@ Klicken Sie auf `Install WordPress`{.action}, sobald alles korrekt eingegeben is
 
 Die Installation ist vollständig, wenn folgende Seite angezeigt wird:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 Klicken Sie auf den Button `Log in`{.action}, um den Zugriff auf den Verwaltungsbereich Ihres neuen WordPress mit den zuvor in Schritt 3.3 erstellten Login-Daten zu testen.
 
@@ -132,7 +132,7 @@ Klicken Sie auf den Button `Log in`{.action}, um den Zugriff auf den Verwaltungs
 
 Wenn Sie eingeloggt sind, erscheint folgende Seite:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-asia.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the WordPress source files have been correctly placed in your root folder, the WordPress page for selecting the language appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Select the site language and click `Continue`{.action}.
 
@@ -59,13 +59,13 @@ Select the site language and click `Continue`{.action}.
 
 WordPress will ask you to retrieve the login details for your database:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)). Click on `Let's go!`{.action} to continue.
 
 The following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Enter the information requested for the database:
 
@@ -90,7 +90,7 @@ Click `Submit`{.action} to validate the database connection information.
 
 If everything went well, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Click `Launch Installation`{.action}.
 
@@ -100,7 +100,7 @@ Once you have set it up, WordPress will ask you for information on your future w
 
 This will give you access to the administration panel (backend) of your WordPress CMS.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Enter the information requested:
 
@@ -116,7 +116,7 @@ Click `Install WordPress`{.action} as soon as you have entered all of the inform
 
 Installation is complete when the following page is displayed:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 At this stage, simply click on the `Log in`{.action} button to test access to the admin panel of your new WordPress CMS. Enter the credentials created previously in step 3.3.
 
@@ -129,7 +129,7 @@ At this stage, simply click on the `Log in`{.action} button to test access to th
 
 Once connected, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-au.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the WordPress source files have been correctly placed in your root folder, the WordPress page for selecting the language appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Select the site language and click `Continue`{.action}.
 
@@ -59,13 +59,13 @@ Select the site language and click `Continue`{.action}.
 
 WordPress will ask you to retrieve the login details for your database:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)). Click on `Let's go!`{.action} to continue.
 
 The following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Enter the information requested for the database:
 
@@ -90,7 +90,7 @@ Click `Submit`{.action} to validate the database connection information.
 
 If everything went well, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Click `Launch Installation`{.action}.
 
@@ -100,7 +100,7 @@ Once you have set it up, WordPress will ask you for information on your future w
 
 This will give you access to the administration panel (backend) of your WordPress CMS.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Enter the information requested:
 
@@ -116,7 +116,7 @@ Click `Install WordPress`{.action} as soon as you have entered all of the inform
 
 Installation is complete when the following page is displayed:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 At this stage, simply click on the `Log in`{.action} button to test access to the admin panel of your new WordPress CMS. Enter the credentials created previously in step 3.3.
 
@@ -129,7 +129,7 @@ At this stage, simply click on the `Log in`{.action} button to test access to th
 
 Once connected, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-ca.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the WordPress source files have been correctly placed in your root folder, the WordPress page for selecting the language appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Select the site language and click `Continue`{.action}.
 
@@ -59,13 +59,13 @@ Select the site language and click `Continue`{.action}.
 
 WordPress will ask you to retrieve the login details for your database:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)). Click on `Let's go!`{.action} to continue.
 
 The following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Enter the information requested for the database:
 
@@ -90,7 +90,7 @@ Click `Submit`{.action} to validate the database connection information.
 
 If everything went well, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Click `Launch Installation`{.action}.
 
@@ -100,7 +100,7 @@ Once you have set it up, WordPress will ask you for information on your future w
 
 This will give you access to the administration panel (backend) of your WordPress CMS.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Enter the information requested:
 
@@ -116,7 +116,7 @@ Click `Install WordPress`{.action} as soon as you have entered all of the inform
 
 Installation is complete when the following page is displayed:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 At this stage, simply click on the `Log in`{.action} button to test access to the admin panel of your new WordPress CMS. Enter the credentials created previously in step 3.3.
 
@@ -129,7 +129,7 @@ At this stage, simply click on the `Log in`{.action} button to test access to th
 
 Once connected, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-gb.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the WordPress source files have been correctly placed in your root folder, the WordPress page for selecting the language appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Select the site language and click `Continue`{.action}.
 
@@ -59,13 +59,13 @@ Select the site language and click `Continue`{.action}.
 
 WordPress will ask you to retrieve the login details for your database:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)). Click on `Let's go!`{.action} to continue.
 
 The following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Enter the information requested for the database:
 
@@ -90,7 +90,7 @@ Click `Submit`{.action} to validate the database connection information.
 
 If everything went well, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Click `Launch Installation`{.action}.
 
@@ -100,7 +100,7 @@ Once you have set it up, WordPress will ask you for information on your future w
 
 This will give you access to the administration panel (backend) of your WordPress CMS.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Enter the information requested:
 
@@ -116,7 +116,7 @@ Click `Install WordPress`{.action} as soon as you have entered all of the inform
 
 Installation is complete when the following page is displayed:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 At this stage, simply click on the `Log in`{.action} button to test access to the admin panel of your new WordPress CMS. Enter the credentials created previously in step 3.3.
 
@@ -129,7 +129,7 @@ At this stage, simply click on the `Log in`{.action} button to test access to th
 
 Once connected, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-ie.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the WordPress source files have been correctly placed in your root folder, the WordPress page for selecting the language appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Select the site language and click `Continue`{.action}.
 
@@ -59,13 +59,13 @@ Select the site language and click `Continue`{.action}.
 
 WordPress will ask you to retrieve the login details for your database:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)). Click on `Let's go!`{.action} to continue.
 
 The following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Enter the information requested for the database:
 
@@ -90,7 +90,7 @@ Click `Submit`{.action} to validate the database connection information.
 
 If everything went well, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Click `Launch Installation`{.action}.
 
@@ -100,7 +100,7 @@ Once you have set it up, WordPress will ask you for information on your future w
 
 This will give you access to the administration panel (backend) of your WordPress CMS.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Enter the information requested:
 
@@ -116,7 +116,7 @@ Click `Install WordPress`{.action} as soon as you have entered all of the inform
 
 Installation is complete when the following page is displayed:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 At this stage, simply click on the `Log in`{.action} button to test access to the admin panel of your new WordPress CMS. Enter the credentials created previously in step 3.3.
 
@@ -129,7 +129,7 @@ At this stage, simply click on the `Log in`{.action} button to test access to th
 
 Once connected, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-sg.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the WordPress source files have been correctly placed in your root folder, the WordPress page for selecting the language appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Select the site language and click `Continue`{.action}.
 
@@ -59,13 +59,13 @@ Select the site language and click `Continue`{.action}.
 
 WordPress will ask you to retrieve the login details for your database:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)). Click on `Let's go!`{.action} to continue.
 
 The following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Enter the information requested for the database:
 
@@ -90,7 +90,7 @@ Click `Submit`{.action} to validate the database connection information.
 
 If everything went well, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Click `Launch Installation`{.action}.
 
@@ -100,7 +100,7 @@ Once you have set it up, WordPress will ask you for information on your future w
 
 This will give you access to the administration panel (backend) of your WordPress CMS.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Enter the information requested:
 
@@ -116,7 +116,7 @@ Click `Install WordPress`{.action} as soon as you have entered all of the inform
 
 Installation is complete when the following page is displayed:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 At this stage, simply click on the `Log in`{.action} button to test access to the admin panel of your new WordPress CMS. Enter the credentials created previously in step 3.3.
 
@@ -129,7 +129,7 @@ At this stage, simply click on the `Log in`{.action} button to test access to th
 
 Once connected, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.en-us.md
@@ -51,7 +51,7 @@ Enter your domain name into the address bar of your web browser.
 
 If the WordPress source files have been correctly placed in your root folder, the WordPress page for selecting the language appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Select the site language and click `Continue`{.action}.
 
@@ -59,13 +59,13 @@ Select the site language and click `Continue`{.action}.
 
 WordPress will ask you to retrieve the login details for your database:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Have your database login details ready (if necessary, see **Step 1.4** in the [manual installation of a CMS tutorial](/pages/web_cloud/web_hosting/cms_manual_installation)). Click on `Let's go!`{.action} to continue.
 
 The following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Enter the information requested for the database:
 
@@ -90,7 +90,7 @@ Click `Submit`{.action} to validate the database connection information.
 
 If everything went well, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Click `Launch Installation`{.action}.
 
@@ -100,7 +100,7 @@ Once you have set it up, WordPress will ask you for information on your future w
 
 This will give you access to the administration panel (backend) of your WordPress CMS.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Enter the information requested:
 
@@ -116,7 +116,7 @@ Click `Install WordPress`{.action} as soon as you have entered all of the inform
 
 Installation is complete when the following page is displayed:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 At this stage, simply click on the `Log in`{.action} button to test access to the admin panel of your new WordPress CMS. Enter the credentials created previously in step 3.3.
 
@@ -129,7 +129,7 @@ At this stage, simply click on the `Log in`{.action} button to test access to th
 
 Once connected, the following page appears:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.es-es.md
@@ -55,7 +55,7 @@ Escriba su dominio en la barra de búsqueda de su navegador de Internet.
 
 Si los archivos fuente de WordPress se han colocado correctamente en la carpeta raíz, aparecerá la página WordPress en la que podrá seleccionar el idioma:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Seleccione el idioma del sitio web y haga clic en `Continue`{.action}.
 
@@ -63,13 +63,13 @@ Seleccione el idioma del sitio web y haga clic en `Continue`{.action}.
 
 WordPress le pedirá que obtenga las claves de conexión a la base de datos:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Introduzca las claves de la base de datos (si las necesita, consulte el **etapa 1.4** del tutorial sobre la [instalación manual de un CMS](/pages/web_cloud/web_hosting/cms_manual_installation)) y haga clic en `Let's go !`{.action} para continuar.
 
 Se abrirá la siguiente página:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Introduzca la información solicitada para la base de datos:
 
@@ -95,7 +95,7 @@ Haga clic en `Submit`{.action} para validar la información de conexión a la ba
 
 Si todo ha ido bien, aparecerá la siguiente página:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Haga clic en `Run the installation`{.action}.
 
@@ -105,7 +105,7 @@ Una vez realizada la instalación, WordPress le pedirá información sobre su fu
 
 que le permitirá acceder al panel de administración, denominado comúnmente "backup-office", de su CMS WordPress.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Introduzca la información solicitada:
 
@@ -121,7 +121,7 @@ Haga clic en `Install WordPress`{.action} cuando se haya introducido correctamen
 
 La instalación se cerrará si aparece la siguiente página:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 Haga clic en el botón `Log in`{.action} para probar el acceso al "Back-office" de su nuevo CMS WordPress utilizando las claves de administrador creadas anteriormente en el etapa 3.3. Justo antes.
 
@@ -134,7 +134,7 @@ El equipo de OVHcloud no proporciona soporte a otras soluciones, como WordPress,
 
 Una vez se haya conectado, se abrirá la siguiente página:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.es-us.md
@@ -55,7 +55,7 @@ Escriba su dominio en la barra de búsqueda de su navegador de Internet.
 
 Si los archivos fuente de WordPress se han colocado correctamente en la carpeta raíz, aparecerá la página WordPress en la que podrá seleccionar el idioma:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Seleccione el idioma del sitio web y haga clic en `Continue`{.action}.
 
@@ -63,13 +63,13 @@ Seleccione el idioma del sitio web y haga clic en `Continue`{.action}.
 
 WordPress le pedirá que obtenga las claves de conexión a la base de datos:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Introduzca las claves de la base de datos (si las necesita, consulte el **etapa 1.4** del tutorial sobre la [instalación manual de un CMS](/pages/web_cloud/web_hosting/cms_manual_installation)) y haga clic en `Let's go !`{.action} para continuar.
 
 Se abrirá la siguiente página:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Introduzca la información solicitada para la base de datos:
 
@@ -95,7 +95,7 @@ Haga clic en `Submit`{.action} para validar la información de conexión a la ba
 
 Si todo ha ido bien, aparecerá la siguiente página:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Haga clic en `Run the installation`{.action}.
 
@@ -105,7 +105,7 @@ Una vez realizada la instalación, WordPress le pedirá información sobre su fu
 
 que le permitirá acceder al panel de administración, denominado comúnmente "backup-office", de su CMS WordPress.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Introduzca la información solicitada:
 
@@ -121,7 +121,7 @@ Haga clic en `Install WordPress`{.action} cuando se haya introducido correctamen
 
 La instalación se cerrará si aparece la siguiente página:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 Haga clic en el botón `Log in`{.action} para probar el acceso al "Back-office" de su nuevo CMS WordPress utilizando las claves de administrador creadas anteriormente en el etapa 3.3. Justo antes.
 
@@ -134,7 +134,7 @@ El equipo de OVHcloud no proporciona soporte a otras soluciones, como WordPress,
 
 Una vez se haya conectado, se abrirá la siguiente página:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.fr-ca.md
@@ -51,7 +51,7 @@ Saisissez votre domaine dans la barre de recherche de votre navigateur Internet.
 
 Si les fichiers sources de WordPress ont été placés correctement dans votre dossier racine, la page WordPress permettant de sélectionner la langue apparaît :
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Sélectionnez la langue du site puis cliquez sur `Continuer`{.action}.
 
@@ -59,13 +59,13 @@ Sélectionnez la langue du site puis cliquez sur `Continuer`{.action}.
 
 WordPress va vous demander de récupérer les identifiants de connexion à votre base de données :
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Munissez-vous des identifiants de votre base de données (au besoin, consultez **l'étape 1.4** du tutoriel sur l'[installation manuelle d'un CMS](/pages/web_cloud/web_hosting/cms_manual_installation)) puis cliquez sur `C'est parti !`{.action} pour continuer.
 
 La page suivante apparaît :
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Renseignez les informations demandées concernant la base de données :
 
@@ -91,7 +91,7 @@ Cliquez sur `Soumettre`{.action} pour valider les informations de connexion à l
 
 Si tout s'est bien passé, la page suivante apparaît :
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Cliquez sur `Lancer l'installation`{.action}.
 
@@ -101,7 +101,7 @@ Une fois l'installation réalisée, WordPress va vous demander des informations 
 
 Ce dernier vous permettra ensuite d'accéder à l'espace d'administration, communément appelé « Back-office », de votre CMS WordPress.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Renseignez les informations demandées :
 
@@ -117,7 +117,7 @@ Cliquez sur `Installer WordPress`{.action} dès que tout est correctement rensei
 
 L'installation est termninée si la page suivante s'affiche :
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 Il ne vous reste plus qu'à cliquer sur le bouton `Se connecter`{.action} pour tester l'accès au « Back-office » de votre nouveau CMS WordPress à l'aide des identifiants Administrateur préalablement créés lors de l'étape 2.3 de ce tutoriel.
 
@@ -130,7 +130,7 @@ Il ne vous reste plus qu'à cliquer sur le bouton `Se connecter`{.action} pour t
 
 Une fois connecté, la page suivante apparaît :
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.fr-fr.md
@@ -51,7 +51,7 @@ Saisissez votre domaine dans la barre de recherche de votre navigateur Internet.
 
 Si les fichiers sources de WordPress ont été placés correctement dans votre dossier racine, la page WordPress permettant de sélectionner la langue apparaît :
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Sélectionnez la langue du site puis cliquez sur `Continuer`{.action}.
 
@@ -59,13 +59,13 @@ Sélectionnez la langue du site puis cliquez sur `Continuer`{.action}.
 
 WordPress va vous demander de récupérer les identifiants de connexion à votre base de données :
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Munissez-vous des identifiants de votre base de données (au besoin, consultez **l'étape 1.4** du tutoriel sur l'[installation manuelle d'un CMS](/pages/web_cloud/web_hosting/cms_manual_installation)) puis cliquez sur `C'est parti !`{.action} pour continuer.
 
 La page suivante apparaît :
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Renseignez les informations demandées concernant la base de données :
 
@@ -91,7 +91,7 @@ Cliquez sur `Soumettre`{.action} pour valider les informations de connexion à l
 
 Si tout s'est bien passé, la page suivante apparaît :
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Cliquez sur `Lancer l'installation`{.action}.
 
@@ -101,7 +101,7 @@ Une fois l'installation réalisée, WordPress va vous demander des informations 
 
 Ce dernier vous permettra ensuite d'accéder à l'espace d'administration, communément appelé « Back-office », de votre CMS WordPress.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Renseignez les informations demandées :
 
@@ -117,7 +117,7 @@ Cliquez sur `Installer WordPress`{.action} dès que tout est correctement rensei
 
 L'installation est termninée si la page suivante s'affiche :
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 Il ne vous reste plus qu'à cliquer sur le bouton `Se connecter`{.action} pour tester l'accès au « Back-office » de votre nouveau CMS WordPress à l'aide des identifiants Administrateur préalablement créés lors de l'étape 2.3 de ce tutoriel.
 
@@ -130,7 +130,7 @@ Il ne vous reste plus qu'à cliquer sur le bouton `Se connecter`{.action} pour t
 
 Une fois connecté, la page suivante apparaît :
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.it-it.md
@@ -55,7 +55,7 @@ Inserisci il tuo dominio nella barra di ricerca del tuo browser Internet.
 
 Se i file sorgente di WordPress sono stati inseriti correttamente nella tua cartella root, la pagina WordPress che permette di selezionare la lingua apparirà:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Seleziona la lingua del sito e clicca su `Continue`{.action}.
 
@@ -63,13 +63,13 @@ Seleziona la lingua del sito e clicca su `Continue`{.action}.
 
 WordPress ti chiederà di recuperare le credenziali di accesso al tuo database:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Recupera gli identificativi del tuo database (se necessario, consulta **lo Step 1.4** del tutorial sull'[installazione manuale di un CMS](/pages/web_cloud/web_hosting/cms_manual_installation)) e clicca su `Let's go !`{.action} per continuare.
 
 Visualizzi questa pagina:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Inserisci le informazioni richieste relative al database:
 
@@ -95,7 +95,7 @@ Clicca su `Submit`{.action} per confermare le informazioni di connessione al dat
 
 Se tutto è andato bene, visualizzi la pagina seguente:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Clicca su `Run the installation`{.action}.
 
@@ -105,7 +105,7 @@ Una volta completata l'installazione, WordPress ti chiederà informazioni sul tu
 
 che permette di accedere allo spazio di amministrazione del CMS WordPress, comunemente chiamato "Back-office".
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Inserisci le informazioni richieste:
 
@@ -121,7 +121,7 @@ Clicca su `Install WordPress`{.action} non appena tutto è stato inserito corret
 
 L'installazione viene terminata se visualizzi la pagina seguente:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 Clicca su `Log in`{.action} per testare l'accesso al tuo nuovo CMS WordPress utilizzando gli identificativi amministratore creati precedentemente allo Step 3.3.
 
@@ -134,7 +134,7 @@ Clicca su `Log in`{.action} per testare l'accesso al tuo nuovo CMS WordPress uti
 
 Una volta connesso, visualizzi la pagina seguente:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.pl-pl.md
@@ -56,7 +56,7 @@ Wpisz swoją domenę na pasku wyszukiwania przeglądarki internetowej.
 
 Jeśli pliki źródłowe WordPress zostały poprawnie umieszczone w katalogu głównym, pojawi się strona WordPress pozwalająca na wybór języka:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Wybierz język strony i kliknij na `Continue`{.action}.
 
@@ -64,13 +64,13 @@ Wybierz język strony i kliknij na `Continue`{.action}.
 
 WordPress poprosi Cię o pobranie danych do logowania do bazy danych:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Przygotuj dane do logowania do bazy danych (w razie potrzeby sprawdź **etap 1.4** tutoriala na stronie [ręczna instalacja CMS](/pages/web_cloud/web_hosting/cms_manual_installation)), następnie kliknij na `Let's go !`{.action}, aby kontynuować.
 
 Pojawi się następująca strona:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Wpisz wymagane informacje dotyczące bazy danych:
 
@@ -96,7 +96,7 @@ Kliknij polecenie `Submit`{.action}, aby potwierdzić dane do logowania do bazy 
 
 Jeśli wszystko przebiegło pomyślnie, wyświetli się następna strona:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Kliknij polecenie `Run the installation`{.action}.
 
@@ -106,7 +106,7 @@ Po zainstalowaniu modułu WordPress pojawi się problem z informacjami o przysz�
 
 Następnie będziesz mógł przejść do panelu administracyjnego, znanego jako "Back-office", Twojego CMS WordPress.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Wpisz wymagane informacje:
 
@@ -122,7 +122,7 @@ Kliknij polecenie `Install WordPress`{.action} jak tylko wszystko jest poprawnie
 
 Instalacja zostanie zakończona, jeśli pojawi się następna strona:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 Teraz kliknij przycisk `Log in`{.action}, aby przetestować dostęp do "Back-office" Twojego nowego CMS WordPress za pomocą identyfikatorów administratora utworzonych przed etapem 3.3.
 
@@ -135,7 +135,7 @@ Teraz kliknij przycisk `Log in`{.action}, aby przetestować dostęp do "Back-off
 
 Po zalogowaniu pojawi się następująca strona:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation_wordpress/guide.pt-pt.md
@@ -56,7 +56,7 @@ Introduza o seu domínio na barra de pesquisa do seu browser.
 
 Se os ficheiros de origem do WordPress foram corretamente colocados na sua pasta raiz, a página WordPress permite selecionar o idioma:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-select-language.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-select-language.png){.thumbnail}
 
 Selecione a língua do website e clique em `Continue`{.action}.
 
@@ -64,13 +64,13 @@ Selecione a língua do website e clique em `Continue`{.action}.
 
 O WordPress vai pedir-lhe que obtenha os dados de acesso à sua base de dados:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-start.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-start.png){.thumbnail}
 
 Tenha consigo as credenciais da sua base de dados (se necessário, consulte ***a etapa 1.4** do tutorial para a [instalação manual de um CMS](/pages/web_cloud/web_hosting/cms_manual_installation). Depois clique em `Let's go !`{.action} para continuar.
 
 Surge a seguinte página:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-db.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-db.png){.thumbnail}
 
 Insira as informações solicitadas relativas à base de dados:
 
@@ -96,7 +96,7 @@ Clique em `Submit`{.action} para validar as informações de ligação à base d
 
 Se tudo correr bem, aparecerá a seguinte página:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-step-after-db-1.png){.thumbnail}
 
 Clique em `Run the installation`{.action}.
 
@@ -106,7 +106,7 @@ Uma vez concluída a instalação, o WordPress irá pedir-lhe informações sobr
 
 Este último permitir-lhe-á aceder ao espaço de administração, comummente denominado "Back-office", do seu CMS WordPress.
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-config-admin-user.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-config-admin-user.png){.thumbnail}
 
 Insira as informações solicitadas:
 
@@ -122,7 +122,7 @@ Clique em `Install WordPress`{.action} logo que as informações estiverem corre
 
 A instalação terminará se aparecer a seguinte página:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/installation-successfull.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/installation-successfull.png){.thumbnail}
 
 Só precisa de clicar no botão `Log in`{.action} para testar o acesso ao "Back-office" do novo CMS WordPress através dos identificadores de administrador previamente criados na etapa 3.3 imediatamente anterior.
 
@@ -135,7 +135,7 @@ Só precisa de clicar no botão `Log in`{.action} para testar o acesso ao "Back-
 
 Uma vez ligado, surge a seguinte página:
 
-![hosting](https://raw.githubusercontent.com/ovh/docs/develop/templates/external-elements/cms/wordpress/admin-interface.png){.thumbnail}
+![hosting](/pages/assets/screens/other/cms/wordpress/admin-interface.png){.thumbnail}
 
 > [!success]
 >


### PR DESCRIPTION
Old github link deleted and replaced by the new syntax for bank of screens : 

- cms-manual-installation
- cms-manual-installation-drupal
- cms-manual-installation-joomla
- cms-manual-installation-prestashop
- cms-manual-installation-wordpress