### PR TITLE
BYOIP - APNIC support update

### DIFF
--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.de-de.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature (EN)
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2024-04-03
+updated: 2025-02-25
 ---
 
 ## Objective
@@ -29,17 +29,18 @@ You need to own (see below) a public IPv4 block with one of the following RIRs:
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Please note that support for National Internet Registries - NIRs - is experimental at the moment)
 
-It is now possible to use ARIN or RIPE IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
+It is now possible to use ARIN, RIPE or APNIC IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
 
 Unlike the previous policy, where an ARIN block could only be used with OVHcloud services located in Canada or the USA, and a RIPE block could only be used with OVHcloud services located in Europe, this restriction has been lifted.
 
 To be considered as a valid owned block, imported blocks must be one of the following types :
 
-| ARIN (object *Network type*) | RIPE (object *status*) |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object *Network type*) | RIPE (object *status*) | APNIC (object *status*) |
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **For more information :** <br>&bull; [INETNUM Quick Guide](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [Recording network assignments](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 
 ### Your IP range must have a supported size <a name="supportedsize"></a>
@@ -96,6 +97,7 @@ To prove that you are the owner of the range, you will be requested to enter a s
 
 - For RIPE, edit the « **descr** » field of the « **inetnum** » object of the IP.
 - For ARIN, edit the « **Public Comments** » field of the « **Network** » object.
+- For APNIC, edit the « **remarks** » field of « **inetnum** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -105,6 +107,7 @@ To prove that you are the owner of the AS number, you will be required to reuse 
 
 - For RIPE, edit the « **descr** » field of the « **aut-num** » object of the AS number.
 - For ARIN, edit the « **Public Comments** » field of the « **ASN** » object.
+- For APNIC, edit the « **remarks** » field of « **aut-num** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -116,6 +119,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
@@ -225,15 +229,11 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 
-### Can I import an IP range or AS number managed by APNIC/AFRINIC/LACNIC?
+### Can I import an IP range or AS number managed by AFRINIC/LACNIC?
 
 Not for the moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-asia.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2024-04-03
+updated: 2025-02-25
 ---
 
 ## Objective
@@ -29,17 +29,18 @@ You need to own (see below) a public IPv4 block with one of the following RIRs:
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Please note that support for National Internet Registries - NIRs - is experimental at the moment)
 
-It is now possible to use ARIN or RIPE IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
+It is now possible to use ARIN, RIPE or APNIC IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
 
 Unlike the previous policy, where an ARIN block could only be used with OVHcloud services located in Canada or the USA, and a RIPE block could only be used with OVHcloud services located in Europe, this restriction has been lifted.
 
 To be considered as a valid owned block, imported blocks must be one of the following types :
 
-| ARIN (object *Network type*) | RIPE (object *status*) |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object *Network type*) | RIPE (object *status*) | APNIC (object *status*) |
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **For more information :** <br>&bull; [INETNUM Quick Guide](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [Recording network assignments](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 
 ### Your IP range must have a supported size <a name="supportedsize"></a>
@@ -96,6 +97,7 @@ To prove that you are the owner of the range, you will be requested to enter a s
 
 - For RIPE, edit the « **descr** » field of the « **inetnum** » object of the IP.
 - For ARIN, edit the « **Public Comments** » field of the « **Network** » object.
+- For APNIC, edit the « **remarks** » field of « **inetnum** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -105,6 +107,7 @@ To prove that you are the owner of the AS number, you will be required to reuse 
 
 - For RIPE, edit the « **descr** » field of the « **aut-num** » object of the AS number.
 - For ARIN, edit the « **Public Comments** » field of the « **ASN** » object.
+- For APNIC, edit the « **remarks** » field of « **aut-num** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -116,6 +119,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
@@ -225,15 +229,11 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 
-### Can I import an IP range or AS number managed by APNIC/AFRINIC/LACNIC?
+### Can I import an IP range or AS number managed by AFRINIC/LACNIC?
 
 Not for the moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-au.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2024-04-03
+updated: 2025-02-25
 ---
 
 ## Objective
@@ -29,17 +29,18 @@ You need to own (see below) a public IPv4 block with one of the following RIRs:
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Please note that support for National Internet Registries - NIRs - is experimental at the moment)
 
-It is now possible to use ARIN or RIPE IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
+It is now possible to use ARIN, RIPE or APNIC IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
 
 Unlike the previous policy, where an ARIN block could only be used with OVHcloud services located in Canada or the USA, and a RIPE block could only be used with OVHcloud services located in Europe, this restriction has been lifted.
 
 To be considered as a valid owned block, imported blocks must be one of the following types :
 
-| ARIN (object *Network type*) | RIPE (object *status*) |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object *Network type*) | RIPE (object *status*) | APNIC (object *status*) |
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **For more information :** <br>&bull; [INETNUM Quick Guide](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [Recording network assignments](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 
 ### Your IP range must have a supported size <a name="supportedsize"></a>
@@ -96,6 +97,7 @@ To prove that you are the owner of the range, you will be requested to enter a s
 
 - For RIPE, edit the « **descr** » field of the « **inetnum** » object of the IP.
 - For ARIN, edit the « **Public Comments** » field of the « **Network** » object.
+- For APNIC, edit the « **remarks** » field of « **inetnum** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -105,6 +107,7 @@ To prove that you are the owner of the AS number, you will be required to reuse 
 
 - For RIPE, edit the « **descr** » field of the « **aut-num** » object of the AS number.
 - For ARIN, edit the « **Public Comments** » field of the « **ASN** » object.
+- For APNIC, edit the « **remarks** » field of « **aut-num** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -116,6 +119,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
@@ -225,15 +229,11 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 
-### Can I import an IP range or AS number managed by APNIC/AFRINIC/LACNIC?
+### Can I import an IP range or AS number managed by AFRINIC/LACNIC?
 
 Not for the moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-ca.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2024-04-03
+updated: 2025-02-25
 ---
 
 ## Objective
@@ -29,17 +29,18 @@ You need to own (see below) a public IPv4 block with one of the following RIRs:
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Please note that support for National Internet Registries - NIRs - is experimental at the moment)
 
-It is now possible to use ARIN or RIPE IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
+It is now possible to use ARIN, RIPE or APNIC IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
 
 Unlike the previous policy, where an ARIN block could only be used with OVHcloud services located in Canada or the USA, and a RIPE block could only be used with OVHcloud services located in Europe, this restriction has been lifted.
 
 To be considered as a valid owned block, imported blocks must be one of the following types :
 
-| ARIN (object *Network type*) | RIPE (object *status*) |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object *Network type*) | RIPE (object *status*) | APNIC (object *status*) |
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **For more information :** <br>&bull; [INETNUM Quick Guide](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [Recording network assignments](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 
 ### Your IP range must have a supported size <a name="supportedsize"></a>
@@ -96,6 +97,7 @@ To prove that you are the owner of the range, you will be requested to enter a s
 
 - For RIPE, edit the « **descr** » field of the « **inetnum** » object of the IP.
 - For ARIN, edit the « **Public Comments** » field of the « **Network** » object.
+- For APNIC, edit the « **remarks** » field of « **inetnum** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -105,6 +107,7 @@ To prove that you are the owner of the AS number, you will be required to reuse 
 
 - For RIPE, edit the « **descr** » field of the « **aut-num** » object of the AS number.
 - For ARIN, edit the « **Public Comments** » field of the « **ASN** » object.
+- For APNIC, edit the « **remarks** » field of « **aut-num** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -116,6 +119,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
@@ -225,15 +229,11 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 
-### Can I import an IP range or AS number managed by APNIC/AFRINIC/LACNIC?
+### Can I import an IP range or AS number managed by AFRINIC/LACNIC?
 
 Not for the moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-gb.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2025-02-19
+updated: 2025-02-26
 ---
 
 ## Objective

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-gb.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2024-04-03
+updated: 2025-02-19
 ---
 
 ## Objective
@@ -29,17 +29,18 @@ You need to own (see below) a public IPv4 block with one of the following RIRs:
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Please note that support for National Internet Registries - NIRs - is experimental at the moment)
 
-It is now possible to use ARIN or RIPE IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
+It is now possible to use ARIN, RIPE or APNIC IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
 
 Unlike the previous policy, where an ARIN block could only be used with OVHcloud services located in Canada or the USA, and a RIPE block could only be used with OVHcloud services located in Europe, this restriction has been lifted.
 
 To be considered as a valid owned block, imported blocks must be one of the following types :
 
-| ARIN (object *Network type*) | RIPE (object *status*) |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object *Network type*) | RIPE (object *status*) | APNIC (object *status*) |
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **For more information :** <br>&bull; [INETNUM Quick Guide](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [Recording network assignments](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 
 ### Your IP range must have a supported size <a name="supportedsize"></a>
@@ -96,6 +97,7 @@ To prove that you are the owner of the range, you will be requested to enter a s
 
 - For RIPE, edit the « **descr** » field of the « **inetnum** » object of the IP.
 - For ARIN, edit the « **Public Comments** » field of the « **Network** » object.
+- For APNIC, edit the « **remarks** » field of « **inetnum** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -105,6 +107,7 @@ To prove that you are the owner of the AS number, you will be required to reuse 
 
 - For RIPE, edit the « **descr** » field of the « **aut-num** » object of the AS number.
 - For ARIN, edit the « **Public Comments** » field of the « **ASN** » object.
+- For APNIC, edit the « **remarks** » field of « **aut-num** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -116,6 +119,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
@@ -225,15 +229,11 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 
-### Can I import an IP range or AS number managed by APNIC/AFRINIC/LACNIC?
+### Can I import an IP range or AS number managed by AFRINIC/LACNIC?
 
 Not for the moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-ie.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2024-04-03
+updated: 2025-02-25
 ---
 
 ## Objective
@@ -29,17 +29,18 @@ You need to own (see below) a public IPv4 block with one of the following RIRs:
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Please note that support for National Internet Registries - NIRs - is experimental at the moment)
 
-It is now possible to use ARIN or RIPE IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
+It is now possible to use ARIN, RIPE or APNIC IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
 
 Unlike the previous policy, where an ARIN block could only be used with OVHcloud services located in Canada or the USA, and a RIPE block could only be used with OVHcloud services located in Europe, this restriction has been lifted.
 
 To be considered as a valid owned block, imported blocks must be one of the following types :
 
-| ARIN (object *Network type*) | RIPE (object *status*) |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object *Network type*) | RIPE (object *status*) | APNIC (object *status*) |
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **For more information :** <br>&bull; [INETNUM Quick Guide](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [Recording network assignments](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 
 ### Your IP range must have a supported size <a name="supportedsize"></a>
@@ -96,6 +97,7 @@ To prove that you are the owner of the range, you will be requested to enter a s
 
 - For RIPE, edit the « **descr** » field of the « **inetnum** » object of the IP.
 - For ARIN, edit the « **Public Comments** » field of the « **Network** » object.
+- For APNIC, edit the « **remarks** » field of « **inetnum** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -105,6 +107,7 @@ To prove that you are the owner of the AS number, you will be required to reuse 
 
 - For RIPE, edit the « **descr** » field of the « **aut-num** » object of the AS number.
 - For ARIN, edit the « **Public Comments** » field of the « **ASN** » object.
+- For APNIC, edit the « **remarks** » field of « **aut-num** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -116,6 +119,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
@@ -225,15 +229,11 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 
-### Can I import an IP range or AS number managed by APNIC/AFRINIC/LACNIC?
+### Can I import an IP range or AS number managed by AFRINIC/LACNIC?
 
 Not for the moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-sg.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2024-04-03
+updated: 2025-02-25
 ---
 
 ## Objective
@@ -29,17 +29,18 @@ You need to own (see below) a public IPv4 block with one of the following RIRs:
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Please note that support for National Internet Registries - NIRs - is experimental at the moment)
 
-It is now possible to use ARIN or RIPE IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
+It is now possible to use ARIN, RIPE or APNIC IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
 
 Unlike the previous policy, where an ARIN block could only be used with OVHcloud services located in Canada or the USA, and a RIPE block could only be used with OVHcloud services located in Europe, this restriction has been lifted.
 
 To be considered as a valid owned block, imported blocks must be one of the following types :
 
-| ARIN (object *Network type*) | RIPE (object *status*) |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object *Network type*) | RIPE (object *status*) | APNIC (object *status*) |
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **For more information :** <br>&bull; [INETNUM Quick Guide](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [Recording network assignments](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 
 ### Your IP range must have a supported size <a name="supportedsize"></a>
@@ -96,6 +97,7 @@ To prove that you are the owner of the range, you will be requested to enter a s
 
 - For RIPE, edit the « **descr** » field of the « **inetnum** » object of the IP.
 - For ARIN, edit the « **Public Comments** » field of the « **Network** » object.
+- For APNIC, edit the « **remarks** » field of « **inetnum** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -105,6 +107,7 @@ To prove that you are the owner of the AS number, you will be required to reuse 
 
 - For RIPE, edit the « **descr** » field of the « **aut-num** » object of the AS number.
 - For ARIN, edit the « **Public Comments** » field of the « **ASN** » object.
+- For APNIC, edit the « **remarks** » field of « **aut-num** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -116,6 +119,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
@@ -225,15 +229,11 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 
-### Can I import an IP range or AS number managed by APNIC/AFRINIC/LACNIC?
+### Can I import an IP range or AS number managed by AFRINIC/LACNIC?
 
 Not for the moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-us.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2024-04-03
+updated: 2025-02-25
 ---
 
 ## Objective
@@ -29,17 +29,18 @@ You need to own (see below) a public IPv4 block with one of the following RIRs:
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Please note that support for National Internet Registries - NIRs - is experimental at the moment)
 
-It is now possible to use ARIN or RIPE IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
+It is now possible to use ARIN, RIPE or APNIC IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
 
 Unlike the previous policy, where an ARIN block could only be used with OVHcloud services located in Canada or the USA, and a RIPE block could only be used with OVHcloud services located in Europe, this restriction has been lifted.
 
 To be considered as a valid owned block, imported blocks must be one of the following types :
 
-| ARIN (object *Network type*) | RIPE (object *status*) |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object *Network type*) | RIPE (object *status*) | APNIC (object *status*) |
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **For more information :** <br>&bull; [INETNUM Quick Guide](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [Recording network assignments](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 
 ### Your IP range must have a supported size <a name="supportedsize"></a>
@@ -96,6 +97,7 @@ To prove that you are the owner of the range, you will be requested to enter a s
 
 - For RIPE, edit the « **descr** » field of the « **inetnum** » object of the IP.
 - For ARIN, edit the « **Public Comments** » field of the « **Network** » object.
+- For APNIC, edit the « **remarks** » field of « **inetnum** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -105,6 +107,7 @@ To prove that you are the owner of the AS number, you will be required to reuse 
 
 - For RIPE, edit the « **descr** » field of the « **aut-num** » object of the AS number.
 - For ARIN, edit the « **Public Comments** » field of the « **ASN** » object.
+- For APNIC, edit the « **remarks** » field of « **aut-num** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -116,6 +119,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
@@ -225,15 +229,11 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 
-### Can I import an IP range or AS number managed by APNIC/AFRINIC/LACNIC?
+### Can I import an IP range or AS number managed by AFRINIC/LACNIC?
 
 Not for the moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.es-es.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature (EN)
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2024-04-03
+updated: 2025-02-25
 ---
 
 ## Objective
@@ -29,17 +29,18 @@ You need to own (see below) a public IPv4 block with one of the following RIRs:
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Please note that support for National Internet Registries - NIRs - is experimental at the moment)
 
-It is now possible to use ARIN or RIPE IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
+It is now possible to use ARIN, RIPE or APNIC IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
 
 Unlike the previous policy, where an ARIN block could only be used with OVHcloud services located in Canada or the USA, and a RIPE block could only be used with OVHcloud services located in Europe, this restriction has been lifted.
 
 To be considered as a valid owned block, imported blocks must be one of the following types :
 
-| ARIN (object *Network type*) | RIPE (object *status*) |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object *Network type*) | RIPE (object *status*) | APNIC (object *status*) |
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **For more information :** <br>&bull; [INETNUM Quick Guide](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [Recording network assignments](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 
 ### Your IP range must have a supported size <a name="supportedsize"></a>
@@ -96,6 +97,7 @@ To prove that you are the owner of the range, you will be requested to enter a s
 
 - For RIPE, edit the « **descr** » field of the « **inetnum** » object of the IP.
 - For ARIN, edit the « **Public Comments** » field of the « **Network** » object.
+- For APNIC, edit the « **remarks** » field of « **inetnum** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -105,6 +107,7 @@ To prove that you are the owner of the AS number, you will be required to reuse 
 
 - For RIPE, edit the « **descr** » field of the « **aut-num** » object of the AS number.
 - For ARIN, edit the « **Public Comments** » field of the « **ASN** » object.
+- For APNIC, edit the « **remarks** » field of « **aut-num** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -116,6 +119,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
@@ -225,15 +229,11 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 
-### Can I import an IP range or AS number managed by APNIC/AFRINIC/LACNIC?
+### Can I import an IP range or AS number managed by AFRINIC/LACNIC?
 
 Not for the moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.es-us.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature (EN)
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2024-04-03
+updated: 2025-02-25
 ---
 
 ## Objective
@@ -29,17 +29,18 @@ You need to own (see below) a public IPv4 block with one of the following RIRs:
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Please note that support for National Internet Registries - NIRs - is experimental at the moment)
 
-It is now possible to use ARIN or RIPE IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
+It is now possible to use ARIN, RIPE or APNIC IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
 
 Unlike the previous policy, where an ARIN block could only be used with OVHcloud services located in Canada or the USA, and a RIPE block could only be used with OVHcloud services located in Europe, this restriction has been lifted.
 
 To be considered as a valid owned block, imported blocks must be one of the following types :
 
-| ARIN (object *Network type*) | RIPE (object *status*) |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object *Network type*) | RIPE (object *status*) | APNIC (object *status*) |
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **For more information :** <br>&bull; [INETNUM Quick Guide](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [Recording network assignments](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 
 ### Your IP range must have a supported size <a name="supportedsize"></a>
@@ -96,6 +97,7 @@ To prove that you are the owner of the range, you will be requested to enter a s
 
 - For RIPE, edit the « **descr** » field of the « **inetnum** » object of the IP.
 - For ARIN, edit the « **Public Comments** » field of the « **Network** » object.
+- For APNIC, edit the « **remarks** » field of « **inetnum** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -105,6 +107,7 @@ To prove that you are the owner of the AS number, you will be required to reuse 
 
 - For RIPE, edit the « **descr** » field of the « **aut-num** » object of the AS number.
 - For ARIN, edit the « **Public Comments** » field of the « **ASN** » object.
+- For APNIC, edit the « **remarks** » field of « **aut-num** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -116,6 +119,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
@@ -225,15 +229,11 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 
-### Can I import an IP range or AS number managed by APNIC/AFRINIC/LACNIC?
+### Can I import an IP range or AS number managed by AFRINIC/LACNIC?
 
 Not for the moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.fr-ca.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Utiliser la fonctionnalité Bring Your Own IP
 excerpt: Découvrez comment importer facilement votre propre adresse IP comme Additional IP dans votre compte OVHcloud
-updated: 2024-04-03
+updated: 2025-02-25
 ---
 
 ## Objectif
@@ -29,17 +29,18 @@ Vous devez posséder (voir ci-dessous) un bloc IPv4 public auprès de l'un des R
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Veuillez noter que le support pour les Registres Internet Nationaux - NIRs - est actuellement en phase expérimentale)
 
-Il est désormais possible d'utiliser des blocs IP ARIN ou RIPE sur n'importe quel campus OVHcloud. Cette flexibilité améliorée permet une gestion plus efficace et une allocation optimisée des adresses IP pour répondre aux besoins spécifiques de votre entreprise.
+Il est désormais possible d'utiliser des blocs IP ARIN, RIPE ou APNIC sur n'importe quel campus OVHcloud. Cette flexibilité améliorée permet une gestion plus efficace et une allocation optimisée des adresses IP pour répondre aux besoins spécifiques de votre entreprise.
 
 Contrairement à la politique précédente, où un bloc ARIN ne pouvait être utilisé qu'avec des services OVHcloud situés au Canada ou aux États-Unis et un bloc RIPE ne pouvait être utilisé qu'avec des services OVHcloud situés en Europe, cette restriction a été levée.
 
 Pour que le bloc soit considéré comme valide, les blocs importés doivent être de type suivants :
 
-| ARIN (object « Network type ») | RIPE (object « status ») |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **Pour plus d’informations :** <br>&bull; [« Using WhoIs - Network »](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [« Reporting Reassignments »](https://www.arin.net/resources/registry/reassignments/) | **Pour plus d'informations :** <br>[« Description of the INETNUM Object »](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object « Network type ») | RIPE (object « status ») | APNIC (object « status »)
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **Pour plus d’informations :** <br>&bull; [« Using WhoIs - Network »](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [« Reporting Reassignments »](https://www.arin.net/resources/registry/reassignments/) | **Pour plus d'informations :** <br>[« Description of the INETNUM Object »](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **Pour plus d'informations :** <br>&bull; [« INETNUM Quick Guide »](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [« Recording network assignments »](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 ### Avoir une plage d'IP d'une taille prise en charge <a name="haveaniprangeofasupportedsize"></a>
 
@@ -96,6 +97,7 @@ Cela se fera via le portail web du RIR gérant vos adresses IP. Ce token sera fo
 
 - Pour RIPE, éditez le champ « **descr** » de l'objet « **inetnum** » de l'IP.
 - Pour ARIN, éditez le champ « **Public Comments** » de l'objet « **Network** ».
+- Pour APNIC, éditez le champ « **remarks** » de l'objet « **inetnum** ».
 
 Il est nécessaire que le token apparaisse dans le champ de description (voir ci-dessus) de l'objet WHOIS, sur une ligne dédiée. D'autres lignes peuvent être présentes, à condition que le token soit présent dans sa propre ligne dédiée dans la description. Le token doit être ajouté avant la commande et ne doit pas être supprimé avant la fin de la livraison.
 
@@ -106,6 +108,7 @@ Cela se fera via le portail web du RIR gérant votre numéro AS. Ce token sera f
 
 - Pour RIPE, éditez le champ « **descr** » de l'objet « **aut-num** » du numéro AS.
 - Pour ARIN, éditez le champ « **Public Comments** » de l'objet « **ASN** ».
+- Pour APNIC, éditez le champ « **remarks** » de l'objet « **aut-num** ».
 
 Il est nécessaire que le token apparaisse dans le champ de description (voir ci-dessus) de l'objet WHOIS, sur une ligne dédiée. D'autres lignes peuvent être présentes, à condition que le token soit présent dans sa propre ligne dédiée dans la description. Le token doit être ajouté avant la commande et ne doit pas être supprimé avant la fin de la livraison.
 
@@ -117,6 +120,7 @@ Pour plus d'informations sur les objets de routage (*route objects*), veuillez c
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > Si votre bloc IP importé est déjà annoncé sur Internet à partir d’autre sites qu’OVHcloud lors de l’utilisation du service BYOIP (multihoming), vous risquez d’éventuelles pertes de paquets ou d'autres difficultés de routage. Nous ne serons par conséquent pas en mesure de vous garantir la connectivité aux services OVHcloud avec votre bloc IP importé.
@@ -226,15 +230,11 @@ Pas au lancement de l'offre BYOIP. Cependant, si tel est votre souhait, nous vou
 
 Oui. Pour plus d'informations, veuillez vous reporter à la section [Découpage de plages d'addresses](#range-slicing) ci-dessus.
 
-### Puis-je importer une plage d'adresses IP ARIN dans des campus acceptant uniquement des plages d'adresses IP RIPE et inversement ?
-
-Oui, avec la mise à jour de notre politique, il est désormais possible d'utiliser des blocs IP ARIN ou RIPE sur n'importe quel campus OVHcloud où le produit BYOIP est disponible. Nous avons éliminé les restrictions précédentes pour offrir une plus grande flexibilité et efficacité dans la gestion et l'allocation des adresses IP. Vous pouvez importer et utiliser vos blocs IP en fonction de vos besoins spécifiques, indépendamment de la localisation géographique du campus.
-
-### Puis-je importer un numéro AS ARIN avec une plage d'adresses IP RIPE et inversement ?
+### Puis-je importer un numéro AS et une plage d'adresses IP provenant de RIR différents ?
 
 Oui.
 
-### Puis-je importer une plage d’adresses IP ou un numéro AS géré par IP APNIC/AFRINIC/LACNIC ?
+### Puis-je importer une plage d’adresses IP ou un numéro AS géré par IP AFRINIC/LACNIC ?
 
 Pas pour le moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.fr-fr.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Utiliser la fonctionnalité Bring Your Own IP
 excerpt: Découvrez comment importer facilement votre propre adresse IP comme Additional IP dans votre compte OVHcloud
-updated: 2025-02-19
+updated: 2025-02-26
 ---
 
 ## Objectif

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.fr-fr.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Utiliser la fonctionnalité Bring Your Own IP
 excerpt: Découvrez comment importer facilement votre propre adresse IP comme Additional IP dans votre compte OVHcloud
-updated: 2024-04-03
+updated: 2025-02-19
 ---
 
 ## Objectif
@@ -29,17 +29,18 @@ Vous devez posséder (voir ci-dessous) un bloc IPv4 public auprès de l'un des R
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Veuillez noter que le support pour les Registres Internet Nationaux - NIRs - est actuellement en phase expérimentale)
 
-Il est désormais possible d'utiliser des blocs IP ARIN ou RIPE sur n'importe quel campus OVHcloud. Cette flexibilité améliorée permet une gestion plus efficace et une allocation optimisée des adresses IP pour répondre aux besoins spécifiques de votre entreprise.
+Il est désormais possible d'utiliser des blocs IP ARIN, RIPE ou APNIC sur n'importe quel campus OVHcloud. Cette flexibilité améliorée permet une gestion plus efficace et une allocation optimisée des adresses IP pour répondre aux besoins spécifiques de votre entreprise.
 
 Contrairement à la politique précédente, où un bloc ARIN ne pouvait être utilisé qu'avec des services OVHcloud situés au Canada ou aux États-Unis et un bloc RIPE ne pouvait être utilisé qu'avec des services OVHcloud situés en Europe, cette restriction a été levée.
 
 Pour que le bloc soit considéré comme valide, les blocs importés doivent être de type suivants :
 
-| ARIN (object « Network type ») | RIPE (object « status ») |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **Pour plus d’informations :** <br>&bull; [« Using WhoIs - Network »](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [« Reporting Reassignments »](https://www.arin.net/resources/registry/reassignments/) | **Pour plus d'informations :** <br>[« Description of the INETNUM Object »](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object « Network type ») | RIPE (object « status ») | APNIC (object « status »)
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **Pour plus d’informations :** <br>&bull; [« Using WhoIs - Network »](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [« Reporting Reassignments »](https://www.arin.net/resources/registry/reassignments/) | **Pour plus d'informations :** <br>[« Description of the INETNUM Object »](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **Pour plus d'informations :** <br>&bull; [« INETNUM Quick Guide »](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [« Recording network assignments »](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 ### Avoir une plage d'IP d'une taille prise en charge <a name="haveaniprangeofasupportedsize"></a>
 
@@ -96,6 +97,7 @@ Cela se fera via le portail web du RIR gérant vos adresses IP. Ce token sera fo
 
 - Pour RIPE, éditez le champ « **descr** » de l'objet « **inetnum** » de l'IP.
 - Pour ARIN, éditez le champ « **Public Comments** » de l'objet « **Network** ».
+- Pour APNIC, éditez le champ « **remarks** » de l'objet « **inetnum** ».
 
 Il est nécessaire que le token apparaisse dans le champ de description (voir ci-dessus) de l'objet WHOIS, sur une ligne dédiée. D'autres lignes peuvent être présentes, à condition que le token soit présent dans sa propre ligne dédiée dans la description. Le token doit être ajouté avant la commande et ne doit pas être supprimé avant la fin de la livraison.
 
@@ -106,6 +108,7 @@ Cela se fera via le portail web du RIR gérant votre numéro AS. Ce token sera f
 
 - Pour RIPE, éditez le champ « **descr** » de l'objet « **aut-num** » du numéro AS.
 - Pour ARIN, éditez le champ « **Public Comments** » de l'objet « **ASN** ».
+- Pour APNIC, éditez le champ « **remarks** » de l'objet « **aut-num** ».
 
 Il est nécessaire que le token apparaisse dans le champ de description (voir ci-dessus) de l'objet WHOIS, sur une ligne dédiée. D'autres lignes peuvent être présentes, à condition que le token soit présent dans sa propre ligne dédiée dans la description. Le token doit être ajouté avant la commande et ne doit pas être supprimé avant la fin de la livraison.
 
@@ -117,6 +120,7 @@ Pour plus d'informations sur les objets de routage (*route objects*), veuillez c
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > Si votre bloc IP importé est déjà annoncé sur Internet à partir d’autre sites qu’OVHcloud lors de l’utilisation du service BYOIP (multihoming), vous risquez d’éventuelles pertes de paquets ou d'autres difficultés de routage. Nous ne serons par conséquent pas en mesure de vous garantir la connectivité aux services OVHcloud avec votre bloc IP importé.
@@ -226,15 +230,11 @@ Pas au lancement de l'offre BYOIP. Cependant, si tel est votre souhait, nous vou
 
 Oui. Pour plus d'informations, veuillez vous reporter à la section [Découpage de plages d'addresses](#range-slicing) ci-dessus.
 
-### Puis-je importer une plage d'adresses IP ARIN dans des campus acceptant uniquement des plages d'adresses IP RIPE et inversement ?
-
-Oui, avec la mise à jour de notre politique, il est désormais possible d'utiliser des blocs IP ARIN ou RIPE sur n'importe quel campus OVHcloud où le produit BYOIP est disponible. Nous avons éliminé les restrictions précédentes pour offrir une plus grande flexibilité et efficacité dans la gestion et l'allocation des adresses IP. Vous pouvez importer et utiliser vos blocs IP en fonction de vos besoins spécifiques, indépendamment de la localisation géographique du campus.
-
-### Puis-je importer un numéro AS ARIN avec une plage d'adresses IP RIPE et inversement ?
+### Puis-je importer un numéro AS et une plage d'adresses IP provenant de RIR différents ?
 
 Oui.
 
-### Puis-je importer une plage d’adresses IP ou un numéro AS géré par IP APNIC/AFRINIC/LACNIC ?
+### Puis-je importer une plage d’adresses IP ou un numéro AS géré par IP AFRINIC/LACNIC ?
 
 Pas pour le moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.it-it.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature (EN)
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2024-04-03
+updated: 2025-02-25
 ---
 
 ## Objective
@@ -29,17 +29,18 @@ You need to own (see below) a public IPv4 block with one of the following RIRs:
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Please note that support for National Internet Registries - NIRs - is experimental at the moment)
 
-It is now possible to use ARIN or RIPE IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
+It is now possible to use ARIN, RIPE or APNIC IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
 
 Unlike the previous policy, where an ARIN block could only be used with OVHcloud services located in Canada or the USA, and a RIPE block could only be used with OVHcloud services located in Europe, this restriction has been lifted.
 
 To be considered as a valid owned block, imported blocks must be one of the following types :
 
-| ARIN (object *Network type*) | RIPE (object *status*) |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object *Network type*) | RIPE (object *status*) | APNIC (object *status*) |
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **For more information :** <br>&bull; [INETNUM Quick Guide](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [Recording network assignments](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 
 ### Your IP range must have a supported size <a name="supportedsize"></a>
@@ -96,6 +97,7 @@ To prove that you are the owner of the range, you will be requested to enter a s
 
 - For RIPE, edit the « **descr** » field of the « **inetnum** » object of the IP.
 - For ARIN, edit the « **Public Comments** » field of the « **Network** » object.
+- For APNIC, edit the « **remarks** » field of « **inetnum** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -105,6 +107,7 @@ To prove that you are the owner of the AS number, you will be required to reuse 
 
 - For RIPE, edit the « **descr** » field of the « **aut-num** » object of the AS number.
 - For ARIN, edit the « **Public Comments** » field of the « **ASN** » object.
+- For APNIC, edit the « **remarks** » field of « **aut-num** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -116,6 +119,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
@@ -225,15 +229,11 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 
-### Can I import an IP range or AS number managed by APNIC/AFRINIC/LACNIC?
+### Can I import an IP range or AS number managed by AFRINIC/LACNIC?
 
 Not for the moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.pl-pl.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature (EN)
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2024-04-03
+updated: 2025-02-25
 ---
 
 ## Objective
@@ -29,17 +29,18 @@ You need to own (see below) a public IPv4 block with one of the following RIRs:
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Please note that support for National Internet Registries - NIRs - is experimental at the moment)
 
-It is now possible to use ARIN or RIPE IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
+It is now possible to use ARIN, RIPE or APNIC IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
 
 Unlike the previous policy, where an ARIN block could only be used with OVHcloud services located in Canada or the USA, and a RIPE block could only be used with OVHcloud services located in Europe, this restriction has been lifted.
 
 To be considered as a valid owned block, imported blocks must be one of the following types :
 
-| ARIN (object *Network type*) | RIPE (object *status*) |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object *Network type*) | RIPE (object *status*) | APNIC (object *status*) |
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **For more information :** <br>&bull; [INETNUM Quick Guide](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [Recording network assignments](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 
 ### Your IP range must have a supported size <a name="supportedsize"></a>
@@ -96,6 +97,7 @@ To prove that you are the owner of the range, you will be requested to enter a s
 
 - For RIPE, edit the « **descr** » field of the « **inetnum** » object of the IP.
 - For ARIN, edit the « **Public Comments** » field of the « **Network** » object.
+- For APNIC, edit the « **remarks** » field of « **inetnum** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -105,6 +107,7 @@ To prove that you are the owner of the AS number, you will be required to reuse 
 
 - For RIPE, edit the « **descr** » field of the « **aut-num** » object of the AS number.
 - For ARIN, edit the « **Public Comments** » field of the « **ASN** » object.
+- For APNIC, edit the « **remarks** » field of « **aut-num** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -116,6 +119,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
@@ -225,15 +229,11 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 
-### Can I import an IP range or AS number managed by APNIC/AFRINIC/LACNIC?
+### Can I import an IP range or AS number managed by AFRINIC/LACNIC?
 
 Not for the moment.
 

--- a/pages/network/bring_your_own_ip/bring-your-own-IP/guide.pt-pt.md
+++ b/pages/network/bring_your_own_ip/bring-your-own-IP/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the Bring Your Own IP feature (EN)
 excerpt: Find out how to easily import your own IP as Additional IP to your OVHcloud account
-updated: 2024-04-03
+updated: 2025-02-25
 ---
 
 ## Objective
@@ -29,17 +29,18 @@ You need to own (see below) a public IPv4 block with one of the following RIRs:
 
 - [ARIN](https://www.arin.net/)
 - [RIPE](https://www.ripe.net/)
+- [APNIC](https://www.apnic.net/) (Please note that support for National Internet Registries - NIRs - is experimental at the moment)
 
-It is now possible to use ARIN or RIPE IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
+It is now possible to use ARIN, RIPE or APNIC IP blocks on any OVHcloud campus. This enhanced flexibility enables more efficient management and optimized allocation of IP addresses to meet your company's specific needs.
 
 Unlike the previous policy, where an ARIN block could only be used with OVHcloud services located in Canada or the USA, and a RIPE block could only be used with OVHcloud services located in Europe, this restriction has been lifted.
 
 To be considered as a valid owned block, imported blocks must be one of the following types :
 
-| ARIN (object *Network type*) | RIPE (object *status*) |
-| :--- | :--- |
-| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |
-| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |
+| ARIN (object *Network type*) | RIPE (object *status*) | APNIC (object *status*) |
+| :--- | :--- | :--- |
+| &bull; Direct Allocation <br>&bull; Direct Assignment <br>&bull; Reallocated <br>&bull; Reassigned  |  &bull; ALLOCATED PA <br>&bull; LIR-PARTITIONED PA  <br>&bull; SUB-ALLOCATED PA  <br>&bull; ASSIGNED PA  <br>&bull; ASSIGNED PI  <br>&bull; LEGACY   |  &bull; Allocated-Portable <br>&bull; Allocated-Non-Portable <br>&bull; Assigned-Portable <br>&bull; Assigned-Non-Portable  |
+| **For more information :** <br>&bull; [Using WhoIs - Network](https://www.arin.net/resources/registry/whois/#network) <br>&bull; [Reporting Reassignments](https://www.arin.net/resources/registry/reassignments/) | **For more information :** <br>[Description of the INETNUM Object](https://apps.db.ripe.net/docs/04.RPSL-Object-Types/02-Descriptions-of-Primary-Objects.html#description-of-the-inetnum-object) |  **For more information :** <br>&bull; [INETNUM Quick Guide](https://www.apnic.net/manage-ip/using-whois/guide/inetnum/) <br>&bull; [Recording network assignments](https://www.apnic.net/manage-ip/using-whois/updating-whois/network-assignments/) |
 
 
 ### Your IP range must have a supported size <a name="supportedsize"></a>
@@ -96,6 +97,7 @@ To prove that you are the owner of the range, you will be requested to enter a s
 
 - For RIPE, edit the « **descr** » field of the « **inetnum** » object of the IP.
 - For ARIN, edit the « **Public Comments** » field of the « **Network** » object.
+- For APNIC, edit the « **remarks** » field of « **inetnum** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -105,6 +107,7 @@ To prove that you are the owner of the AS number, you will be required to reuse 
 
 - For RIPE, edit the « **descr** » field of the « **aut-num** » object of the AS number.
 - For ARIN, edit the « **Public Comments** » field of the « **ASN** » object.
+- For APNIC, edit the « **remarks** » field of « **aut-num** » object.
 
 The token needs to appears in the description field (see above) of the whois object, in a dedicated line. Other lines may be present, as long as the token is present in its own dedicated line in the description. The token must be added before placing the order, and must not be removed until the end of the delivery process.
 
@@ -116,6 +119,7 @@ For more information on route objects, please refer to your RIR’s documentatio
 
 - RIPE - [Managing Route Objects](https://www.ripe.net/manage-ips-and-asns/db/support/managing-route-objects-in-the-irr)
 - ARIN - [Submitting Routing Information](https://www.arin.net/resources/manage/irr/#submitting-routing-information)
+- APNIC - [Creating Route Objects](https://www.apnic.net/manage-ip/using-whois/guide/creating-route-objects/)
 
 > [!warning]
 > If your imported IP block is already advertized on the Internet from sites other than OVHcloud (multihoming case), you risk packet loss or other routing issues. We will therefore not be able to guarantee connectivity to OVHcloud services with your imported IP block.
@@ -225,15 +229,11 @@ Not at product launch, but feel free to contact us to discuss this.
 
 Yes, please see the [Range slicing](#range-slicing) section for more details.
 
-### Can I import an ARIN range in campuses accepting only RIPE ranges, and vice-versa?
-
-Yes, with our updated policy, it is now possible to use ARIN or RIPE IP blocks on OVHcloud campus where the BYOIP product is available. We've removed previous restrictions to offer greater flexibility and efficiency in IP address management and allocation. You can import and use your IP blocks according to your specific needs, regardless of the geographical location of the campus.
-
-### Can I import an ARIN AS number with a RIPE IP range, and vice-versa?
+### Can I import an IP and an AS number that are not in the same RIR?
 
 Yes.
 
-### Can I import an IP range or AS number managed by APNIC/AFRINIC/LACNIC?
+### Can I import an IP range or AS number managed by AFRINIC/LACNIC?
 
 Not for the moment.
 


### PR DESCRIPTION
This version aggregates all the previous edits that were rolled back due to an early merge, and acknowledges current experimental support of NIRs instead of stating they are not supported at all.

ETA of the feature: 2025/02/26