### PR TITLE
Update proxy link in Kubernetes Dashboard intall guide

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.de-de.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-asia.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-au.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-ca.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-gb.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-ie.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-sg.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-us.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.es-es.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.es-us.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.fr-ca.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.fr-fr.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.it-it.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.pl-pl.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.pt-pt.md
@@ -184,7 +184,7 @@ Starting to serve on 127.0.0.1:8001
 ```
 
 Next, access the Dashboard at:  
-<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/>
+<http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/>
 
 In the log-in page, select authentication by token, and use the bearer token you recovered in the previous step.
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-kubernetes-dashboard/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the Kubernetes Dashboard on OVHcloud Managed Kubernetes
 excerpt: 'Find out how to install the Kubernetes Dashboard on your OVHcloud Managed Kubernetes Service'
-updated: 2023-02-16
+updated: 2025-02-27
 ---
 
 The [Kubernetes Dashboard](https://github.com/kubernetes/dashboard){.external} is a general purpose, web-based UI for Kubernetes clusters. It allows users to manage and troubleshoot applications running in their cluster, as well as manage the cluster itself.


### PR DESCRIPTION
Since Kubernetes Dashboard 7.0.0, nginx has been replaced by kong, so the way to access the dashboard has changed