### PR TITLE
KevS-SK-1892-KFT0023064-KFT0023202-Update-How-to-renew-OVHcloud-services-for-Account-and-service-managment-TRANSLATIONS

### DIFF
--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.de-de.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Wie verlängere ich meine OVHcloud Dienste?
 excerpt: Erfahren Sie hier, wie Sie Ihre Dienstleistungen und deren Verlängerung in Ihrem Kundencenter verwalten
-updated: 2024-12-23
+updated: 2025-01-28
 ---
 
 ## Ziel
@@ -124,6 +124,15 @@ Rechts neben einem Dienst klicken Sie auf den Button `...`{.action} in der Spalt
 >> Sie können diese Dienste jederzeit vor ihrem Ablaufdatum verlängern und die Dauer ihrer Verlängerung auswählen.
 >> In diesem Fall wird die abonnierte Laufzeit der Gültigkeitsdauer hinzugefügt. Sie verlieren die verbleibende Laufzeit nicht.
 >>
+>> > [!success]
+>> >
+>> > Wenn der Dienst, den Sie verlängern möchten, über zugehörige Optionen verfügt und Sie diese auch verlängern möchten, setzen Sie im Interface für die Online-Zahlung **kein Häkchen bei** der weißen Schaltfläche(n), gefolgt von der Erklärung `Nicht verlängern` für jede der angezeigten Optionen.
+>> > Wenn Sie dieses/diese weiße(n) Kästchen ankreuzen, beantragen Sie die Verlängerung Ihres Hauptdienstes **OHNE** die damit verbundenen Optionen.
+>> >
+>> > Nachdem Sie Ihre Auswahl getroffen haben, klicken Sie auf `Bestätigen`{.action}.
+>> >
+>> > Zur Information: Die Preise für einige Optionen werden erst angezeigt, wenn der Verlängerungsauftrag erstellt wurde.
+>>
 > **Meinen Dienst kündigen**
 >>
 >>![Kündigen](/pages/assets/screens/control_panel/product-selection/right-column/my-solutions-and-services/cancel-en.png){.thumbnail}
@@ -142,6 +151,15 @@ Rechts neben einem Dienst klicken Sie auf den Button `...`{.action} in der Spalt
 >>
 >> Sie werden auf ein Zahlungsformular weitergeleitet.
 >> Sie können diese Dienste jederzeit vor ihrem Ablaufdatum verlängern und die Dauer ihrer Verlängerung auswählen.
+>>
+>> > [!success]
+>> >
+>> > Wenn der Dienst, den Sie verlängern möchten, über zugehörige Optionen verfügt und Sie diese auch verlängern möchten, setzen Sie im Interface für die Online-Zahlung **kein Häkchen bei** der weißen Schaltfläche(n), gefolgt von der Erklärung `Nicht verlängern` für jede der angezeigten Optionen.
+>> > Wenn Sie dieses/diese weiße(n) Kästchen ankreuzen, beantragen Sie die Verlängerung Ihres Hauptdienstes **OHNE** die damit verbundenen Optionen.
+>> >
+>> > Nachdem Sie Ihre Auswahl getroffen haben, klicken Sie auf `Bestätigen`{.action}.
+>> >
+>> > Zur Information: Die Preise für einige Optionen werden erst angezeigt, wenn der Verlängerungsauftrag erstellt wurde.
 >>
 > **Meine Rechnung bezahlen**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.de-de.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.de-de.md
@@ -121,17 +121,17 @@ Rechts neben einem Dienst klicken Sie auf den Button `...`{.action} in der Spalt
 >>
 >> Sie werden auf ein Online-Zahlungsinterface weitergeleitet.
 >>
->> Sie können diese Dienste jederzeit vor ihrem Ablaufdatum verlängern und die Dauer ihrer Verlängerung auswählen.
+>> Sie können diese Dienste jederzeit vor ihrem Ablaufdatum verlängern und die Dauer ihrer Verlängerung auswählen.  
 >> In diesem Fall wird die abonnierte Laufzeit der Gültigkeitsdauer hinzugefügt. Sie verlieren die verbleibende Laufzeit nicht.
 >>
 >> > [!success]
 >> >
->> > Wenn der Dienst, den Sie verlängern möchten, über zugehörige Optionen verfügt und Sie diese auch verlängern möchten, setzen Sie im Interface für die Online-Zahlung **kein Häkchen bei** der weißen Schaltfläche(n), gefolgt von der Erklärung `Nicht verlängern` für jede der angezeigten Optionen.
->> > Wenn Sie dieses/diese weiße(n) Kästchen ankreuzen, beantragen Sie die Verlängerung Ihres Hauptdienstes **OHNE** die damit verbundenen Optionen.
+>> > Wenn der Dienst, den Sie verlängern möchten, über optionale Zusatzdienste verfügt und Sie diese auch verlängern möchten, aktivieren Sie im Interface für die Online-Zahlung **nicht die Option** der Schaltflächen bei `Nicht verlängern` für die angezeigten Dienste.  
+>> > Wenn Sie diese Optionen anhaken, beantragen Sie die Verlängerung Ihres Hauptdienstes **OHNE** die damit verbundenen Service-Dienste.
 >> >
 >> > Nachdem Sie Ihre Auswahl getroffen haben, klicken Sie auf `Bestätigen`{.action}.
 >> >
->> > Zur Information: Die Preise für einige Optionen werden erst angezeigt, wenn der Verlängerungsauftrag erstellt wurde.
+>> > Zur Information: Die Preise für einige Dienste werden erst angezeigt, wenn der Verlängerungsauftrag erstellt wurde.
 >>
 > **Meinen Dienst kündigen**
 >>
@@ -149,17 +149,17 @@ Rechts neben einem Dienst klicken Sie auf den Button `...`{.action} in der Spalt
 >>
 >> Diese Aktion ist nur für Dienstleistungen mit **manueller Verlängerung** verfügbar.
 >>
->> Sie werden auf ein Zahlungsformular weitergeleitet.
+>> Sie werden auf ein Zahlungsformular weitergeleitet.  
 >> Sie können diese Dienste jederzeit vor ihrem Ablaufdatum verlängern und die Dauer ihrer Verlängerung auswählen.
 >>
 >> > [!success]
 >> >
->> > Wenn der Dienst, den Sie verlängern möchten, über zugehörige Optionen verfügt und Sie diese auch verlängern möchten, setzen Sie im Interface für die Online-Zahlung **kein Häkchen bei** der weißen Schaltfläche(n), gefolgt von der Erklärung `Nicht verlängern` für jede der angezeigten Optionen.
->> > Wenn Sie dieses/diese weiße(n) Kästchen ankreuzen, beantragen Sie die Verlängerung Ihres Hauptdienstes **OHNE** die damit verbundenen Optionen.
+>> > Wenn der Dienst, den Sie verlängern möchten, über optionale Zusatzdienste verfügt und Sie diese auch verlängern möchten, aktivieren Sie im Interface für die Online-Zahlung **nicht die Option** der Schaltflächen bei `Nicht verlängern` für die angezeigten Dienste.  
+>> > Wenn Sie diese Optionen anhaken, beantragen Sie die Verlängerung Ihres Hauptdienstes **OHNE** die damit verbundenen Service-Dienste.
 >> >
 >> > Nachdem Sie Ihre Auswahl getroffen haben, klicken Sie auf `Bestätigen`{.action}.
 >> >
->> > Zur Information: Die Preise für einige Optionen werden erst angezeigt, wenn der Verlängerungsauftrag erstellt wurde.
+>> > Zur Information: Die Preise für einige Dienste werden erst angezeigt, wenn der Verlängerungsauftrag erstellt wurde.
 >>
 > **Meine Rechnung bezahlen**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-asia.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Managing renewal for OVHcloud services
 excerpt: Find out how to manage automatic renewal for your services via the OVHcloud Control Panel
-updated: 2024-12-23
+updated: 2025-01-28
 ---
 
 ## Objective
@@ -124,6 +124,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
 >> In this case, the duration of validity subscribed to will be added to the current validity period. You will not lose any remaining validity time.
 >>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
+>>
 > **Cancel my subscription**
 >>
 >>![cancel](/pages/assets/screens/control_panel/product-selection/right-column/my-solutions-and-services/cancel-en.png){.thumbnail}
@@ -132,7 +141,7 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> When choosing this action, automatic payment and renewal will be disabled for the service you have selected.
 >>
->> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
+>> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
 >>
 > **Renew service**
 >>
@@ -142,6 +151,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> You will then be redirected to an online payment interface.
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
+>>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
 >>
 > **Pay my bill**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-au.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Managing renewal for OVHcloud services
 excerpt: Find out how to manage automatic renewal for your services via the OVHcloud Control Panel
-updated: 2024-12-23
+updated: 2025-01-28
 ---
 
 ## Objective
@@ -124,6 +124,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
 >> In this case, the duration of validity subscribed to will be added to the current validity period. You will not lose any remaining validity time.
 >>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
+>>
 > **Cancel my subscription**
 >>
 >>![cancel](/pages/assets/screens/control_panel/product-selection/right-column/my-solutions-and-services/cancel-en.png){.thumbnail}
@@ -132,7 +141,7 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> When choosing this action, automatic payment and renewal will be disabled for the service you have selected.
 >>
->> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
+>> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
 >>
 > **Renew service**
 >>
@@ -142,6 +151,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> You will then be redirected to an online payment interface.
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
+>>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
 >>
 > **Pay my bill**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-ca.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Managing renewal for OVHcloud services
 excerpt: Find out how to manage automatic renewal for your services via the OVHcloud Control Panel
-updated: 2024-12-23
+updated: 2025-01-28
 ---
 
 ## Objective
@@ -124,6 +124,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
 >> In this case, the duration of validity subscribed to will be added to the current validity period. You will not lose any remaining validity time.
 >>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
+>>
 > **Cancel my subscription**
 >>
 >>![cancel](/pages/assets/screens/control_panel/product-selection/right-column/my-solutions-and-services/cancel-en.png){.thumbnail}
@@ -132,7 +141,7 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> When choosing this action, automatic payment and renewal will be disabled for the service you have selected.
 >>
->> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
+>> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
 >>
 > **Renew service**
 >>
@@ -142,6 +151,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> You will then be redirected to an online payment interface.
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
+>>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
 >>
 > **Pay my bill**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-gb.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: How to renew OVHcloud services
 excerpt: Find out how to manage your services and their renewal via the OVHcloud Control Panel
-updated: 2024-12-23
+updated: 2025-01-28
 ---
 
 ## Objective
@@ -124,6 +124,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
 >> In this case, the duration of validity subscribed to will be added to the current validity period. You will not lose any remaining validity time.
 >>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
+>>
 > **Cancel my subscription**
 >>
 >>![cancel](/pages/assets/screens/control_panel/product-selection/right-column/my-solutions-and-services/cancel-en.png){.thumbnail}
@@ -132,7 +141,7 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> When choosing this action, automatic payment and renewal will be disabled for the service you have selected.
 >>
->> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
+>> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
 >>
 > **Renew service**
 >>
@@ -142,6 +151,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> You will then be redirected to an online payment interface.
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
+>>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
 >>
 > **Pay my bill**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-ie.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Managing renewal for OVHcloud services
 excerpt: Find out how to manage automatic renewal for your services via the OVHcloud Control Panel
-updated: 2024-12-23
+updated: 2025-01-28
 ---
 
 ## Objective
@@ -124,6 +124,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
 >> In this case, the duration of validity subscribed to will be added to the current validity period. You will not lose any remaining validity time.
 >>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
+>>
 > **Cancel my subscription**
 >>
 >>![cancel](/pages/assets/screens/control_panel/product-selection/right-column/my-solutions-and-services/cancel-en.png){.thumbnail}
@@ -132,7 +141,7 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> When choosing this action, automatic payment and renewal will be disabled for the service you have selected.
 >>
->> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
+>> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
 >>
 > **Renew service**
 >>
@@ -142,6 +151,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> You will then be redirected to an online payment interface.
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
+>>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
 >>
 > **Pay my bill**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-sg.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Managing renewal for OVHcloud services
 excerpt: Find out how to manage automatic renewal for your services via the OVHcloud Control Panel
-updated: 2024-12-23
+updated: 2025-01-28
 ---
 
 ## Objective
@@ -124,6 +124,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
 >> In this case, the duration of validity subscribed to will be added to the current validity period. You will not lose any remaining validity time.
 >>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
+>>
 > **Cancel my subscription**
 >>
 >>![cancel](/pages/assets/screens/control_panel/product-selection/right-column/my-solutions-and-services/cancel-en.png){.thumbnail}
@@ -132,7 +141,7 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> When choosing this action, automatic payment and renewal will be disabled for the service you have selected.
 >>
->> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
+>> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
 >>
 > **Renew service**
 >>
@@ -142,6 +151,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> You will then be redirected to an online payment interface.
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
+>>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
 >>
 > **Pay my bill**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-us.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Managing renewal for OVHcloud services
 excerpt: Find out how to manage automatic renewal for your services via the OVHcloud Control Panel
-updated: 2024-12-23
+updated: 2025-01-28
 ---
 
 ## Objective
@@ -124,6 +124,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
 >> In this case, the duration of validity subscribed to will be added to the current validity period. You will not lose any remaining validity time.
 >>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
+>>
 > **Cancel my subscription**
 >>
 >>![cancel](/pages/assets/screens/control_panel/product-selection/right-column/my-solutions-and-services/cancel-en.png){.thumbnail}
@@ -132,7 +141,7 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> When choosing this action, automatic payment and renewal will be disabled for the service you have selected.
 >>
->> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
+>> For more information on cancelling OVHcloud services, follow the instructions in our guide **[How to cancel your OVHcloud services](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**.
 >>
 > **Renew service**
 >>
@@ -142,6 +151,15 @@ To the right of a service, click the `...`{.action}' button in the `Actions` col
 >>
 >> You will then be redirected to an online payment interface.
 >> You can renew these services at any time before their expiry, as well as choose the renewal duration.
+>>
+>> > [!success]
+>> >
+>> > Once you are in the online payment interface, if the service you want to renew has associated options and you also want to renew them, **don't tick** the white button(s) followed by the words `Do not renew` associated with each of the options displayed.
+>> > If you tick this/these white button(s), you will request renewal for your main service **WITHOUT** any associated options.
+>> >
+>> > Once you have made your choices, proceed with your order by clicking `Confirm`{.action}.
+>> >
+>> > Please note that some options are only priced when the renewal purchase order is generated.
 >>
 > **Pay my bill**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.es-es.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Cómo renovar mis servicios OVHcloud
 excerpt: Descubra cómo gestionar sus servicios y su renovación desde el área de cliente
-updated: 2024-12-23
+updated: 2025-01-28
 ---
 
 ## Objetivo
@@ -49,7 +49,7 @@ Antes de continuar leyendo esta guía, debe cumplir los siguientes requisitos:
 >> Para los servicios con una frecuencia de renovación automática superior a 1 mes (3 meses, 6 meses, 12 meses), el mes anterior a la fecha de renovación automática le enviaremos un recordatorio por correo electrónico, en el que se indicarán los servicios que van a renovarse próximamente.
 >>Si no desea prolongar alguno de estos servicios, solo tiene que [darlo de baja en su área de cliente](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services).
 >>
->> **Atención**: la ausencia de una forma de pago en su cuenta no activa la baja automática de sus servicios. Para dar de baja servicios, consulte nuestra guía "[Cómo dar de baja los servicios de OVHcloud ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)".
+>> **Atención**: la ausencia de una forma de pago en su cuenta no activa la baja automática de sus servicios. Para dar de baja servicios, consulte nuestra guía "[Cómo dar de baja los servicios de OVHcloud](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)".
 >>
 > **Renovación manual**
 >>
@@ -124,6 +124,15 @@ A la derecha de un servicio, haga clic en el botón `...`{.action} en la columna
 >> Puede renovar estos servicios en cualquier momento antes de su expiración, así como elegir la duración de su renovación.
 >> En este caso, el período de validez contratado se sumará al tiempo de validez en curso. No perderá el tiempo de validez restante.
 >>
+>> > [!success]
+>> >
+>> > Una vez en la interfaz de pago online, si el servicio que desea renovar dispone de opciones asociadas y desea renovarlas, **no marque** el botón o los botones blancos seguidos de la indicación `No renovarlo` asociada a cada una de las opciones mostradas.
+>> > Si marca este botón(s) blanco(s), deberá renovar su servicio principal **SIN** con las opciones asociadas.
+>> >
+>> > Una vez que haya elegido el tipo de pedido, haga clic en `Aceptar`{.action}.
+>> >
+>> > Para su información, el precio de algunas opciones no aparece hasta que se genera la orden de pedido de renovación.
+>>
 > **Dar de baja mi servicio**
 >>
 >> ![dar de baja](/pages/assets/screens/control_panel/product-selection/right-column/my-solutions-and-services/cancel-en.png){.thumbnail}
@@ -132,7 +141,7 @@ A la derecha de un servicio, haga clic en el botón `...`{.action} en la columna
 >>
 >> Al elegir esta acción, se desactivan la renovación y el cargo automáticos para el servicio seleccionado.
 >>
->> Para más información sobre la baja de los servicios de OVHcloud, siga las instrucciones de la guía "**[Cómo dar de baja los servicios de OVHcloud ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**".
+>> Para más información sobre la baja de los servicios de OVHcloud, siga las instrucciones de la guía "**[Cómo dar de baja los servicios de OVHcloud](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**".
 >>
 > **Renovar el servicio**
 >>
@@ -142,6 +151,15 @@ A la derecha de un servicio, haga clic en el botón `...`{.action} en la columna
 >>
 >> Será redirigido a una interfaz de pago online.
 >> Puede renovar estos servicios en cualquier momento antes de su expiración, así como elegir la duración de su renovación.
+>>
+>> > [!success]
+>> >
+>> > Una vez en la interfaz de pago online, si el servicio que desea renovar dispone de opciones asociadas y desea renovarlas, **no marque** el botón o los botones blancos seguidos de la indicación `No renovarlo` asociada a cada una de las opciones mostradas.
+>> > Si marca este botón(s) blanco(s), deberá renovar su servicio principal **SIN** con las opciones asociadas.
+>> >
+>> > Una vez que haya elegido el tipo de pedido, haga clic en `Aceptar`{.action}.
+>> >
+>> > Para su información, el precio de algunas opciones no aparece hasta que se genera la orden de pedido de renovación.
 >>
 > **Abonar mi factura**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.es-es.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.es-es.md
@@ -127,7 +127,7 @@ A la derecha de un servicio, haga clic en el botón `...`{.action} en la columna
 >> > [!success]
 >> >
 >> > Una vez en la interfaz de pago online, si el servicio que desea renovar dispone de opciones asociadas y desea renovarlas, **no marque** el botón o los botones blancos seguidos de la indicación `No renovarlo` asociada a cada una de las opciones mostradas.
->> > Si marca este botón(s) blanco(s), deberá renovar su servicio principal **SIN** con las opciones asociadas.
+>> > Si marca estos botones blancos, solicitará la renovación del servicio principal **SIN** las opciones asociadas.
 >> >
 >> > Una vez que haya elegido el tipo de pedido, haga clic en `Aceptar`{.action}.
 >> >

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.es-es.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.es-es.md
@@ -155,7 +155,7 @@ A la derecha de un servicio, haga clic en el botón `...`{.action} en la columna
 >> > [!success]
 >> >
 >> > Una vez en la interfaz de pago online, si el servicio que desea renovar dispone de opciones asociadas y desea renovarlas, **no marque** el botón o los botones blancos seguidos de la indicación `No renovarlo` asociada a cada una de las opciones mostradas.
->> > Si marca este botón(s) blanco(s), deberá renovar su servicio principal **SIN** con las opciones asociadas.
+>> > Si marca estos botones blancos, solicitará la renovación del servicio principal **SIN** las opciones asociadas.
 >> >
 >> > Una vez que haya elegido el tipo de pedido, haga clic en `Aceptar`{.action}.
 >> >

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.es-us.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Gestionar la renovación de los servicios
 excerpt: Descubra cómo gestionar la renovación de los servicios de OVHcloud desde el área de cliente
-updated: 2024-12-23
+updated: 2025-01-28
 ---
 
 ## Objetivo
@@ -49,7 +49,7 @@ Antes de continuar leyendo esta guía, debe cumplir los siguientes requisitos:
 >> Para los servicios con una frecuencia de renovación automática superior a 1 mes (3 meses, 6 meses, 12 meses), el mes anterior a la fecha de renovación automática le enviaremos un recordatorio por correo electrónico, en el que se indicarán los servicios que van a renovarse próximamente.
 >>Si no desea prolongar alguno de estos servicios, solo tiene que [darlo de baja en su área de cliente](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services).
 >>
->> **Atención**: la ausencia de una forma de pago en su cuenta no activa la baja automática de sus servicios. Para dar de baja servicios, consulte nuestra guía "[Cómo dar de baja los servicios de OVHcloud ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)".
+>> **Atención**: la ausencia de una forma de pago en su cuenta no activa la baja automática de sus servicios. Para dar de baja servicios, consulte nuestra guía "[Cómo dar de baja los servicios de OVHcloud](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)".
 >>
 > **Renovación manual**
 >>
@@ -124,6 +124,15 @@ A la derecha de un servicio, haga clic en el botón `...`{.action} en la columna
 >> Puede renovar estos servicios en cualquier momento antes de su expiración, así como elegir la duración de su renovación.
 >> En este caso, el período de validez contratado se sumará al tiempo de validez en curso. No perderá el tiempo de validez restante.
 >>
+>> > [!success]
+>> >
+>> > Una vez en la interfaz de pago online, si el servicio que desea renovar dispone de opciones asociadas y desea renovarlas, **no marque** el botón o los botones blancos seguidos de la indicación `No renovarlo` asociada a cada una de las opciones mostradas.
+>> > Si marca este botón(s) blanco(s), deberá renovar su servicio principal **SIN** con las opciones asociadas.
+>> >
+>> > Una vez que haya elegido el tipo de pedido, haga clic en `Aceptar`{.action}.
+>> >
+>> > Para su información, el precio de algunas opciones no aparece hasta que se genera la orden de pedido de renovación.
+>>
 > **Dar de baja mi servicio**
 >>
 >> ![dar de baja](/pages/assets/screens/control_panel/product-selection/right-column/my-solutions-and-services/cancel-en.png){.thumbnail}
@@ -132,7 +141,7 @@ A la derecha de un servicio, haga clic en el botón `...`{.action} en la columna
 >>
 >> Al elegir esta acción, se desactivan la renovación y el cargo automáticos para el servicio seleccionado.
 >>
->> Para más información sobre la baja de los servicios de OVHcloud, siga las instrucciones de la guía "**[Cómo dar de baja los servicios de OVHcloud ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**".
+>> Para más información sobre la baja de los servicios de OVHcloud, siga las instrucciones de la guía "**[Cómo dar de baja los servicios de OVHcloud](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**".
 >>
 > **Renovar el servicio**
 >>
@@ -142,6 +151,15 @@ A la derecha de un servicio, haga clic en el botón `...`{.action} en la columna
 >>
 >> Será redirigido a una interfaz de pago online.
 >> Puede renovar estos servicios en cualquier momento antes de su expiración, así como elegir la duración de su renovación.
+>>
+>> > [!success]
+>> >
+>> > Una vez en la interfaz de pago online, si el servicio que desea renovar dispone de opciones asociadas y desea renovarlas, **no marque** el botón o los botones blancos seguidos de la indicación `No renovarlo` asociada a cada una de las opciones mostradas.
+>> > Si marca este botón(s) blanco(s), deberá renovar su servicio principal **SIN** con las opciones asociadas.
+>> >
+>> > Una vez que haya elegido el tipo de pedido, haga clic en `Aceptar`{.action}.
+>> >
+>> > Para su información, el precio de algunas opciones no aparece hasta que se genera la orden de pedido de renovación.
 >>
 > **Abonar mi factura**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.es-us.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.es-us.md
@@ -127,7 +127,7 @@ A la derecha de un servicio, haga clic en el botón `...`{.action} en la columna
 >> > [!success]
 >> >
 >> > Una vez en la interfaz de pago online, si el servicio que desea renovar dispone de opciones asociadas y desea renovarlas, **no marque** el botón o los botones blancos seguidos de la indicación `No renovarlo` asociada a cada una de las opciones mostradas.
->> > Si marca este botón(s) blanco(s), deberá renovar su servicio principal **SIN** con las opciones asociadas.
+>> > Si marca estos botones blancos, solicitará la renovación del servicio principal **SIN** las opciones asociadas.
 >> >
 >> > Una vez que haya elegido el tipo de pedido, haga clic en `Aceptar`{.action}.
 >> >
@@ -155,7 +155,7 @@ A la derecha de un servicio, haga clic en el botón `...`{.action} en la columna
 >> > [!success]
 >> >
 >> > Una vez en la interfaz de pago online, si el servicio que desea renovar dispone de opciones asociadas y desea renovarlas, **no marque** el botón o los botones blancos seguidos de la indicación `No renovarlo` asociada a cada una de las opciones mostradas.
->> > Si marca este botón(s) blanco(s), deberá renovar su servicio principal **SIN** con las opciones asociadas.
+>> > Si marca estos botones blancos, solicitará la renovación del servicio principal **SIN** las opciones asociadas.
 >> >
 >> > Una vez que haya elegido el tipo de pedido, haga clic en `Aceptar`{.action}.
 >> >

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.fr-ca.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.fr-ca.md
@@ -51,7 +51,7 @@ Avant de poursuivre la lecture de ce guide, vous devez remplir les conditions su
 >> Pour les services ayant une fréquence de renouvellement automatique supérieure à 1 mois (3 mois, 6 mois, 12 mois), un rappel vous est également envoyé par e-mail le mois précédent la date de renouvellement automatique, récapitulant les services allant être renouvelés prochainement.
 >>Si vous ne souhaitez pas prolonger l'un de ces services, il vous suffit alors [de le résilier dans votre espace client](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services).
 >>
->> **Attention**, l'absence d'un moyen de paiement dans votre compte ne déclenche pas une résiliation automatique de vos services. Pour résilier des services, consultez notre guide « [Comment résilier vos services OVHcloud ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services) ».
+>> **Attention**, l'absence d'un moyen de paiement dans votre compte ne déclenche pas une résiliation automatique de vos services. Pour résilier des services, consultez notre guide « [Comment résilier vos services OVHcloud](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services) ».
 >>
 > **Le renouvellement manuel**
 >>
@@ -144,7 +144,7 @@ La page **Gestion de mes offres et services** contient un tableau de gestion de 
 >>
 >> En choisissant cette action, le renouvellement et le prélèvement automatiques sont désactivés pour le service que vous avez sélectionné.
 >>
->> Pour plus d'informations sur la résiliation des services OVHcloud, suivez les instructions du guide « **[Comment résilier vos services OVHcloud ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)** ».
+>> Pour plus d'informations sur la résiliation des services OVHcloud, suivez les instructions du guide « **[Comment résilier vos services OVHcloud](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)** ».
 >>
 > **Renouveler le service**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.fr-fr.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.fr-fr.md
@@ -51,7 +51,7 @@ Avant de poursuivre la lecture de ce guide, vous devez remplir les conditions su
 >> Pour les services ayant une fréquence de renouvellement automatique supérieure à 1 mois (3 mois, 6 mois, 12 mois), un rappel vous est également envoyé par e-mail le mois précédent la date de renouvellement automatique, récapitulant les services allant être renouvelés prochainement.
 >>Si vous ne souhaitez pas prolonger l'un de ces services, il vous suffit alors [de le résilier dans votre espace client](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services).
 >>
->> **Attention**, l'absence d'un moyen de paiement dans votre compte ne déclenche pas une résiliation automatique de vos services. Pour résilier des services, consultez notre guide « [Comment résilier vos services OVHcloud ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services) ».
+>> **Attention**, l'absence d'un moyen de paiement dans votre compte ne déclenche pas une résiliation automatique de vos services. Pour résilier des services, consultez notre guide « [Comment résilier vos services OVHcloud](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services) ».
 >>
 > **Le renouvellement manuel**
 >>
@@ -144,7 +144,7 @@ La page **Gestion de mes offres et services** contient un tableau de gestion de 
 >>
 >> En choisissant cette action, le renouvellement et le prélèvement automatiques sont désactivés pour le service que vous avez sélectionné.
 >>
->> Pour plus d'informations sur la résiliation des services OVHcloud, suivez les instructions du guide « **[Comment résilier vos services OVHcloud ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)** ».
+>> Pour plus d'informations sur la résiliation des services OVHcloud, suivez les instructions du guide « **[Comment résilier vos services OVHcloud](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)** ».
 >>
 > **Renouveler le service**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.it-it.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Come rinnovare i servizi OVHcloud
 excerpt: Scopri come gestire i tuoi servizi e i loro rinnovi nella tua area clienti OVHcloud.
-updated: 2024-12-23
+updated: 2025-01-28
 ---
 
 ## Obiettivo
@@ -124,6 +124,15 @@ A destra di un servizio, clicca sul pulsante `...`{.action} nella colonna `Azion
 >> È possibile rinnovare i servizi in qualsiasi momento prima della loro scadenza e scegliere la durata del rinnovo.
 >> In questo caso, il periodo di validità sottoscritto sarà aggiunto a quello in corso. Il periodo di validità rimanente non andrà perso.
 >>
+>> > [!success]
+>> >
+>> > Dall’interfaccia di pagamento online, se il servizio che vuoi rinnovare dispone di opzioni associate e vuoi anche rinnovarle, **non spuntare** il(i) pulsante(i) bianco(i) seguito(i) dalla dicitura `Non rinnovarlo` associato(i) a ciascuna delle opzioni visualizzate.
+>> > Se selezioni questo o questi pulsanti bianchi, richiedi il rinnovo del tuo servizio principale **SENZA** le eventuali opzioni associate.
+>> >
+>> > Una volta effettuate le scelte, prosegui cliccando su `Conferma`{.action}.
+>> >
+>> > Per informazione, il prezzo di alcune opzioni viene visualizzato solo quando viene generato il buono d'ordine di rinnovo.
+>>
 > **Disattivare il servizio**
 >>
 >> ![disattiva](/pages/assets/screens/control_panel/product-selection/right-column/my-solutions-and-services/cancel-en.png){.thumbnail}
@@ -132,7 +141,7 @@ A destra di un servizio, clicca sul pulsante `...`{.action} nella colonna `Azion
 >>
 >> Selezionando questa azione, il rinnovo e l'addebito preautorizzato vengono disattivati per il servizio selezionato.
 >>
->> Per maggiori informazioni sulla disattivazione dei servizi OVHcloud, segui le istruzioni contenute nella guida **"[Come disattivare i servizi OVHcloud ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)"**.
+>> Per maggiori informazioni sulla disattivazione dei servizi OVHcloud, segui le istruzioni contenute nella guida **"[Come disattivare i servizi OVHcloud](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)"**.
 >>
 > **Rinnova il servizio**
 >>
@@ -142,6 +151,15 @@ A destra di un servizio, clicca sul pulsante `...`{.action} nella colonna `Azion
 >>
 >> Sarai reindirizzato verso un’interfaccia di pagamento online.
 >> È possibile rinnovare i servizi in qualsiasi momento prima della loro scadenza e scegliere la durata del rinnovo.
+>>
+>> > [!success]
+>> >
+>> > Dall’interfaccia di pagamento online, se il servizio che vuoi rinnovare dispone di opzioni associate e vuoi anche rinnovarle, **non spuntare** il(i) pulsante(i) bianco(i) seguito(i) dalla dicitura `Non rinnovarlo` associato(i) a ciascuna delle opzioni visualizzate.
+>> > Se selezioni questo o questi pulsanti bianchi, richiedi il rinnovo del tuo servizio principale **SENZA** le eventuali opzioni associate.
+>> >
+>> > Una volta effettuate le scelte, prosegui cliccando su `Conferma`{.action}.
+>> >
+>> > Per informazione, il prezzo di alcune opzioni viene visualizzato solo quando viene generato il buono d'ordine di rinnovo.
 >>
 > **Paga la tua fattura**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.pl-pl.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Jak odnawiać usługi OVHcloud
 excerpt: Dowiedz się, jak zarządzać usługami i odnawianiem usług w Panelu klienta
-updated: 2024-12-23
+updated: 2025-01-28
 ---
 
 ## Wprowadzenie
@@ -124,6 +124,15 @@ Po prawej stronie usługi kliknij przycisk `...`{.action} w kolumnie `Filtruj`, 
 >> Możesz odnowić te usługi w dowolnym momencie przed ich wygaśnięciem, a także wybrać czas ich odnowienia.
 >> W tym przypadku zamówiony czas ważności zostanie dodany do bieżącego czasu ważności. Nie tracisz pozostałego czasu ważności usługi.
 >>
+>> > [!success]
+>> >
+>> > Po uruchomieniu internetowego interfejsu płatności, jeśli usługa, którą chcesz odnowić ma powiązane opcje i chcesz ją odnowić, **nie zaznaczaj białego(-ych) przycisku(-ów)**, po którym następuje(-ych) wzmianka `Nie odnawiaj`(ów) przypisanego do każdej z wyświetlonych opcji.
+>> > Jeśli zaznaczysz ten(e) biały(e) przycisk(y), poprosisz o odnowienie głównej usługi **BEZ** jej ewentualnych opcji.
+>> >
+>> > Po dokonaniu wyboru, kontynuuj realizację zamówienia, klikając `Zatwierdź`{.action}.
+>> >
+>> > W celach informacyjnych ceny niektórych opcji są wyświetlane dopiero po wygenerowaniu zamówienia na odnowienie usługi.
+>>
 > **Rezygnuję z usługi**
 >>
 >> ![Zrezygnuj](/pages/assets/screens/control_panel/product-selection/right-column/my-solutions-and-services/cancel-en.png){.thumbnail}
@@ -132,7 +141,7 @@ Po prawej stronie usługi kliknij przycisk `...`{.action} w kolumnie `Filtruj`, 
 >>
 >> Po wybraniu tej operacji automatyczne odnawianie i pobieranie środków zostanie wyłączone dla wybranej usługi.
 >>
->> Aby uzyskać więcej informacji na temat rezygnacji z usług OVHcloud, postępuj zgodnie z instrukcjami zawartymi w przewodniku "**[Jak zrezygnować z usług OVHcloud ](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**".
+>> Aby uzyskać więcej informacji na temat rezygnacji z usług OVHcloud, postępuj zgodnie z instrukcjami zawartymi w przewodniku "**[Jak zrezygnować z usług OVHcloud](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_cancel_services)**".
 >>
 > **Odnów usługę**
 >>
@@ -142,6 +151,15 @@ Po prawej stronie usługi kliknij przycisk `...`{.action} w kolumnie `Filtruj`, 
 >>
 >> Zostaniesz wówczas przekierowany do interfejsu płatności online.
 >> Możesz odnowić te usługi w dowolnym momencie przed ich wygaśnięciem, a także wybrać czas ich odnowienia.
+>>
+>> > [!success]
+>> >
+>> > Po uruchomieniu internetowego interfejsu płatności, jeśli usługa, którą chcesz odnowić ma powiązane opcje i chcesz ją odnowić, **nie zaznaczaj białego(-ych) przycisku(-ów)**, po którym następuje(-ych) wzmianka `Nie odnawiaj`(ów) przypisanego do każdej z wyświetlonych opcji.
+>> > Jeśli zaznaczysz ten(e) biały(e) przycisk(y), poprosisz o odnowienie głównej usługi **BEZ** jej ewentualnych opcji.
+>> >
+>> > Po dokonaniu wyboru, kontynuuj realizację zamówienia, klikając `Zatwierdź`{.action}.
+>> >
+>> > W celach informacyjnych ceny niektórych opcji są wyświetlane dopiero po wygenerowaniu zamówienia na odnowienie usługi.
 >>
 > **Ureguluj należności**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.pt-pt.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Como renovar os meus serviços OVHcloud
 excerpt: Saiba como gerir os seus serviços e a sua renovação na sua Área de Cliente
-updated: 2024-12-23
+updated: 2025-01-28
 ---
 
 ## Objetivo
@@ -126,6 +126,15 @@ A página **Gestão das minhas ofertas e serviços** contém uma tabela de gest�
 >> Pode renovar estes serviços a qualquer momento antes de eles expirarem, bem como escolher o período de renovação dos mesmos.
 >> Neste caso, o período de validade subscrito será adicionado ao período de validade a decorrer. Não perderá o tempo de validade restante.
 >>
+>> > [!success]
+>> >
+>> > Uma vez na interface de pagamento online, se o serviço que deseja renovar dispõe de opções associadas e se também as deseja renovar, **não marque** o(s) botão(s) branco(s) seguido(s) da menção `Não renovar` associado(s) a cada uma das opções apresentadas.
+>> > Se selecionar este(s) botão(ões) branco(s), deverá solicitar a renovação do seu serviço principal **SEM** as suas eventuais opções relacionadas.
+>> >
+>> > Depois de fazer as suas escolhas, prossiga a encomenda clicando em `Validar`{.action}.
+>> >
+>> > Para informação, o preço de certas opções só é apresentado quando é gerada a nota de encomenda de renovação.
+>>
 > **Rescindir o meu serviço**
 >>
 >> ![Cancelar](/pages/assets/screens/control_panel/product-selection/right-column/my-solutions-and-services/cancel-en.png){.thumbnail}
@@ -144,6 +153,15 @@ A página **Gestão das minhas ofertas e serviços** contém uma tabela de gest�
 >>
 >> Será reencaminhado para uma interface de pagamento online.
 >> Pode renovar estes serviços a qualquer momento antes de eles expirarem, bem como escolher o período de renovação dos mesmos.
+>>
+>> > [!success]
+>> >
+>> > Uma vez na interface de pagamento online, se o serviço que deseja renovar dispõe de opções associadas e se também as deseja renovar, **não marque** o(s) botão(s) branco(s) seguido(s) da menção `Não renovar` associado(s) a cada uma das opções apresentadas.
+>> > Se selecionar este(s) botão(ões) branco(s), deverá solicitar a renovação do seu serviço principal **SEM** as suas eventuais opções relacionadas.
+>> >
+>> > Depois de fazer as suas escolhas, prossiga a encomenda clicando em `Validar`{.action}.
+>> >
+>> > Para informação, o preço de certas opções só é apresentado quando é gerada a nota de encomenda de renovação.
 >>
 > **Pagar a minha fatura**
 >>

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.pt-pt.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.pt-pt.md
@@ -157,7 +157,7 @@ A página **Gestão das minhas ofertas e serviços** contém uma tabela de gest�
 >> > [!success]
 >> >
 >> > Uma vez na interface de pagamento online, se o serviço que deseja renovar dispõe de opções associadas e se também as deseja renovar, **não marque** o(s) botão(s) branco(s) seguido(s) da menção `Não renovar` associado(s) a cada uma das opções apresentadas.
->> > Se selecionar este(s) botão(ões) branco(s), deverá solicitar a renovação do seu serviço principal **SEM** as suas eventuais opções relacionadas.
+>> > Se selecionar estes botões brancos, irá solicitar a renovação do seu serviço principal **SEM** as suas eventuais opções associadas.
 >> >
 >> > Depois de fazer as suas escolhas, prossiga a encomenda clicando em `Validar`{.action}.
 >> >

--- a/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.pt-pt.md
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal/guide.pt-pt.md
@@ -129,7 +129,7 @@ A página **Gestão das minhas ofertas e serviços** contém uma tabela de gest�
 >> > [!success]
 >> >
 >> > Uma vez na interface de pagamento online, se o serviço que deseja renovar dispõe de opções associadas e se também as deseja renovar, **não marque** o(s) botão(s) branco(s) seguido(s) da menção `Não renovar` associado(s) a cada uma das opções apresentadas.
->> > Se selecionar este(s) botão(ões) branco(s), deverá solicitar a renovação do seu serviço principal **SEM** as suas eventuais opções relacionadas.
+>> > Se selecionar estes botões brancos, irá solicitar a renovação do seu serviço principal **SEM** as suas eventuais opções associadas.
 >> >
 >> > Depois de fazer as suas escolhas, prossiga a encomenda clicando em `Validar`{.action}.
 >> >


### PR DESCRIPTION
All translaitons are done.

Need proof by @Y0Coss and @tcpdumpfbacke.

I can't retrieve translations based on this page => https://www.ovh.com/cgi-bin/order/renew.cgi (we must add a domain and click to confirm to show the next step with options). It could be god especially for the term "don't renew this" (FR => Ne pas le renouveler")

If I try to change subs (into the link or with the flags at the top right corner) => it redirect to a commercial page.