### PR TITLE
docs(mks/premium): remove limitations that no longer apply

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.de-de.md
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-asia.md
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-au.md
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-ca.md
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-ie.md
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-sg.md
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-us.md
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.es-es.md
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.es-us.md
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.fr-ca.md
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-19
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-19
 ---
 
 <style>
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.it-it.md
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.pl-pl.md
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-04-30
+updated: 2025-05-20
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.pt-pt.md
@@ -48,10 +48,6 @@ This list is subject to change as new features will be introduced during the Bet
 
 Upgrading an existing cluster is not supported at the moment, we'll deliver this functionality once we support the next Kubernetes release (1.33).
 
-### Cluster rename
-
-Renaming an existing cluster is not supported at the moment.
-
 ### Logs Data Platform integration
 
 Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) is not supported at the moment.
@@ -59,10 +55,6 @@ Audit logs forwarding to the [Logs Data Platform](/pages/public_cloud/containers
 ### ETCD Quota
 
 Real-time monitoring of the etcd storage usage is not supported at the moment, current etcd quota is 8GB per cluster.
-
-### API server admission plugins configuration
-
-The configuration of the [API server admission plugins](/pages/public_cloud/containers_orchestration/managed_kubernetes/apiserver-flags-configuration) is not available at the moment.
 
 ### API Server IP restrictions
 
@@ -74,10 +66,6 @@ Retrieve the gateway IP of your cluster's gateway in the [OVHcloud Control Panel
 ```bash
 openstack router show ROUTER_ID -c external_gateway_info
 ```
-
-### Security Policies
-
-Changing the Security Policy after the cluster creation is not supported yet.
 
 ### Anti-affinity
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/premium/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: MKS Premium Plan
 excerpt: 'Features and limitations of the MKS Premium Plan in Beta version'
-updated: 2025-05-20
+updated: 2025-05-27
 ---
 
 <style>


### PR DESCRIPTION
## What type of Pull Request is this?

- Update of existing guide(s)


## Description

We will enable soon three functionality on Premium : 
- Cluster rename
- API Server admissions update
- Security policy update

## Mandatory information
- This Pull Request shouldn't be merged before: 26 may 2025
- This Pull Request content should be replicated for the US OVHcloud documentation : NO