### PR TITLE
Public VCF aaS limitations - Updating general limitations table

### DIFF
--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.de-de.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-19
 ---
 
 ## Objective
@@ -27,7 +27,7 @@ Before getting started, review the following guides to better understand VMware 
 | vCPU (per VM) | 32 | 32 | 32 | Number of available vCPUs per VM. |
 | RAM (per VM) | 128 GB | 128 GB | 128 GB | Maximum RAM per VM (min. 0.5 GB). |
 | Network Cards (per VM) | 5 | 10 | 10 | Maximum number of network adapters per VM. |
-| Edge Gateway (per organization) | N/A | 42 | 42 | Maximum number of Edge Gateways per organization. |
+| Edge Gateway (per organization) | N/A | 5 | 5 | Maximum number of Edge Gateways per organization. |
 | Public IPs (per vDC) | N/A | 2 | 2 | Number of available public IPs per vDC. |
 | Storage (per VM) | 1.5 TB | 1.5 TB | 1.5 TB | Storage limit on NFS/vSAN. |
 | Snapshots (per VM) | 3 | 3 | 3 | Maximum of 3 snapshots per VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-asia.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-19
 ---
 
 ## Objective
@@ -27,7 +27,7 @@ Before getting started, review the following guides to better understand VMware 
 | vCPU (per VM) | 32 | 32 | 32 | Number of available vCPUs per VM. |
 | RAM (per VM) | 128 GB | 128 GB | 128 GB | Maximum RAM per VM (min. 0.5 GB). |
 | Network Cards (per VM) | 5 | 10 | 10 | Maximum number of network adapters per VM. |
-| Edge Gateway (per organization) | N/A | 42 | 42 | Maximum number of Edge Gateways per organization. |
+| Edge Gateway (per organization) | N/A | 5 | 5 | Maximum number of Edge Gateways per organization. |
 | Public IPs (per vDC) | N/A | 2 | 2 | Number of available public IPs per vDC. |
 | Storage (per VM) | 1.5 TB | 1.5 TB | 1.5 TB | Storage limit on NFS/vSAN. |
 | Snapshots (per VM) | 3 | 3 | 3 | Maximum of 3 snapshots per VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-au.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-19
 ---
 
 ## Objective
@@ -27,7 +27,7 @@ Before getting started, review the following guides to better understand VMware 
 | vCPU (per VM) | 32 | 32 | 32 | Number of available vCPUs per VM. |
 | RAM (per VM) | 128 GB | 128 GB | 128 GB | Maximum RAM per VM (min. 0.5 GB). |
 | Network Cards (per VM) | 5 | 10 | 10 | Maximum number of network adapters per VM. |
-| Edge Gateway (per organization) | N/A | 42 | 42 | Maximum number of Edge Gateways per organization. |
+| Edge Gateway (per organization) | N/A | 5 | 5 | Maximum number of Edge Gateways per organization. |
 | Public IPs (per vDC) | N/A | 2 | 2 | Number of available public IPs per vDC. |
 | Storage (per VM) | 1.5 TB | 1.5 TB | 1.5 TB | Storage limit on NFS/vSAN. |
 | Snapshots (per VM) | 3 | 3 | 3 | Maximum of 3 snapshots per VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-19
 ---
 
 ## Objective
@@ -27,7 +27,7 @@ Before getting started, review the following guides to better understand VMware 
 | vCPU (per VM) | 32 | 32 | 32 | Number of available vCPUs per VM. |
 | RAM (per VM) | 128 GB | 128 GB | 128 GB | Maximum RAM per VM (min. 0.5 GB). |
 | Network Cards (per VM) | 5 | 10 | 10 | Maximum number of network adapters per VM. |
-| Edge Gateway (per organization) | N/A | 42 | 42 | Maximum number of Edge Gateways per organization. |
+| Edge Gateway (per organization) | N/A | 5 | 5 | Maximum number of Edge Gateways per organization. |
 | Public IPs (per vDC) | N/A | 2 | 2 | Number of available public IPs per vDC. |
 | Storage (per VM) | 1.5 TB | 1.5 TB | 1.5 TB | Storage limit on NFS/vSAN. |
 | Snapshots (per VM) | 3 | 3 | 3 | Maximum of 3 snapshots per VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-gb.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-18
 ---
 
 ## Objective
@@ -27,7 +27,7 @@ Before getting started, review the following guides to better understand VMware 
 | vCPU (per VM) | 32 | 32 | 32 | Number of available vCPUs per VM. |
 | RAM (per VM) | 128 GB | 128 GB | 128 GB | Maximum RAM per VM (min. 0.5 GB). |
 | Network Cards (per VM) | 5 | 10 | 10 | Maximum number of network adapters per VM. |
-| Edge Gateway (per organization) | N/A | 42 | 42 | Maximum number of Edge Gateways per organization. |
+| Edge Gateway (per organization) | N/A | 5 | 5 | Maximum number of Edge Gateways per organization. |
 | Public IPs (per vDC) | N/A | 2 | 2 | Number of available public IPs per vDC. |
 | Storage (per VM) | 1.5 TB | 1.5 TB | 1.5 TB | Storage limit on NFS/vSAN. |
 | Snapshots (per VM) | 3 | 3 | 3 | Maximum of 3 snapshots per VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-gb.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-18
+updated: 2025-03-19
 ---
 
 ## Objective

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-ie.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-19
 ---
 
 ## Objective
@@ -27,7 +27,7 @@ Before getting started, review the following guides to better understand VMware 
 | vCPU (per VM) | 32 | 32 | 32 | Number of available vCPUs per VM. |
 | RAM (per VM) | 128 GB | 128 GB | 128 GB | Maximum RAM per VM (min. 0.5 GB). |
 | Network Cards (per VM) | 5 | 10 | 10 | Maximum number of network adapters per VM. |
-| Edge Gateway (per organization) | N/A | 42 | 42 | Maximum number of Edge Gateways per organization. |
+| Edge Gateway (per organization) | N/A | 5 | 5 | Maximum number of Edge Gateways per organization. |
 | Public IPs (per vDC) | N/A | 2 | 2 | Number of available public IPs per vDC. |
 | Storage (per VM) | 1.5 TB | 1.5 TB | 1.5 TB | Storage limit on NFS/vSAN. |
 | Snapshots (per VM) | 3 | 3 | 3 | Maximum of 3 snapshots per VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-sg.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-19
 ---
 
 ## Objective
@@ -27,7 +27,7 @@ Before getting started, review the following guides to better understand VMware 
 | vCPU (per VM) | 32 | 32 | 32 | Number of available vCPUs per VM. |
 | RAM (per VM) | 128 GB | 128 GB | 128 GB | Maximum RAM per VM (min. 0.5 GB). |
 | Network Cards (per VM) | 5 | 10 | 10 | Maximum number of network adapters per VM. |
-| Edge Gateway (per organization) | N/A | 42 | 42 | Maximum number of Edge Gateways per organization. |
+| Edge Gateway (per organization) | N/A | 5 | 5 | Maximum number of Edge Gateways per organization. |
 | Public IPs (per vDC) | N/A | 2 | 2 | Number of available public IPs per vDC. |
 | Storage (per VM) | 1.5 TB | 1.5 TB | 1.5 TB | Storage limit on NFS/vSAN. |
 | Snapshots (per VM) | 3 | 3 | 3 | Maximum of 3 snapshots per VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-19
 ---
 
 ## Objective
@@ -27,7 +27,7 @@ Before getting started, review the following guides to better understand VMware 
 | vCPU (per VM) | 32 | 32 | 32 | Number of available vCPUs per VM. |
 | RAM (per VM) | 128 GB | 128 GB | 128 GB | Maximum RAM per VM (min. 0.5 GB). |
 | Network Cards (per VM) | 5 | 10 | 10 | Maximum number of network adapters per VM. |
-| Edge Gateway (per organization) | N/A | 42 | 42 | Maximum number of Edge Gateways per organization. |
+| Edge Gateway (per organization) | N/A | 5 | 5 | Maximum number of Edge Gateways per organization. |
 | Public IPs (per vDC) | N/A | 2 | 2 | Number of available public IPs per vDC. |
 | Storage (per VM) | 1.5 TB | 1.5 TB | 1.5 TB | Storage limit on NFS/vSAN. |
 | Snapshots (per VM) | 3 | 3 | 3 | Maximum of 3 snapshots per VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.es-es.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-19
 ---
 
 ## Objective
@@ -27,7 +27,7 @@ Before getting started, review the following guides to better understand VMware 
 | vCPU (per VM) | 32 | 32 | 32 | Number of available vCPUs per VM. |
 | RAM (per VM) | 128 GB | 128 GB | 128 GB | Maximum RAM per VM (min. 0.5 GB). |
 | Network Cards (per VM) | 5 | 10 | 10 | Maximum number of network adapters per VM. |
-| Edge Gateway (per organization) | N/A | 42 | 42 | Maximum number of Edge Gateways per organization. |
+| Edge Gateway (per organization) | N/A | 5 | 5 | Maximum number of Edge Gateways per organization. |
 | Public IPs (per vDC) | N/A | 2 | 2 | Number of available public IPs per vDC. |
 | Storage (per VM) | 1.5 TB | 1.5 TB | 1.5 TB | Storage limit on NFS/vSAN. |
 | Snapshots (per VM) | 3 | 3 | 3 | Maximum of 3 snapshots per VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.es-us.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-19
 ---
 
 ## Objective
@@ -27,7 +27,7 @@ Before getting started, review the following guides to better understand VMware 
 | vCPU (per VM) | 32 | 32 | 32 | Number of available vCPUs per VM. |
 | RAM (per VM) | 128 GB | 128 GB | 128 GB | Maximum RAM per VM (min. 0.5 GB). |
 | Network Cards (per VM) | 5 | 10 | 10 | Maximum number of network adapters per VM. |
-| Edge Gateway (per organization) | N/A | 42 | 42 | Maximum number of Edge Gateways per organization. |
+| Edge Gateway (per organization) | N/A | 5 | 5 | Maximum number of Edge Gateways per organization. |
 | Public IPs (per vDC) | N/A | 2 | 2 | Number of available public IPs per vDC. |
 | Storage (per VM) | 1.5 TB | 1.5 TB | 1.5 TB | Storage limit on NFS/vSAN. |
 | Snapshots (per VM) | 3 | 3 | 3 | Maximum of 3 snapshots per VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Capacités techniques et limites de Public VCF aaS (alias Managed VCD)"
 excerpt: "Découvrez les capacités techniques et les limites de Public VCF aaS (alias Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-19
 ---
 
 ## Objectif
@@ -26,7 +26,7 @@ Avant de commencer, consultez les guides suivants pour mieux comprendre VMware C
 | vCPU (par VM) | 32 | 32 | 32 | Nombre de vCPUs disponibles par VM. |
 | RAM (par VM) | 128 Go | 128 Go | 128 Go | Quantité maximale de RAM par VM (min. 0,5 Go). |
 | Cartes réseau (par VM) | 5 | 10 | 10 | Nombre maximal d'adaptateurs réseau par VM. |
-| Edge Gateway (par organisation) | N/A | 42 | 42 | Nombre maximal d'Edge Gateways par organisation. |
+| Edge Gateway (par organisation) | N/A | 5 | 5 | Nombre maximal d'Edge Gateways par organisation. |
 | IP publiques (par vDC) | N/A | 2 | 2 | Nombre d’IP publiques disponibles par vDC. |
 | Stockage (par VM) | 1,5 To | 1,5 To | 1,5 To | Limite de stockage sur NFS/vSAN. |
 | Snapshots (par VM) | 3 | 3 | 3 | Nombre maximal de snapshots par VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Capacités techniques et limites de Public VCF aaS (alias Managed VCD)"
 excerpt: "Découvrez les capacités techniques et les limites de Public VCF aaS (alias Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-18
 ---
 
 ## Objectif
@@ -26,7 +26,7 @@ Avant de commencer, consultez les guides suivants pour mieux comprendre VMware C
 | vCPU (par VM) | 32 | 32 | 32 | Nombre de vCPUs disponibles par VM. |
 | RAM (par VM) | 128 Go | 128 Go | 128 Go | Quantité maximale de RAM par VM (min. 0,5 Go). |
 | Cartes réseau (par VM) | 5 | 10 | 10 | Nombre maximal d'adaptateurs réseau par VM. |
-| Edge Gateway (par organisation) | N/A | 42 | 42 | Nombre maximal d'Edge Gateways par organisation. |
+| Edge Gateway (par organisation) | N/A | 5 | 5 | Nombre maximal d'Edge Gateways par organisation. |
 | IP publiques (par vDC) | N/A | 2 | 2 | Nombre d’IP publiques disponibles par vDC. |
 | Stockage (par VM) | 1,5 To | 1,5 To | 1,5 To | Limite de stockage sur NFS/vSAN. |
 | Snapshots (par VM) | 3 | 3 | 3 | Nombre maximal de snapshots par VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Capacités techniques et limites de Public VCF aaS (alias Managed VCD)"
 excerpt: "Découvrez les capacités techniques et les limites de Public VCF aaS (alias Managed VCD)"
-updated: 2025-03-18
+updated: 2025-03-19
 ---
 
 ## Objectif

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.it-it.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-19
 ---
 
 ## Objective
@@ -27,7 +27,7 @@ Before getting started, review the following guides to better understand VMware 
 | vCPU (per VM) | 32 | 32 | 32 | Number of available vCPUs per VM. |
 | RAM (per VM) | 128 GB | 128 GB | 128 GB | Maximum RAM per VM (min. 0.5 GB). |
 | Network Cards (per VM) | 5 | 10 | 10 | Maximum number of network adapters per VM. |
-| Edge Gateway (per organization) | N/A | 42 | 42 | Maximum number of Edge Gateways per organization. |
+| Edge Gateway (per organization) | N/A | 5 | 5 | Maximum number of Edge Gateways per organization. |
 | Public IPs (per vDC) | N/A | 2 | 2 | Number of available public IPs per vDC. |
 | Storage (per VM) | 1.5 TB | 1.5 TB | 1.5 TB | Storage limit on NFS/vSAN. |
 | Snapshots (per VM) | 3 | 3 | 3 | Maximum of 3 snapshots per VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-19
 ---
 
 ## Objective
@@ -27,7 +27,7 @@ Before getting started, review the following guides to better understand VMware 
 | vCPU (per VM) | 32 | 32 | 32 | Number of available vCPUs per VM. |
 | RAM (per VM) | 128 GB | 128 GB | 128 GB | Maximum RAM per VM (min. 0.5 GB). |
 | Network Cards (per VM) | 5 | 10 | 10 | Maximum number of network adapters per VM. |
-| Edge Gateway (per organization) | N/A | 42 | 42 | Maximum number of Edge Gateways per organization. |
+| Edge Gateway (per organization) | N/A | 5 | 5 | Maximum number of Edge Gateways per organization. |
 | Public IPs (per vDC) | N/A | 2 | 2 | Number of available public IPs per vDC. |
 | Storage (per VM) | 1.5 TB | 1.5 TB | 1.5 TB | Storage limit on NFS/vSAN. |
 | Snapshots (per VM) | 3 | 3 | 3 | Maximum of 3 snapshots per VM. |

--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/vcd-limitations/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
 excerpt: "Learn about the technical capabilities and limitations of Public VCF aaS (aka Managed VCD)"
-updated: 2025-03-13
+updated: 2025-03-19
 ---
 
 ## Objective
@@ -27,7 +27,7 @@ Before getting started, review the following guides to better understand VMware 
 | vCPU (per VM) | 32 | 32 | 32 | Number of available vCPUs per VM. |
 | RAM (per VM) | 128 GB | 128 GB | 128 GB | Maximum RAM per VM (min. 0.5 GB). |
 | Network Cards (per VM) | 5 | 10 | 10 | Maximum number of network adapters per VM. |
-| Edge Gateway (per organization) | N/A | 42 | 42 | Maximum number of Edge Gateways per organization. |
+| Edge Gateway (per organization) | N/A | 5 | 5 | Maximum number of Edge Gateways per organization. |
 | Public IPs (per vDC) | N/A | 2 | 2 | Number of available public IPs per vDC. |
 | Storage (per VM) | 1.5 TB | 1.5 TB | 1.5 TB | Storage limit on NFS/vSAN. |
 | Snapshots (per VM) | 3 | 3 | 3 | Maximum of 3 snapshots per VM. |


### PR DESCRIPTION
Changed the maximum number of Edge Gateways per organization from 42 to 5. 