### PR TITLE
fix(L3 services SNAT documentation): update the old version of the command

### DIFF
--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.de-de.md
@@ -65,7 +65,7 @@ Create a VM with a Floating IP as explained in [this guide](/pages/public_cloud/
 Create a VM with a private network only. In our example, our VM is called **vmpriv**:
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-asia.md
@@ -65,7 +65,7 @@ Create a VM with a Floating IP as explained in [this guide](/pages/public_cloud/
 Create a VM with a private network only. In our example, our VM is called **vmpriv**:
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-au.md
@@ -65,7 +65,7 @@ Create a VM with a Floating IP as explained in [this guide](/pages/public_cloud/
 Create a VM with a private network only. In our example, our VM is called **vmpriv**:
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-ca.md
@@ -65,7 +65,7 @@ Create a VM with a Floating IP as explained in [this guide](/pages/public_cloud/
 Create a VM with a private network only. In our example, our VM is called **vmpriv**:
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-gb.md
@@ -65,7 +65,7 @@ Create a VM with a Floating IP as explained in [this guide](/pages/public_cloud/
 Create a VM with a private network only. In our example, our VM is called **vmpriv**:
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-ie.md
@@ -65,7 +65,7 @@ Create a VM with a Floating IP as explained in [this guide](/pages/public_cloud/
 Create a VM with a private network only. In our example, our VM is called **vmpriv**:
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-sg.md
@@ -65,7 +65,7 @@ Create a VM with a Floating IP as explained in [this guide](/pages/public_cloud/
 Create a VM with a private network only. In our example, our VM is called **vmpriv**:
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-us.md
@@ -65,7 +65,7 @@ Create a VM with a Floating IP as explained in [this guide](/pages/public_cloud/
 Create a VM with a private network only. In our example, our VM is called **vmpriv**:
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.es-es.md
@@ -65,7 +65,7 @@ Create a VM with a Floating IP as explained in [this guide](/pages/public_cloud/
 Create a VM with a private network only. In our example, our VM is called **vmpriv**:
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.es-us.md
@@ -65,7 +65,7 @@ Create a VM with a Floating IP as explained in [this guide](/pages/public_cloud/
 Create a VM with a private network only. In our example, our VM is called **vmpriv**:
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.fr-ca.md
@@ -61,7 +61,7 @@ Créez une VM avec une Floating IP comme expliqué dans ce [guide](/pages/public
 Créez une VM avec uniquement un réseau privé. Dans notre exemple, notre VM s'appelle **vmpriv** :
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.fr-fr.md
@@ -61,7 +61,7 @@ Créez une VM avec une Floating IP comme expliqué dans ce [guide](/pages/public
 Créez une VM avec uniquement un réseau privé. Dans notre exemple, notre VM s'appelle **vmpriv** :
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.it-it.md
@@ -65,7 +65,7 @@ Create a VM with a Floating IP as explained in [this guide](/pages/public_cloud/
 Create a VM with a private network only. In our example, our VM is called **vmpriv**:
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.pl-pl.md
@@ -65,7 +65,7 @@ Create a VM with a Floating IP as explained in [this guide](/pages/public_cloud/
 Create a VM with a private network only. In our example, our VM is called **vmpriv**:
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.pt-pt.md
@@ -65,7 +65,7 @@ Create a VM with a Floating IP as explained in [this guide](/pages/public_cloud/
 Create a VM with a private network only. In our example, our VM is called **vmpriv**:
 
 ```bash
-$ openstack server create --image 'Ubuntu 22.04' --flavor s1-8 --key-name test-key --net test-network vmpriv
+$ openstack server create --image 'Ubuntu 22.04' --flavor d2-8 --key-name test-key --net test-network vmpriv
 $ openstack server show vmpriv -c name -c status -c addresses
 +-----------+---------------------------+
 | Field     | Value                     |


### PR DESCRIPTION
Refer to SK-1807.
PR to update the old version of the instance creation command. (In the past, this was a ‘s1-8’ flavour, but it no longer exists and has been replaced by a ‘d2-8’ flavour. ) 