### PR TITLE
update guide and center imgs

### DIFF
--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.de-de.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.de-de.md
@@ -1,52 +1,69 @@
 ---
 title: Users - Manage AI users and roles
-excerpt: Learn the concept behind AI Training users
-updated: 2021-03-01
+excerpt: Learn the concept behind AI Solutions users
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.gg/ovhcloud) 
+- On the OVHcloud [Discord server](https://discord.gg/ovhcloud)

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-asia.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-asia.md
@@ -1,52 +1,69 @@
 ---
 title: Users - Manage AI users and roles
-excerpt: Learn the concept behind AI Training users
-updated: 2021-03-01
+excerpt: Learn the concept behind AI Solutions users
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.gg/ovhcloud) 
+- On the OVHcloud [Discord server](https://discord.gg/ovhcloud)

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-au.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-au.md
@@ -1,52 +1,69 @@
 ---
 title: Users - Manage AI users and roles
-excerpt: Learn the concept behind AI Training users
-updated: 2021-03-01
+excerpt: Learn the concept behind AI Solutions users
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.gg/ovhcloud) 
+- On the OVHcloud [Discord server](https://discord.gg/ovhcloud)

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-ca.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-ca.md
@@ -1,52 +1,69 @@
 ---
 title: Users - Manage AI users and roles
-excerpt: Learn the concept behind AI Training users
-updated: 2021-03-01
+excerpt: Learn the concept behind AI Solutions users
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.gg/ovhcloud) 
+- On the OVHcloud [Discord server](https://discord.gg/ovhcloud)

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-gb.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-gb.md
@@ -19,7 +19,7 @@ The objective of this guide is to demonstrate how to create, configure, and dele
 ## Requirements
 
 - A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Creating and Editing AI users
 
@@ -27,11 +27,11 @@ To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud P
 
 - The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in access existing already deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
 In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-To apply these roles, log in to the [OVHcloud Control Panel](/links/manager), and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then, click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
 ![image](images/03_users_menu.png){.thumbnail .img-center}
 
@@ -60,7 +60,7 @@ To edit an existing user, simply click the `...`{.action} button next to the use
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-gb.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-gb.md
@@ -1,6 +1,6 @@
 ---
 title: Users - Manage AI users and roles
-excerpt: Learn the concept behind AI Training users
+excerpt: Learn the concept behind AI Solutions users
 updated: 2024-12-13
 ---
 

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-gb.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-gb.md
@@ -1,42 +1,59 @@
 ---
 title: Users - Manage AI users and roles
 excerpt: Learn the concept behind AI Training users
-updated: 2021-03-01
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in access existing already deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager), and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then, click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
@@ -49,4 +66,4 @@ If you need training or technical assistance to implement our solutions, contact
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.gg/ovhcloud) 
+- On the OVHcloud [Discord server](https://discord.gg/ovhcloud)

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-ie.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-ie.md
@@ -1,52 +1,69 @@
 ---
 title: Users - Manage AI users and roles
-excerpt: Learn the concept behind AI Training users
-updated: 2021-03-01
+excerpt: Learn the concept behind AI Solutions users
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.gg/ovhcloud) 
+- On the OVHcloud [Discord server](https://discord.gg/ovhcloud)

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-sg.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-sg.md
@@ -1,52 +1,69 @@
 ---
 title: Users - Manage AI users and roles
-excerpt: Learn the concept behind AI Training users
-updated: 2021-03-01
+excerpt: Learn the concept behind AI Solutions users
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.gg/ovhcloud) 
+- On the OVHcloud [Discord server](https://discord.gg/ovhcloud)

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-us.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.en-us.md
@@ -1,52 +1,69 @@
 ---
 title: Users - Manage AI users and roles
-excerpt: Learn the concept behind AI Training users
-updated: 2021-03-01
+excerpt: Learn the concept behind AI Solutions users
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.gg/ovhcloud) 
+- On the OVHcloud [Discord server](https://discord.gg/ovhcloud)

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.es-es.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.es-es.md
@@ -1,52 +1,69 @@
 ---
 title: Users - Manage AI users and roles
-excerpt: Learn the concept behind AI Training users
-updated: 2021-03-01
+excerpt: Learn the concept behind AI Solutions users
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.gg/ovhcloud) 
+- On the OVHcloud [Discord server](https://discord.gg/ovhcloud)

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.es-us.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.es-us.md
@@ -1,52 +1,69 @@
 ---
 title: Users - Manage AI users and roles
-excerpt: Learn the concept behind AI Training users
-updated: 2021-03-01
+excerpt: Learn the concept behind AI Solutions users
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.gg/ovhcloud) 
+- On the OVHcloud [Discord server](https://discord.gg/ovhcloud)

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.fr-ca.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.fr-ca.md
@@ -1,49 +1,66 @@
 ---
 title: Utilisateurs - Gérer les utilisateurs AI et leurs rôles (EN)
-excerpt: Comprendre le concept des utilisateurs des AI Tools
-updated: 2021-03-01
+excerpt: Comprendre le concept des utilisateurs des AI Solutions
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr-ca/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.fr-fr.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.fr-fr.md
@@ -1,49 +1,66 @@
 ---
 title: Utilisateurs - Gérer les utilisateurs AI et leurs rôles (EN)
-excerpt: Comprendre le concept des utilisateurs des AI Tools
-updated: 2021-03-01
+excerpt: Comprendre le concept des utilisateurs des AI Solutions
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.it-it.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.it-it.md
@@ -1,52 +1,69 @@
 ---
 title: Users - Manage AI users and roles
-excerpt: Learn the concept behind AI Training users
-updated: 2021-03-01
+excerpt: Learn the concept behind AI Solutions users
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.gg/ovhcloud) 
+- On the OVHcloud [Discord server](https://discord.gg/ovhcloud)

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.pl-pl.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.pl-pl.md
@@ -1,52 +1,69 @@
 ---
 title: Users - Manage AI users and roles
-excerpt: Learn the concept behind AI Training users
-updated: 2021-03-01
+excerpt: Learn the concept behind AI Solutions users
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.gg/ovhcloud) 
+- On the OVHcloud [Discord server](https://discord.gg/ovhcloud)

--- a/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.pt-pt.md
+++ b/pages/public_cloud/ai_machine_learning/gi_01_manage_users/guide.pt-pt.md
@@ -1,52 +1,69 @@
 ---
 title: Users - Manage AI users and roles
-excerpt: Learn the concept behind AI Training users
-updated: 2021-03-01
+excerpt: Learn the concept behind AI Solutions users
+updated: 2024-12-13
 ---
+
+<style>
+.img-center {
+  text-align: center !important;
+}
+</style>
 
 ## Objective
 
-The **users** of the AI Training platform are simply your Public Cloud users that you can create in the OVHcloud Control Panel. To give access to **AI Training** to any of your users, you need to grant them the **AI Training Operator** role. Then you can use this user's credentials to authenticate.
+The **users** of the **OVHcloud AI Solutions** are simply the users of your [Public Cloud project](/links/public-cloud/public-cloud), which can be created and managed in the [OVHcloud Control Panel (UI)](/links/manager).
 
-**AI Training** includes the OVHcloud Object Storage as a persistent storage solution for your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data). To use these features the user needs to be granted the **Objectstore Operator** role since it implies read/write access to the Object Storage.
+The objective of this guide is to demonstrate how to create, configure, and delete AI users and their roles.
 
 ## Requirements
 
-- A **Public cloud** project
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
+- Access to the [OVHcloud Control Panel](/links/manager)
 
-## Instructions
+## Creating and Editing AI users
 
-### Creating AI Training users
+To grant access to **OVHcloud AI Solutions** to the users of your Public Cloud Project, you can assign them either the **AI Training Operator** or **AI Training Reader** role.
 
-To use **AI Training** with the `ovhai` CLI or to access jobs urls you need to create users with the correct roles.
+- The **AI Training Operator** role provides complete access to **AI Notebooks, AI Training, and AI Deploy** solutions. With this role, users can launch, stop, and delete AI Solutions, as well as authenticate to existing AI Notebooks, Jobs, and Apps, and the [ovhai CLI](/pages/public_cloud/ai_machine_learning/cli_10_howto_install_cli) using their credentials.
 
-Users management is available in the `Public Cloud` Control Panel under `Project Management` > `Users & Roles`
+- If you don't need to launch, stop, or delete **AI Solutions**, but are only interested in accessing already existing deployed ones, the **AI Training Reader** role is sufficient. This role allows users to access existing AI Solutions, but not to launch, stop, or delete them.
 
-![image](images/03_users_menu.png){.thumbnail}
+In addition to the AI Training role, we strongly recommend adding the **ObjectStore Operator** role to your AI users. This role provides read/write access to the **OVHcloud Object Storage**, which is a persistent storage solution to store your [data](/pages/public_cloud/ai_machine_learning/gi_02_concepts_data) that is incorporated into our AI Solutions. This way, you can access your data within the **AI Solutions**.
 
-Create a new user and specify the required roles. Two roles are used within **AI Training**:
+To apply these roles, log in to the [OVHcloud Control Panel](/links/manager) and navigate to the `Public Cloud`{.action} section, in the horizontal menu at the top of the website. Select the Public Cloud project you want to use. Then click on the `Project Management`{.action} category in the left-hand vertical menu to access the `Users & Roles`{.action} section.
 
-- AI Training Operator: Grants access to **AI Training**
-- Objectstore Operator: Grants read/write access to the OVHcloud Object Storage.
+![image](images/03_users_menu.png){.thumbnail .img-center}
 
-It is recommended to assign both roles.
+On this page, you can either **create a new user** for your Public Cloud project or **edit the roles of an existing user**.
 
-![image](images/04_users_roles.png){.thumbnail}
+**1\. Create a new user**
+
+Click on `+ Add user`{.action}, specify a name as the user's description, and **assign the required roles** to use the AI Solutions with the Object Storage (**AI Training Operator** or **AI Training Reader**, depending on the level of access you want to grant, and the **ObjectStore Operator**).
+
+![image](images/04_users_roles.png){.thumbnail .img-center}
+
+This will generate a password that will allow you to authenticate to your AI Notebooks, Jobs and Apps, as well as via the `ovhai` CLI.
+
+If you ever lose this password, you can regenerate it at any time by clicking the `...`{.action} button next to your user, and then on `Generate a password`{.action}.
+
+**2\. Edit an existing user roles**
+
+To edit an existing user, simply click the `...`{.action} button next to the user, and select `Edit roles` to modify its existing roles.
 
 > [!primary]
 >
-> - Access to **AI Training** can be revoked anytime by deleting the user or removing its **AI Training Operator** role.
+> - Access to **AI Solutions** can be revoked anytime by deleting the user or removing its **AI Training Operator / Reader** role.
 > - To be able to use the OVHcloud Object Storage, make sure that the user has the **Objectstore Operator** role.
 
 ## Going further
 
 - You can check the [OVHcloud documentation on how to submit a job](/pages/public_cloud/ai_machine_learning/training_guide_02_howto_submit_job).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 ## Feedback
 
 Please send us your questions, feedback and suggestions to improve the service:
 
-- On the OVHcloud [Discord server](https://discord.gg/ovhcloud) 
+- On the OVHcloud [Discord server](https://discord.gg/ovhcloud)


### PR DESCRIPTION
Back in the time, we used to only have the `AI Training` product. This is why this guide was only mentioning this product, and not all the existing AI Solutions (`AI Notebooks`, `AI Training` & `AI Deploy`). 

This update is there to fix that. However, note that the role is still named after AI Training.

Note that I've:

- tried to center the images using style.
- modified guide excerpt