### PR TITLE
fix: display API endpoints in tabs; adjust wording

### DIFF
--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.de-de.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.de-de.md
@@ -46,7 +46,7 @@ To enable forwarding, you can use the following APIs:
 > [!tabs]
 > Audit logs
 >>
->> **Description:** Forward account audit logs
+>> **Description:** Forward account audit logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -54,7 +54,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Activity logs
 >>
->> **Description:** Forward API and Control Panel account logs
+>> **Description:** Forward API and Control Panel account logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -62,7 +62,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Access policy logs
 >>
->> **Description:** Forward account IAM logs to a dedicated logs stream
+>> **Description:** Forward account IAM logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -106,30 +106,33 @@ Alternatively, you can retrieve your streams using the Logs Data Platform API:
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
 
-> [!primary]
-> You can find the available `kind` using the following APIs:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+You can find the available `kind` using the following APIs:
+
+> [!tabs]
+> Audit logs kinds
+>>
+>> **Description:** Get audit logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Activity logs kinds
+>>
+>> **Description:** Get API and Control Panel logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Access policy logs kinds
+>>
+>> **Description:** Get account IAM logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 
 ### Access to OVHcloud account logs

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-asia.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-asia.md
@@ -46,7 +46,7 @@ To enable forwarding, you can use the following APIs:
 > [!tabs]
 > Audit logs
 >>
->> **Description:** Forward account audit logs
+>> **Description:** Forward account audit logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -54,7 +54,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Activity logs
 >>
->> **Description:** Forward API and Control Panel account logs
+>> **Description:** Forward API and Control Panel account logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -62,7 +62,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Access policy logs
 >>
->> **Description:** Forward account IAM logs to a dedicated logs stream
+>> **Description:** Forward account IAM logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -106,30 +106,33 @@ Alternatively, you can retrieve your streams using the Logs Data Platform API:
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
 
-> [!primary]
-> You can find the available `kind` using the following APIs:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+You can find the available `kind` using the following APIs:
+
+> [!tabs]
+> Audit logs kinds
+>>
+>> **Description:** Get audit logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Activity logs kinds
+>>
+>> **Description:** Get API and Control Panel logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Access policy logs kinds
+>>
+>> **Description:** Get account IAM logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 
 ### Access to OVHcloud account logs

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-au.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-au.md
@@ -46,7 +46,7 @@ To enable forwarding, you can use the following APIs:
 > [!tabs]
 > Audit logs
 >>
->> **Description:** Forward account audit logs
+>> **Description:** Forward account audit logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -54,7 +54,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Activity logs
 >>
->> **Description:** Forward API and Control Panel account logs
+>> **Description:** Forward API and Control Panel account logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -62,7 +62,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Access policy logs
 >>
->> **Description:** Forward account IAM logs to a dedicated logs stream
+>> **Description:** Forward account IAM logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -106,30 +106,33 @@ Alternatively, you can retrieve your streams using the Logs Data Platform API:
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
 
-> [!primary]
-> You can find the available `kind` using the following APIs:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+You can find the available `kind` using the following APIs:
+
+> [!tabs]
+> Audit logs kinds
+>>
+>> **Description:** Get audit logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Activity logs kinds
+>>
+>> **Description:** Get API and Control Panel logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Access policy logs kinds
+>>
+>> **Description:** Get account IAM logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 
 ### Access to OVHcloud account logs

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-ca.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-ca.md
@@ -46,7 +46,7 @@ To enable forwarding, you can use the following APIs:
 > [!tabs]
 > Audit logs
 >>
->> **Description:** Forward account audit logs
+>> **Description:** Forward account audit logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -54,7 +54,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Activity logs
 >>
->> **Description:** Forward API and Control Panel account logs
+>> **Description:** Forward API and Control Panel account logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -62,7 +62,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Access policy logs
 >>
->> **Description:** Forward account IAM logs to a dedicated logs stream
+>> **Description:** Forward account IAM logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -106,30 +106,33 @@ Alternatively, you can retrieve your streams using the Logs Data Platform API:
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
 
-> [!primary]
-> You can find the available `kind` using the following APIs:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+You can find the available `kind` using the following APIs:
+
+> [!tabs]
+> Audit logs kinds
+>>
+>> **Description:** Get audit logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Activity logs kinds
+>>
+>> **Description:** Get API and Control Panel logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Access policy logs kinds
+>>
+>> **Description:** Get account IAM logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 
 ### Access to OVHcloud account logs

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-gb.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-gb.md
@@ -46,7 +46,7 @@ To enable forwarding, you can use the following APIs:
 > [!tabs]
 > Audit logs
 >>
->> **Description:** Forward account audit logs
+>> **Description:** Forward account audit logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -54,7 +54,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Activity logs
 >>
->> **Description:** Forward API and Control Panel account logs
+>> **Description:** Forward API and Control Panel account logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -62,7 +62,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Access policy logs
 >>
->> **Description:** Forward account IAM logs to a dedicated logs stream
+>> **Description:** Forward account IAM logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -106,30 +106,33 @@ Alternatively, you can retrieve your streams using the Logs Data Platform API:
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
 
-> [!primary]
-> You can find the available `kind` using the following APIs:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+You can find the available `kind` using the following APIs:
+
+> [!tabs]
+> Audit logs kinds
+>>
+>> **Description:** Get audit logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Activity logs kinds
+>>
+>> **Description:** Get API and Control Panel logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Access policy logs kinds
+>>
+>> **Description:** Get account IAM logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 
 ### Access to OVHcloud account logs

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-ie.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-ie.md
@@ -46,7 +46,7 @@ To enable forwarding, you can use the following APIs:
 > [!tabs]
 > Audit logs
 >>
->> **Description:** Forward account audit logs
+>> **Description:** Forward account audit logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -54,7 +54,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Activity logs
 >>
->> **Description:** Forward API and Control Panel account logs
+>> **Description:** Forward API and Control Panel account logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -62,7 +62,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Access policy logs
 >>
->> **Description:** Forward account IAM logs to a dedicated logs stream
+>> **Description:** Forward account IAM logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -106,30 +106,33 @@ Alternatively, you can retrieve your streams using the Logs Data Platform API:
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
 
-> [!primary]
-> You can find the available `kind` using the following APIs:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+You can find the available `kind` using the following APIs:
+
+> [!tabs]
+> Audit logs kinds
+>>
+>> **Description:** Get audit logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Activity logs kinds
+>>
+>> **Description:** Get API and Control Panel logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Access policy logs kinds
+>>
+>> **Description:** Get account IAM logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 
 ### Access to OVHcloud account logs

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-sg.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-sg.md
@@ -46,7 +46,7 @@ To enable forwarding, you can use the following APIs:
 > [!tabs]
 > Audit logs
 >>
->> **Description:** Forward account audit logs
+>> **Description:** Forward account audit logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -54,7 +54,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Activity logs
 >>
->> **Description:** Forward API and Control Panel account logs
+>> **Description:** Forward API and Control Panel account logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -62,7 +62,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Access policy logs
 >>
->> **Description:** Forward account IAM logs to a dedicated logs stream
+>> **Description:** Forward account IAM logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -106,30 +106,33 @@ Alternatively, you can retrieve your streams using the Logs Data Platform API:
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
 
-> [!primary]
-> You can find the available `kind` using the following APIs:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+You can find the available `kind` using the following APIs:
+
+> [!tabs]
+> Audit logs kinds
+>>
+>> **Description:** Get audit logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Activity logs kinds
+>>
+>> **Description:** Get API and Control Panel logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Access policy logs kinds
+>>
+>> **Description:** Get account IAM logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 
 ### Access to OVHcloud account logs

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-us.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.en-us.md
@@ -46,7 +46,7 @@ To enable forwarding, you can use the following APIs:
 > [!tabs]
 > Audit logs
 >>
->> **Description:** Forward account audit logs
+>> **Description:** Forward account audit logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -54,7 +54,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Activity logs
 >>
->> **Description:** Forward API and Control Panel account logs
+>> **Description:** Forward API and Control Panel account logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -62,7 +62,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Access policy logs
 >>
->> **Description:** Forward account IAM logs to a dedicated logs stream
+>> **Description:** Forward account IAM logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -106,30 +106,33 @@ Alternatively, you can retrieve your streams using the Logs Data Platform API:
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
 
-> [!primary]
-> You can find the available `kind` using the following APIs:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+You can find the available `kind` using the following APIs:
+
+> [!tabs]
+> Audit logs kinds
+>>
+>> **Description:** Get audit logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Activity logs kinds
+>>
+>> **Description:** Get API and Control Panel logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Access policy logs kinds
+>>
+>> **Description:** Get account IAM logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 
 ### Access to OVHcloud account logs

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.es-es.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.es-es.md
@@ -46,7 +46,7 @@ To enable forwarding, you can use the following APIs:
 > [!tabs]
 > Audit logs
 >>
->> **Description:** Forward account audit logs
+>> **Description:** Forward account audit logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -54,7 +54,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Activity logs
 >>
->> **Description:** Forward API and Control Panel account logs
+>> **Description:** Forward API and Control Panel account logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -62,7 +62,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Access policy logs
 >>
->> **Description:** Forward account IAM logs to a dedicated logs stream
+>> **Description:** Forward account IAM logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -106,30 +106,33 @@ Alternatively, you can retrieve your streams using the Logs Data Platform API:
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
 
-> [!primary]
-> You can find the available `kind` using the following APIs:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+You can find the available `kind` using the following APIs:
+
+> [!tabs]
+> Audit logs kinds
+>>
+>> **Description:** Get audit logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Activity logs kinds
+>>
+>> **Description:** Get API and Control Panel logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Access policy logs kinds
+>>
+>> **Description:** Get account IAM logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 
 ### Access to OVHcloud account logs

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.es-us.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.es-us.md
@@ -46,7 +46,7 @@ To enable forwarding, you can use the following APIs:
 > [!tabs]
 > Audit logs
 >>
->> **Description:** Forward account audit logs
+>> **Description:** Forward account audit logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -54,7 +54,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Activity logs
 >>
->> **Description:** Forward API and Control Panel account logs
+>> **Description:** Forward API and Control Panel account logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -62,7 +62,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Access policy logs
 >>
->> **Description:** Forward account IAM logs to a dedicated logs stream
+>> **Description:** Forward account IAM logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -106,30 +106,33 @@ Alternatively, you can retrieve your streams using the Logs Data Platform API:
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
 
-> [!primary]
-> You can find the available `kind` using the following APIs:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+You can find the available `kind` using the following APIs:
+
+> [!tabs]
+> Audit logs kinds
+>>
+>> **Description:** Get audit logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Activity logs kinds
+>>
+>> **Description:** Get API and Control Panel logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Access policy logs kinds
+>>
+>> **Description:** Get account IAM logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 
 ### Access to OVHcloud account logs

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.fr-ca.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.fr-ca.md
@@ -44,25 +44,25 @@ Notez que l'activation du transfert est gratuite, mais vous serez facturé pour 
 Pour activer la redirection, utilisez les API suivantes :
 
 > [!tabs]
-> Journaux d'audit
+> Logs d'audit
 >>
->> **Description:** Transfère les journaux d'audit des comptes
+>> **Description:** Transfert des logs d'audit des comptes vers un flux de données dédié
 >>
 >> > [!api]
 >> >
 >> > @api {v1} /me POST /me/logs/audit/log/subscription
 >> >
-> Journaux d'activité
+> Logs d'activité
 >>
->> **Description:** Journaux de l'API de transfert et des comptes du Panneau de configuration
+>> **Description:** Transfert des logs de l'API OVHcloud et de l'espace client vers un flux de données dédié
 >>
 >> > [!api]
 >> >
 >> > @api {v1} /me POST /me/api/log/subscription
 >> >
-> Accéder aux journaux de stratégie
+> Logs de politique d'accès
 >>
->> **Description:** Transfère les journaux IAM du compte vers un flux de journaux dédié
+>> **Description:** Transfert des logs de politique d'accès IAM du compte vers un flux de données dédié
 >>
 >> > [!api]
 >> >
@@ -105,30 +105,33 @@ Vous pouvez également récupérer vos flux à l'aide de l'API Logs Data Platfor
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
-> [!primary]
-> Vous pouvez retrouvez les différents `kind` possible en utilisant les APIs suivantes:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+Vous pouvez retrouver les différents `kind` possibles en utilisant les appels API suivants :
+
+> [!tabs]
+> Catégories de logs d'audit
+>>
+>> **Description:** Lister les catégories de logs d'audit
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Catégories de logs d'activité
+>>
+>> **Description:** Lister les catégories de logs de l'API et de l'espace client
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Catégories des logs de politiques d'accès
+>>
+>> **Description:** Lister les catégories des logs de politiques d'accès IAM
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 ### Accès aux logs des comptes OVHcloud
 

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.fr-fr.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.fr-fr.md
@@ -44,25 +44,25 @@ Notez que l'activation du transfert est gratuite, mais vous serez facturé pour 
 Pour activer la redirection, utilisez les API suivantes :
 
 > [!tabs]
-> Journaux d'audit
+> Logs d'audit
 >>
->> **Description:** Transfère les journaux d'audit des comptes
+>> **Description:** Transfert des logs d'audit des comptes vers un flux de données dédié
 >>
 >> > [!api]
 >> >
 >> > @api {v1} /me POST /me/logs/audit/log/subscription
 >> >
-> Journaux d'activité
+> Logs d'activité
 >>
->> **Description:** Journaux de l'API de transfert et des comptes du Panneau de configuration
+>> **Description:** Transfert des logs de l'API OVHcloud et de l'espace client vers un flux de données dédié
 >>
 >> > [!api]
 >> >
 >> > @api {v1} /me POST /me/api/log/subscription
 >> >
-> Accéder aux journaux de stratégie
+> Logs de politique d'accès
 >>
->> **Description:** Transfère les journaux IAM du compte vers un flux de journaux dédié
+>> **Description:** Transfert des logs de politique d'accès IAM du compte vers un flux de données dédié
 >>
 >> > [!api]
 >> >
@@ -105,30 +105,33 @@ Vous pouvez également récupérer vos flux à l'aide de l'API Logs Data Platfor
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
-> [!primary]
-> Vous pouvez retrouvez les différents `kind` possible en utilisant les APIs suivantes:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+Vous pouvez retrouver les différents `kind` possibles en utilisant les appels API suivants :
+
+> [!tabs]
+> Catégories de logs d'audit
+>>
+>> **Description:** Lister les catégories de logs d'audit
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Catégories de logs d'activité
+>>
+>> **Description:** Lister les catégories de logs de l'API et de l'espace client
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Catégories des logs de politiques d'accès
+>>
+>> **Description:** Lister les catégories des logs de politiques d'accès IAM
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 ### Accès aux logs des comptes OVHcloud
 

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.it-it.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.it-it.md
@@ -46,7 +46,7 @@ To enable forwarding, you can use the following APIs:
 > [!tabs]
 > Audit logs
 >>
->> **Description:** Forward account audit logs
+>> **Description:** Forward account audit logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -54,7 +54,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Activity logs
 >>
->> **Description:** Forward API and Control Panel account logs
+>> **Description:** Forward API and Control Panel account logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -62,7 +62,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Access policy logs
 >>
->> **Description:** Forward account IAM logs to a dedicated logs stream
+>> **Description:** Forward account IAM logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -106,30 +106,33 @@ Alternatively, you can retrieve your streams using the Logs Data Platform API:
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
 
-> [!primary]
-> You can find the available `kind` using the following APIs:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+You can find the available `kind` using the following APIs:
+
+> [!tabs]
+> Audit logs kinds
+>>
+>> **Description:** Get audit logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Activity logs kinds
+>>
+>> **Description:** Get API and Control Panel logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Access policy logs kinds
+>>
+>> **Description:** Get account IAM logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 
 ### Access to OVHcloud account logs

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.pl-pl.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.pl-pl.md
@@ -46,7 +46,7 @@ To enable forwarding, you can use the following APIs:
 > [!tabs]
 > Audit logs
 >>
->> **Description:** Forward account audit logs
+>> **Description:** Forward account audit logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -54,7 +54,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Activity logs
 >>
->> **Description:** Forward API and Control Panel account logs
+>> **Description:** Forward API and Control Panel account logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -62,7 +62,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Access policy logs
 >>
->> **Description:** Forward account IAM logs to a dedicated logs stream
+>> **Description:** Forward account IAM logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -106,30 +106,33 @@ Alternatively, you can retrieve your streams using the Logs Data Platform API:
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
 
-> [!primary]
-> You can find the available `kind` using the following APIs:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+You can find the available `kind` using the following APIs:
+
+> [!tabs]
+> Audit logs kinds
+>>
+>> **Description:** Get audit logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Activity logs kinds
+>>
+>> **Description:** Get API and Control Panel logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Access policy logs kinds
+>>
+>> **Description:** Get account IAM logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 
 ### Access to OVHcloud account logs

--- a/pages/manage_and_operate/iam/iam-logs-forwarding/guide.pt-pt.md
+++ b/pages/manage_and_operate/iam/iam-logs-forwarding/guide.pt-pt.md
@@ -46,7 +46,7 @@ To enable forwarding, you can use the following APIs:
 > [!tabs]
 > Audit logs
 >>
->> **Description:** Forward account audit logs
+>> **Description:** Forward account audit logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -54,7 +54,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Activity logs
 >>
->> **Description:** Forward API and Control Panel account logs
+>> **Description:** Forward API and Control Panel account logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -62,7 +62,7 @@ To enable forwarding, you can use the following APIs:
 >> >
 > Access policy logs
 >>
->> **Description:** Forward account IAM logs to a dedicated logs stream
+>> **Description:** Forward account IAM logs to a dedicated data stream
 >>
 >> > [!api]
 >> >
@@ -106,30 +106,33 @@ Alternatively, you can retrieve your streams using the Logs Data Platform API:
 > @api {v1} /dbaas/logs GET /dbaas/logs/{serviceName}/output/graylog/stream/{streamId}
 
 
-> [!primary]
-> You can find the available `kind` using the following APIs:
->
-> **Audit logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/logs/audit/log/kind
-> >
->
-> **Activity logs:**
->
-> > [!api]
-> >
-> > @api {v1} /me GET /me/api/log/kind
-> >
->
-> **Access policy logs:**
->
-> > [!api]
-> >
-> > @api {v2} /iam GET /iam/log/kind
-> >
->
+You can find the available `kind` using the following APIs:
+
+> [!tabs]
+> Audit logs kinds
+>>
+>> **Description:** Get audit logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/logs/audit/log/kind
+>> >
+> Activity logs kinds
+>>
+>> **Description:** Get API and Control Panel logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v1} /me GET /me/api/log/kind
+>> >
+> Access policy logs kinds
+>>
+>> **Description:** Get account IAM logs kinds
+>>
+>> > [!api]
+>> >
+>> > @api {v2} /iam GET /iam/log/kind
+>> >
 
 
 ### Access to OVHcloud account logs


### PR DESCRIPTION
After https://github.com/ovh/docs/pull/7521

Display API in tabs; adjust wording