### PR TITLE
Delete "renderer: networkd" from IP aliasing network configuration

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.de-de.md
@@ -281,7 +281,6 @@ Bearbeiten Sie anschließend die Datei mit folgendem Inhalt und ersetzen Sie `IN
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -294,7 +293,6 @@ Wenn Sie zwei Additional IPs konfigurieren müssen, sollte die Konfigurationsdat
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -313,7 +311,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-asia.md
@@ -267,7 +267,6 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -280,7 +279,6 @@ If you have two Additional IPs to configure, the configuration file should look 
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -298,7 +296,6 @@ Configuration example:
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     eth0:
       dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-au.md
@@ -267,7 +267,6 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -280,7 +279,6 @@ If you have two Additional IPs to configure, the configuration file should look 
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -298,7 +296,6 @@ Configuration example:
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     eth0:
       dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-ca.md
@@ -267,7 +267,6 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -280,7 +279,6 @@ If you have two Additional IPs to configure, the configuration file should look 
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -298,7 +296,6 @@ Configuration example:
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     eth0:
       dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-gb.md
@@ -267,7 +267,6 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -280,7 +279,6 @@ If you have two Additional IPs to configure, the configuration file should look 
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -298,7 +296,6 @@ Configuration example:
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     eth0:
       dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-ie.md
@@ -267,7 +267,6 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -280,7 +279,6 @@ If you have two Additional IPs to configure, the configuration file should look 
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -298,7 +296,6 @@ Configuration example:
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     eth0:
       dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-sg.md
@@ -267,7 +267,6 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -280,7 +279,6 @@ If you have two Additional IPs to configure, the configuration file should look 
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -298,7 +296,6 @@ Configuration example:
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     eth0:
       dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-us.md
@@ -267,7 +267,6 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -280,7 +279,6 @@ If you have two Additional IPs to configure, the configuration file should look 
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -298,7 +296,6 @@ Configuration example:
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     eth0:
       dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.es-es.md
@@ -273,7 +273,6 @@ A continuación, edite el fichero con el siguiente contenido, sustituyendo `INTE
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -286,7 +285,6 @@ Si tiene dos direcciones Additional IP que configurar, el archivo de configuraci
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -305,7 +303,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.es-us.md
@@ -273,7 +273,6 @@ A continuación, edite el fichero con el siguiente contenido, sustituyendo `INTE
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -286,7 +285,6 @@ Si tiene dos direcciones Additional IP que configurar, el archivo de configuraci
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -305,7 +303,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.fr-ca.md
@@ -274,7 +274,6 @@ Ensuite, éditez le fichier avec le contenu ci-dessous, en remplaçant `INTERFAC
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -287,7 +286,6 @@ Si vous avez deux adresses Additional IP à configurer, le fichier de configurat
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -306,7 +304,6 @@ Exemple de configuration :
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     eth0:
       dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.fr-fr.md
@@ -274,7 +274,6 @@ Ensuite, éditez le fichier avec le contenu ci-dessous, en remplaçant `INTERFAC
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -287,7 +286,6 @@ Si vous avez deux adresses Additional IP à configurer, le fichier de configurat
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     INTERFACE_NAME:
       dhcp4: true
@@ -306,7 +304,6 @@ Exemple de configuration :
 ```yaml
 network:
   version: 2
-  renderer: networkd
   ethernets:
     eth0:
       dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.it-it.md
@@ -283,7 +283,6 @@ Successivamente, modifica il file con il contenuto seguente, sostituendo `INTERF
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -296,7 +295,6 @@ Se è necessario configurare due indirizzi Additional IP, il file di configurazi
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -315,7 +313,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.pl-pl.md
@@ -278,7 +278,6 @@ Następnie edytuj plik, zastępując polecenia `INTERFACE_NAME` i `ADDITIONAL_IP
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -291,7 +290,6 @@ Jeśli chcesz skonfigurować dwa adresy Additional IP, plik konfiguracyjny powin
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -311,7 +309,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.pt-pt.md
@@ -281,7 +281,6 @@ De seguida, edite o ficheiro com o conteúdo abaixo, substituindo `INTERFACE_NAM
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -295,7 +294,6 @@ Se tiver dois endereços Additional IP a configurar, o ficheiro de configuraçã
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -314,7 +312,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.de-de.md
@@ -163,7 +163,6 @@ Editieren Sie die Datei mit dem unten stehenden Inhalt und ersetzen Sie `INTERFA
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -176,7 +175,6 @@ Wenn Sie mehr als eine Additional IP-Adresse konfigurieren müssen, sollte die K
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -195,7 +193,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-asia.md
@@ -163,7 +163,6 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -176,7 +175,6 @@ If you have more Additional IPs to configure, the configuration file should look
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -195,7 +193,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-au.md
@@ -163,7 +163,6 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -176,7 +175,6 @@ If you have more Additional IPs to configure, the configuration file should look
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -195,7 +193,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-ca.md
@@ -163,7 +163,6 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -176,7 +175,6 @@ If you have more Additional IPs to configure, the configuration file should look
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -195,7 +193,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-gb.md
@@ -163,7 +163,7 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
    version: 2
-   renderer: networkd
+   : networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -176,7 +176,6 @@ If you have more Additional IPs to configure, the configuration file should look
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -195,7 +194,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-ie.md
@@ -163,7 +163,6 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -176,7 +175,6 @@ If you have more Additional IPs to configure, the configuration file should look
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -195,7 +193,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-sg.md
@@ -163,7 +163,6 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -176,7 +175,6 @@ If you have more Additional IPs to configure, the configuration file should look
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -195,7 +193,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-us.md
@@ -163,7 +163,6 @@ Edit the file with the content below, replacing `INTERFACE_NAME` and `ADDITIONAL
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -176,7 +175,6 @@ If you have more Additional IPs to configure, the configuration file should look
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -195,7 +193,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.es-es.md
@@ -172,7 +172,6 @@ Edite el fichero con el siguiente contenido, sustituyendo `INTERFACE_NAME` y `AD
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -185,7 +184,6 @@ Si tiene que configurar más de una dirección Additional IP, el archivo de conf
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -204,7 +202,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.es-us.md
@@ -172,7 +172,6 @@ Edite el fichero con el siguiente contenido, sustituyendo `INTERFACE_NAME` y `AD
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -185,7 +184,6 @@ Si tiene que configurar más de una dirección Additional IP, el archivo de conf
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -204,7 +202,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.fr-ca.md
@@ -166,7 +166,6 @@ Editez le fichier avec le contenu ci-dessous, en remplaçant `INTERFACE_NAME` et
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -179,7 +178,6 @@ Si vous avez plus d'une adresse Additional IP à configurer, le fichier de confi
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -199,7 +197,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.fr-fr.md
@@ -166,7 +166,6 @@ Editez le fichier avec le contenu ci-dessous, en remplaçant `INTERFACE_NAME` et
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -179,7 +178,6 @@ Si vous avez plus d'une adresse Additional IP à configurer, le fichier de confi
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -199,7 +197,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.it-it.md
@@ -170,7 +170,6 @@ Non modificare le linee esistenti nel file di configurazione. Aggiungi il tuo in
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -183,7 +182,6 @@ Se è necessario configurare più di un indirizzo Additional IP, il file di conf
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -202,7 +200,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.pl-pl.md
@@ -170,7 +170,6 @@ Edytuj plik, zastępując polecenia `INTERFACE_NAME` i `ADDITIONAL_IP` własnymi
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -183,7 +182,6 @@ Jeśli masz więcej niż jeden adres Additional IP do skonfigurowania, plik konf
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -202,7 +200,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.pt-pt.md
@@ -161,7 +161,6 @@ Edite o ficheiro com o conteúdo abaixo, substituindo `INTERFACE_NAME` e `ADDITI
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -174,7 +173,6 @@ Se tiver mais do que um endereço Additional IP a configurar, o ficheiro de conf
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        INTERFACE_NAME:
            dhcp4: true
@@ -193,7 +191,6 @@ network:
 ```yaml
 network:
    version: 2
-   renderer: networkd
    ethernets:
        eth0:
            dhcp4: true


### PR DESCRIPTION
The `renderer: networkd` line was removed because, by default, Ubuntu uses `networkd` as the network renderer for managing network interfaces. Explicitly specifying `renderer: networkd` in the configuration is redundant in cases where the default network manager is already in use.

However, when a custom network manager, such as `NetworkManager`, is applied, defining multiple renderers can lead to conflicts. For example, if `NetworkManager` is managing the interface, specifying `networkd` as the renderer in this configuration can cause both network managers to attempt control, potentially resulting in unpredictable behaviour and network issues.