### PR TITLE
chore(mks): update mks versions for 1.30 release

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.de-de.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-asia.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-au.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-ca.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-gb.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-ie.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-sg.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.en-us.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.es-es.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.es-us.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.fr-ca.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.fr-fr.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.it-it.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.pl-pl.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Configuring the API server flags on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to configure the managed components of your Kubernetes: CoreDNS, IPVS, and even API server admission plugins on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-05-22
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration/guide.pt-pt.md
@@ -243,7 +243,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   customization {
     apiserver {
@@ -256,7 +256,7 @@ resource "ovh_cloud_project_kube" "cluster" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30, while disabling the "AlwaysPullImages" admission plugin (e.g. in order to avoid our kubelet agents from reaching the Docker Hub download rate limit).
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -324,7 +324,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -373,7 +373,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
 
       + customization {
           + apiserver {
@@ -450,7 +450,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
 
       - customization {
           - apiserver {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.de-de.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-asia.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-au.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-ca.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-gb.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-ie.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-sg.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-us.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.es-es.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.es-us.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.fr-ca.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.fr-fr.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.it-it.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.pl-pl.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.pt-pt.md
@@ -167,13 +167,13 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "NEVER_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.24 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA5 region, using the Kubernetes version 1.30 (the last and recommended version at the time we wrote this tutorial), with a security update policy that equals to "Do not update".
 
 Now we need to initialise Terraform, generate a plan, and apply it.
 
@@ -241,7 +241,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -277,7 +277,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = "NEVER_UPDATE"
       + url                         = (known after apply)
-      + version                     = "1.24"
+      + version                     = "1.30"
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -325,7 +325,7 @@ resource "ovh_cloud_project_kube" "cluster" {
   service_name = var.service_name
   name         = "my-super-cluster"
   region       = "GRA5"
-  version      = "1.24"
+  version      = "1.30"
 
   update_policy = "ALWAYS_UPDATE" # "ALWAYS_UPDATE" by default but you can choose also "MINIMAL_DOWNTIME" or "NEVER_UPDATE"
 }
@@ -391,7 +391,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c3.gra.k8s.ovh.net" -> null
-      - version                     = "1.24" -> null
+      - version                     = "1.30" -> null
     }
 
 Plan: 0 to add, 0 to change, 1 to destroy.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/change-security-update/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Changing the security update policy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to change the security update policy on an OVHcloud Managed Kubernetes cluster'
-updated: 2024-02-15
+updated: 2024-07-05
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.de-de.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/de/pu
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-asia.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/asia/
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-au.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/en-au
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ca.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/en-ca
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/en-gb
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/en-ie
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-sg.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/en-sg
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-us.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/en/pu
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 #### Network prerequisite to expose your Load Balancers publicly
 
 The first step is to make sure that you have an existing vRack on your Public Cloud Project. To do so you can follow this guide that explains how to [Configure a vRack for Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack).

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-es.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/es-es
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-us.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/es/pu
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-ca.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/fr-ca
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-fr.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/fr/pu
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.it-it.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/it/pu
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pl-pl.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/pl/pu
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-04-26
+updated: 2024-07-05
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pt-pt.md
@@ -28,12 +28,12 @@ To be able to deploy [Public Cloud Load Balancer](https://www.ovhcloud.com/pt/pu
 
 | Kubernetes versions |
 |-------------|
-| 1.24.17-7>= |
 | 1.25.16-7>= |
 | 1.26.4-3>=  |
 | 1.27.12-1>= |
 | 1.28.8-1>=  |
 | 1.29.3-3>=  |
+| 1.30.2-1 >= |
 
 #### Network prerequisite to expose your Load Balancers publicly
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
+updated: 2024-07-05
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +35,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +48,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +61,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-asia.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +47,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +60,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-au.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,25 +34,24 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
-
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 ## CNI (Cluster Network Interface)
 
 The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.external} which embedded [calico](https://github.com/projectcalico/calico){.external} for policy and [flannel](https://github.com/coreos/flannel/){.external} for networking.
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +59,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-ca.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +47,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +60,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-gb.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +47,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +60,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-ie.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +47,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +60,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-sg.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +47,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +60,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-us.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +47,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +60,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.es-es.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +47,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +60,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.es-us.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +47,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +60,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.fr-ca.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +47,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +60,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.fr-fr.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +47,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +60,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.it-it.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +47,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +60,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.pl-pl.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +47,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +60,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.pt-pt.md
@@ -1,8 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2024-07-03
----
+updated: 2024-07-05
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
 
@@ -10,12 +9,12 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.24` (deprecated)
 * `1.25` (deprecated)
 * `1.26`
 * `1.27`
 * `1.28`
 * `1.29`
+* `1.30`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,12 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.24`: 1.6.20 (deprecated)
 * `1.25`: 1.6.20 (deprecated)
 * `1.26`: 1.6.20
-* `1.27`: 1.6.20
-* `1.28`: 1.6.20
-* `1.29`: 1.6.27
+* `1.27`: 1.7.18
+* `1.28`: 1.7.18
+* `1.29`: 1.7.18
+* `1.30`: 1.7.18
 
 ## CNI (Cluster Network Interface)
 
@@ -48,12 +47,12 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal){.ext
 
 The versions installed depends on the Kubernetes version:
 
-* `1.24`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.25`: calico v3.27.3, flannel v0.21.3 (deprecated)
 * `1.26`: calico v3.27.3, flannel v0.21.3
-* `1.27`: calico v3.27.3, flannel v0.21.3
-* `1.28`: calico v3.27.3, flannel v0.21.3
-* `1.29`: calico v3.27.3, flannel v0.21.3
+* `1.27`: calico v3.28.0, flannel v0.24.3
+* `1.28`: calico v3.28.0, flannel v0.24.3
+* `1.29`: calico v3.28.0, flannel v0.24.3
+* `1.30`: calico v3.28.0, flannel v0.24.3
 
 ## CSI (Container Storage Interface)
 
@@ -61,23 +60,23 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.24`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.25`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0 (deprecated)
 * `1.26`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
 * `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
 * `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 
 ## Other components
 
 The versions are:
 
-* `1.24`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.25`: coredns v1.11.1, metrics-server v0.6.4 (deprecated)
 * `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.1, metrics-server v0.6.4
-* `1.28`: coredns v1.11.1, metrics-server v0.6.4
-* `1.29`: coredns v1.11.1, metrics-server v0.6.4
+* `1.27`: coredns v1.11.1, metrics-server v0.7.1
+* `1.28`: coredns v1.11.1, metrics-server v0.7.1
+* `1.29`: coredns v1.11.1, metrics-server v0.7.1
+* `1.30`: coredns v1.11.1, metrics-server v0.7.1
 
 ## Enabled policies
 


### PR DESCRIPTION
Updating the docs following the https://github.com/ovh/public-cloud-roadmap/issues/575 release

Changes:
* Remove the 1.24 version after its EOL, update version numbers in `software-versions-reserved-resources/`
* Bumps version numbers in the terraform manifests examples