### PR TITLE
proxmox-network-HG-Scale: remove unneeded parameters + other fixes

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/proxmox-network-HG-Scale/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/proxmox-network-HG-Scale/guide.en-gb.md
@@ -363,8 +363,6 @@ iface bond0 inet dhcp
         bond-slaves ens33f0 ens33f1
         bond-miimon 100
         bond-mode 802.3ad
-        post-up echo 1 > /proc/sys/net/ipv4/conf/bond0/proxy_arp
-        post-up echo 1 > /proc/sys/net/ipv4/ip_forward
 
 auto bond1
 # LACP aggregate on private interfaces

--- a/pages/bare_metal_cloud/dedicated_servers/proxmox-network-HG-Scale/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/proxmox-network-HG-Scale/guide.en-gb.md
@@ -52,7 +52,6 @@ You need to:
 - create an aggregate (linux bond), only for the High Grade & SCALE ranges
 - create a bridge
 - authorize forwarding
-- authorize proxy_arp
 - add routes
 
 #### Configure the hypervisor
@@ -67,18 +66,15 @@ SSH PUB_IP_DEDICATED_SERVER
 > [!tabs]
 > High Grade & SCALE ranges
 >>
->> - **Enable ip_forward and proxy_arp**:
+>> - **Enable ip_forward**:
 >>
->> Enable the `sysctl` `ip_forward` and `proxy_arp` parameters. To do this, we recommend modifying the `sysctl.conf` configuration file.
+>> Enable the `ip_forward` sysctl parameter. To do this, we recommend modifying the `sysctl.conf` configuration file.
 >>
->> Add the following lines to `/etc/sysctl.conf`:
+>> Add the following line to `/etc/sysctl.conf`:
 >>
 >> ```text
 >> # Enable ip_forward
 >> net.ipv4.ip_forward = 1
->>
->> # Enabling proxy_arp for public bond
->> net.ipv4.conf.bond0.proxy_arp = 1
 >> ```
 >>
 >> Next, reload the sysctl configuration:
@@ -172,24 +168,6 @@ SSH PUB_IP_DEDICATED_SERVER
 >>
 >> ```
 > ADVANCE range
->>
->> - **Enable ip_forward**:
->>
->> Enable the `ip_forward` sysctl parameter. To do this, we recommend modifying the `sysctl.conf` configuration file.
->>
->> Add the following line to `/etc/sysctl.conf`:
->>
->> ```text
->> # Enable ip_forward
->> net.ipv4.ip_forward = 1
->> ```
->>
->> Next, reload the sysctl configuration:
->>
->> ```bash
->> sysctl -p
->> ```
->>
 >> For servers from the ADVANCE range that do not have 4 network interfaces, there is no need to configure bonding. You can go directly to configuring the available interfaces.
 >>
 >> Everything happens in the file `/etc/network/interfaces`:
@@ -206,7 +184,6 @@ SSH PUB_IP_DEDICATED_SERVER
 >> iface enp8s0f0np0 inet static
 >>     address PUB_IP_DEDICATED_SERVER/32
 >>     gateway 100.64.0.1
->>     post-up echo 1 > /proc/sys/ipv4/enp8s0f0np0/proxy_arp
 >> 
 >> auto vmbr0
 >> iface vmbr0 inet static

--- a/pages/bare_metal_cloud/dedicated_servers/proxmox-network-HG-Scale/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/proxmox-network-HG-Scale/guide.en-gb.md
@@ -172,6 +172,24 @@ SSH PUB_IP_DEDICATED_SERVER
 >>
 >> ```
 > ADVANCE range
+>>
+>> - **Enable ip_forward**:
+>>
+>> Enable the `ip_forward` sysctl parameter. To do this, we recommend modifying the `sysctl.conf` configuration file.
+>>
+>> Add the following line to `/etc/sysctl.conf`:
+>>
+>> ```text
+>> # Enable ip_forward
+>> net.ipv4.ip_forward = 1
+>> ```
+>>
+>> Next, reload the sysctl configuration:
+>>
+>> ```bash
+>> sysctl -p
+>> ```
+>>
 >> For servers from the ADVANCE range that do not have 4 network interfaces, there is no need to configure bonding. You can go directly to configuring the available interfaces.
 >>
 >> Everything happens in the file `/etc/network/interfaces`:
@@ -188,7 +206,6 @@ SSH PUB_IP_DEDICATED_SERVER
 >> iface enp8s0f0np0 inet static
 >>     address PUB_IP_DEDICATED_SERVER/32
 >>     gateway 100.64.0.1
->>     post-up echo 1 > /proc/sys/net/ipv4/ip_forward
 >>     post-up echo 1 > /proc/sys/ipv4/enp8s0f0np0/proxy_arp
 >> 
 >> auto vmbr0


### PR DESCRIPTION
* proxmox-network-HG-Scale: remove unnecessary sysctl parameters for vRack

  Remove ip_forward and proxy_arp for the vRack section. ip_forward is not
required because there is no IP forwarding done. The VMs are in a
network (the vRack) where they communicate directly with the gateway
(the gateway answers ARP requests in the vRack), so there is no need for
proxy_arp either. I tested this in SK-1686.

* proxmox-network-HG-Scale: set ip_forward in sysctl.conf for ADV

  Set ip_forward in sysctl.conf for the ADV range too. Setting it when
the interface comes up is not the best practice and we already fixed
this for HGR/SCALE ranges.

* proxmox-network-HG-Scale: remove references to Proxy ARP

  Proxy ARP is not required when the additional IP is routed either
because the VM communicates with the host via a specific 192.168.0.0/24
subnet. Its gateway is within this subnet, so the VM sends ARP requests
to 192.168.0.1 which is on the host, therefore Proxy ARP is not
required.

