### PR TITLE
Domains - DynDNS - Disabling language fallback for CA/APAC

### DIFF
--- a/pages/web_cloud/domains/dns_dynhost/meta.yaml
+++ b/pages/web_cloud/domains/dns_dynhost/meta.yaml
@@ -1,3 +1,12 @@
 id: b561b8ca-d7cd-4726-925c-fd8b5e6efe03
 full_slug: dns-dynhost
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us


### PR DESCRIPTION
<!--
Hello 👋
Thank you for submitting a Pull Request.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details. As long as your Pull Request is a draft, the OVHcloud Guides Team will not start proofreading it.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

DO NOT USE a fork if you are an OVHcloud employee. Instead, please contact the OVHcloud Guides Team so to be granted /write access to this repository.

Feel free to apply labels on your Pull Request, selecting them from the list to your right.

Before submitting a Pull Request, please ensure you have:

- 📖 Read the OVHcloud Documentation readme: https://github.com/ovh/docs/blob/develop/readme.md
- 🇬🇧 Edited (at least) the en-gb version of a guide.
- 🇫🇷 Edited also the fr-fr version if you are a French speaker.
- 🌐 Edited all the files if you're doing a fix or a minor update (this is not mandatory but recommended).
- 👷‍♀️ Created a small PR, if applicable.
- ✅ Tested every step you're documenting.
- 📝 Used descriptive commit messages.
- 📐 Resized images which width exceeds 1400px.
- 📝 Edited or blurred any sensitive/private information from your text and images (IPs, user IDs, private URLs, etc.).
-->

## What type of Pull Request is this?

- Fix

## Description

As a result of the languages fallback mechanism introduction, the DynDNS guide for domains was made available for CA & APAC country but the feature is not available in these countries.
This update will disable the language fallback for this guide.
