### PR TITLE
feat(mks): support proxy protocol v2 for Octavia integration

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
@@ -273,7 +273,11 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+  Values:
+  - `v1`, `true`: enable the ProxyProtocol version 1
+  - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -275,9 +275,10 @@ spec:
 
   Enable the ProxyProtocol on all listeners. Default is 'false'.
 
-  Values:
-  - `v1`, `true`: enable the ProxyProtocol version 1
-  - `v2`: enable the ProxyProtocol version 2
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2024-08-23
+updated: 2024-09-11
 ---
 
 > [!warning]
@@ -273,7 +273,12 @@ spec:
 
 - `loadbalancer.openstack.org/proxy-protocol`
 
-  If 'true', the loadbalancer pool protocol will be set as `PROXY`. Default is 'false'.
+  Enable the ProxyProtocol on all listeners. Default is 'false'.
+
+> **Values:**
+>
+> - `v1`, `true`: enable the ProxyProtocol version 1
+> - `v2`: enable the ProxyProtocol version 2
 
 - `loadbalancer.openstack.org/timeout-client-data`
 


### PR DESCRIPTION
New feature on the MKS's Octavia integration.

We now support the proxy protocol v2 on LoadBalancer based on Octavia.


DO NOT MERGE - Feature not released yet.
