### PR TITLE
chore(mks): refactor LoadBalancer limitation

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-02-17
 ---
 
 > [!warning]
@@ -64,7 +64,7 @@ If you have an existing/already deployed cluster and if:
 ## Limitations
 
 - Layer 7 Policy & Rules and TLS Termination (`TERMINATED_HTTPS` listener) are not available yet. For such use cases you can rely on [Octavia Ingress Controller](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/octavia-ingress-controller/using-octavia-ingress-controller.md)
-- UDP proxy protocol is not supported
+- Proxy Protocol is only supported for TCP services.
 
 ## Billing
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ie.md
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, checkout our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Checkout [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -54,13 +54,13 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
 If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, checkout our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
 ## OpenStack & Quota
 
 Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-Also, MKS Cluster's quota relies on your project's quota. Checkout [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-01-30
+updated: 2025-02-17
 ---
 
 <style>
@@ -51,27 +51,16 @@ We advise you to save your data in Persistent Volumes (PV), not to save data dir
 
 ## LoadBalancer
 
-Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer.
-The lifespan of the external Load Balancer (and thus the associated IP address) is linked to the lifespan of this Kubernetes resource.
+Creating a Kubernetes service of type LoadBalancer in a Managed Kubernetes cluster triggers the creation of a Public Cloud Load Balancer based on OpenStack Octavia.
+If the LoadBalancer has been created through a K8s service, the lifespan of the external Load Balancer (and thus the associated IP address if not explicity specified to keep it) is linked to the lifespan of this Kubernetes resource.
 
-There is a default quota of 200 external Load Balancers per Openstack project (also named Openstack tenant).
-This limit can be exceptionally raised upon request through our support team.
+To get more information about the deployment of a LoadBalancer deployment in a MKS cluster, consult our documentation to [expose services through a LoadBalancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer).
 
-There is also a limit of __10 open ports__ on every Load Balancer, and these ports must be in a range between __6 and 65535__.
-(Additionally, node-ports are using default range of 30000 - 32767 , allowing you to expose 2767 services/ports).
+## OpenStack & Quota
 
-A Public Cloud Load Balancer has the following non-configurable timeouts:
+Our Managed Kubernetes service is based on OpenStack, and your nodes, persistent volumes and load balancers are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
 
-- 20 seconds for the backend connection to be established
-- 180 seconds for the client & server connections
-
-> [!primary]
->
-> The use of the UDP protocol is not supported.
-
-## OpenStack
-
-Our Managed Kubernetes service is based on OpenStack, and your nodes and persistent volumes are built on it, using OVHcloud Public Cloud. As such, you can see them in the `Compute` > `Instances` section of your [OVHcloud Public Cloud Control Panel](/links/manager). Though it doesn't mean that you can deal directly with these nodes and persistent volumes the same way you can do it for other Public Cloud instances.
+Also, MKS Cluster's quota relies on your project's quota. Consult [this documentation](/pages/public_cloud/compute/increasing_public_cloud_quota) to increase your quota.
 
 The *managed* part of OVHcloud Managed Kubernetes Service means that we have configured those nodes and volumes to be part of our Managed Kubernetes.  
 Please refrain from manipulating them from the *OVHcloud Public Cloud Control Panel* (modifying ports left opened, renaming, resizing volumes...), as you could break them.


### PR DESCRIPTION
Some refactor to:
- remove LoadBalancer old limitations on MKS
- remove ambiguity on UDP protocol support by the LoadBalancer on MKS

EMEA & US are concern by this change.