### PR TITLE
Languages fallback - Testing deactivation on Zimbra guide

### DIFF
--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra/meta.yaml
@@ -1,3 +1,12 @@
 id: 6FAB1A47-C6B9-4A2C-A934-4061628196DF
 full_slug: zimbra-getting-started
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us


### PR DESCRIPTION
<!--
Hello 👋
Thank you for submitting a Pull Request.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details. As long as your Pull Request is a draft, the OVHcloud Guides Team will not start proofreading it.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

DO NOT USE a fork if you are an OVHcloud employee. Instead, please contact the OVHcloud Guides Team so to be granted /write access to this repository.

Feel free to apply labels on your Pull Request, selecting them from the list to your right.

Before submitting a Pull Request, please ensure you have:

- 📖 Read the OVHcloud Documentation readme: https://github.com/ovh/docs/blob/develop/readme.md
- 🇬🇧 Edited (at least) the en-gb version of a guide.
- 🇫🇷 Edited also the fr-fr version if you are a French speaker.
- 🌐 Edited all the files if you're doing a fix or a minor update (this is not mandatory but recommended).
- 👷‍♀️ Created a small PR, if applicable.
- ✅ Tested every step you're documenting.
- 📝 Used descriptive commit messages.
- 📐 Resized images which width exceeds 1400px.
- 📝 Edited or blurred any sensitive/private information from your text and images (IPs, user IDs, private URLs, etc.).
-->

## What type of Pull Request is this?

- Optimization

## Description

The Languages Fallback mechanism needs to be blocked for documentation of some products.
This pull request will test the disabling mechanism on only one guide.
