### PR TITLE
fix(backing-up-cluster-with-velero): disable checksumAlgorithm

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-us.md
@@ -134,7 +134,7 @@ Install Velero, including all prerequisites, into the cluster and start the depl
 velero install \
   --features=EnableCSI \
   --provider aws \
-  --plugins velero/velero-plugin-for-aws:v1.6.0,velero/velero-plugin-for-csi:v0.4.0 \
+  --plugins velero/velero-plugin-for-aws:v1.10.1,velero/velero-plugin-for-csi:v0.4.0 \
   --bucket <your bucket name> \
   --secret-file ./credentials \
   --backup-location-config region=<public cloud region without digit>,s3ForcePathStyle="true",s3Url=https://s3.<public cloud region without digit>.cloud.ovh.net,checksumAlgorithm="" \

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-us.md
@@ -147,7 +147,7 @@ In our case, with the cluster in the `GRA` region, that meant:
 velero install \
   --features=EnableCSI \
   --provider aws \
-  --plugins velero/velero-plugin-for-aws:v1.6.0,velero/velero-plugin-for-csi:v0.4.0 \
+  --plugins velero/velero-plugin-for-aws:v1.10.1,velero/velero-plugin-for-csi:v0.4.0 \
   --bucket velero-s3 \
   --secret-file .aws/credentials \
   --backup-location-config region=gra,s3ForcePathStyle="true",s3Url=https://s3.gra.cloud.ovh.net,checksumAlgorithm="" \

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backing-up-cluster-with-velero/guide.en-us.md
@@ -137,7 +137,7 @@ velero install \
   --plugins velero/velero-plugin-for-aws:v1.6.0,velero/velero-plugin-for-csi:v0.4.0 \
   --bucket <your bucket name> \
   --secret-file ./credentials \
-  --backup-location-config region=<public cloud region without digit>,s3ForcePathStyle="true",s3Url=https://s3.<public cloud region without digit>.cloud.ovh.net \
+  --backup-location-config region=<public cloud region without digit>,s3ForcePathStyle="true",s3Url=https://s3.<public cloud region without digit>.cloud.ovh.net,checksumAlgorithm="" \
   --snapshot-location-config region=<public cloud region without digit>,enableSharedConfig=true
 ```
 
@@ -150,7 +150,7 @@ velero install \
   --plugins velero/velero-plugin-for-aws:v1.6.0,velero/velero-plugin-for-csi:v0.4.0 \
   --bucket velero-s3 \
   --secret-file .aws/credentials \
-  --backup-location-config region=gra,s3ForcePathStyle="true",s3Url=https://s3.gra.cloud.ovh.net \
+  --backup-location-config region=gra,s3ForcePathStyle="true",s3Url=https://s3.gra.cloud.ovh.net,checksumAlgorithm="" \
   --snapshot-location-config region=gra,enableSharedConfig=true
 ```
 
@@ -161,7 +161,7 @@ $ velero install \
   --plugins velero/velero-plugin-for-aws:v1.6.0,velero/velero-plugin-for-csi:v0.4.0 \
   --bucket velero-s3 \
   --secret-file .aws/credentials \
-  --backup-location-config region=gra,s3ForcePathStyle="true",s3Url=https://s3.gra.cloud.ovh.net \
+  --backup-location-config region=gra,s3ForcePathStyle="true",s3Url=https://s3.gra.cloud.ovh.net,checksumAlgorithm="" \
   --snapshot-location-config region=gra,enableSharedConfig=true
 CustomResourceDefinition/backups.velero.io: attempting to create resource
 CustomResourceDefinition/backups.velero.io: attempting to create resource client


### PR DESCRIPTION
Starting with Version 1.9.2 of the velero-aws plugin, `checksumAlgorithm` is set to CRC32, which OVH doesn't support. As such, without disabling it, backups fail due to invalid parameters being sent to OVH.