### PR TITLE
fix(LDP): port missing in Bonfire guide code snippets

### DIFF
--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.de-de.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.de-de.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-asia.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-asia.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-au.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-au.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-ca.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-gb.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-ie.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-ie.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-sg.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-sg.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.en-us.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.es-es.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.es-es.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.es-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.es-us.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.fr-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.fr-ca.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.fr-fr.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.fr-fr.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.it-it.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.it-it.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.pl-pl.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.pl-pl.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 

--- a/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.pt-pt.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/cli_bonfire/guide.pt-pt.md
@@ -1,6 +1,6 @@
 ---
 title: CLI - bonfire, querying graylog from a CLI
-updated: 2020-07-27
+updated: 2024-07-24
 ---
 
 ## Objective
@@ -28,21 +28,11 @@ $ pip install --user bonfire
 ### tail -f
 
 ```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -f
+$ bonfire -h "<your_cluster>.logs.ovh.com" --port 443 --endpoint "/api" -u "<your_ldp_username>" --tls -f
 Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
 Please select a stream to query:
 0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
 Enter stream number: [0]:
-```
-
-### /tmp/what.log
-
-```shell-session
-$ bonfire -h "<your_cluster>.logs.ovh.com" --endpoint "/api" -u "<your_ldp_username>" --tls -@ "2 minutes ago" "*" -o "/tmp/what.log"
-Enter password for logs-username@<your_cluster>.logs.ovh.com/api:443:
-Please select a stream to query:
-0: Stream 'My stream' (id: 55210a04e4b09e9fa4fa0209)
-Enter stream number: [0]: 0
 ```
 
 ### Password management
@@ -131,7 +121,8 @@ $ bonfire --node sadev -@ 2015-07-20 -k :libceph
 
 ### Parametric queries
 
-You can also define queries with parameters and define this parameter from the command line:
+You can also define queries with parameters and define this parameter from the command line. For example if you want to use a parametric query **uuid** for a field named **container_uuid**, you can do:
+
 
 **.bonfire.cfg**
 


### PR DESCRIPTION
Hi, this PR fixes a missing port in this guide preventing users to connect the CLI to Logs Data Platform. The default port changed years ago but wasn't reflected in the guide. The US launch needs all LDP guides to be up to date, hence the dependency priority. 

After editing:
This PR also remove a non working code snippet from the guide and explain more another feature. 

