### PR TITLE
BYOIP - FAQ edit after feedback

### DIFF
--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.de-de.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.de-de.md
@@ -229,11 +229,7 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-asia.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-asia.md
@@ -229,11 +229,7 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-au.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-au.md
@@ -229,11 +229,7 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-ca.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-ca.md
@@ -229,11 +229,7 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-gb.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-gb.md
@@ -229,11 +229,7 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-ie.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-ie.md
@@ -229,11 +229,7 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-sg.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-sg.md
@@ -229,11 +229,7 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-us.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-us.md
@@ -229,11 +229,7 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.es-es.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.es-es.md
@@ -229,11 +229,7 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.es-us.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.es-us.md
@@ -229,11 +229,7 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.fr-ca.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.fr-ca.md
@@ -230,11 +230,7 @@ Pas au lancement de l'offre BYOIP. Cependant, si tel est votre souhait, nous vou
 
 Oui. Pour plus d'informations, veuillez vous reporter à la section [Découpage de plages d'addresses](#range-slicing) ci-dessus.
 
-### Puis-je importer une plage d'adresses IP ARIN dans des campus acceptant uniquement des plages d'adresses IP RIPE et inversement ?
-
-Oui, avec la mise à jour de notre politique, il est désormais possible d'utiliser des blocs IP ARIN ou RIPE sur n'importe quel campus OVHcloud où le produit BYOIP est disponible. Nous avons éliminé les restrictions précédentes pour offrir une plus grande flexibilité et efficacité dans la gestion et l'allocation des adresses IP. Vous pouvez importer et utiliser vos blocs IP en fonction de vos besoins spécifiques, indépendamment de la localisation géographique du campus.
-
-### Puis-je importer un numéro AS ARIN avec une plage d'adresses IP RIPE et inversement ?
+### Puis-je importer un numéro AS et une plage d'adresses IP provenant de RIR différents ?
 
 Oui.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.fr-fr.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.fr-fr.md
@@ -230,11 +230,7 @@ Pas au lancement de l'offre BYOIP. Cependant, si tel est votre souhait, nous vou
 
 Oui. Pour plus d'informations, veuillez vous reporter à la section [Découpage de plages d'addresses](#range-slicing) ci-dessus.
 
-### Puis-je importer une plage d'adresses IP ARIN dans des campus acceptant uniquement des plages d'adresses IP RIPE et inversement ?
-
-Oui, avec la mise à jour de notre politique, il est désormais possible d'utiliser des blocs IP ARIN ou RIPE sur n'importe quel campus OVHcloud où le produit BYOIP est disponible. Nous avons éliminé les restrictions précédentes pour offrir une plus grande flexibilité et efficacité dans la gestion et l'allocation des adresses IP. Vous pouvez importer et utiliser vos blocs IP en fonction de vos besoins spécifiques, indépendamment de la localisation géographique du campus.
-
-### Puis-je importer un numéro AS ARIN avec une plage d'adresses IP RIPE et inversement ?
+### Puis-je importer un numéro AS et une plage d'adresses IP provenant de RIR différents ?
 
 Oui.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.it-it.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.it-it.md
@@ -229,11 +229,7 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.pl-pl.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.pl-pl.md
@@ -229,11 +229,7 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.pt-pt.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.pt-pt.md
@@ -229,11 +229,7 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 


### PR DESCRIPTION
Feedback provided by the PM points to obsolete FAQs. One was modified to use broader terms, so that APNIC is included by default. Another was deleted because of redundancy.