### PR TITLE
Alpha disclaimer + H6 titles change

### DIFF
--- a/pages/network/bgp_service/bgp_service_config/guide.de-de.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.de-de.md
@@ -1,12 +1,17 @@
 ---
 title: BGP Service configuration
 excerpt: By using BGP Service, you gain full control over your routing policies and network resilience. Follow this guide to set up and optimize your BGP sessions
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objective
 
 BGP Service allows you to build highly available infrastructures by running standard BGP (Border Gateway Protocol) straight from your OVHcloud hosts. It can be used with OVHcloud Additional IP or with your own IP addresses, by using Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
+>
 
 ## Requirements
 
@@ -22,11 +27,6 @@ BGP Service allows you to build highly available infrastructures by running stan
 ### Step 1: Join the Alpha
 
 First, you need to request to join the alpha on the following [page](https://labs.ovhcloud.com/en/). After we receive your application, we will contact you by email.
-
-> [!primary]
->
-> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
->
 
 ### Step 2: Prepare your IP addresses
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Step 2: Configure FRR
 
-##### FRR configuration for Route Servers
+##### ***FRR configuration for Route Servers***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the route server(s).
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### FRR configuration for Hosts
+##### ***FRR configuration for Hosts***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the hosts.
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.en-asia.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.en-asia.md
@@ -1,12 +1,17 @@
 ---
 title: BGP Service configuration
 excerpt: By using BGP Service, you gain full control over your routing policies and network resilience. Follow this guide to set up and optimize your BGP sessions
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objective
 
 BGP Service allows you to build highly available infrastructures by running standard BGP (Border Gateway Protocol) straight from your OVHcloud hosts. It can be used with OVHcloud Additional IP or with your own IP addresses, by using Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
+>
 
 ## Requirements
 
@@ -22,11 +27,6 @@ BGP Service allows you to build highly available infrastructures by running stan
 ### Step 1: Join the Alpha
 
 First, you need to request to join the alpha on the following [page](https://labs.ovhcloud.com/en/). After we receive your application, we will contact you by email.
-
-> [!primary]
->
-> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
->
 
 ### Step 2: Prepare your IP addresses
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Step 2: Configure FRR
 
-##### FRR configuration for Route Servers
+##### ***FRR configuration for Route Servers***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the route server(s).
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### FRR configuration for Hosts
+##### ***FRR configuration for Hosts***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the hosts.
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.en-au.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.en-au.md
@@ -1,12 +1,17 @@
 ---
 title: BGP Service configuration
 excerpt: By using BGP Service, you gain full control over your routing policies and network resilience. Follow this guide to set up and optimize your BGP sessions
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objective
 
 BGP Service allows you to build highly available infrastructures by running standard BGP (Border Gateway Protocol) straight from your OVHcloud hosts. It can be used with OVHcloud Additional IP or with your own IP addresses, by using Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
+>
 
 ## Requirements
 
@@ -22,11 +27,6 @@ BGP Service allows you to build highly available infrastructures by running stan
 ### Step 1: Join the Alpha
 
 First, you need to request to join the alpha on the following [page](https://labs.ovhcloud.com/en/). After we receive your application, we will contact you by email.
-
-> [!primary]
->
-> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
->
 
 ### Step 2: Prepare your IP addresses
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Step 2: Configure FRR
 
-##### FRR configuration for Route Servers
+##### ***FRR configuration for Route Servers***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the route server(s).
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### FRR configuration for Hosts
+##### ***FRR configuration for Hosts***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the hosts.
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.en-ca.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.en-ca.md
@@ -1,12 +1,17 @@
 ---
 title: BGP Service configuration
 excerpt: By using BGP Service, you gain full control over your routing policies and network resilience. Follow this guide to set up and optimize your BGP sessions
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objective
 
 BGP Service allows you to build highly available infrastructures by running standard BGP (Border Gateway Protocol) straight from your OVHcloud hosts. It can be used with OVHcloud Additional IP or with your own IP addresses, by using Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
+>
 
 ## Requirements
 
@@ -22,11 +27,6 @@ BGP Service allows you to build highly available infrastructures by running stan
 ### Step 1: Join the Alpha
 
 First, you need to request to join the alpha on the following [page](https://labs.ovhcloud.com/en/). After we receive your application, we will contact you by email.
-
-> [!primary]
->
-> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
->
 
 ### Step 2: Prepare your IP addresses
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Step 2: Configure FRR
 
-##### FRR configuration for Route Servers
+##### ***FRR configuration for Route Servers***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the route server(s).
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### FRR configuration for Hosts
+##### ***FRR configuration for Hosts***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the hosts.
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.en-gb.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.en-gb.md
@@ -1,12 +1,17 @@
 ---
 title: BGP Service configuration
 excerpt: By using BGP Service, you gain full control over your routing policies and network resilience. Follow this guide to set up and optimize your BGP sessions
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objective
 
 BGP Service allows you to build highly available infrastructures by running standard BGP (Border Gateway Protocol) straight from your OVHcloud hosts. It can be used with OVHcloud Additional IP or with your own IP addresses, by using Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
+>
 
 ## Requirements
 
@@ -22,11 +27,6 @@ BGP Service allows you to build highly available infrastructures by running stan
 ### Step 1: Join the Alpha
 
 First, you need to request to join the alpha on the following [page](https://labs.ovhcloud.com/en/). After we receive your application, we will contact you by email.
-
-> [!primary]
->
-> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
->
 
 ### Step 2: Prepare your IP addresses
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Step 2: Configure FRR
 
-##### FRR configuration for Route Servers
+##### ***FRR configuration for Route Servers***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the route server(s).
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### FRR configuration for Hosts
+##### ***FRR configuration for Hosts***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the hosts.
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.en-ie.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.en-ie.md
@@ -1,12 +1,17 @@
 ---
 title: BGP Service configuration
 excerpt: By using BGP Service, you gain full control over your routing policies and network resilience. Follow this guide to set up and optimize your BGP sessions
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objective
 
 BGP Service allows you to build highly available infrastructures by running standard BGP (Border Gateway Protocol) straight from your OVHcloud hosts. It can be used with OVHcloud Additional IP or with your own IP addresses, by using Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
+>
 
 ## Requirements
 
@@ -22,11 +27,6 @@ BGP Service allows you to build highly available infrastructures by running stan
 ### Step 1: Join the Alpha
 
 First, you need to request to join the alpha on the following [page](https://labs.ovhcloud.com/en/). After we receive your application, we will contact you by email.
-
-> [!primary]
->
-> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
->
 
 ### Step 2: Prepare your IP addresses
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Step 2: Configure FRR
 
-##### FRR configuration for Route Servers
+##### ***FRR configuration for Route Servers***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the route server(s).
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### FRR configuration for Hosts
+##### ***FRR configuration for Hosts***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the hosts.
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.en-sg.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.en-sg.md
@@ -1,12 +1,17 @@
 ---
 title: BGP Service configuration
 excerpt: By using BGP Service, you gain full control over your routing policies and network resilience. Follow this guide to set up and optimize your BGP sessions
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objective
 
 BGP Service allows you to build highly available infrastructures by running standard BGP (Border Gateway Protocol) straight from your OVHcloud hosts. It can be used with OVHcloud Additional IP or with your own IP addresses, by using Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
+>
 
 ## Requirements
 
@@ -22,11 +27,6 @@ BGP Service allows you to build highly available infrastructures by running stan
 ### Step 1: Join the Alpha
 
 First, you need to request to join the alpha on the following [page](https://labs.ovhcloud.com/en/). After we receive your application, we will contact you by email.
-
-> [!primary]
->
-> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
->
 
 ### Step 2: Prepare your IP addresses
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Step 2: Configure FRR
 
-##### FRR configuration for Route Servers
+##### ***FRR configuration for Route Servers***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the route server(s).
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### FRR configuration for Hosts
+##### ***FRR configuration for Hosts***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the hosts.
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.en-us.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.en-us.md
@@ -1,12 +1,17 @@
 ---
 title: BGP Service configuration
 excerpt: By using BGP Service, you gain full control over your routing policies and network resilience. Follow this guide to set up and optimize your BGP sessions
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objective
 
 BGP Service allows you to build highly available infrastructures by running standard BGP (Border Gateway Protocol) straight from your OVHcloud hosts. It can be used with OVHcloud Additional IP or with your own IP addresses, by using Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
+>
 
 ## Requirements
 
@@ -22,11 +27,6 @@ BGP Service allows you to build highly available infrastructures by running stan
 ### Step 1: Join the Alpha
 
 First, you need to request to join the alpha on the following [page](https://labs.ovhcloud.com/en/). After we receive your application, we will contact you by email.
-
-> [!primary]
->
-> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
->
 
 ### Step 2: Prepare your IP addresses
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Step 2: Configure FRR
 
-##### FRR configuration for Route Servers
+##### ***FRR configuration for Route Servers***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the route server(s).
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### FRR configuration for Hosts
+##### ***FRR configuration for Hosts***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the hosts.
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.es-es.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.es-es.md
@@ -1,12 +1,17 @@
 ---
 title: BGP Service configuration
 excerpt: By using BGP Service, you gain full control over your routing policies and network resilience. Follow this guide to set up and optimize your BGP sessions
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objective
 
 BGP Service allows you to build highly available infrastructures by running standard BGP (Border Gateway Protocol) straight from your OVHcloud hosts. It can be used with OVHcloud Additional IP or with your own IP addresses, by using Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
+>
 
 ## Requirements
 
@@ -22,11 +27,6 @@ BGP Service allows you to build highly available infrastructures by running stan
 ### Step 1: Join the Alpha
 
 First, you need to request to join the alpha on the following [page](https://labs.ovhcloud.com/en/). After we receive your application, we will contact you by email.
-
-> [!primary]
->
-> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
->
 
 ### Step 2: Prepare your IP addresses
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Step 2: Configure FRR
 
-##### FRR configuration for Route Servers
+##### ***FRR configuration for Route Servers***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the route server(s).
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### FRR configuration for Hosts
+##### ***FRR configuration for Hosts***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the hosts.
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.es-us.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.es-us.md
@@ -1,12 +1,17 @@
 ---
 title: BGP Service configuration
 excerpt: By using BGP Service, you gain full control over your routing policies and network resilience. Follow this guide to set up and optimize your BGP sessions
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objective
 
 BGP Service allows you to build highly available infrastructures by running standard BGP (Border Gateway Protocol) straight from your OVHcloud hosts. It can be used with OVHcloud Additional IP or with your own IP addresses, by using Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
+>
 
 ## Requirements
 
@@ -22,11 +27,6 @@ BGP Service allows you to build highly available infrastructures by running stan
 ### Step 1: Join the Alpha
 
 First, you need to request to join the alpha on the following [page](https://labs.ovhcloud.com/en/). After we receive your application, we will contact you by email.
-
-> [!primary]
->
-> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
->
 
 ### Step 2: Prepare your IP addresses
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Step 2: Configure FRR
 
-##### FRR configuration for Route Servers
+##### ***FRR configuration for Route Servers***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the route server(s).
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### FRR configuration for Hosts
+##### ***FRR configuration for Hosts***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the hosts.
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.fr-ca.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.fr-ca.md
@@ -1,12 +1,17 @@
 ---
 title: Configuration du service BGP
 excerpt: En utilisant le service BGP, vous bénéficiez d'un contrôle total sur vos politiques de routage et la résilience du réseau. Suivez ce guide pour configurer et optimiser vos sessions BGP
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objectif
 
 Le protocole Border Gateway Protocol (BGP) vous permet de construire des infrastructures hautement disponibles en exécutant le protocole de routage BGP standard directement à partir de vos hôtes OVHcloud. Il peut être utilisé avec les Additional IP d’OVHcloud ou avec vos propres adresses IP, en utilisant Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: le service BGP est actuellement en phase alpha. Ce produit n'est pas destiné à être utilisé dans un environnement de production.
+>
 
 ## Prérequis
 
@@ -22,11 +27,6 @@ Le protocole Border Gateway Protocol (BGP) vous permet de construire des infrast
 ### Étape 1 : rejoindre l'Alpha
 
 Vous devez d'abord demander à rejoindre l'alpha sur [cette page](https://labs.ovhcloud.com/en/). Après réception de votre candidature, nous vous contacterons par e-mail.
-
-> [!primary]
->
-> **Important**: le service BGP est actuellement en phase alpha. Ce produit n'est pas destiné à être utilisé dans un environnement de production.
->
 
 ### Étape 2 : préparer vos adresses IP
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Étape 2 : Configurer FRR
 
-##### Configuration de FRR sur les Route Servers
+##### ***Configuration de FRR sur les Route Servers***
 
 > [!primary]
 >
 > Tous les paramètres décrits ci-dessous sont présents dans le fichier de configuration `/etc/frr/frr.conf`.
 
-###### **Configuration des listes de préfixes et route-maps**
+##### Configuration des listes de préfixes et route-maps
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### Configuration de FRR sur les Hôtes
+##### ***Configuration de FRR sur les Hôtes***
 
 > [!primary]
 >
 > Tous les paramètres décrits ci-dessous sont présents dans le fichier de configuration `/etc/frr/frr.conf`.
 
-###### **Configuration des listes de préfixes et route-maps**
+##### Configuration des listes de préfixes et route-maps
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.fr-fr.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.fr-fr.md
@@ -1,12 +1,17 @@
 ---
 title: Configuration du service BGP
 excerpt: En utilisant le service BGP, vous bénéficiez d'un contrôle total sur vos politiques de routage et la résilience du réseau. Suivez ce guide pour configurer et optimiser vos sessions BGP
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objectif
 
 Le protocole Border Gateway Protocol (BGP) vous permet de construire des infrastructures hautement disponibles en exécutant le protocole de routage BGP standard directement à partir de vos hôtes OVHcloud. Il peut être utilisé avec les Additional IP d’OVHcloud ou avec vos propres adresses IP, en utilisant Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: le service BGP est actuellement en phase alpha. Ce produit n'est pas destiné à être utilisé dans un environnement de production.
+>
 
 ## Prérequis
 
@@ -22,11 +27,6 @@ Le protocole Border Gateway Protocol (BGP) vous permet de construire des infrast
 ### Étape 1 : rejoindre l'Alpha
 
 Vous devez d'abord demander à rejoindre l'alpha sur [cette page](https://labs.ovhcloud.com/en/). Après réception de votre candidature, nous vous contacterons par e-mail.
-
-> [!primary]
->
-> **Important**: le service BGP est actuellement en phase alpha. Ce produit n'est pas destiné à être utilisé dans un environnement de production.
->
 
 ### Étape 2 : préparer vos adresses IP
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Étape 2 : Configurer FRR
 
-##### Configuration de FRR sur les Route Servers
+##### ***Configuration de FRR sur les Route Servers***
 
 > [!primary]
 >
 > Tous les paramètres décrits ci-dessous sont présents dans le fichier de configuration `/etc/frr/frr.conf`.
 
-###### **Configuration des listes de préfixes et route-maps**
+##### Configuration des listes de préfixes et route-maps
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### Configuration de FRR sur les Hôtes
+##### ***Configuration de FRR sur les Hôtes***
 
 > [!primary]
 >
 > Tous les paramètres décrits ci-dessous sont présents dans le fichier de configuration `/etc/frr/frr.conf`.
 
-###### **Configuration des listes de préfixes et route-maps**
+##### Configuration des listes de préfixes et route-maps
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.it-it.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.it-it.md
@@ -1,12 +1,17 @@
 ---
 title: BGP Service configuration
 excerpt: By using BGP Service, you gain full control over your routing policies and network resilience. Follow this guide to set up and optimize your BGP sessions
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objective
 
 BGP Service allows you to build highly available infrastructures by running standard BGP (Border Gateway Protocol) straight from your OVHcloud hosts. It can be used with OVHcloud Additional IP or with your own IP addresses, by using Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
+>
 
 ## Requirements
 
@@ -22,11 +27,6 @@ BGP Service allows you to build highly available infrastructures by running stan
 ### Step 1: Join the Alpha
 
 First, you need to request to join the alpha on the following [page](https://labs.ovhcloud.com/en/). After we receive your application, we will contact you by email.
-
-> [!primary]
->
-> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
->
 
 ### Step 2: Prepare your IP addresses
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Step 2: Configure FRR
 
-##### FRR configuration for Route Servers
+##### ***FRR configuration for Route Servers***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the route server(s).
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### FRR configuration for Hosts
+##### ***FRR configuration for Hosts***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the hosts.
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.pl-pl.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.pl-pl.md
@@ -1,12 +1,17 @@
 ---
 title: BGP Service configuration
 excerpt: By using BGP Service, you gain full control over your routing policies and network resilience. Follow this guide to set up and optimize your BGP sessions
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objective
 
 BGP Service allows you to build highly available infrastructures by running standard BGP (Border Gateway Protocol) straight from your OVHcloud hosts. It can be used with OVHcloud Additional IP or with your own IP addresses, by using Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
+>
 
 ## Requirements
 
@@ -22,11 +27,6 @@ BGP Service allows you to build highly available infrastructures by running stan
 ### Step 1: Join the Alpha
 
 First, you need to request to join the alpha on the following [page](https://labs.ovhcloud.com/en/). After we receive your application, we will contact you by email.
-
-> [!primary]
->
-> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
->
 
 ### Step 2: Prepare your IP addresses
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Step 2: Configure FRR
 
-##### FRR configuration for Route Servers
+##### ***FRR configuration for Route Servers***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the route server(s).
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### FRR configuration for Hosts
+##### ***FRR configuration for Hosts***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the hosts.
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >

--- a/pages/network/bgp_service/bgp_service_config/guide.pt-pt.md
+++ b/pages/network/bgp_service/bgp_service_config/guide.pt-pt.md
@@ -1,12 +1,17 @@
 ---
 title: BGP Service configuration
 excerpt: By using BGP Service, you gain full control over your routing policies and network resilience. Follow this guide to set up and optimize your BGP sessions
-updated: 2025-03-06
+updated: 2025-03-07
 ---
 
 ## Objective
 
 BGP Service allows you to build highly available infrastructures by running standard BGP (Border Gateway Protocol) straight from your OVHcloud hosts. It can be used with OVHcloud Additional IP or with your own IP addresses, by using Bring Your Own IP (BYOIP).
+
+> [!warning]
+>
+> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
+>
 
 ## Requirements
 
@@ -22,11 +27,6 @@ BGP Service allows you to build highly available infrastructures by running stan
 ### Step 1: Join the Alpha
 
 First, you need to request to join the alpha on the following [page](https://labs.ovhcloud.com/en/). After we receive your application, we will contact you by email.
-
-> [!primary]
->
-> **Important**: BGP Service is currently in alpha phase. This product is not intended to be used in a production environment.
->
 
 ### Step 2: Prepare your IP addresses
 
@@ -310,13 +310,13 @@ sudo apt update && sudo apt install frr frr-pythontools
 
 #### Step 2: Configure FRR
 
-##### FRR configuration for Route Servers
+##### ***FRR configuration for Route Servers***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the route server(s).
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >
@@ -454,13 +454,13 @@ router bgp <CUSTOMER_ASN>
   neighbor PG_HOST_V6 route-map RM_HOST_V6_OUT out
 ```
 
-##### FRR configuration for Hosts
+##### ***FRR configuration for Hosts***
 
 > [!primary]
 >
 > All of the following parameters should be present in the `/etc/frr/frr.conf` configuration file of the hosts.
 
-###### **Prefix list and Route Map Configuration**
+##### Prefix list and Route Map Configuration
 
 > [!primary]
 >


### PR DESCRIPTION
Moved the alpha disclaimer to the beginning of the article, in the Objective section. Removed H6 titles, and made clearer disctinctions for H5 titles