### PR TITLE
EN: LDP - Deprecation of Filebeat with Logs Data Platform

### DIFF
--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.de-de.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.de-de.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.de-de.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.de-de.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-asia.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-asia.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-asia.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-asia.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-au.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-au.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-au.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-au.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-ca.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-ca.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-gb.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-gb.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-ie.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-ie.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-ie.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-ie.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-sg.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-sg.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-sg.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-sg.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-us.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.en-us.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.es-es.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.es-es.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.es-es.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.es-es.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.es-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.es-us.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.es-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.es-us.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.fr-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.fr-ca.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.fr-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.fr-ca.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.fr-fr.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.fr-fr.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.fr-fr.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.fr-fr.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.it-it.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.it-it.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.it-it.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.it-it.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.pl-pl.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.pl-pl.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.pl-pl.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.pl-pl.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.pt-pt.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.pt-pt.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -13,7 +13,7 @@ This guide will describe how to setup Filebeat OSS on your system for forwarding
 
 > [!warning]
 >
-> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+> As a consequence of the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2), we recommend using an alternative such as [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/).
 >
 
 ## Requirements

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.pt-pt.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_filebeat/guide.pt-pt.md
@@ -1,6 +1,6 @@
 ---
 title: Pushing logs with a forwarder - Filebeat (Linux)
-updated: 2022-06-13
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -10,6 +10,11 @@ updated: 2022-06-13
 The main benefits of Filebeat are it's resilient protocol to send logs, and a variety of modules ready-to-use for most of the common applications.
 
 This guide will describe how to setup Filebeat OSS on your system for forwarding your logs on Logs Data Platform. It will also present you with some configuration setup useful to further structure your logs.
+
+> [!warning]
+>
+> With the upcoming [OpenSearch 2.X upgrade](/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2). We recommend using an alternative like [Fluent Bit](/pages/manage_and_operate/observability/logs_data_platform/ingestion_kubernetes_fluent_bit/)
+>
 
 ## Requirements
 
@@ -202,8 +207,17 @@ output.elasticsearch:
   username: "<username>"
   password: "<password>"
   index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
 
 ```
+
+> [!warning]
+>
+> The headers section of the output configuration is mandatory to ensure compatibility with OpenSearch 2.X.
+>
+
 
 This configuration deactivates the template configuration (unneeded for our endpoint). You need to provide your credentials **<username>** and **<password>** of your account. Like all Logs Data Platform APIs you can also use [tokens](/pages/manage_and_operate/observability/logs_data_platform/security_tokens). Don't change **ldp-logs** since it is our special destination index.
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.de-de.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.de-de.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-asia.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-asia.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-au.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-au.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-ie.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-ie.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-sg.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-sg.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.es-es.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.es-es.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.es-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.es-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.fr-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.fr-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.fr-fr.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.fr-fr.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.it-it.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.it-it.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.pl-pl.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.pl-pl.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.pt-pt.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-21
+updated: 2024-06-24
 ---
 
 ## Objective
@@ -25,7 +25,8 @@ Another change for the OpenSearch API is the [Wildcard query behavior](https://o
 
 ## Filebeat Deprecation
 
-New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative such as [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option.
+
 We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
 
 ```yaml

--- a/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.pt-pt.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/upgrade_upgrade_to_opensearch_2/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: OpenSearch Upgrade to 2.X
 excerpt: Learn about the upgrade of OpenSearch from 1.3 to 2.x and its impact on the Logs Data Platform
-updated: 2024-06-06
+updated: 2024-06-21
 ---
 
 ## Objective
@@ -22,6 +22,31 @@ The main change for OpenSearch 2.X in terms of API is the [removal of type param
 >
 
 Another change for the OpenSearch API is the [Wildcard query behavior](https://opensearch.org/docs/latest/breaking-changes/#250){.external}. This change only affects users using the [wildcard query](https://opensearch.org/docs/latest/query-dsl/term/wildcard/){.external}.
+
+## Filebeat Deprecation
+
+New Filebeat versions are only compatible with Elasticsearch when using Elasticsearch output. Only Filebeat 7.10+ versions are compatible with OpenSearch 1.X. The OpenSearch version endpoint will now provide its proper version instead of 7.10.2. **This change breaks Filebeat compatibility**. We strongly encourage our users to migrate to an alternative like [fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch){.external}, which supports OpenSearch 2.X with the **Suppress_Type_Name** option. 
+We are still providing a way to make Filebeat 7.10+ versions compatible with our OpenSearch 2.X version by using a special header, **X-Es-Compat**, with the value "7.10". Here is a configuration snippet for this purpose:
+
+```yaml
+#-------------------------- OpenSearch output ------------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["<your-cluster>.logs.ovh.com:9200"]
+
+  # Protocol - either `http` (default) or `https`.
+  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  username: "<username>"
+  password: "<password>"
+  index: "ldp-logs"
+  # Header for OpenSearch 2.X
+  headers:
+    X-Es-Compat: "7.10"
+```
+
+This header can be used right now in your current Filebeat configuration and will ensure continuity of service after the upgrade.
 
 ## Graylog
 


### PR DESCRIPTION
Hi this PR add new information about the upcoming OpenSearch 2.X upgrade regarding the depreciation of Filebeat. 

Both upgrade guide and filebeat guide have been updated to reflect the change the users need to make to ensure continuity of service during upgrade. 
