### PR TITLE
Added server range requirement

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.de-de.md
@@ -13,7 +13,7 @@ Die Aggregation basiert auf dem Standard IEEE 802.3ad, Link Aggregation Control 
 
 ## Voraussetzungen
 
-- Sie haben einen [Dedicated Server](/links/bare-metal/bare-metal) in Ihrem Kunden-Account.
+- Sie haben einen [Dedicated Server](/links/bare-metal/bare-metal) der Advance, Scale oder High Grade Reihe.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 - Sie verwenden ein Betriebssystem / einen Hypervisor mit Unterstützung für das Aggregationsprotokoll 802.3ad (LACP).
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-asia.md
@@ -13,7 +13,7 @@ Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) t
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) from the Advance, Scale, or High Grade ranges in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - An Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-au.md
@@ -13,7 +13,7 @@ Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) t
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) from the Advance, Scale, or High Grade ranges in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - An Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-ca.md
@@ -13,7 +13,7 @@ Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) t
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) from the Advance, Scale, or High Grade ranges in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - An Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-gb.md
@@ -13,7 +13,7 @@ Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) t
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) from the Advance, Scale, or High Grade ranges in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - An Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-ie.md
@@ -13,7 +13,7 @@ Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) t
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) from the Advance, Scale, or High Grade ranges in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - An Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-sg.md
@@ -13,7 +13,7 @@ Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) t
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) from the Advance, Scale, or High Grade ranges in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - An Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.en-us.md
@@ -13,7 +13,7 @@ Aggregation is based on IEEE 802.3ad, Link Aggregation Control Protocol (LACP) t
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) from the Advance, Scale, or High Grade ranges in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - An Operating System / Hypervisor that supports the 802.3ad aggregation protocol (LACP)
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.es-es.md
@@ -13,7 +13,7 @@ La agregación se basa en la tecnología IEEE 802.3ad o Link Aggregation Control
 
 ## Requisitos
 
-- Tener un [servidor dedicado de OVHcloud.](/links/bare-metal/bare-metal).
+- Tener un [servidor dedicado OVHcloud](/links/bare-metal/bare-metal) de las gamas Advance, Scale o High Grade.
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 - Tener un sistema operativo/hipervisor que soporta el protocolo de agregación 802.3ad (LACP).
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.es-us.md
@@ -13,7 +13,7 @@ La agregación se basa en la tecnología IEEE 802.3ad o Link Aggregation Control
 
 ## Requisitos
 
-- Tener un [servidor dedicado de OVHcloud.](/links/bare-metal/bare-metal)
+- Tener un [servidor dedicado OVHcloud](/links/bare-metal/bare-metal) de las gamas Advance, Scale o High Grade.
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 - Tener un sistema operativo/hipervisor que soporta el protocolo de agregación 802.3ad (LACP).
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.fr-ca.md
@@ -13,7 +13,7 @@ L'aggrégation se base sur la technologie IEEE 802.3ad, ou Link Aggregation Cont
 
 ## Prérequis
 
-- Disposer d'un [serveur dédié OVHcloud](/links/bare-metal/bare-metal)
+- Disposer d'un [serveur dédié OVHcloud](/links/bare-metal/bare-metal) de gamme Advance, Scale ou High Grade
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 - Un système d'exploitation / hyperviseur supportant le protocole d'aggrégation 802.3ad (LACP)
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.fr-fr.md
@@ -13,7 +13,7 @@ L'aggrégation se base sur la technologie IEEE 802.3ad, ou Link Aggregation Cont
 
 ## Prérequis
 
-- Disposer d'un [serveur dédié OVHcloud](/links/bare-metal/bare-metal)
+- Disposer d'un [serveur dédié OVHcloud](/links/bare-metal/bare-metal) de gamme Advance, Scale ou High Grade
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 - Un système d'exploitation / hyperviseur supportant le protocole d'aggrégation 802.3ad (LACP)
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.it-it.md
@@ -13,7 +13,7 @@ L'aggregazione si basa sulla tecnologia IEEE 802.3ad o Link Aggregation Control 
 
 ## Prerequisiti
 
-- Disporre di un [server dedicato OVHcloud](/links/bare-metal/bare-metal)
+- Disporre di un [server dedicato OVHcloud](/links/bare-metal/bare-metal) di gamma Advance, Scale o High Grade
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 - Disporre di un sistema operativo / Hypervisor che supporta il protocollo di aggregazione 802.3ad (LACP)
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.pl-pl.md
@@ -13,7 +13,7 @@ Aggregacja oparta jest na technologii IEEE 802.3ad lub Link Aggregation Control 
 
 ## Wymagania początkowe
 
-- Posiadanie [serwera dedykowanego OVHcloud](/links/bare-metal/bare-metal)
+- Posiadanie [serwera dedykowanego OVHcloud](/links/bare-metal/bare-metal) z gamy Advance, Scale lub High Grade
 - Zalogowanie do [Panelu klienta OVHcloud](/links/manager)
 - System operacyjny / Hypervisor obsługujący protokół 802.3ad (LACP)
 

--- a/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ola-enable-manager/guide.pt-pt.md
@@ -13,7 +13,7 @@ A agregação baseia-se na tecnologia IEEE 802.3ad, ou Link Aggregation Control 
 
 ## Requisitos
 
-- Dispor de um [servidor dedicado OVHcloud](/links/bare-metal/bare-metal).
+- Dispor de um [servidor dedicado OVHcloud](/links/bare-metal/bare-metal) da gama Advance, Scale ou High Grade.
 - Estar ligado à [Área de Cliente OVHcloud](/links/manager).
 - Um sistema operativo / Hypervisor que suporta o protocolo de agregação 802.3ad (LACP).
 


### PR DESCRIPTION
The requirements didn't specify the ranges compatible with the OLA service (Advance, Scale and High Grade)