### PR TITLE
PGA - HPC : Update/fix port (from 9081 to 9071) on Zerto guides

### DIFF
--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.de-de.md
@@ -15,7 +15,7 @@ Der Einfachheit halber beschreiben wir die einfachste Konfiguration, bei der das
 - Die Ziel-Managed-Bare-Metal muss über mindestens eine verfügbare öffentliche IP-Adresse für den VPN-Endpunkt verfügen.
 - Der Kundenstandort muss über eine funktionsfähige Zerto-Installation verfügen.
 - Die von Zerto für die Replikation verwendeten virtuellen Maschinen (VRA: Virtual Replication Appliance) sowohl auf Kundenseite als auch bei OVHcloud müssen sich über die TCP-Ports 4007 und 4008 miteinander austauschen können.
-- Die Verwaltungsmaschinen von Zerto (ZVM: Zerto Virtual Manager) sowohl auf Kundenseite als auch bei OVHcloud müssen sich über den TCP-Port 9081 miteinander austauschen können.
+- Die Verwaltungsmaschinen von Zerto (ZVM: Zerto Virtual Manager) sowohl auf Kundenseite als auch bei OVHcloud müssen sich über den TCP-Port 9071 miteinander austauschen können.
 
 ## Beschreibung
 
@@ -214,7 +214,7 @@ Für weitere Informationen können Sie auch die IPSec-Log-Datei in /var/log/ipse
 
 Um das Pairing zwischen dem Kundenstandort und dem OVHcloud Standort zu ermöglichen, muss der Traffic für folgende Ports erlaubt sein:
 
-- Port 9081 zwischen den ZVM
+- Port 9071 zwischen den ZVM
 - Ports 4007 und 4008 zwischen den VRAs
 
 #### 4.1 ZVM-Öffnung
@@ -239,7 +239,7 @@ Wählen Sie für die Bereiche “Source” und “Destination” den Typ “Sing
 
 ![Zerto VPN](images/image-EN-28.png){.thumbnail}
 
-Der autorisierte Ziel-TCP-Port ist der Port 9081.
+Der autorisierte Ziel-TCP-Port ist der Port 9071.
 
 Speichern Sie die Regel und wenden Sie sie an.
 
@@ -315,7 +315,7 @@ Anschließend werden Sie zum Login-Bildschirm des ZVM weitergeleitet, wo folgend
 
 ![Zerto VPN](images/image-EN-40.png){.thumbnail}
 
-Die wahrscheinlichste Ursache ist, dass der OVHcloud ZVM den ZVM des Kunden nicht über den TCP-Port 9081 kontaktieren kann. Der OVHcloud ZVM muss dazu in der Lage sein, die Verbindung herzustellen.
+Die wahrscheinlichste Ursache ist, dass der OVHcloud ZVM den ZVM des Kunden nicht über den TCP-Port 9071 kontaktieren kann. Der OVHcloud ZVM muss dazu in der Lage sein, die Verbindung herzustellen.
 
 ## Weiterführende Informationen
 

--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-asia.md
@@ -16,7 +16,7 @@ We will use the OPNsense open-source VPN Solution as an example, and explain the
 - one public IP, available on the target Managed Bare Metal for the VPN endpoint
 - a Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 ### Solution overview
 
@@ -205,7 +205,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -230,7 +230,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 
@@ -299,7 +299,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-au.md
@@ -16,7 +16,7 @@ We will use the OPNsense open-source VPN Solution as an example, and explain the
 - one public IP, available on the target Managed Bare Metal for the VPN endpoint
 - a Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 ### Solution overview
 
@@ -205,7 +205,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -230,7 +230,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 
@@ -299,7 +299,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-ca.md
@@ -16,7 +16,7 @@ We will use the OPNsense open-source VPN Solution as an example, and explain the
 - one public IP, available on the target Managed Bare Metal for the VPN endpoint
 - a Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 ### Solution overview
 
@@ -205,7 +205,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -230,7 +230,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 
@@ -299,7 +299,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-gb.md
@@ -16,7 +16,7 @@ We will use the OPNsense open-source VPN Solution as an example, and explain the
 - one public IP, available on the target Managed Bare Metal for the VPN endpoint
 - a Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 ### Solution overview
 
@@ -205,7 +205,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -230,7 +230,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 
@@ -299,7 +299,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-ie.md
@@ -16,7 +16,7 @@ We will use the OPNsense open-source VPN Solution as an example, and explain the
 - one public IP, available on the target Managed Bare Metal for the VPN endpoint
 - a Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 ### Solution overview
 
@@ -205,7 +205,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -230,7 +230,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 
@@ -299,7 +299,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-sg.md
@@ -16,7 +16,7 @@ We will use the OPNsense open-source VPN Solution as an example, and explain the
 - one public IP, available on the target Managed Bare Metal for the VPN endpoint
 - a Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 ### Solution overview
 
@@ -205,7 +205,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -230,7 +230,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 
@@ -299,7 +299,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.en-us.md
@@ -16,7 +16,7 @@ We will use the OPNsense open-source VPN Solution as an example, and explain the
 - one public IP, available on the target Managed Bare Metal for the VPN endpoint
 - a Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 ### Solution overview
 
@@ -205,7 +205,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -230,7 +230,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 
@@ -299,7 +299,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.es-es.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.es-es.md
@@ -15,7 +15,7 @@ Para facilitar la explicación, vamos a describir la forma más sencilla de esta
 - Una dirección IP pública disponible en el Managed Bare Metal de destino para el punto de conexión VPN.
 - Una plataforma Zerto instalada y operativa en la infraestructura del cliente.
 - Las máquinas de replicación Zerto (VRA: Virtual Replication Appliance) tanto del lado del cliente como del lado de OVHcloud deben poder intercambiar datos en los puertos TCP 4007 y 4008.
-- Las máquinas de administración Zerto (ZVM: Zerto Virtual Manager) del lado del cliente y del lado de OVHcloud deben poder intercambiar datos en los puertos TCP 9081.
+- Las máquinas de administración Zerto (ZVM: Zerto Virtual Manager) del lado del cliente y del lado de OVHcloud deben poder intercambiar datos en los puertos TCP 9071.
 
 ## Procedimiento
 
@@ -214,7 +214,7 @@ También puede consultar el archivo de log IPSec en /var/log/ipsec.log.
 
 Para permitir el emparejamiento de la infraestructura del cliente con la de OVHcloud, se debe autorizar el tráfico entre:
 
-- El puerto 9081 y las ZVM
+- El puerto 9071 y las ZVM
 - Los puertos 4007/4008 y las vRAs
 
 #### 4.1 Abrir puertos en ZVM
@@ -239,7 +239,7 @@ En los campos «Source» y «Destination» seleccione el tipo «Single host or N
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-El puerto TCP de destino autorizado es el 9081.
+El puerto TCP de destino autorizado es el 9071.
 
 Guarde la regla y aplique los cambios.
 
@@ -315,7 +315,7 @@ Será redirigido a la pantalla de acceso a la ZVM con el siguiente mensaje de er
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-La causa más probable es que la ZVM OVHcloud no pueda comunicarse con la ZVM del cliente en el puerto TCP 9081. Es necesario que se pueda iniciar la conexión.
+La causa más probable es que la ZVM OVHcloud no pueda comunicarse con la ZVM del cliente en el puerto TCP 9071. Es necesario que se pueda iniciar la conexión.
 
 ## Más información
 

--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.es-us.md
@@ -15,7 +15,7 @@ Para facilitar la explicación, vamos a describir la forma más sencilla de esta
 - Una dirección IP pública disponible en el Managed Bare Metal de destino para el punto de conexión VPN.
 - Una plataforma Zerto instalada y operativa en la infraestructura del cliente.
 - Las máquinas de replicación Zerto (VRA: Virtual Replication Appliance) tanto del lado del cliente como del lado de OVHcloud deben poder intercambiar datos en los puertos TCP 4007 y 4008.
-- Las máquinas de administración Zerto (ZVM: Zerto Virtual Manager) del lado del cliente y del lado de OVHcloud deben poder intercambiar datos en los puertos TCP 9081.
+- Las máquinas de administración Zerto (ZVM: Zerto Virtual Manager) del lado del cliente y del lado de OVHcloud deben poder intercambiar datos en los puertos TCP 9071.
 
 ## Procedimiento
 
@@ -214,7 +214,7 @@ También puede consultar el archivo de log IPSec en /var/log/ipsec.log.
 
 Para permitir el emparejamiento de la infraestructura del cliente con la de OVHcloud, se debe autorizar el tráfico entre:
 
-- El puerto 9081 y las ZVM
+- El puerto 9071 y las ZVM
 - Los puertos 4007/4008 y las vRAs
 
 #### 4.1 Abrir puertos en ZVM
@@ -239,7 +239,7 @@ En los campos «Source» y «Destination» seleccione el tipo «Single host or N
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-El puerto TCP de destino autorizado es el 9081.
+El puerto TCP de destino autorizado es el 9071.
 
 Guarde la regla y aplique los cambios.
 
@@ -315,7 +315,7 @@ Será redirigido a la pantalla de acceso a la ZVM con el siguiente mensaje de er
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-La causa más probable es que la ZVM OVHcloud no pueda comunicarse con la ZVM del cliente en el puerto TCP 9081. Es necesario que se pueda iniciar la conexión.
+La causa más probable es que la ZVM OVHcloud no pueda comunicarse con la ZVM del cliente en el puerto TCP 9071. Es necesario que se pueda iniciar la conexión.
 
 ## Más información
 

--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.fr-ca.md
@@ -15,7 +15,7 @@ Pour faciliter les explications, nous décrirons la configuration la plus simple
 - Le PCC de destination doit disposer d'au moins une adresse IP publique disponible pour le point de connexion VPN.
 - Le site client doit disposer d’une installation Zerto opérationnelle.
 - Les machines de réplication Zerto (VRA : Virtual Réplication Appliance) coté client et coté OVHCloud doivent pouvoir échanger entre elles sur les ports TCP 4007 et 4008
-- Les machines d’administration Zerto (ZVM : Zerto Virtual Manager) coté client et coté OVHCloud doivent pouvoir échanger entre elles sur les ports TCP 9081
+- Les machines d’administration Zerto (ZVM : Zerto Virtual Manager) coté client et coté OVHCloud doivent pouvoir échanger entre elles sur les ports TCP 9071
 
 ## En pratique
 
@@ -214,7 +214,7 @@ Vous pouvez également consulter le fichier de log IPSec dans /var/log/ipsec.log
 
 Afin de permettre l’appairage entre le site client et le site OVHcloud, vous devez autoriser :
 
-- Le port 9081 entre les ZVM
+- Le port 9071 entre les ZVM
 - Les ports 4007 et 4008 entre les vRAs
 
 #### 4.1 Ouvertures ZVM
@@ -239,7 +239,7 @@ Les sections Source et Destination sont de type « Single host or Network » et 
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-Le port TCP de destination autorisé est le 9081.
+Le port TCP de destination autorisé est le 9071.
 
 Sauvegardez la règle et déployez-la.
 
@@ -315,7 +315,7 @@ Puis vous êtes ramené à l’écran de connexion de la ZVM avec le message d�
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-La cause la plus probable est que la ZVM OVHCloud n'arrive pas à contacter la ZVM client sur le port TCP 9081. Il est nécessaire qu'elle puisse ouvrir la connexion.
+La cause la plus probable est que la ZVM OVHCloud n'arrive pas à contacter la ZVM client sur le port TCP 9071. Il est nécessaire qu'elle puisse ouvrir la connexion.
 
 ## Aller plus loin
 

--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.fr-fr.md
@@ -15,7 +15,7 @@ Pour faciliter les explications, nous décrirons la configuration la plus simple
 - Le PCC de destination doit disposer d'au moins une adresse IP publique disponible pour le point de connexion VPN.
 - Le site client doit disposer d’une installation Zerto opérationnelle.
 - Les machines de réplication Zerto (VRA : Virtual Réplication Appliance) coté client et coté OVHCloud doivent pouvoir échanger entre elles sur les ports TCP 4007 et 4008
-- Les machines d’administration Zerto (ZVM : Zerto Virtual Manager) coté client et coté OVHCloud doivent pouvoir échanger entre elles sur les ports TCP 9081
+- Les machines d’administration Zerto (ZVM : Zerto Virtual Manager) coté client et coté OVHCloud doivent pouvoir échanger entre elles sur les ports TCP 9071
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.pl-pl.md
@@ -15,7 +15,7 @@ Dla ułatwienia opiszemy najprostszą konfigurację, w której brama VPN ma poł
 - Docelowe PCC musi mieć co najmniej jeden publiczny adres IP dostępny dla punktu połączenia VPN.
 - Lokalizacja klienta musi dysponować działającą instalacją Zerto.
 - Maszyny replikacji Zerto (VRA: Virtual Réplication Appliance) po stronie klienta i po stronie OVHCloud muszą mieć możliwość wymiany informacji na portach TCP 4007 i 4008.
-- Maszyny administracji Zerto (ZVM: Zerto Virtual Manager) po stronie klienta i po stronie OVHCloud muszą mieć możliwość wymiany informacji na portach TCP 9081.
+- Maszyny administracji Zerto (ZVM: Zerto Virtual Manager) po stronie klienta i po stronie OVHCloud muszą mieć możliwość wymiany informacji na portach TCP 9071.
 
 ## W praktyce
 
@@ -214,7 +214,7 @@ Możesz również sprawdzić plik dziennika IPSec w /var/log/ipsec.log.
 
 Aby umożliwić powiązanie między lokalizacją klienta a lokalizacją OVHcloud, musisz odblokować:
 
-- Port 9081 między maszynami ZVM
+- Port 9071 między maszynami ZVM
 - Porty 4007 i 4008 między maszynami vRA
 
 #### 4.1 Otwieranie połączeń dla ZVM
@@ -239,7 +239,7 @@ Sekcje Source i Destination są typu “Single host or Network” i oznaczają o
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-Dozwolony docelowy port TCP to 9081.
+Dozwolony docelowy port TCP to 9071.
 
 Zapisz regułę i zastosuj ją.
 
@@ -315,7 +315,7 @@ Nastąpi przekierowanie do ekranu połączenia ZVM i pojawi się następujący k
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-Najbardziej prawdopodobną przyczyną jest to, że ZVM OVHCloud nie może nawiązać połączenia z ZVM klienta na porcie TCP 9081. Jest to niezbędne dla otwarcia połączenia.
+Najbardziej prawdopodobną przyczyną jest to, że ZVM OVHCloud nie może nawiązać połączenia z ZVM klienta na porcie TCP 9071. Jest to niezbędne dla otwarcia połączenia.
 
 ## Sprawdź również
 

--- a/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/zerto-virtual-replication-customer-to-ovhcloud/guide.pt-pt.md
@@ -16,7 +16,7 @@ Para facilitar as explicações, vamos descrever a configuração mais simples d
 - Um endereço de IP público disponível na Managed Bare Metal de destino, para o ponto de conexão VPN.
 - Uma plataforma Zerto instalada e operacional na infraestrutura do cliente.
 - As máquinas de replicação Zerto (VRA: Virtual Replication Appliance), tanto do lado do cliente quanto do lado da OVHcloud, devem poder comunicar-se pelas portas TCP 4007 e 4008.
-- As máquinas de gestão Zerto (ZVM: Zerto Virtual Manager), tanto do lado do cliente quanto do lado da OVHcloud, devem poder comunicar-se pelas portas TCP 9081.
+- As máquinas de gestão Zerto (ZVM: Zerto Virtual Manager), tanto do lado do cliente quanto do lado da OVHcloud, devem poder comunicar-se pelas portas TCP 9071.
 
 ## Instruções
 
@@ -215,7 +215,7 @@ Pode igualmente consultar o ficheiro de registo IPSec em /var/log/ipsec.log.
 
 O emparelhamento da infraestrutura do cliente com a da OVHcloud requer a autorização do tráfego entre:
 
-- a porta 9081 e as ZVM;
+- a porta 9071 e as ZVM;
 - as portas 4007/4008 e as vRA.
 
 #### 4.1. Abertura de portas em ZVM
@@ -240,7 +240,7 @@ As secções Source e Destination são do tipo «Single host or Network» e faze
 
 ![Zerto VPN](images/image-EN-28.png){.thumbnail}
 
-A porta TCP de destino autorizada é a 9081.
+A porta TCP de destino autorizada é a 9071.
 
 Guarde a regra e aplique-a.
 
@@ -316,7 +316,7 @@ De seguida, será conduzido ao ecrã de conexão da ZVM através desta mensagem 
 
 ![Zerto VPN](images/image-EN-40.png){.thumbnail}
 
-A causa mais provável é que a ZVM OVHcloud não consegue comunicar com a ZVM cliente pela porta TCP 9081. É necessário que se estabeleça a conexão.
+A causa mais provável é que a ZVM OVHcloud não consegue comunicar com a ZVM cliente pela porta TCP 9071. É necessário que se estabeleça a conexão.
 
 ## Quer saber mais?
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.de-de.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.de-de.md
@@ -21,7 +21,7 @@ Lesen Sie hierzu unsere Anleitung zu "[Zerto zwischen zwei OVHcloud Rechenzentre
 - Die Ziel-Private-Cloud muss über mindestens eine verfügbare öffentliche IP-Adresse für den VPN-Endpunkt verfügen.
 - Der Kundenstandort muss über eine funktionsfähige Zerto-Installation verfügen.
 - Die von Zerto für die Replikation verwendeten virtuellen Maschinen (VRA: Virtual Replication Appliance) sowohl auf Kundenseite als auch bei OVHcloud müssen sich über die TCP-Ports 4007 und 4008 miteinander austauschen können.
-- Die Verwaltungsmaschinen von Zerto (ZVM: Zerto Virtual Manager) sowohl auf Kundenseite als auch bei OVHcloud müssen sich über den TCP-Port 9081 miteinander austauschen können.
+- Die Verwaltungsmaschinen von Zerto (ZVM: Zerto Virtual Manager) sowohl auf Kundenseite als auch bei OVHcloud müssen sich über den TCP-Port 9071 miteinander austauschen können.
 
 > [!primary]
 >

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.de-de.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.de-de.md
@@ -235,7 +235,7 @@ Für weitere Informationen können Sie auch die IPSec-Log-Datei in /var/log/ipse
 
 Um das Pairing zwischen dem Kundenstandort und dem OVHcloud Standort zu ermöglichen, muss der Traffic für folgende Ports erlaubt sein:
 
-- Port 9081 zwischen den ZVM
+- Port 9071 zwischen den ZVM
 - Ports 4007 und 4008 zwischen den VRAs
 
 #### 4.1 ZVM-Öffnung
@@ -260,7 +260,7 @@ Wählen Sie für die Bereiche „Source“ und „Destination“ den Typ „Sing
 
 ![Zerto VPN](images/image-EN-28.png){.thumbnail}
 
-Der autorisierte Ziel-TCP-Port ist der Port 9081.
+Der autorisierte Ziel-TCP-Port ist der Port 9071.
 
 Speichern Sie die Regel und wenden Sie sie an.
 
@@ -336,7 +336,7 @@ Anschließend werden Sie zum Login-Bildschirm des ZVM weitergeleitet, wo folgend
 
 ![Zerto VPN](images/image-EN-40.png){.thumbnail}
 
-Die wahrscheinlichste Ursache ist, dass der OVHcloud ZVM den ZVM des Kunden nicht über den TCP-Port 9081 kontaktieren kann. Der OVHcloud ZVM muss dazu in der Lage sein, die Verbindung herzustellen.
+Die wahrscheinlichste Ursache ist, dass der OVHcloud ZVM den ZVM des Kunden nicht über den TCP-Port 9071 kontaktieren kann. Der OVHcloud ZVM muss dazu in der Lage sein, die Verbindung herzustellen.
 
 ## Weiterführende Informationen
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-asia.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-asia.md
@@ -18,7 +18,7 @@ Check out [Zerto between two OVHcloud datacenters](/pages/hosted_private_cloud/h
 - One public IP, available on the target Hosted Private Cloud for the VPN endpoint
 - A Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 > [!primary]
 >
@@ -221,7 +221,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -246,7 +246,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 
@@ -315,7 +315,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-au.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-au.md
@@ -18,7 +18,7 @@ Check out [Zerto between two OVHcloud datacenters](/pages/hosted_private_cloud/h
 - One public IP, available on the target Hosted Private Cloud for the VPN endpoint
 - A Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 > [!primary]
 >
@@ -221,7 +221,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -246,7 +246,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 
@@ -315,7 +315,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-ca.md
@@ -18,7 +18,7 @@ Check out [Zerto between two OVHcloud datacenters](/pages/hosted_private_cloud/h
 - One public IP, available on the target Hosted Private Cloud for the VPN endpoint
 - A Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 > [!primary]
 >
@@ -221,7 +221,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -246,7 +246,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 
@@ -315,7 +315,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-gb.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-gb.md
@@ -18,7 +18,7 @@ Check out [Zerto between two OVHcloud datacenters](/pages/hosted_private_cloud/h
 - One public IP, available on the target Hosted Private Cloud for the VPN endpoint
 - A Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 > [!primary]
 >
@@ -221,7 +221,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -246,7 +246,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 
@@ -315,7 +315,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-ie.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-ie.md
@@ -18,7 +18,7 @@ Check out [Zerto between two OVHcloud datacenters](/pages/hosted_private_cloud/h
 - One public IP, available on the target Hosted Private Cloud for the VPN endpoint
 - A Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 > [!primary]
 >
@@ -221,7 +221,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -246,7 +246,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 
@@ -315,7 +315,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-sg.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-sg.md
@@ -18,7 +18,7 @@ Check out [Zerto between two OVHcloud datacenters](/pages/hosted_private_cloud/h
 - One public IP, available on the target Hosted Private Cloud for the VPN endpoint
 - A Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 > [!primary]
 >
@@ -246,7 +246,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-sg.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-sg.md
@@ -221,7 +221,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -315,7 +315,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.en-us.md
@@ -18,7 +18,7 @@ Check out [Zerto between two OVHcloud datacenters](/pages/hosted_private_cloud/h
 - One public IP, available on the target Hosted Private Cloud for the VPN endpoint
 - A Zerto platform installed on the on-premises platform
 - VRAs (Virtual Replication Appliances) on both sides that are able to connect to the counterpart on TCP ports 4007 and 4008
-- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9081
+- Zerto administration consoles or ZVMs (Zerto Virtual Managers) that are able to connect to the counterpart on TCP port 9071
 
 > [!primary]
 >
@@ -221,7 +221,7 @@ You can check the IPSec logfile in /var/log/ipsec.log on the OPNsense appliance 
 
 To allow pairings of on-premises and OVHcloud instances, traffic must be authorised on the following ports:
 
-* TCP 9081 between ZVMs
+* TCP 9071 between ZVMs
 * TCP 4007/4008 between vRAs
 
 #### 4.1 ZVM opening.
@@ -246,7 +246,7 @@ For "Source" and "Destination", select "Single host or Network" type. The source
 
 ![](images/image-EN-28.png){.thumbnail}
 
-Destination TCP port is 9081. Click `Save`{.action} and `Apply Change`{.action}.
+Destination TCP port is 9071. Click `Save`{.action} and `Apply Change`{.action}.
 
 #### 4.2 vRAs opening.
 
@@ -315,7 +315,7 @@ You will then be brought back to the log-in screen, with the following error mes
 
 ![](images/image-EN-40.png){.thumbnail}
 
-The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9081 (it needs to be able to initiate the connection).
+The most probable cause is that the OVHcloud ZVM is not authorised to contact your on-premises ZVM on TCP 9071 (it needs to be able to initiate the connection).
 
 ## Go further
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.es-es.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.es-es.md
@@ -21,7 +21,7 @@ Para el segundo caso, consulte nuestra guía "[Zerto entre dos datacenters de OV
 - Una dirección IP pública disponible en el Private Cloud de destino para el punto de conexión VPN.
 - Una plataforma Zerto instalada y operativa en la infraestructura del cliente.
 - Las máquinas de replicación Zerto (VRA: Virtual Replication Appliance) tanto del lado del cliente como del lado de OVHcloud deben poder intercambiar datos en los puertos TCP 4007 y 4008.
-- Las máquinas de administración Zerto (ZVM: Zerto Virtual Manager) del lado del cliente y del lado de OVHcloud deben poder intercambiar datos en los puertos TCP 9081.
+- Las máquinas de administración Zerto (ZVM: Zerto Virtual Manager) del lado del cliente y del lado de OVHcloud deben poder intercambiar datos en los puertos TCP 9071.
 
 > [!primary]
 >
@@ -236,7 +236,7 @@ También puede consultar el archivo de log IPSec en /var/log/ipsec.log.
 
 Para permitir el emparejamiento de la infraestructura del cliente con la de OVHcloud, se debe autorizar el tráfico entre:
 
-- El puerto 9081 y las ZVM
+- El puerto 9071 y las ZVM
 - Los puertos 4007/4008 y las vRAs
 
 #### 4.1 Abrir puertos en ZVM
@@ -261,7 +261,7 @@ En los campos «Source» y «Destination» seleccione el tipo «Single host or N
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-El puerto TCP de destino autorizado es el 9081.
+El puerto TCP de destino autorizado es el 9071.
 
 Guarde la regla y aplique los cambios.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.es-es.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.es-es.md
@@ -337,7 +337,7 @@ Será redirigido a la pantalla de acceso a la ZVM con el siguiente mensaje de er
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-La causa más probable es que la ZVM OVHcloud no pueda comunicarse con la ZVM del cliente en el puerto TCP 9081. Es necesario que se pueda iniciar la conexión.
+La causa más probable es que la ZVM OVHcloud no pueda comunicarse con la ZVM del cliente en el puerto TCP 9071. Es necesario que se pueda iniciar la conexión.
 
 ## Más información
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.es-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.es-us.md
@@ -21,7 +21,7 @@ Para el segundo caso, consulte nuestra guía "[Zerto entre dos datacenters de OV
 - Una dirección IP pública disponible en el Private Cloud de destino para el punto de conexión VPN.
 - Una plataforma Zerto instalada y operativa en la infraestructura del cliente.
 - Las máquinas de replicación Zerto (VRA: Virtual Replication Appliance) tanto del lado del cliente como del lado de OVHcloud deben poder intercambiar datos en los puertos TCP 4007 y 4008.
-- Las máquinas de administración Zerto (ZVM: Zerto Virtual Manager) del lado del cliente y del lado de OVHcloud deben poder intercambiar datos en los puertos TCP 9081.
+- Las máquinas de administración Zerto (ZVM: Zerto Virtual Manager) del lado del cliente y del lado de OVHcloud deben poder intercambiar datos en los puertos TCP 9071.
 
 > [!primary]
 >
@@ -236,7 +236,7 @@ También puede consultar el archivo de log IPSec en /var/log/ipsec.log.
 
 Para permitir el emparejamiento de la infraestructura del cliente con la de OVHcloud, se debe autorizar el tráfico entre:
 
-- El puerto 9081 y las ZVM
+- El puerto 9071 y las ZVM
 - Los puertos 4007/4008 y las vRAs
 
 #### 4.1 Abrir puertos en ZVM
@@ -261,7 +261,7 @@ En los campos «Source» y «Destination» seleccione el tipo «Single host or N
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-El puerto TCP de destino autorizado es el 9081.
+El puerto TCP de destino autorizado es el 9071.
 
 Guarde la regla y aplique los cambios.
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.es-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.es-us.md
@@ -337,7 +337,7 @@ Será redirigido a la pantalla de acceso a la ZVM con el siguiente mensaje de er
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-La causa más probable es que la ZVM OVHcloud no pueda comunicarse con la ZVM del cliente en el puerto TCP 9081. Es necesario que se pueda iniciar la conexión.
+La causa más probable es que la ZVM OVHcloud no pueda comunicarse con la ZVM del cliente en el puerto TCP 9071. Es necesario que se pueda iniciar la conexión.
 
 ## Más información
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.fr-ca.md
@@ -17,7 +17,7 @@ Consultez notre guide « [Zerto entre deux datacenters OVHcloud](/pages/hosted_p
 - Le PCC de destination doit disposer d'au moins une adresse IP publique disponible pour le point de connexion VPN.
 - Le site client doit disposer d’une installation Zerto opérationnelle.
 - Les machines de réplication Zerto (VRA : Virtual Réplication Appliance) coté client et coté OVHCloud doivent pouvoir échanger entre elles sur les ports TCP 4007 et 4008
-- Les machines d’administration Zerto (ZVM : Zerto Virtual Manager) coté client et coté OVHCloud doivent pouvoir échanger entre elles sur les ports TCP 9081
+- Les machines d’administration Zerto (ZVM : Zerto Virtual Manager) coté client et coté OVHCloud doivent pouvoir échanger entre elles sur les ports TCP 9071
 
 > [!primary]
 >
@@ -230,7 +230,7 @@ Vous pouvez également consulter le fichier de log IPSec dans /var/log/ipsec.log
 
 Afin de permettre l’appairage entre le site client et le site OVHcloud, vous devez autoriser :
 
-- Le port 9081 entre les ZVM
+- Le port 9071 entre les ZVM
 - Les ports 4007 et 4008 entre les vRAs
 
 #### 4.1 Ouvertures ZVM
@@ -255,7 +255,7 @@ Les sections Source et Destination sont de type « Single host or Network » et 
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-Le port TCP de destination autorisé est le 9081.
+Le port TCP de destination autorisé est le 9071.
 
 Sauvegardez la règle et déployez-la.
 
@@ -331,7 +331,7 @@ Puis vous êtes ramené à l’écran de connexion de la ZVM avec le message d�
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-La cause la plus probable est que la ZVM OVHCloud n'arrive pas à contacter la ZVM client sur le port TCP 9081. Il est nécessaire qu'elle puisse ouvrir la connexion.
+La cause la plus probable est que la ZVM OVHCloud n'arrive pas à contacter la ZVM client sur le port TCP 9071. Il est nécessaire qu'elle puisse ouvrir la connexion.
 
 ## Aller plus loin
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.fr-fr.md
@@ -17,7 +17,7 @@ Consultez notre guide « [Zerto entre deux datacenters OVHcloud](/pages/hosted_p
 - Le PCC de destination doit disposer d'au moins une adresse IP publique disponible pour le point de connexion VPN.
 - Le site client doit disposer d’une installation Zerto opérationnelle.
 - Les machines de réplication Zerto (VRA : Virtual Réplication Appliance) coté client et coté OVHCloud doivent pouvoir échanger entre elles sur les ports TCP 4007 et 4008
-- Les machines d’administration Zerto (ZVM : Zerto Virtual Manager) coté client et coté OVHCloud doivent pouvoir échanger entre elles sur les ports TCP 9081
+- Les machines d’administration Zerto (ZVM : Zerto Virtual Manager) coté client et coté OVHCloud doivent pouvoir échanger entre elles sur les ports TCP 9071
 
 > [!primary]
 >
@@ -230,7 +230,7 @@ Vous pouvez également consulter le fichier de log IPSec dans /var/log/ipsec.log
 
 Afin de permettre l’appairage entre le site client et le site OVHcloud, vous devez autoriser :
 
-- Le port 9081 entre les ZVM
+- Le port 9071 entre les ZVM
 - Les ports 4007 et 4008 entre les vRAs
 
 #### 4.1 Ouvertures ZVM
@@ -255,7 +255,7 @@ Les sections Source et Destination sont de type « Single host or Network » et 
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-Le port TCP de destination autorisé est le 9081.
+Le port TCP de destination autorisé est le 9071.
 
 Sauvegardez la règle et déployez-la.
 
@@ -331,7 +331,7 @@ Puis vous êtes ramené à l’écran de connexion de la ZVM avec le message d�
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-La cause la plus probable est que la ZVM OVHCloud n'arrive pas à contacter la ZVM client sur le port TCP 9081. Il est nécessaire qu'elle puisse ouvrir la connexion.
+La cause la plus probable est que la ZVM OVHCloud n'arrive pas à contacter la ZVM client sur le port TCP 9071. Il est nécessaire qu'elle puisse ouvrir la connexion.
 
 ## Aller plus loin
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.it-it.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.it-it.md
@@ -21,7 +21,7 @@ Per il secondo caso, consulta la nostra guida "[Zerto tra due datacenter OVHclou
 - Un indirizzo IP pubblico disponibile nel Private Cloud di destinazione, verso il punto di connessione VPN.
 - Una piattaforma Zerto installata e operativa nell'infrastruttura del cliente.
 - Le macchine di replica Zerto (VRA: Virtual Replication Appliance) lato cliente e lato OVHcloud devono essere in grado di comunicare tra di loro sulle porte TCP 4007 e 4008 
-- Le macchine di gestione Zerto (ZVM: Zerto Virtual Manager) lato cliente e lato OVHcloud devono essere in grado di comunicare tra loro sulle porte TCP 9081
+- Le macchine di gestione Zerto (ZVM: Zerto Virtual Manager) lato cliente e lato OVHcloud devono essere in grado di comunicare tra loro sulle porte TCP 9071
 
 > [!primary]
 >
@@ -236,7 +236,7 @@ Puoi anche consultare il file di log IPSEec in /var/log/ipsec.log
 
 Per consentire il collegamento tra l’infrastruttura del cliente e quella di OVHcloud, è necessario autorizzare:
 
-- La porta 9081 tra le ZVM
+- La porta 9071 tra le ZVM
 - Le porte 4007 e 4008 tra le vRAs
 
 #### 4.1 Apri le porte sulla ZVM
@@ -261,7 +261,7 @@ Le sezioni Sorgente e Destinazione sono di tipo “Single host o Network” e fa
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-La porta TCP di destinazione autorizzata è la 9081.
+La porta TCP di destinazione autorizzata è la 9071.
 
 Salva la regola e applicala.
 
@@ -337,7 +337,7 @@ Dopodiché sarai reindirizzato alla pagina di login della ZVM con il seguente me
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-La causa più probabile è che la ZVM OVHcloud non riesca a contattare la ZVM del cliente tramite la porta TCP 9081. La ZVM OVHcloud deve essere in grado di stabilire la connessione.
+La causa più probabile è che la ZVM OVHcloud non riesca a contattare la ZVM del cliente tramite la porta TCP 9071. La ZVM OVHcloud deve essere in grado di stabilire la connessione.
 
 ## Per saperne di più
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.pl-pl.md
@@ -21,7 +21,7 @@ W drugim przypadku zapoznaj się z naszym przewodnikiem "[Zerto między dwoma ce
 - Docelowe PCC musi mieć co najmniej jeden publiczny adres IP dostępny dla punktu połączenia VPN.
 - Lokalizacja klienta musi dysponować działającą instalacją Zerto.
 - Maszyny replikacji Zerto (VRA: Virtual Réplication Appliance) po stronie klienta i po stronie OVHCloud muszą mieć możliwość wymiany informacji na portach TCP 4007 i 4008.
-- Maszyny administracji Zerto (ZVM: Zerto Virtual Manager) po stronie klienta i po stronie OVHCloud muszą mieć możliwość wymiany informacji na portach TCP 9081.
+- Maszyny administracji Zerto (ZVM: Zerto Virtual Manager) po stronie klienta i po stronie OVHCloud muszą mieć możliwość wymiany informacji na portach TCP 9071.
 
 > [!primary]
 >
@@ -236,7 +236,7 @@ Możesz również sprawdzić plik dziennika IPSec w /var/log/ipsec.log.
 
 Aby umożliwić powiązanie między lokalizacją klienta a lokalizacją OVHcloud, musisz odblokować:
 
-- Port 9081 między maszynami ZVM
+- Port 9071 między maszynami ZVM
 - Porty 4007 i 4008 między maszynami vRA
 
 #### 4.1 Otwieranie połączeń dla ZVM
@@ -261,7 +261,7 @@ Sekcje Source i Destination są typu „Single host or Network” i oznaczają o
 
 ![zerto vpn](images/image-EN-28.png){.thumbnail}
 
-Dozwolony docelowy port TCP to 9081.
+Dozwolony docelowy port TCP to 9071.
 
 Zapisz regułę i zastosuj ją.
 
@@ -337,7 +337,7 @@ Nastąpi przekierowanie do ekranu połączenia ZVM i pojawi się następujący k
 
 ![zerto vpn](images/image-EN-40.png){.thumbnail}
 
-Najbardziej prawdopodobną przyczyną jest to, że ZVM OVHCloud nie może nawiązać połączenia z ZVM klienta na porcie TCP 9081. Jest to niezbędne dla otwarcia połączenia.
+Najbardziej prawdopodobną przyczyną jest to, że ZVM OVHCloud nie może nawiązać połączenia z ZVM klienta na porcie TCP 9071. Jest to niezbędne dla otwarcia połączenia.
 
 ## Sprawdź również
 

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/zerto-virtual-replication-customer-to-ovhcloud/guide.pt-pt.md
@@ -21,7 +21,7 @@ Para mais informações sobre a segunda opção, consulte o nosso guia "[Zerto e
 - Um endereço de IP público disponível na Private Cloud de destino, para o ponto de conexão VPN.
 - Uma plataforma Zerto instalada e operacional na infraestrutura do cliente.
 - As máquinas de replicação Zerto (VRA: Virtual Replication Appliance), tanto do lado do cliente quanto do lado da OVHcloud, devem poder comunicar-se pelas portas TCP 4007 e 4008.
-- As máquinas de gestão Zerto (ZVM: Zerto Virtual Manager), tanto do lado do cliente quanto do lado da OVHcloud, devem poder comunicar-se pelas portas TCP 9081.
+- As máquinas de gestão Zerto (ZVM: Zerto Virtual Manager), tanto do lado do cliente quanto do lado da OVHcloud, devem poder comunicar-se pelas portas TCP 9071.
 
 > [!primary]
 >
@@ -236,7 +236,7 @@ Pode igualmente consultar o ficheiro de registo IPSec em /var/log/ipsec.log.
 
 O emparelhamento da infraestrutura do cliente com a da OVHcloud requer a autorização do tráfego entre:
 
-- a porta 9081 e as ZVM;
+- a porta 9071 e as ZVM;
 - as portas 4007/4008 e as vRA.
 
 #### 4.1. Abertura de portas em ZVM
@@ -261,7 +261,7 @@ As secções Source e Destination são do tipo «Single host or Network» e faze
 
 ![Zerto VPN](images/image-EN-28.png){.thumbnail}
 
-A porta TCP de destino autorizada é a 9081.
+A porta TCP de destino autorizada é a 9071.
 
 Guarde a regra e aplique-a.
 
@@ -337,7 +337,7 @@ De seguida, será conduzido ao ecrã de conexão da ZVM através desta mensagem 
 
 ![Zerto VPN](images/image-EN-40.png){.thumbnail}
 
-A causa mais provável é que a ZVM OVHcloud não consegue comunicar com a ZVM cliente pela porta TCP 9081. É necessário que se estabeleça a conexão.
+A causa mais provável é que a ZVM OVHcloud não consegue comunicar com a ZVM cliente pela porta TCP 9071. É necessário que se estabeleça a conexão.
 
 ## Quer saber mais?
 


### PR DESCRIPTION
Changed all ports 9081 to 9071 on guides (all versions).
Link : https://help.ovhcloud.com/csm/fr-vmware-zerto-virtual-replication-customer-to-ovh?id=kb_article_view&sysparm_article=KB0046459
