### PR TITLE
feat(mks): update default timeout values when migrating from iolb to octavia

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/migrate-loadbalancer-iolb-to-octavia/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: How to migrate from Load Balancer for MKS (IOLB) to Public Cloud Load Balancer (Octavia)
 excerpt: "The purpose of this guide is to help OVHcloud Managed Kubernetes Service (MKS) users to migrate from an existing Load Balancer for Managed Kubernetes to a Public Cloud Load Balancer"
-updated: 2025-02-14
+updated: 2025-05-14
 ---
 
 <style>
@@ -121,8 +121,11 @@ spec:
 
 ```yaml
 annotations:
-  loadbalancer.ovhcloud.com/class: "octavia" // if your cluster <1.31
-  loadbalancer.ovhcloud.com/flavor: "small" // Available values: small (default) | medium | large | xl
+  loadbalancer.ovhcloud.com/class: "octavia" # if your cluster <1.31
+  loadbalancer.ovhcloud.com/flavor: "small" # Available values: small (default) | medium | large | xl
+  loadbalancer.openstack.org/timeout-client-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-connect: 20000 # The default value (in milliseconds) on the iolb solution, can be customized
+  loadbalancer.openstack.org/timeout-member-data: 180000 # The default value (in milliseconds) on the iolb solution, can be customized
 ```
 
 Apply the new service with:


### PR DESCRIPTION
## What type of Pull Request is this?

- Fix

## Description

This PR specifies the default iolb timeout configuration to set when migrating from iolb to octavia

## Mandatory information

- This Pull Request can be merged as soon as possible.

- This Pull Request content should be replicated for the US OVHcloud documentation : YES