### PR TITLE
MKS - Getting source IP behind LB - New annotation for version >= 1.31

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/getting-source-ip-behind-loadbalancer/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/getting-source-ip-behind-loadbalancer/guide.en-us.md
@@ -176,8 +176,11 @@ Copy the next YAML snippet in a `patch-ingress-controller-service.yml` file:
 
 ```yaml
 metadata:
-  annotations:
-    service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: "v2"
+    annotations:
+      # For Managed Kubernetes Service version < 1.31
+      service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: "v2"
+      # For Managed Kubernetes Service version >= 1.31
+      # loadbalancer.openstack.org/proxy-protocol : "v2"
 spec:
   externalTrafficPolicy: Local
 ```
@@ -238,7 +241,10 @@ controller:
   service:
     externalTrafficPolicy: "Local"
     annotations:
+      # For Managed Kubernetes Service version < 1.31
       service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: "v2"
+      # For Managed Kubernetes Service version >= 1.31
+      # loadbalancer.openstack.org/proxy-protocol : "v2"
   config:
     use-proxy-protocol: "true"
     real-ip-header: "proxy_protocol"
@@ -252,7 +258,10 @@ controller:
   service:
     externalTrafficPolicy: "Local"
     annotations:
+      # For Managed Kubernetes Service version < 1.31
       service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: "v2"
+      # For Managed Kubernetes Service version >= 1.31
+      # loadbalancer.openstack.org/proxy-protocol : "v2"
   config:
     use-proxy-protocol: "true"
     real-ip-header: "proxy_protocol"

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/getting-source-ip-behind-loadbalancer/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/getting-source-ip-behind-loadbalancer/guide.en-us.md
@@ -1,8 +1,14 @@
 ---
 title: Getting the source IP behind the LoadBalancer
 excerpt: 'Find out how to get the source IP behind the LoadBalancer on OVHcloud Managed Kubernetes'
-updated: 2022-09-14
+updated: 2024-11-18
 ---
+
+> [!warning]
+>
+> Usage of the [Public Cloud Load Balancer](/links/public-cloud/load-balancer) with Managed Kubernetes Service (MKS) is now in General Availability.
+> However this LoadBalancer (based on Octavia project) is not the default one yet for clusters running Kubernetes versions <1.31. For those clusters, you must use the annotation `loadbalancer.ovhcloud.com/class: octavia` to deploy an Octavia LoadBalancer from your MKS cluster.
+>
 
 ## Before you begin
 


### PR DESCRIPTION
Add new annotation  : For Managed Kubernetes Service version >= 1.31