### PR TITLE
[PUBM-41432] pxe-with-full-private-dedicated: remove exception for T3

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.de-de.md
@@ -32,10 +32,6 @@ This choice offers your infrastructure the best possible isolation/protection fo
 The only significant difference is that [private networks](/pages/network/ovhcloud_connect/occ-concepts-overview/#private-connection) do not have access to everything that does not belong to your infrastructure.<br>
 As a result, a server isolated by its private network prevents the boot mechanism. This means that when systems are booted via the **Netboot** (Network Boot) method, they are based on OVHcloud’s internal network and shared services.
 
-> [!warning]
-> Please note that with 2nd and 3rd generation Advance servers on a T3 architecture (one public interface and one vRack interface) it is not possible to have two interfaces in the vRack and configure PXE.
->
-
 ### Netboot startup overview
 
 A major component exists in 2 versions:

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your server reboot with the OVHcloud Link Aggregation feature (EN)"
 excerpt: "Find out how to reboot your OVHcloud servers, working through your active private aggregation"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objective

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-asia.md
@@ -32,10 +32,6 @@ This choice offers your infrastructure the best possible isolation/protection fo
 The only significant difference is that [private networks](/pages/network/ovhcloud_connect/occ-concepts-overview#private-connection) do not have access to everything that does not belong to your infrastructure.<br>
 As a result, a server isolated by its private network prevents the boot mechanism. This means that when systems are booted via the **Netboot** (Network Boot) method, they are based on OVHcloud’s internal network and shared services.
 
-> [!warning]
-> Please note that with 2nd and 3rd generation Advance servers on a T3 architecture (one public interface and one vRack interface) it is not possible to have two interfaces in the vRack and configure PXE.
->
-
 ### Netboot startup overview
 
 A major component exists in 2 versions:

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your server reboot with the OVHcloud Link Aggregation feature"
 excerpt: "Find out how to reboot your OVHcloud servers, working through your active private aggregation"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objective

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-au.md
@@ -32,10 +32,6 @@ This choice offers your infrastructure the best possible isolation/protection fo
 The only significant difference is that [private networks](/pages/network/ovhcloud_connect/occ-concepts-overview#private-connection) do not have access to everything that does not belong to your infrastructure.<br>
 As a result, a server isolated by its private network prevents the boot mechanism. This means that when systems are booted via the **Netboot** (Network Boot) method, they are based on OVHcloud’s internal network and shared services.
 
-> [!warning]
-> Please note that with 2nd and 3rd generation Advance servers on a T3 architecture (one public interface and one vRack interface) it is not possible to have two interfaces in the vRack and configure PXE.
->
-
 ### Netboot startup overview
 
 A major component exists in 2 versions:

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your server reboot with the OVHcloud Link Aggregation feature"
 excerpt: "Find out how to reboot your OVHcloud servers, working through your active private aggregation"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objective

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-ca.md
@@ -32,10 +32,6 @@ This choice offers your infrastructure the best possible isolation/protection fo
 The only significant difference is that [private networks](/pages/network/ovhcloud_connect/occ-concepts-overview#private-connection) do not have access to everything that does not belong to your infrastructure.<br>
 As a result, a server isolated by its private network prevents the boot mechanism. This means that when systems are booted via the **Netboot** (Network Boot) method, they are based on OVHcloud’s internal network and shared services.
 
-> [!warning]
-> Please note that with 2nd and 3rd generation Advance servers on a T3 architecture (one public interface and one vRack interface) it is not possible to have two interfaces in the vRack and configure PXE.
->
-
 ### Netboot startup overview
 
 A major component exists in 2 versions:

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your server reboot with the OVHcloud Link Aggregation feature"
 excerpt: "Find out how to reboot your OVHcloud servers, working through your active private aggregation"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objective

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-gb.md
@@ -32,10 +32,6 @@ This choice offers your infrastructure the best possible isolation/protection fo
 The only significant difference is that [private networks](/pages/network/ovhcloud_connect/occ-concepts-overview#private-connection) do not have access to everything that does not belong to your infrastructure.<br>
 As a result, a server isolated by its private network prevents the boot mechanism. This means that when systems are booted via the **Netboot** (Network Boot) method, they are based on OVHcloud’s internal network and shared services.
 
-> [!warning]
-> Please note that with 2nd and 3rd generation Advance servers on a T3 architecture (one public interface and one vRack interface) it is not possible to have two interfaces in the vRack and configure PXE.
->
-
 ### Netboot startup overview
 
 A major component exists in 2 versions:

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your server reboot with the OVHcloud Link Aggregation feature"
 excerpt: "Find out how to reboot your OVHcloud servers, working through your active private aggregation"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objective

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-ie.md
@@ -32,10 +32,6 @@ This choice offers your infrastructure the best possible isolation/protection fo
 The only significant difference is that [private networks](/pages/network/ovhcloud_connect/occ-concepts-overview#private-connection) do not have access to everything that does not belong to your infrastructure.<br>
 As a result, a server isolated by its private network prevents the boot mechanism. This means that when systems are booted via the **Netboot** (Network Boot) method, they are based on OVHcloud’s internal network and shared services.
 
-> [!warning]
-> Please note that with 2nd and 3rd generation Advance servers on a T3 architecture (one public interface and one vRack interface) it is not possible to have two interfaces in the vRack and configure PXE.
->
-
 ### Netboot startup overview
 
 A major component exists in 2 versions:

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your server reboot with the OVHcloud Link Aggregation feature"
 excerpt: "Find out how to reboot your OVHcloud servers, working through your active private aggregation"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objective

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-sg.md
@@ -32,10 +32,6 @@ This choice offers your infrastructure the best possible isolation/protection fo
 The only significant difference is that [private networks](/pages/network/ovhcloud_connect/occ-concepts-overview#private-connection) do not have access to everything that does not belong to your infrastructure.<br>
 As a result, a server isolated by its private network prevents the boot mechanism. This means that when systems are booted via the **Netboot** (Network Boot) method, they are based on OVHcloud’s internal network and shared services.
 
-> [!warning]
-> Please note that with 2nd and 3rd generation Advance servers on a T3 architecture (one public interface and one vRack interface) it is not possible to have two interfaces in the vRack and configure PXE.
->
-
 ### Netboot startup overview
 
 A major component exists in 2 versions:

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your server reboot with the OVHcloud Link Aggregation feature"
 excerpt: "Find out how to reboot your OVHcloud servers, working through your active private aggregation"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objective

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-us.md
@@ -32,10 +32,6 @@ This choice offers your infrastructure the best possible isolation/protection fo
 The only significant difference is that [private networks](/pages/network/ovhcloud_connect/occ-concepts-overview#private-connection) do not have access to everything that does not belong to your infrastructure.<br>
 As a result, a server isolated by its private network prevents the boot mechanism. This means that when systems are booted via the **Netboot** (Network Boot) method, they are based on OVHcloud’s internal network and shared services.
 
-> [!warning]
-> Please note that with 2nd and 3rd generation Advance servers on a T3 architecture (one public interface and one vRack interface) it is not possible to have two interfaces in the vRack and configure PXE.
->
-
 ### Netboot startup overview
 
 A major component exists in 2 versions:

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your server reboot with the OVHcloud Link Aggregation feature"
 excerpt: "Find out how to reboot your OVHcloud servers, working through your active private aggregation"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objective

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.es-es.md
@@ -32,10 +32,6 @@ This choice offers your infrastructure the best possible isolation/protection fo
 The only significant difference is that [private networks](/pages/network/ovhcloud_connect/occ-concepts-overview#private-connection) do not have access to everything that does not belong to your infrastructure.<br>
 As a result, a server isolated by its private network prevents the boot mechanism. This means that when systems are booted via the **Netboot** (Network Boot) method, they are based on OVHcloud’s internal network and shared services.
 
-> [!warning]
-> Please note that with 2nd and 3rd generation Advance servers on a T3 architecture (one public interface and one vRack interface) it is not possible to have two interfaces in the vRack and configure PXE.
->
-
 ### Netboot startup overview
 
 A major component exists in 2 versions:

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your server reboot with the OVHcloud Link Aggregation feature (EN)"
 excerpt: "Find out how to reboot your OVHcloud servers, working through your active private aggregation"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objective

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.es-us.md
@@ -32,10 +32,6 @@ This choice offers your infrastructure the best possible isolation/protection fo
 The only significant difference is that [private networks](/pages/network/ovhcloud_connect/occ-concepts-overview#private-connection) do not have access to everything that does not belong to your infrastructure.<br>
 As a result, a server isolated by its private network prevents the boot mechanism. This means that when systems are booted via the **Netboot** (Network Boot) method, they are based on OVHcloud’s internal network and shared services.
 
-> [!warning]
-> Please note that with 2nd and 3rd generation Advance servers on a T3 architecture (one public interface and one vRack interface) it is not possible to have two interfaces in the vRack and configure PXE.
->
-
 ### Netboot startup overview
 
 A major component exists in 2 versions:

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your server reboot with the OVHcloud Link Aggregation feature (EN)"
 excerpt: "Find out how to reboot your OVHcloud servers, working through your active private aggregation"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objective

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.fr-ca.md
@@ -32,10 +32,6 @@ Ce choix propose à votre infrastructure la meilleure isolation/protection possi
 La seule différence majeure notable est que les [réseaux privés](/pages/network/ovhcloud_connect/occ-concepts-overview#prive) n'ont donc pas accès à tout ce qui n'appartient pas à votre infrastructure.<br>
 Par conséquent, un serveur isolé de par son réseau privé empêche le mecanisme de démarrage. C'est à dire que lorsque les systèmes sont démarrés via le méthode **Netboot** (Network Boot), ces derniers s'appuient sur le réseau interne d'OVHcloud et ses services mutualisés.
 
-> [!warning]
-> Veuillez noter qu'avec les serveurs Advance de 2ème et 3ème génération sur une architecture T3 (une interface publique et une interface vRack), il n'est pas possible d'avoir deux interfaces dans le vRack et de configurer PXE.
->
-
 ### Présentation rapide d'un démarrage en Netboot
 
 Un composant majeur existe en 2 versions :

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Gestion du reboot de vos serveurs avec la fonctionnalité OVHcloud Link Aggregation"
 excerpt: "Découvrez comment réaliser les redémarrages de vos serveurs OVHcloud fonctionnant à travers votre agrégation privée active"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objectif

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.fr-fr.md
@@ -32,10 +32,6 @@ Ce choix propose à votre infrastructure la meilleure isolation/protection possi
 La seule différence majeure notable est que les [réseaux privés](/pages/network/ovhcloud_connect/occ-concepts-overview#prive) n'ont donc pas accès à tout ce qui n'appartient pas à votre infrastructure.<br>
 Par conséquent, un serveur isolé de par son réseau privé empêche le mecanisme de démarrage. C'est à dire que lorsque les systèmes sont démarrés via le méthode **Netboot** (Network Boot), ces derniers s'appuient sur le réseau interne d'OVHcloud et ses services mutualisés.
 
-> [!warning]
-> Veuillez noter qu'avec les serveurs Advance de 2ème et 3ème génération sur une architecture T3 (une interface publique et une interface vRack), il n'est pas possible d'avoir deux interfaces dans le vRack et de configurer PXE.
->
-
 ### Présentation rapide d'un démarrage en Netboot
 
 Un composant majeur existe en 2 versions :

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Gestion du reboot de vos serveurs avec la fonctionnalité OVHcloud Link Aggregation"
 excerpt: "Découvrez comment réaliser les redémarrages de vos serveurs OVHcloud fonctionnant à travers votre agrégation privée active"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objectif

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.it-it.md
@@ -32,10 +32,6 @@ This choice offers your infrastructure the best possible isolation/protection fo
 The only significant difference is that [private networks](/pages/network/ovhcloud_connect/occ-concepts-overview#private-connection) do not have access to everything that does not belong to your infrastructure.<br>
 As a result, a server isolated by its private network prevents the boot mechanism. This means that when systems are booted via the **Netboot** (Network Boot) method, they are based on OVHcloud’s internal network and shared services.
 
-> [!warning]
-> Please note that with 2nd and 3rd generation Advance servers on a T3 architecture (one public interface and one vRack interface) it is not possible to have two interfaces in the vRack and configure PXE.
->
-
 ### Netboot startup overview
 
 A major component exists in 2 versions:

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your server reboot with the OVHcloud Link Aggregation feature (EN)"
 excerpt: "Find out how to reboot your OVHcloud servers, working through your active private aggregation"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objective

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.pl-pl.md
@@ -32,10 +32,6 @@ This choice offers your infrastructure the best possible isolation/protection fo
 The only significant difference is that [private networks](/pages/network/ovhcloud_connect/occ-concepts-overview#private-connection) do not have access to everything that does not belong to your infrastructure.<br>
 As a result, a server isolated by its private network prevents the boot mechanism. This means that when systems are booted via the **Netboot** (Network Boot) method, they are based on OVHcloud’s internal network and shared services.
 
-> [!warning]
-> Please note that with 2nd and 3rd generation Advance servers on a T3 architecture (one public interface and one vRack interface) it is not possible to have two interfaces in the vRack and configure PXE.
->
-
 ### Netboot startup overview
 
 A major component exists in 2 versions:

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your server reboot with the OVHcloud Link Aggregation feature (EN)"
 excerpt: "Find out how to reboot your OVHcloud servers, working through your active private aggregation"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objective

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.pt-pt.md
@@ -32,10 +32,6 @@ This choice offers your infrastructure the best possible isolation/protection fo
 The only significant difference is that [private networks](/pages/network/ovhcloud_connect/occ-concepts-overview#private-connection) do not have access to everything that does not belong to your infrastructure.<br>
 As a result, a server isolated by its private network prevents the boot mechanism. This means that when systems are booted via the **Netboot** (Network Boot) method, they are based on OVHcloud’s internal network and shared services.
 
-> [!warning]
-> Please note that with 2nd and 3rd generation Advance servers on a T3 architecture (one public interface and one vRack interface) it is not possible to have two interfaces in the vRack and configure PXE.
->
-
 ### Netboot startup overview
 
 A major component exists in 2 versions:

--- a/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pxe-with-full-private-dedicated/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Manage your server reboot with the OVHcloud Link Aggregation feature (EN)"
 excerpt: "Find out how to reboot your OVHcloud servers, working through your active private aggregation"
-updated: 2024-10-02
+updated: 2025-01-28
 ---
 
 ## Objective


### PR DESCRIPTION
T3 servers now have working fallback when LACP is not enabled, allowing them to use DHCP to boot.