### PR TITLE
New KBs - Adding reference categories for DB guides

### DIFF
--- a/pages/public_cloud/public_cloud_databases/cassandra_01_capabilities/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/cassandra_01_capabilities/meta.yaml
@@ -2,3 +2,4 @@ id: ccf013e8-6988-486c-86af-b9a462ca9e35
 full_slug: public-cloud-databases-cassandra-capabilities
 engine: cassandra
 section: dashboard
+reference_category: public-cloud-databases-cassandra-guides

--- a/pages/public_cloud/public_cloud_databases/cassandra_02_prepare_for_incoming_connections/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/cassandra_02_prepare_for_incoming_connections/meta.yaml
@@ -2,3 +2,4 @@ id: f2f2c9b6-a0da-4afa-abed-6078c03c9b69
 full_slug: public-cloud-databases-cassandra-configure-instance
 engine: cassandra
 section: settings
+reference_category: public-cloud-databases-cassandra-guides

--- a/pages/public_cloud/public_cloud_databases/cassandra_03_advanced_parameters_references/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/cassandra_03_advanced_parameters_references/meta.yaml
@@ -2,3 +2,4 @@ id: 4daeb713-6395-4d46-b37c-cb33ba287257
 full_slug: public-cloud-databases-cassandra-advanced-parameters-references
 engine: cassandra
 section: settings
+reference_category: public-cloud-databases-cassandra-guides

--- a/pages/public_cloud/public_cloud_databases/databases_01_order_control_panel/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_01_order_control_panel/meta.yaml
@@ -2,3 +2,4 @@ id: c8c6cbfb-1855-4efb-8ff6-b865a4959ac0
 full_slug: public-cloud-databases-getting-started
 engine: all
 section: onboarding
+reference_category: public-cloud-databases-cassandra-guides

--- a/pages/public_cloud/public_cloud_databases/databases_02_order_api/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_02_order_api/meta.yaml
@@ -1,2 +1,3 @@
 id: 0aec99c6-5879-48f9-8280-cd1e76a37838
 full_slug: public-cloud-databases-order-api
+reference_category: public-cloud-databases-cassandra-guides

--- a/pages/public_cloud/public_cloud_databases/databases_03_advanced_configuration/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_03_advanced_configuration/meta.yaml
@@ -2,3 +2,4 @@ id: dbbac3da-b325-431e-bae8-857eb6f41e13
 full_slug: public-cloud-databases-advanced-configuration
 engine: all
 section: settings
+reference_category: public-cloud-databases-cassandra-guides

--- a/pages/public_cloud/public_cloud_databases/databases_04_troubleshooting/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_04_troubleshooting/meta.yaml
@@ -2,3 +2,4 @@ id: c7197d7c-ef81-419b-804d-6edd56e6408f
 full_slug: public-cloud-databases-troubleshooting
 engine: all
 section: dashboard
+reference_category: public-cloud-databases-general-guides

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/meta.yaml
@@ -2,3 +2,4 @@ id: ce10baef-1c91-4dfc-b586-60dfedfba09b
 full_slug: public-cloud-databases-backups
 engine: all
 section: backups
+reference_category: public-cloud-databases-general-guides

--- a/pages/public_cloud/public_cloud_databases/databases_06_restore_backup/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_06_restore_backup/meta.yaml
@@ -2,3 +2,4 @@ id: f74be24d-7854-4986-9ff6-12b624b79427
 full_slug: public-cloud-databases-restore-backup
 engine: all
 section: backups
+reference_category: public-cloud-databases-general-guides

--- a/pages/public_cloud/public_cloud_databases/databases_07_cross_service_integration/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_07_cross_service_integration/meta.yaml
@@ -2,3 +2,4 @@ id: 23389a5a-3ce4-4c21-a932-befe9e66eb1f
 full_slug: public-cloud-databases-cross-service-integration
 engine: all
 section: integrations
+reference_category: public-cloud-databases-general-guides

--- a/pages/public_cloud/public_cloud_databases/databases_08_vrack/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_08_vrack/meta.yaml
@@ -2,3 +2,4 @@ id: 85e41673-3cb7-46ca-86b0-47103a6147d2
 full_slug: public-cloud-databases-configure-vrack
 engine: all
 section: settings
+reference_category: public-cloud-databases-general-guides

--- a/pages/public_cloud/public_cloud_databases/databases_09_order_terraform/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_09_order_terraform/meta.yaml
@@ -1,2 +1,3 @@
 id: 47d1eb38-6557-4cfb-8c96-98eb6a31d33e
 full_slug: public-cloud-databases-order-terraform
+reference_category: public-cloud-databases-general-guides

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/meta.yaml
@@ -1,2 +1,3 @@
 id: 9a73a2be-30b7-4c4c-8c53-5f6f6fb6838c
 full_slug: public-cloud-databases-handling-disk-full
+reference_category: public-cloud-databases-general-guides

--- a/pages/public_cloud/public_cloud_databases/databases_11_resize_your_cluster_storage/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_11_resize_your_cluster_storage/meta.yaml
@@ -1,2 +1,3 @@
 id: f6b017f8-17ef-47ed-b5af-a51ad0b23844
 full_slug: public-cloud-databases-resize-cluster-storage
+reference_category: public-cloud-databases-general-guides

--- a/pages/public_cloud/public_cloud_databases/databases_13_update_your_cluster_flavor/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_13_update_your_cluster_flavor/meta.yaml
@@ -1,2 +1,3 @@
 id: 9edf3314-206b-4976-ad97-570c275aab6f
 full_slug: public-cloud-databases-update-cluster-flavor
+reference_category: public-cloud-databases-general-guides

--- a/pages/public_cloud/public_cloud_databases/databases_14_upgrade_your_cluster_plan/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_14_upgrade_your_cluster_plan/meta.yaml
@@ -1,2 +1,3 @@
 id: 325eb89c-c933-44c6-83c6-8f4f54e680c9
 full_slug: public-cloud-databases-update-cluster-plan
+reference_category: public-cloud-databases-general-guides

--- a/pages/public_cloud/public_cloud_databases/databases_15_maintenances/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_15_maintenances/meta.yaml
@@ -2,3 +2,4 @@ id: 60467c92-8af6-4721-b72c-9f4917c05b1d
 full_slug: public-cloud-databases-maintenance
 engine: all
 section: settings
+reference_category: public-cloud-databases-general-information

--- a/pages/public_cloud/public_cloud_databases/databases_16_logs_to_customer/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_16_logs_to_customer/meta.yaml
@@ -2,3 +2,4 @@ id: 86be8acc-e6bf-4144-843d-71da48c71e93
 full_slug: public-cloud-databases-logs-to-customers
 engine: all
 section: logs
+reference_category: public-cloud-databases-general-guides

--- a/pages/public_cloud/public_cloud_databases/databases_17_metrics_via_prometheus/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/databases_17_metrics_via_prometheus/meta.yaml
@@ -1,2 +1,3 @@
 id: 93f0972f-f0ec-40a3-bc8d-dc6e07263105
 full_slug: public-cloud-databases-service-metrics-with-prometheus
+reference_category: public-cloud-databases-general-guides

--- a/pages/public_cloud/public_cloud_databases/grafana_01_capabilities/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/grafana_01_capabilities/meta.yaml
@@ -2,3 +2,4 @@ id: 099d6644-7dcd-4247-aabb-76e46dd3fc1b
 full_slug: public-cloud-databases-grafana-capabilities
 engine: grafana
 section: dashboard
+reference_category: public-cloud-databases-grafana-guides

--- a/pages/public_cloud/public_cloud_databases/grafana_02_prepare_for_incoming_connections/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/grafana_02_prepare_for_incoming_connections/meta.yaml
@@ -2,3 +2,4 @@ id: 64da680f-28e8-4d1c-b978-b95707805f9b
 full_slug: public-cloud-databases-grafana-configure-instance
 engine: grafana
 section: settings
+reference_category: public-cloud-databases-grafana-guides

--- a/pages/public_cloud/public_cloud_databases/grafana_03_advanced_parameters_references/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/grafana_03_advanced_parameters_references/meta.yaml
@@ -2,3 +2,4 @@ id: 2af7cc99-b7cf-4779-9074-8d8cfdfacc36
 full_slug: public-cloud-databases-grafana-advanced-parameters-references
 engine: grafana
 section: settings
+reference_category: public-cloud-databases-grafana-guides

--- a/pages/public_cloud/public_cloud_databases/grafana_tuto_01_reverse_proxy/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/grafana_tuto_01_reverse_proxy/meta.yaml
@@ -2,3 +2,4 @@ id: b27bd13f-0dfd-4520-b01e-57288ad4ae12
 full_slug: public-cloud-databases-grafana-reverse-proxy
 engine: grafana
 section: dashboard
+reference_category: public-cloud-databases-grafana-tutorials

--- a/pages/public_cloud/public_cloud_databases/grafana_tuto_02_using_api/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/grafana_tuto_02_using_api/meta.yaml
@@ -1,2 +1,3 @@
 id: 908ac7a8-4b90-4cfd-8ab4-79c8f34e0dbf
 full_slug: public-cloud-databases-grafana-using_api
+reference_category: public-cloud-databases-grafana-tutorials

--- a/pages/public_cloud/public_cloud_databases/information_01_security_overview/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/information_01_security_overview/meta.yaml
@@ -2,3 +2,4 @@ id: 5d63e515-9ca0-454a-803f-3dd61be5bf94
 full_slug: public-cloud-databases-concepts-security-overview
 engine: all
 section: dashboard
+reference_category: public-cloud-databases-general-information

--- a/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy/meta.yaml
@@ -2,3 +2,4 @@ id: ac56f39e-b948-421a-a76e-f739de6585f6
 full_slug: public-cloud-databases-lifecycle-policy
 engine: all
 section: dashboard
+reference_category: public-cloud-databases-general-information

--- a/pages/public_cloud/public_cloud_databases/information_04_faq/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/information_04_faq/meta.yaml
@@ -2,3 +2,4 @@ id: a8fd3cd7-01cb-4b19-9882-c85ec86ba49d
 full_slug: public-cloud-databases-faq
 engine: all
 section: dashboard
+reference_category: public-cloud-databases-general-information

--- a/pages/public_cloud/public_cloud_databases/information_05_capabilities/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/information_05_capabilities/meta.yaml
@@ -1,2 +1,3 @@
 id: 31f1eaf8-d85a-4f28-9f98-56e24184781c
 full_slug: public-cloud-databases-capabilities
+reference_category: public-cloud-databases-general-information

--- a/pages/public_cloud/public_cloud_databases/kafka_01_capabilities/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/kafka_01_capabilities/meta.yaml
@@ -2,3 +2,4 @@ id: 00a50392-e50f-4fd5-92f0-d537de0b3d9b
 full_slug: public-cloud-databases-kafka-capabilities
 engine: kafka
 section: dashboard
+reference_category: public-cloud-databases-kafka-guides

--- a/pages/public_cloud/public_cloud_databases/kafka_02_getting_started/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/kafka_02_getting_started/meta.yaml
@@ -2,3 +2,4 @@ id: f15354bd-dbc3-432f-a389-49f1c70da327
 full_slug: public-cloud-databases-kafka-getting-started
 engine: kafka
 section: dashboard
+reference_category: public-cloud-databases-kafka-guides

--- a/pages/public_cloud/public_cloud_databases/kafka_03_advanced_parameters_references/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/kafka_03_advanced_parameters_references/meta.yaml
@@ -2,3 +2,4 @@ id: dfd74711-429f-4b93-84f8-674375756e83
 full_slug: public-cloud-databases-kafka-advanced-parameters-references
 engine: kafka
 section: settings
+reference_category: public-cloud-databases-kafka-guides

--- a/pages/public_cloud/public_cloud_databases/kafka_04_dev_python_basics/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/kafka_04_dev_python_basics/meta.yaml
@@ -2,3 +2,4 @@ id: c25a4e2a-a600-4acb-807b-7035145e0a9d
 full_slug: public-cloud-databases-kafka-dev-python-basics
 engine: kafka
 section: dashboard
+reference_category: public-cloud-databases-kafka-guides

--- a/pages/public_cloud/public_cloud_databases/kafkaconnect_01_capabilities/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/kafkaconnect_01_capabilities/meta.yaml
@@ -2,3 +2,4 @@ id: ca3a246b-42da-4cc8-a4eb-afbfc13aab39
 full_slug: public-cloud-databases-kafkaconnect-capabilities
 engine: kafkaConnect
 section: dashboard
+reference_category: public-cloud-databases-kafka-connect-guides

--- a/pages/public_cloud/public_cloud_databases/kafkaconnect_02_advanced_parameters_references/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/kafkaconnect_02_advanced_parameters_references/meta.yaml
@@ -2,3 +2,4 @@ id: f40c2036-64b7-4390-9247-695f9c3add87
 full_slug: public-cloud-databases-kafkaconnect-advanced-parameters-references
 engine: kafkaConnect
 section: settings
+reference_category: public-cloud-databases-kafka-connect-guides

--- a/pages/public_cloud/public_cloud_databases/m3aggregator_01_capabilities/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/m3aggregator_01_capabilities/meta.yaml
@@ -2,3 +2,4 @@ id: 6b0074b1-43f7-4258-b837-725084e33c88
 full_slug: public-cloud-databases-m3aggregator-capabilities
 engine: m3aggregator
 section: dashboard
+reference_category: public-cloud-databases-m3-aggregator-guides

--- a/pages/public_cloud/public_cloud_databases/m3db_01_capabilities/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/m3db_01_capabilities/meta.yaml
@@ -2,3 +2,4 @@ id: 5b4461f5-134c-4834-96d6-dbdfc645a63e
 full_slug: public-cloud-databases-m3db-capabilities
 engine: m3db
 section: dashboard
+reference_category: public-cloud-databases-m3db-guides

--- a/pages/public_cloud/public_cloud_databases/m3db_02_prepare_for_incoming_connections/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/m3db_02_prepare_for_incoming_connections/meta.yaml
@@ -2,3 +2,4 @@ id: 0266623f-6706-4e7a-8435-d105855f1083
 full_slug: public-cloud-databases-m3db-configure-instance
 engine: m3db
 section: settings
+reference_category: public-cloud-databases-m3db-guides

--- a/pages/public_cloud/public_cloud_databases/mirrormaker_01_capabilities/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mirrormaker_01_capabilities/meta.yaml
@@ -2,3 +2,4 @@ id: c39babee-4177-4619-a854-df203a5a9089
 full_slug: public-cloud-databases-mirrormaker-capabilities
 engine: kafkaMirrorMaker
 section: dashboard
+reference_category: public-cloud-databases-kafka-mirrormaker-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_01_concept_capabilities/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_01_concept_capabilities/meta.yaml
@@ -2,3 +2,4 @@ id: afa97cc0-c8ee-4701-a9d3-27cf37100696
 full_slug: public-cloud-databases-mongodb-capabilities
 engine: mongodb
 section: dashboard
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_02_manage_control_panel/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_02_manage_control_panel/meta.yaml
@@ -1,2 +1,3 @@
 id: ce600844-a355-4aa8-a781-b8335ad8d350
 full_slug: public-cloud-databases-mongodb-managing-service
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_03_connect_cli/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_03_connect_cli/meta.yaml
@@ -2,3 +2,4 @@ id: 4d727aa4-6f93-49a7-8d4d-0236521bcf49
 full_slug: public-cloud-databases-mongodb-connect
 engine: mongodb
 section: dashboard
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_04_connect_php/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_04_connect_php/meta.yaml
@@ -2,3 +2,4 @@ id: 06d99d28-1032-4dc5-b61e-3571465e0be1
 full_slug: public-cloud-databases-mongodb-connect-php
 engine: mongodb
 section: dashboard
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_05_connect_python/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_05_connect_python/meta.yaml
@@ -2,3 +2,4 @@ id: 67c942a1-c8a2-4f9c-88ac-026ec3e0d6ec
 full_slug: public-cloud-databases-mongodb-connect-python
 engine: mongodb
 section: dashboard
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_06_howto_backup_restore/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_06_howto_backup_restore/meta.yaml
@@ -2,3 +2,4 @@ id: a146418b-db2f-4f7e-bb4c-9d029d8dcd1d
 full_slug: public-cloud-databases-mongodb-backups-restores
 engine: mongodb
 section: backups
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_07_connect_compass/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_07_connect_compass/meta.yaml
@@ -2,3 +2,4 @@ id: 98e42572-6b47-45e2-8c0d-c4c0786803ba
 full_slug: public-cloud-databases-mongodb-connect-compass
 engine: mongodb
 section: dashboard
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_08_analytics/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_08_analytics/meta.yaml
@@ -1,2 +1,3 @@
 id: 064560d1-bd87-4b5e-b0c2-495c67fca267
 full_slug: public-cloud-databases-mongodb-analytics-node
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_10_connection_strings/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_10_connection_strings/meta.yaml
@@ -2,3 +2,4 @@ id: 8f777792-4d9a-45b5-8895-1343772a1a80
 full_slug: public-cloud-databases-mongodb-connection-strings
 engine: mongodb
 section: dashboard
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_11_howto_migrate_to_discovery/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_11_howto_migrate_to_discovery/meta.yaml
@@ -1,2 +1,3 @@
 id: bc780bd1-ab09-4d99-98a4-cf8716c30f4d
 full_slug: public-cloud-databases-mongodb-migrate-discovery-cli
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_12_howto_migrate_to_production_or_advanced/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_12_howto_migrate_to_production_or_advanced/meta.yaml
@@ -1,2 +1,3 @@
 id: 135e73f0-219c-4e3c-b05b-b71c827c481b
 full_slug: public-cloud-databases-mongodb-migrate-production-advanced-cli
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_13_getting_started/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_13_getting_started/meta.yaml
@@ -2,3 +2,4 @@ id: 0660de92-ee66-4ff1-82d3-ba824f4a5e14
 full_slug: public-cloud-databases-mongodb-getting-started
 engine: mongodb
 section: dashboard
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_14_deploy_with_terraform/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_14_deploy_with_terraform/meta.yaml
@@ -1,2 +1,3 @@
 id: cae61309-0272-4ef8-a423-291bf941be88
 full_slug: public-cloud-databases-mongodb-terraform-deployment
+reference_category: public-cloud-databases-mongodb-tutorials

--- a/pages/public_cloud/public_cloud_databases/mongodb_15_monitoring/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_15_monitoring/meta.yaml
@@ -2,3 +2,4 @@ id: b4951cb0-41ef-4c5d-bf21-1d911eae0c48
 full_slug: public-cloud-databases-mongodb-monitoring
 engine: mongodb
 section: metrics
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_16_automated_migration_new_offers/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_16_automated_migration_new_offers/meta.yaml
@@ -1,2 +1,3 @@
 id: 826830cd-5764-44d5-83cd-bbd10fb1bfd8
 full_slug: public-cloud-databases-mongodb-new-offers-migration
+reference_category: public-cloud-databases-mongodb-guides

--- a/pages/public_cloud/public_cloud_databases/mongodb_tuto_01_connect_nodejs_to_managed_mongodb/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mongodb_tuto_01_connect_nodejs_to_managed_mongodb/meta.yaml
@@ -2,3 +2,4 @@ id: ec8aa517-d2bc-412d-bc4b-757928a1fa92
 full_slug: public-cloud-databases-mongodb-build-nodejs-app
 engine: mongodb
 section: dashboard
+reference_category: public-cloud-databases-mongodb-tutorials

--- a/pages/public_cloud/public_cloud_databases/mysql_01_capabilities/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mysql_01_capabilities/meta.yaml
@@ -2,3 +2,4 @@ id: a78695cd-9218-4bec-9010-3b21a2847b96
 full_slug: public-cloud-databases-mysql-capabilities
 engine: mysql
 section: dashboard
+reference_category: public-cloud-databases-mysql-guides

--- a/pages/public_cloud/public_cloud_databases/mysql_03_connect_cli/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mysql_03_connect_cli/meta.yaml
@@ -2,3 +2,4 @@ id: fdc1b796-5d5a-41a1-9434-589950802af9
 full_slug: public-cloud-databases-mysql-connect
 engine: mysql
 section: landing
+reference_category: public-cloud-databases-mysql-guides

--- a/pages/public_cloud/public_cloud_databases/mysql_04_connect_php/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mysql_04_connect_php/meta.yaml
@@ -2,3 +2,4 @@ id: e1f253c8-f082-4c60-8345-f297420e7c6b
 full_slug: public-cloud-databases-mysql-connect-php
 engine: mysql
 section: dashboard
+reference_category: public-cloud-databases-mysql-guides

--- a/pages/public_cloud/public_cloud_databases/mysql_05_connect_python/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mysql_05_connect_python/meta.yaml
@@ -2,3 +2,4 @@ id: 63fcb9b6-cffc-4eaa-93ee-4c1dcea63ed6
 full_slug: public-cloud-databases-mysql-connect-python
 engine: mysql
 section: dashboard
+reference_category: public-cloud-databases-mysql-guides

--- a/pages/public_cloud/public_cloud_databases/mysql_06_connect_workbench/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mysql_06_connect_workbench/meta.yaml
@@ -2,3 +2,4 @@ id: 51b9a462-de80-4360-996c-aa92c698f55d
 full_slug: public-cloud-databases-mysql-connect-workbench
 engine: mysql
 section: dashboard
+reference_category: public-cloud-databases-mysql-guides

--- a/pages/public_cloud/public_cloud_databases/mysql_07_prepare_for_incoming_connections/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mysql_07_prepare_for_incoming_connections/meta.yaml
@@ -2,3 +2,4 @@ id: 70fe65f0-95f7-41d5-b820-8977e857366b
 full_slug: public-cloud-databases-mysql-configure-instance
 engine: mysql
 section: settings
+reference_category: public-cloud-databases-mysql-guides

--- a/pages/public_cloud/public_cloud_databases/mysql_08_advanced_parameters_references/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mysql_08_advanced_parameters_references/meta.yaml
@@ -2,3 +2,4 @@ id: e6746060-89cf-4355-b984-ec45807f21a1
 full_slug: public-cloud-databases-mysql-advanced-parameters-references
 engine: mysql
 section: settings
+reference_category: public-cloud-databases-mysql-guides

--- a/pages/public_cloud/public_cloud_databases/mysql_tuto_01_connect-k8s-to-managed-mysql/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/mysql_tuto_01_connect-k8s-to-managed-mysql/meta.yaml
@@ -2,3 +2,4 @@ id: 531ee985-c1d5-4ae4-afda-f53a8c30c5e8
 full_slug: public-cloud-databases-mysql-connect-kubernetes
 engine: mysql
 section: dashboard
+reference_category: public-cloud-databases-mysql-tutorials

--- a/pages/public_cloud/public_cloud_databases/opensearch_01_capabilities/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/opensearch_01_capabilities/meta.yaml
@@ -2,3 +2,4 @@ id: e2bc9c16-055e-4f76-9894-b1d94fd2e5c8
 full_slug: public-cloud-databases-opensearch-capabilities
 engine: opensearch
 section: dashboard
+reference_category: public-cloud-databases-opensearch-guides

--- a/pages/public_cloud/public_cloud_databases/opensearch_02_getting_Started/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/opensearch_02_getting_Started/meta.yaml
@@ -2,3 +2,4 @@ id: 0dfb383e-3de9-4f21-b8a9-18cf9e15639b
 full_slug: public-cloud-databases-opensearch-getting-started
 engine: opensearch
 section: dashboard
+reference_category: public-cloud-databases-opensearch-guides

--- a/pages/public_cloud/public_cloud_databases/opensearch_03_advanced_parameters_references/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/opensearch_03_advanced_parameters_references/meta.yaml
@@ -2,3 +2,4 @@ id: 697bdcdd-c436-43a0-a84c-784497290014
 full_slug: public-cloud-databases-opensearch-advanced-parameters-references
 engine: opensearch
 section: settings
+reference_category: public-cloud-databases-opensearch-guides

--- a/pages/public_cloud/public_cloud_databases/opensearch_200_elk_like/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/opensearch_200_elk_like/meta.yaml
@@ -2,3 +2,4 @@ id: 5f044a05-92ab-4989-9ceb-2b9ea292427b
 full_slug: public-cloud-databases-opensearch-logstash
 engine: opensearch
 section: dashboard
+reference_category: public-cloud-databases-opensearch-guides

--- a/pages/public_cloud/public_cloud_databases/postgresql_01_capabilities/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_01_capabilities/meta.yaml
@@ -2,3 +2,4 @@ id: 3e35a1df-8b54-4d25-b2e7-de842cdccc26
 full_slug: public-cloud-databases-postgresql-capabilities
 engine: postgresql
 section: dashboard
+reference_category: public-cloud-databases-postgresql-guides

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/meta.yaml
@@ -2,3 +2,4 @@ id: b5450576-3103-4d4f-81d0-4611157f4609
 full_slug: public-cloud-databases-postgresql-extensions
 engine: postgresql
 section: dashboard
+reference_category: public-cloud-databases-postgresql-guides

--- a/pages/public_cloud/public_cloud_databases/postgresql_03_connect_cli/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_03_connect_cli/meta.yaml
@@ -2,3 +2,4 @@ id: 7cbe7848-e2d7-4f1b-a020-4f40aa2ac2ee
 full_slug: public-cloud-databases-postgresql-connect
 engine: postgresql
 section: dashboard
+reference_category: public-cloud-databases-postgresql-guides

--- a/pages/public_cloud/public_cloud_databases/postgresql_04_connect_php/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_04_connect_php/meta.yaml
@@ -2,3 +2,4 @@ id: fbfe41ad-369c-40f8-805b-d688a7b4ce3f
 full_slug: public-cloud-databases-postgresql-connect-php
 engine: postgresql
 section: dashboard
+reference_category: public-cloud-databases-postgresql-guides

--- a/pages/public_cloud/public_cloud_databases/postgresql_05_connect_python/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_05_connect_python/meta.yaml
@@ -2,3 +2,4 @@ id: a1542e54-03b0-4512-b3f3-7259f74ed534
 full_slug: public-cloud-databases-postgresql-connect-python
 engine: postgresql
 section: dashboard
+reference_category: public-cloud-databases-postgresql-guides

--- a/pages/public_cloud/public_cloud_databases/postgresql_06_connect_pgadmin/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_06_connect_pgadmin/meta.yaml
@@ -2,3 +2,4 @@ id: cc960db1-d187-495a-bcf2-9f3277a8edde
 full_slug: public-cloud-databases-postgresql-connect-pgadmin
 engine: postgresql
 section: dashboard
+reference_category: public-cloud-databases-postgresql-guides

--- a/pages/public_cloud/public_cloud_databases/postgresql_07_prepare_for_incoming_connections/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_07_prepare_for_incoming_connections/meta.yaml
@@ -2,3 +2,4 @@ id: 242280ec-1e33-4ff3-becf-41091d22c4d5
 full_slug: public-cloud-databases-postgresql-configure-instance
 engine: postgresql
 section: settings
+reference_category: public-cloud-databases-postgresql-guides

--- a/pages/public_cloud/public_cloud_databases/postgresql_08_pool/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_08_pool/meta.yaml
@@ -2,3 +2,4 @@ id: 44e38c82-a619-4c31-b21d-06f7cf6586c7
 full_slug: public-cloud-databases-postgresql-pools
 engine: postgresql
 section: pools
+reference_category: public-cloud-databases-postgresql-guides

--- a/pages/public_cloud/public_cloud_databases/postgresql_09_concept_high_availability/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_09_concept_high_availability/meta.yaml
@@ -2,3 +2,4 @@ id: dd2cdd7e-8359-4529-9936-acc2f6403a9f
 full_slug: public-cloud-databases-postgresql-concept-high-availability
 engine: postgresql
 section: dashboard
+reference_category: public-cloud-databases-postgresql-guides

--- a/pages/public_cloud/public_cloud_databases/postgresql_10_advanced_parameters_references/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_10_advanced_parameters_references/meta.yaml
@@ -2,3 +2,4 @@ id: 60131347-dcf7-4320-bf1d-dae6f777287b
 full_slug: public-cloud-databases-postgresql-advanced-parameters-references
 engine: postgresql
 section: settings
+reference_category: public-cloud-databases-postgresql-guides

--- a/pages/public_cloud/public_cloud_databases/postgresql_11_terminate_queries/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_11_terminate_queries/meta.yaml
@@ -2,3 +2,4 @@ id: 6e3ff09a-ad11-11ed-afa1-0242ac120002
 full_slug: public-cloud-databases-postgresql-terminate-queries
 engine: postgresql
 section: queries
+reference_category: public-cloud-databases-postgresql-guides

--- a/pages/public_cloud/public_cloud_databases/postgresql_tuto_01_connect_strapi_to_managed_postgresql/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_tuto_01_connect_strapi_to_managed_postgresql/meta.yaml
@@ -2,3 +2,4 @@ id: d56f5080-37df-4852-8a30-f1374b24879a
 full_slug: public-cloud-databases-postgresql-connect-strapi
 engine: postgresql
 section: dashboard
+reference_category: public-cloud-databases-postgresql-tutorials

--- a/pages/public_cloud/public_cloud_databases/postgresql_tuto_02_connect_wagtail_to_managed_postgresql/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_tuto_02_connect_wagtail_to_managed_postgresql/meta.yaml
@@ -2,3 +2,4 @@ id: 67af6d6b-900a-40fc-92e6-f5da637cdfc5
 full_slug: public-cloud-databases-postgresql-connect-wagtail
 engine: postgresql
 section: dashboard
+reference_category: public-cloud-databases-postgresql-tutorials

--- a/pages/public_cloud/public_cloud_databases/postgresql_tuto_03_migrate_ecdb/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/postgresql_tuto_03_migrate_ecdb/meta.yaml
@@ -1,2 +1,3 @@
 id: 0d027f1a-7b68-45fa-9cf3-c5fff5ace4ac
 full_slug: public-cloud-databases-postgresql-migrate-on-prem-to-pcd
+reference_category: public-cloud-databases-postgresql-tutorials

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/meta.yaml
@@ -2,3 +2,4 @@ id: 9f7c6e36-a1f2-40cb-87ff-ec8a55efdaf3
 full_slug: public-cloud-databases-redis-capabilities
 engine: redis
 section: dashboard
+reference_category: public-cloud-databases-redis-guides

--- a/pages/public_cloud/public_cloud_databases/redis_03_connect_cli/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/redis_03_connect_cli/meta.yaml
@@ -2,3 +2,4 @@ id: d7ece82b-3b80-4d42-b733-7ca4716dcd76
 full_slug: public-cloud-databases-redis-connect
 engine: redis
 section: dashboard
+reference_category: public-cloud-databases-redis-guides

--- a/pages/public_cloud/public_cloud_databases/redis_04_connect_php/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/redis_04_connect_php/meta.yaml
@@ -2,3 +2,4 @@ id: 0e9976f6-c2f2-46cf-9805-902beabd2226
 full_slug: public-cloud-databases-redis-connect-php
 engine: redis
 section: dashboard
+reference_category: public-cloud-databases-redis-guides

--- a/pages/public_cloud/public_cloud_databases/redis_05_connect_python/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/redis_05_connect_python/meta.yaml
@@ -2,3 +2,4 @@ id: f425e63f-fd34-4bfb-8358-39b3bfd1f6a2
 full_slug: public-cloud-databases-redis-connect-python
 engine: redis
 section: dashboard
+reference_category: public-cloud-databases-redis-guides

--- a/pages/public_cloud/public_cloud_databases/redis_06_connect_redisinsight/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/redis_06_connect_redisinsight/meta.yaml
@@ -2,3 +2,4 @@ id: 711bf033-6046-4cf0-9f8e-bba75cdbc010
 full_slug: public-cloud-databases-redis-connect-redisinsight
 engine: redis
 section: dashboard
+reference_category: public-cloud-databases-redis-guides

--- a/pages/public_cloud/public_cloud_databases/redis_07_update_acls/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/redis_07_update_acls/meta.yaml
@@ -2,3 +2,4 @@ id: 561e5a80-de0e-4cf0-898c-68c668699156
 full_slug: public-cloud-databases-redis-acls
 engine: redis
 section: acls
+reference_category: public-cloud-databases-redis-guides

--- a/pages/public_cloud/public_cloud_databases/redis_08_prepare_for_incoming_connections/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/redis_08_prepare_for_incoming_connections/meta.yaml
@@ -2,3 +2,4 @@ id: b90bd95d-af4f-4478-8943-25161e602b6f
 full_slug: public-cloud-databases-redis-configure-instance
 engine: redis
 section: settings
+reference_category: public-cloud-databases-redis-guides

--- a/pages/public_cloud/public_cloud_databases/redis_09_advanced_parameters_references/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/redis_09_advanced_parameters_references/meta.yaml
@@ -2,3 +2,4 @@ id: a4c4d0df-6ada-4602-bfb0-3d02683fe4bf
 full_slug: public-cloud-databases-redis-advanced-parameters-references
 engine: redis
 section: settings
+reference_category: public-cloud-databases-redis-guides

--- a/pages/public_cloud/public_cloud_databases/redis_tuto_01_wordpress/meta.yaml
+++ b/pages/public_cloud/public_cloud_databases/redis_tuto_01_wordpress/meta.yaml
@@ -2,3 +2,4 @@ id: 40488d71-2184-4249-986c-e1ea9ca2d06f
 full_slug: public-cloud-databases-redis-boost-wordpress
 engine: redis
 section: dashboard
+reference_category: public-cloud-databases-redis-tutorials

--- a/pages/web_cloud/web_cloud_databases/clouddb-eos-eol/meta.yaml
+++ b/pages/web_cloud/web_cloud_databases/clouddb-eos-eol/meta.yaml
@@ -1,3 +1,4 @@
 id: e5f55c2c-a0ac-4481-9d5b-0399917f1654
 full_slug: web-cloud-db-eos-eol
 translation_banner: true
+reference_category: web-cloud-clouddb-technical-resources

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/meta.yaml
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/meta.yaml
@@ -1,3 +1,4 @@
 id: e2491666-ad66-486d-bb5c-95249c2d9e12
 full_slug: web-cloud-db-configure-optimise-database-server
 translation_banner: true
+reference_category: web-cloud-clouddb-configuration

--- a/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/meta.yaml
+++ b/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/meta.yaml
@@ -1,3 +1,4 @@
 id: dc3a135a-9f6e-464b-b87f-4d7d91cb9781
 full_slug: web-cloud-db-connecting-database-server
 translation_banner: true
+reference_category: web-cloud-clouddb-configuration

--- a/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server/meta.yaml
+++ b/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server/meta.yaml
@@ -1,3 +1,4 @@
 id: 7dcef9f3-7dd0-4d1b-94fe-b65fb8d2dec5
 full_slug: web-cloud-db-create-databases-users
 translation_banner: true
+reference_category: web-cloud-clouddb-configuration

--- a/pages/web_cloud/web_cloud_databases/eol-policy/meta.yaml
+++ b/pages/web_cloud/web_cloud_databases/eol-policy/meta.yaml
@@ -1,3 +1,4 @@
 id: bea06884-e2a8-46f5-a26c-01c28b8b6a33
 full_slug: web-cloud-db-managed-db-lifecycle-policy
 translation_banner: true
+reference_category: web-cloud-clouddb-technical-resources

--- a/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/meta.yaml
+++ b/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/meta.yaml
@@ -1,3 +1,4 @@
 id: 342b9153-54b4-4168-a84a-05dbb0ca34b2
 full_slug: web-cloud-db-restore-import-database
 translation_banner: true
+reference_category: web-cloud-clouddb-configuration

--- a/pages/web_cloud/web_cloud_databases/retrieve-logs/meta.yaml
+++ b/pages/web_cloud/web_cloud_databases/retrieve-logs/meta.yaml
@@ -1,3 +1,4 @@
 id: c0451359-341b-4aea-8722-7c494bc58d40
 full_slug: web-cloud-db-retrieve-logs
 translation_banner: true
+reference_category: web-cloud-clouddb-configuration

--- a/pages/web_cloud/web_cloud_databases/save-export-on-database-server/meta.yaml
+++ b/pages/web_cloud/web_cloud_databases/save-export-on-database-server/meta.yaml
@@ -1,3 +1,4 @@
 id: 914f8ae8-e8d7-4048-8d4a-b9697d206c5a
 full_slug: web-cloud-db-backup-export-database-server
 translation_banner: true
+reference_category: web-cloud-clouddb-configuration

--- a/pages/web_cloud/web_cloud_databases/starting_with_clouddb/meta.yaml
+++ b/pages/web_cloud/web_cloud_databases/starting_with_clouddb/meta.yaml
@@ -1,3 +1,4 @@
 id: 86692c01-9147-4a40-874a-f641390632c7
 full_slug: web-cloud-db-getting-started
 translation_banner: true
+reference_category: web-cloud-clouddb-getting-started

--- a/pages/web_cloud/web_cloud_databases/using-mysql-mariadb/meta.yaml
+++ b/pages/web_cloud/web_cloud_databases/using-mysql-mariadb/meta.yaml
@@ -1,3 +1,4 @@
 id: 6c564560-b63b-4a93-993b-9ea37274ad99
 full_slug: web-cloud-db-getting-started-mysql-mariadb
 translation_banner: true
+reference_category: web-cloud-clouddb-getting-started

--- a/pages/web_cloud/web_cloud_databases/using-pgsql/meta.yaml
+++ b/pages/web_cloud/web_cloud_databases/using-pgsql/meta.yaml
@@ -1,2 +1,3 @@
 id: 917b6ed8-965a-4e99-aac7-8bd9fc309e01
 full_slug: web-cloud-db-getting-started-postgresql
+reference_category: web-cloud-clouddb-getting-started


### PR DESCRIPTION
Anticipating the production of new Knowledge Bases which will contain multi-localised guides.
Addition of `reference_category` tags in meta.yaml files of:

- Web Cloud Databases
- Public Cloud Databases