### PR TITLE
fix(LDP): EN - rewrite Rust guide for US launch

### DIFF
--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.de-de.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.de-de.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-asia.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-asia.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-au.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-au.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-ca.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-gb.md
@@ -1,11 +1,11 @@
 ---
 title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-ie.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-ie.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-sg.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-sg.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.en-us.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.es-es.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.es-es.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.es-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.es-us.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.fr-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.fr-ca.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.fr-fr.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.fr-fr.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.it-it.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.it-it.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.pl-pl.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.pl-pl.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.

--- a/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.pt-pt.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/ingestion_rust_loggers/guide.pt-pt.md
@@ -1,11 +1,11 @@
 ---
-title: Pushing logs with a SDK - Rust - gelf_logger and log4rs-gelf
-updated: 2023-01-16
+title: Pushing logs with a logging library - Rust - gelf_logger and log4rs-gelf
+updated: 2024-07-19
 ---
 
 ## Objective
 
-This guide will show you how to push your logs to Logs Data Platform using Rust.
+This guide will explain how to push your logs to Logs Data Platform using Rust.
 
 Rust has a logging implementation ([log](https://docs.rs/log/*/log/){.external}) which is widely used. OVHcloud has implemented this system to support the [GELF format](https://go2docs.graylog.org/4-x/getting_in_log_data/gelf.html?tocpath=Getting%20in%20Log%20Data%7CLog%20Sources%7CGELF%7C_____0#GELFPayloadSpecification#gelf-payload-specification){.external}:
 
@@ -23,58 +23,122 @@ Those loggers will:
 
 To complete this guide you will need:
 
-- Rust, we recommend the Nightly version.
+- Rust, we recommend the last stable version.
 - [Activated your Logs Data Platform account.](https://www.ovh.com/fr/order/express/#/new/express/resume?products=~%28~%28planCode~%27logs-account~productId~%27logs%29){.external}
 - [To create at least one Stream and get its token.](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)
+- Install the **serde** crate with the **serde_derive** feature.
+- Install the **log** crate with the **serde** feature.
+
 
 ## gelf_logger
 
-You can start using it by first adding it to your `Cargo.toml`:
+You can install the **gelf_logger** crate by adding the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gelf_logger = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.gelf_logger]
-version = "0.1"
-features = ["ovh-ldp"]
+gelf_logger = { version = "0.3.0", features = ["ovh-ldp"] }
 ```
 
-End then in you `main.rs`:
+Alternatively, the following cargo command will install it:
+
+```shell-session
+$ cargo add gelf_logger -F ovh-ldp
+```
+
+
+Here is a full main.rs file showing how to use the **log** and the **gelf_logger** API.
 
 ```rust
-extern crate gelf_logger;
-#[macro_use]
-extern crate log;
+use gelf_logger::{
+    gelf_alert, gelf_critical, gelf_debug, gelf_emergency, gelf_error, gelf_info, gelf_log,
+    gelf_notice, gelf_warn, Builder, GelfLevel,
+};
+use log::{error, info, warn, LevelFilter};
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+struct Request<'a> {
+    id: u16,
+    method: &'a str,
+    path: &'a str,
+}
 
 fn main() {
-    let cfg = Config::ldp("gra1.logs.ovh.com", "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX");
+    Builder::new()
+        .filter_level(LevelFilter::Info)
+        .ovh_ldp(
+            "<YOUR-LDP-CLUSTER-ADDRESS>".to_owned(),
+            "<YOUR-WRITE-TOKEN>".to_owned(),
+        )
+        .init();
 
-    // Initialize logger
-    gelf_logger::init(cfg).unwrap();
+    // basic logs
+    info!("hello from rust");
 
-    // Send log using a macro defined in the create log
-    info!("common message");
+    // Basic key-value logs.
+    info!(count = 5; "packet received");
+    warn!(user = "foo"; "unknown user");
+    error!(err:err = "abc".parse::<u32>().unwrap_err(); "parse error");
 
-    // make sure all buffered records are sent before exiting
-    gelf_logger::flush().unwrap();
+    let req = Request {
+        id: 42,
+        method: "GET",
+        path: "/login",
+    };
+    // Will serialize as a `Debug` string.
+    info!(req:?; "incoming request");
+    // Will flatten all the field and add them as additional fields.
+    info!(req:serde; "incoming request flattened");
+
+    // Gelf specific levels.
+    gelf_log!(GelfLevel::Emergency, foo = "bar"; "an emergency log");
+    gelf_emergency!(foo = "bar"; "an emergency log");
+    gelf_alert!(foo = "bar"; "an alert log");
+    gelf_critical!(foo = "bar"; "a critical log");
+    gelf_error!(foo = "bar"; "an error log");
+    gelf_warn!(foo = "bar"; "a warn log");
+    gelf_notice!(foo = "bar"; "a notice log");
+    gelf_info!(foo = "bar"; "an info log");
+    gelf_debug!(foo = "bar"; "a debug log");
+
+    // Flush underlying TCP socket.
+    // This will only flush. The socket may be dropped without proper closing.
+    log::logger().flush();
 }
 ```
+
+Don't forget to modify the placeholder **<YOUR-LDP-CLUSTER-ADDRESS>** to the cluster where your stream resides. There is no need to put the Gelf port. Example: "gra3.logs.ovh.com".
+
+Don't forget to modify the placeholder **<YOUR-WRITE-TOKEN>** to the actual value of the write token of your stream.
 
 You could also look at the [generated API documentaton](https://docs.rs/gelf_logger/*){.external}.
 
 ## log4rs-gelf
 
-You can start using it by first adding it to your `Cargo.toml`:
+Install **log4rs** and **log4rs-gelf** in your Rust project.
+
+
+Here is the modified Cargo.toml file:
 
 ```toml
 [dependencies]
-log4rs_gelf = { version = "0.1", features = ["ovh-ldp"] }
-# or
-[dependencies.log4rs_gelf]
-version = "0.1"
-features = ["ovh-ldp"]
+log = { version = "0.4.22", features = ["serde"] }
+log4rs = "1.3.0"
+log4rs-gelf = { version = "0.1.4", features = ["ovh-ldp"] }
+serde = { version = "1.0.204", features = ["derive"] }
 ```
+
+Alternatively, use the following cargo commands:
+
+
+```shell-session
+$ cargo add log4rs
+```
+
+```shell-session
+$ cargo add log4rs-gelf -F ovh-ldp
+```
+
 
 ### Examples
 
@@ -102,43 +166,26 @@ root:
 And then:
 
 ```rust
-extern crate log4rs_gelf;
+use core::time;
+use std::thread::sleep;
+
+use log::{info, warn};
 
 fn main() {
-    log4rs_gelf::init_file("/tmp/log4rs.yml", None).unwrap();
+    // reading
+    log4rs_gelf::init_file("./log4rs.yml", None).unwrap();
 
-    // Do whatever
+    // using log crate APIs
+    info!("Hello from rust");
+    warn!("Warning from rust");
 
-    log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
+    // simulating some work (log framework is asynchronous)
+    sleep(time::Duration::from_secs(5));
+
+    // flushing remaining logs
+    log4rs_gelf::flush().expect("Failed to send buffer, log records could be lost !");
 }
-```
 
-#### Programmatically constructing a configuration
-
-```rust
-extern crate log;
-extern crate log4rs;
-extern crate log4rs_gelf;
-
-use log4rs::config::{Config, Appender, Root};
-use log::LevelFilter;
-
-fn main() {
-    let buffer = log4rs_gelf::BufferAppender::builder("gra1.logs.ovh.com","XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX")
-        .build()
-        .unwrap();
-
-   let config = Config::builder()
-       .appender(Appender::builder().build("gelf", Box::new(buffer)))
-       .build(Root::builder().appender("gelf").build(LevelFilter::Info))
-       .unwrap();
-
-   log4rs_gelf::init_config(config).unwrap();
-
-   // Do whatever
-
-   log4rs_gelf::flush().expect("Failed to send buffer, log records can be lost !");
-}
 ```
 
 You could also look at the [generated API documentation](https://docs.rs/log4rs-gelf/*){.external}.


### PR DESCRIPTION
Hi this PR rewrites most of the code snippet used as example for the user. Indeed this guide has not been updated since 2023 and the snippets are no longer compatible with updated dependencies and the SDK writtent by OVH has also changed. 

The documentation change is necessary to validate the documentation before the US launch of LDP hence the Dependency Priority Label. 

Thank you ! 