### PR TITLE
Remplacement OVHcloud 3-AZ par BareMetal 3-AZ dans la présentation de l'offre

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.de-de.md
@@ -1,12 +1,8 @@
 ---
-title: "OVHcloud 3-AZ Region - Vorstellung des Angebots"
-excerpt: "Entdecken Sie den OVHcloud 3-AZ Dienst, der eine unübertroffene Hochverfügbarkeit und Redundanz zwischen drei Rechenzentren bietet"
+title: "Bare Metal 3-AZ Region - Vorstellung des Angebots"
+excerpt: "Entdecken Sie den Bare Metal 3-AZ Dienst, der eine unübertroffene Hochverfügbarkeit und Redundanz zwischen drei Rechenzentren bietet"
 updated: 2024-05-30
 ---
-
-> [!primary]
-> Diese Übersetzung wurde durch unseren Partner SYSTRAN automatisch erstellt. In manchen Fällen können ungenaue Formulierungen verwendet worden sein, z.B. bei der Beschriftung von Schaltflächen oder technischen Details. Bitte ziehen Sie im Zweifelsfall die englische oder französische Fassung der Anleitung zu Rate. Möchten Sie mithelfen, diese Übersetzung zu verbessern? Dann nutzen Sie dazu bitte den Button "Beitragen" auf dieser Seite.
->
 
 ## Ziel
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-asia.md
@@ -1,6 +1,6 @@
 ---
-title: 'OVHcloud 3-AZ Region - Service presentation'
-excerpt: 'Discover OVHcloud 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
+title: 'Bare Metal 3-AZ Region - Service presentation'
+excerpt: 'Discover Bare Metal 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
 updated: 2024-05-30
 ---
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-au.md
@@ -1,6 +1,6 @@
 ---
-title: 'OVHcloud 3-AZ Region - Service presentation'
-excerpt: 'Discover OVHcloud 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
+title: 'Bare Metal 3-AZ Region - Service presentation'
+excerpt: 'Discover Bare Metal 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
 updated: 2024-05-30
 ---
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-ca.md
@@ -1,6 +1,6 @@
 ---
-title: 'OVHcloud 3-AZ Region - Service presentation'
-excerpt: 'Discover OVHcloud 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
+title: 'Bare Metal 3-AZ Region - Service presentation'
+excerpt: 'Discover Bare Metal 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
 updated: 2024-05-30
 ---
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-gb.md
@@ -1,6 +1,6 @@
 ---
-title: 'OVHcloud 3-AZ Region - Service presentation'
-excerpt: 'Discover OVHcloud 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
+title: 'Bare Metal 3-AZ Region - Service presentation'
+excerpt: 'Discover Bare Metal 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
 updated: 2024-05-30
 ---
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-ie.md
@@ -1,6 +1,6 @@
 ---
-title: 'OVHcloud 3-AZ Region - Service presentation'
-excerpt: 'Discover OVHcloud 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
+title: 'Bare Metal 3-AZ Region - Service presentation'
+excerpt: 'Discover Bare Metal 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
 updated: 2024-05-30
 ---
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-sg.md
@@ -1,6 +1,6 @@
 ---
-title: 'OVHcloud 3-AZ Region - Service presentation'
-excerpt: 'Discover OVHcloud 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
+title: 'Bare Metal 3-AZ Region - Service presentation'
+excerpt: 'Discover Bare Metal 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
 updated: 2024-05-30
 ---
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.en-us.md
@@ -1,6 +1,6 @@
 ---
-title: 'OVHcloud 3-AZ Region - Service presentation'
-excerpt: 'Discover OVHcloud 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
+title: 'Bare Metal 3-AZ Region - Service presentation'
+excerpt: 'Discover Bare Metal 3-AZ service, offering unparalleled high availability and redundancy across three data centers'
 updated: 2024-05-30
 ---
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.es-es.md
@@ -1,12 +1,8 @@
 ---
-title: "OVHcloud 3-AZ Region - Presentación del producto"
-excerpt: 'Descubra el servicio OVHcloud 3-AZ, que ofrece una alta disponibilidad y redundancia sin igual entre tres datacenters'
+title: "Bare Metal 3-AZ Region - Presentación del producto"
+excerpt: 'Descubra el servicio Bare Metal 3-AZ, que ofrece una alta disponibilidad y redundancia sin igual entre tres datacenters'
 updated: 2024-05-30
 ---
-
-> [!primary]
-> Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón "Contribuir" de esta página.
->
 
 ## Objetivo
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.es-us.md
@@ -1,12 +1,8 @@
 ---
-title: "OVHcloud 3-AZ Region - Presentación del producto"
-excerpt: 'Descubra el servicio OVHcloud 3-AZ, que ofrece una alta disponibilidad y redundancia sin igual entre tres datacenters'
+title: "Bare Metal 3-AZ Region - Presentación del producto"
+excerpt: 'Descubra el servicio Bare Metal 3-AZ, que ofrece una alta disponibilidad y redundancia sin igual entre tres datacenters'
 updated: 2024-05-30
 ---
-
-> [!primary]
-> Esta traducción ha sido generada de forma automática por nuestro partner SYSTRAN. En algunos casos puede contener términos imprecisos, como en las etiquetas de los botones o los detalles técnicos. En caso de duda, le recomendamos que consulte la versión inglesa o francesa de la guía. Si quiere ayudarnos a mejorar esta traducción, por favor, utilice el botón "Contribuir" de esta página.
->
 
 ## Objetivo
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.fr-ca.md
@@ -1,6 +1,6 @@
 ---
-title: "OVHcloud 3-AZ Region - Présentation de l'offre"
-excerpt: 'Découvrez le service OVHcloud 3-AZ, qui offre une haute disponibilité et une redondance inégalées entre trois datacenters'
+title: "Bare Metal 3-AZ Region - Présentation de l'offre"
+excerpt: 'Découvrez le service Bare Metal 3-AZ, qui offre une haute disponibilité et une redondance inégalées entre trois datacenters'
 updated: 2024-05-30
 ---
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.fr-fr.md
@@ -1,6 +1,6 @@
 ---
-title: "OVHcloud 3-AZ Region - Présentation de l'offre"
-excerpt: 'Découvrez le service OVHcloud 3-AZ, qui offre une haute disponibilité et une redondance inégalées entre trois datacenters'
+title: "BareMetal 3-AZ Region - Présentation de l'offre"
+excerpt: 'Découvrez le service BareMetal 3-AZ, qui offre une haute disponibilité et une redondance inégalées entre trois datacenters'
 updated: 2024-05-30
 ---
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.fr-fr.md
@@ -1,5 +1,5 @@
 ---
-title: "BareMetal 3-AZ Region - Présentation de l'offre"
+title: "Bare Metal 3-AZ Region - Présentation de l'offre"
 excerpt: 'Découvrez le service BareMetal 3-AZ, qui offre une haute disponibilité et une redondance inégalées entre trois datacenters'
 updated: 2024-05-30
 ---

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.fr-fr.md
@@ -1,6 +1,6 @@
 ---
 title: "Bare Metal 3-AZ Region - Présentation de l'offre"
-excerpt: 'Découvrez le service BareMetal 3-AZ, qui offre une haute disponibilité et une redondance inégalées entre trois datacenters'
+excerpt: 'Découvrez le service Bare Metal 3-AZ, qui offre une haute disponibilité et une redondance inégalées entre trois datacenters'
 updated: 2024-05-30
 ---
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.it-it.md
@@ -1,12 +1,8 @@
 ---
-title: "OVHcloud 3-AZ Region - Presentazione dell'offerta"
-excerpt: 'Scopri il servizio OVHcloud 3-AZ, che offre massima disponibilità e ridondanza tra tre datacenter'
+title: "Bare Metal 3-AZ Region - Presentazione dell'offerta"
+excerpt: 'Scopri il servizio Bare Metal 3-AZ, che offre massima disponibilità e ridondanza tra tre datacenter'
 updated: 2024-05-30
 ---
-
-> [!primary]
-> Questa traduzione è stata generata automaticamente dal nostro partner SYSTRAN. I contenuti potrebbero presentare imprecisioni, ad esempio la nomenclatura dei pulsanti o alcuni dettagli tecnici. In caso di dubbi consigliamo di fare riferimento alla versione inglese o francese della guida. Per aiutarci a migliorare questa traduzione, utilizza il pulsante "Contribuisci" di questa pagina.
->
 
 ## Obiettivo
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.pl-pl.md
@@ -1,12 +1,8 @@
 ---
-title: "OVHcloud 3-AZ Region - Prezentacja oferty"
-excerpt: 'Odkryj usługę OVHcloud 3-AZ, która oferuje niezrównaną wysoką dostępność i redundancję między trzema centrami danych'
+title: "Bare Metal 3-AZ Region - Prezentacja oferty"
+excerpt: 'Odkryj usługę Bare Metal 3-AZ, która oferuje niezrównaną wysoką dostępność i redundancję między trzema centrami danych'
 updated: 2024-05-30
 ---
-
-> [!primary]
-> Tłumaczenie zostało wygenerowane automatycznie przez system naszego partnera SYSTRAN. W niektórych przypadkach mogą wystąpić nieprecyzyjne sformułowania, na przykład w tłumaczeniu nazw przycisków lub szczegółów technicznych. W przypadku jakichkolwiek wątpliwości zalecamy zapoznanie się z angielską/francuską wersją przewodnika. Jeśli chcesz przyczynić się do ulepszenia tłumaczenia, kliknij przycisk “Zgłóś propozycję modyfikacji” na tej stronie.
->
 
 ## Wprowadzenie
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/guide.pt-pt.md
@@ -1,12 +1,8 @@
 ---
-title: "OVHcloud 3-AZ Region - Apresentação da oferta"
-excerpt: 'Descubra o serviço OVHcloud 3-AZ, que oferece uma alta disponibilidade e uma redundância inigualáveis entre três datacenters'
+title: "Bare Metal 3-AZ Region - Apresentação da oferta"
+excerpt: 'Descubra o serviço Bare Metal 3-AZ, que oferece uma alta disponibilidade e uma redundância inigualáveis entre três datacenters'
 updated: 2024-05-30
 ---
-
-> [!primary]
-> Esta tradução foi automaticamente gerada pelo nosso parceiro SYSTRAN. Em certos casos, poderão ocorrer formulações imprecisas, como por exemplo nomes de botões ou detalhes técnicos. Recomendamos que consulte a versão inglesa ou francesa do manual, caso tenha alguma dúvida. Se nos quiser ajudar a melhorar esta tradução, clique em "Contribuir" nesta página.
->
 
 ## Objetivo
 

--- a/pages/bare_metal_cloud/dedicated_servers/3az-presentation/meta.yaml
+++ b/pages/bare_metal_cloud/dedicated_servers/3az-presentation/meta.yaml
@@ -1,2 +1,3 @@
 id: 8d83d906-6411-495e-9f71-00b20667a1ec
 full_slug: dedicated-servers-3az-cluster
+translation_banner: true

--- a/pages/index.md
+++ b/pages/index.md
@@ -116,7 +116,7 @@
             + [How to use the IPMI console with a dedicated server](bare_metal_cloud/dedicated_servers/using_ipmi_on_dedicated_servers)
             + [Migrate data from one dedicated server to another](bare_metal_cloud/dedicated_servers/migrate_a_server_to_another)
             + [Dedicated servers - Shared Responsibility](account_and_service_management/responsibility_sharing/dedicated-servers)
-            + [OVHcloud 3-AZ Region - Service presentation](bare_metal_cloud/dedicated_servers/3az-presentation)
+            + [Bare Metal 3-AZ Region - Service presentation](bare_metal_cloud/dedicated_servers/3az-presentation)
         + [Security](bare-metal-cloud-dedicated-servers-security)
             + [Dedicated Servers service Security Specifications](account_and_service_management/account_information/security-specifications-dedicated-servers)
             + [Configuring the firewall on Linux with iptables](bare_metal_cloud/dedicated_servers/firewall-Linux-iptable)


### PR DESCRIPTION
Remplacement des instances de "OVHcloud 3-AZ" par "BareMetal 3-AZ" pour plus de clarté auprès des clients, en prévision d'autres lancements de produits 3-AZ.