### PR TITLE
Dedicated Servers - Bridge IP mode - General update

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: 'Mode bridge IP'
 excerpt: 'Apprenez à utiliser le mode bridge pour configurer l’accès à Internet de vos machines virtuelles'
-updated: 2024-10-09
+updated: 2024-10-10
 ---
 
 > [!primary]
@@ -47,7 +47,7 @@ Pour cet exemple, nous utiliserons les valeurs suivantes dans nos exemples de co
 ### Assigner une adresse MAC virtuelle
 
 > [!warning]
-> Dans le cas d'un bloc d'IP, les adresses MAC virtuelles se créent sur les IP unitaires dans le bloc.
+> Dans le cas d'un bloc d'IP, les adresses MAC virtuelles se créent sur chaque IP individuelle dans le bloc.
 
 Connectez-vous à votre [espace client OVHcloud](/links/manager), cliquez sur le menu `Bare Metal Cloud`{.action} puis sur la section `Network`{.action}. Cliquez ensuite sur `IP`{.action}.
 
@@ -122,7 +122,7 @@ Vous pouvez maintenant démarrer votre machine virtuelle et passer aux étapes s
 
 > [!warning]
 >
-> L'hyperviseur ESXi n'est plus supporté par OVHcloud. Retrouvez plus d'informations sur [cette page dédiée](/pages/bare_metal_cloud/dedicated_servers/esxi-end-of-support/guide.fr-fr.md).
+> L'hyperviseur ESXi n'est plus supporté par OVHcloud. Retrouvez plus d'informations sur [cette page dédiée](/pages/bare_metal_cloud/dedicated_servers/esxi-end-of-support).
 > 
 
 > [!warning]
@@ -315,7 +315,7 @@ rtt min/avg/max/mdev = 24.925/28.028/30.840/2.254 ms
 ```
 
 Si vous recevez une réponse, cela signifie que l’Additional IP a été correctement configurée. Si ce n'est pas le cas, redémarrez votre machine virtuelle et recommencez la commande ping.
-Si vous souhaite zplus d'informations sur `nmcli`, redirigez vous vers [cette page](https://docs.redhat.com/fr/documentation/red_hat_enterprise_linux/7/html/networking_guide/sec-using_the_networkmanager_command_line_tool_nmcli)
+Si vous souhaitez plus d'informations sur `nmcli`, consultez [cette page](https://docs.redhat.com/fr/documentation/red_hat_enterprise_linux/7/html/networking_guide/sec-using_the_networkmanager_command_line_tool_nmcli).
 
 #### FreeBSD
 
@@ -377,16 +377,16 @@ Si vous recevez une réponse, cela signifie que l’Additional IP a été correc
 
 #### Ubuntu 
 
-Tout d'abord, désactivez Cloud-init :
+Tout d'abord, désactivez cloud-init :
+
 ```bash
 touch /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
 ```
 
 > [!warning]
 >
->Dans le cas ou vous souhaitez configurer votre VM avec Cloud-init, redirigez-vous vers [cette page](https://cloud-init.io/)
+> Si vous souhaitez configurer votre VM avec cloud-init, consultez vers [cette page](https://cloud-init.io/)
 >
-
 
 Ajoutez cette ligne au fichier `99-disable-network-config.cfg` :
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
@@ -65,7 +65,7 @@ Après quelques secondes, une adresse MAC virtuelle apparaîtra dans la colonne 
 
 ### Déterminer l'adresse de la passerelle (gateway) <a name="determinegateway"></a>
 
-Pour configurer vos machines virtuelles pour l'accès à Internet, vous devez connaître la passerelle de votre machine hôte, c’est-à-dire, votre serveur dédié.
+Pour configurer vos machines virtuelles pour l'accès à Internet, vous devez connaître la passerelle de votre machine hôte, c’est-à-dire votre serveur dédié.
 
 Vous pouvez récupérer l'adresse de la passerelle via [votre espace client](#viacontrolpanel) ou l’[API OVHcloud](#viaapi).
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
@@ -387,6 +387,7 @@ touch /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
 
 
 Ajoutez cette ligne au fichier `99-disable-network-config.cfg` :
+
 ```bash
 network: {config: disabled}
 ```

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
@@ -405,6 +405,7 @@ sudo chmod 600 *.yaml
 ```
 
 Exécutez la commande suivante pour identifier le nom de votre interface :
+
 ```bash
 ip addr
 ```

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
@@ -17,7 +17,7 @@ La mise en réseau en mode bridge peut être utilisée pour configurer vos machi
 
 * Posséder un serveur dédié avec un hyperviseur installé ([VMware ESXi](http://www.vmware.com/products/esxi-and-esx/overview.html){.external}, Citrix Xen Server, Proxmox, par exemple).
 * Bénéficier d'au moins une adresse [Additional IP](/links/network/additional-ip) routée vers le serveur.
-* Être connecté à votre [espace client OVHcloud](/links/manager) ou à l'API.
+* Être connecté à votre [espace client OVHcloud](/links/manager) ou à l['API OVHcloud](/pages/pages/manage_and_operate/api/first-steps).
 
 > [!warning]
 > Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: 'Mode bridge IP'
 excerpt: 'Apprenez à utiliser le mode bridge pour configurer l’accès à Internet de vos machines virtuelles'
-updated: 2024-07-15
+updated: 2024-10-09
 ---
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
@@ -57,7 +57,7 @@ Cliquez sur le bouton `...`{.action} à côté de l'Additional IP de votre choix
 
 ![Ajouter une MAC virtuelle (1)](images/addvmac.png){.thumbnail}
 
-Sélectionnez « ovh », ou « vmware » si le système est un ESXI, dans la liste déroulante « Type », tapez un nom dans le champ « Nom de la machine virtuelle », puis cliquez sur `Valider`{.action}.
+Sélectionnez « ovh » (ou « vmware » si le système est un ESXI) dans la liste déroulante « Type ». Entrez un nom dans le champ « Nom de la machine virtuelle », puis cliquez sur `Valider`{.action}.
 
 ![Ajouter une MAC virtuelle (2)](images/addvmac2.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
@@ -392,7 +392,8 @@ Ajoutez cette ligne au fichier `99-disable-network-config.cfg` :
 network: {config: disabled}
 ```
 
-Ensuite, créez le fichier de configuration réseau dans /etc/netplan/ avec la commande suivante :
+Créez ensuite le fichier de configuration réseau dans `/etc/netplan/` avec la commande suivante :
+
 ```bash
 touch /etc/netplan/00-installer-config.yaml
 ```

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
@@ -398,7 +398,8 @@ Créez ensuite le fichier de configuration réseau dans `/etc/netplan/` avec la 
 touch /etc/netplan/00-installer-config.yaml
 ```
 
-Puis apliquez ces permissions sur `/etc/netplan` :
+Puis appliquez ces permissions sur `/etc/netplan` :
+
 ```bash
 cd /etc/netplan
 sudo chmod 600 *.yaml

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
@@ -13,6 +13,8 @@ updated: 2024-10-09
 
 La mise en réseau en mode bridge peut être utilisée pour configurer vos machines virtuelles. Quelques modifications sont nécessaires pour que la configuration fonctionne sur notre réseau.
 
+**Ce guide vous montre comment utiliser le mode bridge pour configurer l'accès à Internet pour vos machines virtuelles.**
+
 ## Prérequis
 
 * Posséder un serveur dédié avec un hyperviseur installé ([VMware ESXi](http://www.vmware.com/products/esxi-and-esx/overview.html){.external}, Citrix Xen Server, Proxmox, par exemple).


### PR DESCRIPTION
Retrait de la vidéo, outdated interface.
Modifier quelques tournures de phrase.
Ajout encart endsupport ESXI.
Ajout lien pour manager les IP
Retrait gateway par défaut en "254".
Regrouper alma/rocky en une catégorie, même conf en 8/9.
Alma/Rocky managé avec nmcli/ajout du lien.

Ajout info cloudinit Ubuntu.

Modif une commande FreeBSD.

change date