### PR TITLE
fix: aws cli syntax cors config.

### DIFF
--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.de-de.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.de-de.md
@@ -50,7 +50,7 @@ The rules for accepted CORS requests are configured at the bucket level.
 Using the AWS CLI, set up CORS on the bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:
@@ -74,7 +74,7 @@ Let's assume we have a frontend web application hosted on `https://my-app.xyz` t
 We enable CORS on the my-media bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-asia.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-asia.md
@@ -50,7 +50,7 @@ The rules for accepted CORS requests are configured at the bucket level.
 Using the AWS CLI, set up CORS on the bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:
@@ -74,7 +74,7 @@ Let's assume we have a frontend web application hosted on `https://my-app.xyz` t
 We enable CORS on the my-media bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-au.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-au.md
@@ -50,7 +50,7 @@ The rules for accepted CORS requests are configured at the bucket level.
 Using the AWS CLI, set up CORS on the bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:
@@ -74,7 +74,7 @@ Let's assume we have a frontend web application hosted on `https://my-app.xyz` t
 We enable CORS on the my-media bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-ca.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-ca.md
@@ -50,7 +50,7 @@ The rules for accepted CORS requests are configured at the bucket level.
 Using the AWS CLI, set up CORS on the bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:
@@ -74,7 +74,7 @@ Let's assume we have a frontend web application hosted on `https://my-app.xyz` t
 We enable CORS on the my-media bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-gb.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-gb.md
@@ -50,7 +50,7 @@ The rules for accepted CORS requests are configured at the bucket level.
 Using the AWS CLI, set up CORS on the bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:
@@ -74,7 +74,7 @@ Let's assume we have a frontend web application hosted on `https://my-app.xyz` t
 We enable CORS on the my-media bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-ie.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-ie.md
@@ -50,7 +50,7 @@ The rules for accepted CORS requests are configured at the bucket level.
 Using the AWS CLI, set up CORS on the bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:
@@ -74,7 +74,7 @@ Let's assume we have a frontend web application hosted on `https://my-app.xyz` t
 We enable CORS on the my-media bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-sg.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-sg.md
@@ -50,7 +50,7 @@ The rules for accepted CORS requests are configured at the bucket level.
 Using the AWS CLI, set up CORS on the bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:
@@ -74,7 +74,7 @@ Let's assume we have a frontend web application hosted on `https://my-app.xyz` t
 We enable CORS on the my-media bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-us.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.en-us.md
@@ -50,7 +50,7 @@ The rules for accepted CORS requests are configured at the bucket level.
 Using the AWS CLI, set up CORS on the bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:
@@ -74,7 +74,7 @@ Let's assume we have a frontend web application hosted on `https://my-app.xyz` t
 We enable CORS on the my-media bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.es-es.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.es-es.md
@@ -50,7 +50,7 @@ The rules for accepted CORS requests are configured at the bucket level.
 Using the AWS CLI, set up CORS on the bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:
@@ -74,7 +74,7 @@ Let's assume we have a frontend web application hosted on `https://my-app.xyz` t
 We enable CORS on the my-media bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.es-us.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.es-us.md
@@ -50,7 +50,7 @@ The rules for accepted CORS requests are configured at the bucket level.
 Using the AWS CLI, set up CORS on the bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:
@@ -74,7 +74,7 @@ Let's assume we have a frontend web application hosted on `https://my-app.xyz` t
 We enable CORS on the my-media bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.fr-ca.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.fr-ca.md
@@ -50,7 +50,7 @@ Les règles pour les requêtes CORS acceptées sont configurées au niveau du bu
 A l'aide de la CLI AWS, configurez CORS sur le bucket :
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 Le fichier cors.json contient la configuration suivante :
@@ -75,7 +75,7 @@ Supposons que nous avons une application web frontend hébergée sur `https://my
 Nous activons CORS sur le bucket my-media :
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 Le fichier cors.json contient la configuration suivante :

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.fr-fr.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.fr-fr.md
@@ -50,7 +50,7 @@ Les règles pour les requêtes CORS acceptées sont configurées au niveau du bu
 A l'aide de la CLI AWS, configurez CORS sur le bucket :
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 Le fichier cors.json contient la configuration suivante :
@@ -75,7 +75,7 @@ Supposons que nous avons une application web frontend hébergée sur `https://my
 Nous activons CORS sur le bucket my-media :
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 Le fichier cors.json contient la configuration suivante :

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.it-it.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.it-it.md
@@ -50,7 +50,7 @@ The rules for accepted CORS requests are configured at the bucket level.
 Using the AWS CLI, set up CORS on the bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:
@@ -74,7 +74,7 @@ Let's assume we have a frontend web application hosted on `https://my-app.xyz` t
 We enable CORS on the my-media bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.pl-pl.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.pl-pl.md
@@ -50,7 +50,7 @@ The rules for accepted CORS requests are configured at the bucket level.
 Using the AWS CLI, set up CORS on the bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:
@@ -74,7 +74,7 @@ Let's assume we have a frontend web application hosted on `https://my-app.xyz` t
 We enable CORS on the my-media bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:

--- a/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.pt-pt.md
+++ b/pages/storage_and_backup/object_storage/s3_setting_up_cors/guide.pt-pt.md
@@ -50,7 +50,7 @@ The rules for accepted CORS requests are configured at the bucket level.
 Using the AWS CLI, set up CORS on the bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-bucket --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-bucket --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:
@@ -74,7 +74,7 @@ Let's assume we have a frontend web application hosted on `https://my-app.xyz` t
 We enable CORS on the my-media bucket:
 
 ```sh
-aws s3api put-bucket-cors --bucket my-media --cors-configuration cors.json
+aws s3api put-bucket-cors --bucket my-media --cors-configuration file://cors.json
 ```
 
 The cors.json file contains the following configuration:


### PR DESCRIPTION
## What type of Pull Request is this?

- Update of existing guide(s)
- Fix

## Description

This commit fixes the proposed CLI syntax for setting a CORS configuration on object storage buckets. I guess AWS got updated at some point. It just doesn't work without the `file://` anymore (aws-cli/2.27.12).

## Mandatory information

- This Pull Request can be merged as soon as possible.
- This Pull Request content should be replicated for the US OVHcloud documentation : YES