### PR TITLE
chore(mks/octavia): remove warning proxyprotocol version

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
@@ -411,11 +411,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
 
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
-
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 
 In order to migrate from an existing [Loadbalancer for Kubernetes](/links/public-cloud/load-balancer-kubernetes) to a [Public Cloud Load Balancer](/links/public-cloud/load-balancer) you will have to modify an existing Service and change its LoadBalancer class.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-01-03
+updated: 2025-01-30
 ---
 
 > [!warning]
@@ -410,11 +410,6 @@ test-lb-todel        LoadBalancer   10.3.107.18   141.94.215.240   80:30172/TCP 
 #### Use PROXY protocol to preserve client IP
 
 When exposing services like nginx-ingress-controller, it's a common requirement that the client connection information could pass through proxy servers and load balancers, therefore visible to the backend services. Knowing the originating IP address of a client may be useful for setting a particular language for a website, keeping a denylist of IP addresses, or simply for logging and statistics purposes. You can follow the official Cloud Controller Manager documentation on how to [Use PROXY protocol to preserve client IP](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/expose-applications-using-loadbalancer-type-service.md#use-proxy-protocol-to-preserve-client-ip).
-
-> [!warning]
->
-> Only ProxyProtocol version 1 is supported at the moment by the MKS's integration.
->
 
 #### Migrate from Loadbalancer for Kubernetes to Public Cloud Load Balancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://ca.api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://ca.api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://ca.api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ie.md
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://ca.api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://ca.api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://ca.api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://ca.api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2024-10-02
+updated: 2025-01-30
 ---
 
 <style>
@@ -137,7 +137,7 @@ The `vRack` feature is currently available and compliant with our Managed Kubern
 To prevent any conflict, we advise you to keep `DHCP` service running in your private network.
 
 > [!warning]
-> If you create your subnet via the [OVHcloud APIv6](https://api.ovh.com/console/#/cloud/project/{serviceName}/network/private/{networkId}/subnet#POST), please ensure that this option `noGateway` is checked if you do not have a gateway on this subnet. Not doing so will result in faulty services of type LoadBalancer.
+> At the moment, MKS worker nodes cannot use provided Subnet's DNS nameservers.
 >
 
 > [!warning]


### PR DESCRIPTION
We had forget to remove this Warning when we have released the ProxyProtocolv2 support for MKS/Octavia