### PR TITLE
Lso patch lifecycle doc

### DIFF
--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.de-de.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Smart Storage Management with Lifecycle Rules
 excerpt: Learn how to optimise your storage costs with OVHcloud lifecycle rules
-updated: 2025-05-13
+updated: 2025-06-05
 ---
 
 <style>
@@ -54,14 +54,7 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
-> [!warning]
-> 
-> The release of the feature will be done in 2 phases:
->
-> - Phase 1: support for expiration only
-> - Phase 2: support for transitions
-
-## Expiration (available)
+## Expiration
 
 Lifecycle rules are processed asynchronously and on a best-effort basis. Most rules are applied within 24 hours, but for very large buckets or when processing many objects, it might take longer. During this delay, you continue to be billed for the object's current storage tier, even if the rule (e.g., expiration or transition) has already been triggered but not yet completed. For example, if an object is set to be deleted on day 30 but is only processed on day 32, you may be billed for an additional two days.
 
@@ -393,7 +386,7 @@ In a versioned bucket, the following configuration does the following actions:
 
 ///
 
-## Transition (coming soon)
+## Transition
 
 ### Supported transitions
 
@@ -403,11 +396,12 @@ In a versioned bucket, the following configuration does the following actions:
 
 The following are the currently supported transitions:
 
-| from/to          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
-| ---------------- | ---------------- | --------- | -------------------------- |------------ |
-| High Performance |        -         | yes       |             yes            | no          |
-| Standard         | forbidden        | -         |             yes            | no          |
-| Cold Archive     | forbidden        | forbidden |             forbidden      | -           |
+| from/to          | High Performance | Standard  | Infrequent Access |Cold Archive |
+| ---------------- | ---------------- | --------- | ----------------- |------------ |
+| High Performance |        -         | yes       |    yes            | no          |
+| Standard         | forbidden        | -         |    yes            | no          |
+| Infrequent Access| forbidden        | forbidden |    -              | no          |
+| Cold Archive     | forbidden        | forbidden |    forbidden      | -           |
 
 ### Minimum object size
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-asia.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Smart Storage Management with Lifecycle Rules
 excerpt: Learn how to optimise your storage costs with OVHcloud lifecycle rules
-updated: 2025-05-13
+updated: 2025-06-05
 ---
 
 <style>
@@ -54,14 +54,7 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
-> [!warning]
-> 
-> The release of the feature will be done in 2 phases:
->
-> - Phase 1: support for expiration only
-> - Phase 2: support for transitions
-
-## Expiration (available)
+## Expiration
 
 Lifecycle rules are processed asynchronously and on a best-effort basis. Most rules are applied within 24 hours, but for very large buckets or when processing many objects, it might take longer. During this delay, you continue to be billed for the object's current storage tier, even if the rule (e.g., expiration or transition) has already been triggered but not yet completed. For example, if an object is set to be deleted on day 30 but is only processed on day 32, you may be billed for an additional two days.
 
@@ -393,7 +386,7 @@ In a versioned bucket, the following configuration does the following actions:
 
 ///
 
-## Transition (coming soon)
+## Transition
 
 ### Supported transitions
 
@@ -403,11 +396,12 @@ In a versioned bucket, the following configuration does the following actions:
 
 The following are the currently supported transitions:
 
-| from/to          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
-| ---------------- | ---------------- | --------- | -------------------------- |------------ |
-| High Performance |        -         | yes       |             yes            | no          |
-| Standard         | forbidden        | -         |             yes            | no          |
-| Cold Archive     | forbidden        | forbidden |             forbidden      | -           |
+| from/to          | High Performance | Standard  | Infrequent Access |Cold Archive |
+| ---------------- | ---------------- | --------- | ----------------- |------------ |
+| High Performance |        -         | yes       |    yes            | no          |
+| Standard         | forbidden        | -         |    yes            | no          |
+| Infrequent Access| forbidden        | forbidden |    -              | no          |
+| Cold Archive     | forbidden        | forbidden |    forbidden      | -           |
 
 ### Minimum object size
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-au.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Smart Storage Management with Lifecycle Rules
 excerpt: Learn how to optimise your storage costs with OVHcloud lifecycle rules
-updated: 2025-05-13
+updated: 2025-06-05
 ---
 
 <style>
@@ -54,14 +54,7 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
-> [!warning]
-> 
-> The release of the feature will be done in 2 phases:
->
-> - Phase 1: support for expiration only
-> - Phase 2: support for transitions
-
-## Expiration (available)
+## Expiration
 
 Lifecycle rules are processed asynchronously and on a best-effort basis. Most rules are applied within 24 hours, but for very large buckets or when processing many objects, it might take longer. During this delay, you continue to be billed for the object's current storage tier, even if the rule (e.g., expiration or transition) has already been triggered but not yet completed. For example, if an object is set to be deleted on day 30 but is only processed on day 32, you may be billed for an additional two days.
 
@@ -393,7 +386,7 @@ In a versioned bucket, the following configuration does the following actions:
 
 ///
 
-## Transition (coming soon)
+## Transition
 
 ### Supported transitions
 
@@ -403,11 +396,12 @@ In a versioned bucket, the following configuration does the following actions:
 
 The following are the currently supported transitions:
 
-| from/to          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
-| ---------------- | ---------------- | --------- | -------------------------- |------------ |
-| High Performance |        -         | yes       |             yes            | no          |
-| Standard         | forbidden        | -         |             yes            | no          |
-| Cold Archive     | forbidden        | forbidden |             forbidden      | -           |
+| from/to          | High Performance | Standard  | Infrequent Access |Cold Archive |
+| ---------------- | ---------------- | --------- | ----------------- |------------ |
+| High Performance |        -         | yes       |    yes            | no          |
+| Standard         | forbidden        | -         |    yes            | no          |
+| Infrequent Access| forbidden        | forbidden |    -              | no          |
+| Cold Archive     | forbidden        | forbidden |    forbidden      | -           |
 
 ### Minimum object size
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-ca.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Smart Storage Management with Lifecycle Rules
 excerpt: Learn how to optimise your storage costs with OVHcloud lifecycle rules
-updated: 2025-05-13
+updated: 2025-06-05
 ---
 
 <style>
@@ -54,14 +54,7 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
-> [!warning]
-> 
-> The release of the feature will be done in 2 phases:
->
-> - Phase 1: support for expiration only
-> - Phase 2: support for transitions
-
-## Expiration (available)
+## Expiration
 
 Lifecycle rules are processed asynchronously and on a best-effort basis. Most rules are applied within 24 hours, but for very large buckets or when processing many objects, it might take longer. During this delay, you continue to be billed for the object's current storage tier, even if the rule (e.g., expiration or transition) has already been triggered but not yet completed. For example, if an object is set to be deleted on day 30 but is only processed on day 32, you may be billed for an additional two days.
 
@@ -393,7 +386,7 @@ In a versioned bucket, the following configuration does the following actions:
 
 ///
 
-## Transition (coming soon)
+## Transition
 
 ### Supported transitions
 
@@ -403,11 +396,12 @@ In a versioned bucket, the following configuration does the following actions:
 
 The following are the currently supported transitions:
 
-| from/to          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
-| ---------------- | ---------------- | --------- | -------------------------- |------------ |
-| High Performance |        -         | yes       |             yes            | no          |
-| Standard         | forbidden        | -         |             yes            | no          |
-| Cold Archive     | forbidden        | forbidden |             forbidden      | -           |
+| from/to          | High Performance | Standard  | Infrequent Access |Cold Archive |
+| ---------------- | ---------------- | --------- | ----------------- |------------ |
+| High Performance |        -         | yes       |    yes            | no          |
+| Standard         | forbidden        | -         |    yes            | no          |
+| Infrequent Access| forbidden        | forbidden |    -              | no          |
+| Cold Archive     | forbidden        | forbidden |    forbidden      | -           |
 
 ### Minimum object size
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-gb.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-gb.md
@@ -55,7 +55,7 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
 
-## Expiration (available)
+## Expiration
 
 Lifecycle rules are processed asynchronously and on a best-effort basis. Most rules are applied within 24 hours, but for very large buckets or when processing many objects, it might take longer. During this delay, you continue to be billed for the object's current storage tier, even if the rule (e.g., expiration or transition) has already been triggered but not yet completed. For example, if an object is set to be deleted on day 30 but is only processed on day 32, you may be billed for an additional two days.
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-gb.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-gb.md
@@ -397,11 +397,12 @@ In a versioned bucket, the following configuration does the following actions:
 
 The following are the currently supported transitions:
 
-| from/to          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
-| ---------------- | ---------------- | --------- | -------------------------- |------------ |
-| High Performance |        -         | yes       |             yes            | no          |
-| Standard         | forbidden        | -         |             yes            | no          |
-| Cold Archive     | forbidden        | forbidden |             forbidden      | -           |
+| from/to          | High Performance | Standard  | Infrequent Access |Cold Archive |
+| ---------------- | ---------------- | --------- | ----------------- |------------ |
+| High Performance |        -         | yes       |    yes            | no          |
+| Standard         | forbidden        | -         |    yes            | no          |
+| Infrequent Access| forbidden        | forbidden |    -              | no          |
+| Cold Archive     | forbidden        | forbidden |    forbidden      | -           |
 
 ### Minimum object size
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-gb.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Smart Storage Management with Lifecycle Rules
 excerpt: Learn how to optimise your storage costs with OVHcloud lifecycle rules
-updated: 2025-05-13
+updated: 2025-06-05
 ---
 
 <style>
@@ -53,7 +53,6 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **non-versioned**: there is only one existing version of the object which is the current version and it is deleted permanently.
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
-
 
 ## Expiration
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-gb.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-gb.md
@@ -54,12 +54,6 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
-> [!warning]
-> 
-> The release of the feature will be done in 2 phases:
->
-> - Phase 1: support for expiration only
-> - Phase 2: support for transitions
 
 ## Expiration (available)
 
@@ -393,7 +387,7 @@ In a versioned bucket, the following configuration does the following actions:
 
 ///
 
-## Transition (coming soon)
+## Transition
 
 ### Supported transitions
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-ie.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Smart Storage Management with Lifecycle Rules
 excerpt: Learn how to optimise your storage costs with OVHcloud lifecycle rules
-updated: 2025-05-13
+updated: 2025-06-05
 ---
 
 <style>
@@ -54,14 +54,7 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
-> [!warning]
-> 
-> The release of the feature will be done in 2 phases:
->
-> - Phase 1: support for expiration only
-> - Phase 2: support for transitions
-
-## Expiration (available)
+## Expiration
 
 Lifecycle rules are processed asynchronously and on a best-effort basis. Most rules are applied within 24 hours, but for very large buckets or when processing many objects, it might take longer. During this delay, you continue to be billed for the object's current storage tier, even if the rule (e.g., expiration or transition) has already been triggered but not yet completed. For example, if an object is set to be deleted on day 30 but is only processed on day 32, you may be billed for an additional two days.
 
@@ -393,7 +386,7 @@ In a versioned bucket, the following configuration does the following actions:
 
 ///
 
-## Transition (coming soon)
+## Transition
 
 ### Supported transitions
 
@@ -403,11 +396,12 @@ In a versioned bucket, the following configuration does the following actions:
 
 The following are the currently supported transitions:
 
-| from/to          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
-| ---------------- | ---------------- | --------- | -------------------------- |------------ |
-| High Performance |        -         | yes       |             yes            | no          |
-| Standard         | forbidden        | -         |             yes            | no          |
-| Cold Archive     | forbidden        | forbidden |             forbidden      | -           |
+| from/to          | High Performance | Standard  | Infrequent Access |Cold Archive |
+| ---------------- | ---------------- | --------- | ----------------- |------------ |
+| High Performance |        -         | yes       |    yes            | no          |
+| Standard         | forbidden        | -         |    yes            | no          |
+| Infrequent Access| forbidden        | forbidden |    -              | no          |
+| Cold Archive     | forbidden        | forbidden |    forbidden      | -           |
 
 ### Minimum object size
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-sg.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Smart Storage Management with Lifecycle Rules
 excerpt: Learn how to optimise your storage costs with OVHcloud lifecycle rules
-updated: 2025-05-13
+updated: 2025-06-05
 ---
 
 <style>
@@ -54,14 +54,7 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
-> [!warning]
-> 
-> The release of the feature will be done in 2 phases:
->
-> - Phase 1: support for expiration only
-> - Phase 2: support for transitions
-
-## Expiration (available)
+## Expiration
 
 Lifecycle rules are processed asynchronously and on a best-effort basis. Most rules are applied within 24 hours, but for very large buckets or when processing many objects, it might take longer. During this delay, you continue to be billed for the object's current storage tier, even if the rule (e.g., expiration or transition) has already been triggered but not yet completed. For example, if an object is set to be deleted on day 30 but is only processed on day 32, you may be billed for an additional two days.
 
@@ -393,7 +386,7 @@ In a versioned bucket, the following configuration does the following actions:
 
 ///
 
-## Transition (coming soon)
+## Transition
 
 ### Supported transitions
 
@@ -403,11 +396,12 @@ In a versioned bucket, the following configuration does the following actions:
 
 The following are the currently supported transitions:
 
-| from/to          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
-| ---------------- | ---------------- | --------- | -------------------------- |------------ |
-| High Performance |        -         | yes       |             yes            | no          |
-| Standard         | forbidden        | -         |             yes            | no          |
-| Cold Archive     | forbidden        | forbidden |             forbidden      | -           |
+| from/to          | High Performance | Standard  | Infrequent Access |Cold Archive |
+| ---------------- | ---------------- | --------- | ----------------- |------------ |
+| High Performance |        -         | yes       |    yes            | no          |
+| Standard         | forbidden        | -         |    yes            | no          |
+| Infrequent Access| forbidden        | forbidden |    -              | no          |
+| Cold Archive     | forbidden        | forbidden |    forbidden      | -           |
 
 ### Minimum object size
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-us.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Smart Storage Management with Lifecycle Rules
 excerpt: Learn how to optimise your storage costs with OVHcloud lifecycle rules
-updated: 2025-05-13
+updated: 2025-06-05
 ---
 
 <style>
@@ -54,14 +54,7 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
-> [!warning]
-> 
-> The release of the feature will be done in 2 phases:
->
-> - Phase 1: support for expiration only
-> - Phase 2: support for transitions
-
-## Expiration (available)
+## Expiration
 
 Lifecycle rules are processed asynchronously and on a best-effort basis. Most rules are applied within 24 hours, but for very large buckets or when processing many objects, it might take longer. During this delay, you continue to be billed for the object's current storage tier, even if the rule (e.g., expiration or transition) has already been triggered but not yet completed. For example, if an object is set to be deleted on day 30 but is only processed on day 32, you may be billed for an additional two days.
 
@@ -393,7 +386,7 @@ In a versioned bucket, the following configuration does the following actions:
 
 ///
 
-## Transition (coming soon)
+## Transition
 
 ### Supported transitions
 
@@ -403,11 +396,12 @@ In a versioned bucket, the following configuration does the following actions:
 
 The following are the currently supported transitions:
 
-| from/to          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
-| ---------------- | ---------------- | --------- | -------------------------- |------------ |
-| High Performance |        -         | yes       |             yes            | no          |
-| Standard         | forbidden        | -         |             yes            | no          |
-| Cold Archive     | forbidden        | forbidden |             forbidden      | -           |
+| from/to          | High Performance | Standard  | Infrequent Access |Cold Archive |
+| ---------------- | ---------------- | --------- | ----------------- |------------ |
+| High Performance |        -         | yes       |    yes            | no          |
+| Standard         | forbidden        | -         |    yes            | no          |
+| Infrequent Access| forbidden        | forbidden |    -              | no          |
+| Cold Archive     | forbidden        | forbidden |    forbidden      | -           |
 
 ### Minimum object size
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.es-es.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Smart Storage Management with Lifecycle Rules
 excerpt: Learn how to optimise your storage costs with OVHcloud lifecycle rules
-updated: 2025-05-13
+updated: 2025-06-05
 ---
 
 <style>
@@ -54,14 +54,7 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
-> [!warning]
-> 
-> The release of the feature will be done in 2 phases:
->
-> - Phase 1: support for expiration only
-> - Phase 2: support for transitions
-
-## Expiration (available)
+## Expiration
 
 Lifecycle rules are processed asynchronously and on a best-effort basis. Most rules are applied within 24 hours, but for very large buckets or when processing many objects, it might take longer. During this delay, you continue to be billed for the object's current storage tier, even if the rule (e.g., expiration or transition) has already been triggered but not yet completed. For example, if an object is set to be deleted on day 30 but is only processed on day 32, you may be billed for an additional two days.
 
@@ -393,7 +386,7 @@ In a versioned bucket, the following configuration does the following actions:
 
 ///
 
-## Transition (coming soon)
+## Transition
 
 ### Supported transitions
 
@@ -403,11 +396,12 @@ In a versioned bucket, the following configuration does the following actions:
 
 The following are the currently supported transitions:
 
-| from/to          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
-| ---------------- | ---------------- | --------- | -------------------------- |------------ |
-| High Performance |        -         | yes       |             yes            | no          |
-| Standard         | forbidden        | -         |             yes            | no          |
-| Cold Archive     | forbidden        | forbidden |             forbidden      | -           |
+| from/to          | High Performance | Standard  | Infrequent Access |Cold Archive |
+| ---------------- | ---------------- | --------- | ----------------- |------------ |
+| High Performance |        -         | yes       |    yes            | no          |
+| Standard         | forbidden        | -         |    yes            | no          |
+| Infrequent Access| forbidden        | forbidden |    -              | no          |
+| Cold Archive     | forbidden        | forbidden |    forbidden      | -           |
 
 ### Minimum object size
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.es-us.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Smart Storage Management with Lifecycle Rules
 excerpt: Learn how to optimise your storage costs with OVHcloud lifecycle rules
-updated: 2025-05-13
+updated: 2025-06-05
 ---
 
 <style>
@@ -54,14 +54,7 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
-> [!warning]
-> 
-> The release of the feature will be done in 2 phases:
->
-> - Phase 1: support for expiration only
-> - Phase 2: support for transitions
-
-## Expiration (available)
+## Expiration
 
 Lifecycle rules are processed asynchronously and on a best-effort basis. Most rules are applied within 24 hours, but for very large buckets or when processing many objects, it might take longer. During this delay, you continue to be billed for the object's current storage tier, even if the rule (e.g., expiration or transition) has already been triggered but not yet completed. For example, if an object is set to be deleted on day 30 but is only processed on day 32, you may be billed for an additional two days.
 
@@ -393,7 +386,7 @@ In a versioned bucket, the following configuration does the following actions:
 
 ///
 
-## Transition (coming soon)
+## Transition
 
 ### Supported transitions
 
@@ -403,11 +396,12 @@ In a versioned bucket, the following configuration does the following actions:
 
 The following are the currently supported transitions:
 
-| from/to          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
-| ---------------- | ---------------- | --------- | -------------------------- |------------ |
-| High Performance |        -         | yes       |             yes            | no          |
-| Standard         | forbidden        | -         |             yes            | no          |
-| Cold Archive     | forbidden        | forbidden |             forbidden      | -           |
+| from/to          | High Performance | Standard  | Infrequent Access |Cold Archive |
+| ---------------- | ---------------- | --------- | ----------------- |------------ |
+| High Performance |        -         | yes       |    yes            | no          |
+| Standard         | forbidden        | -         |    yes            | no          |
+| Infrequent Access| forbidden        | forbidden |    -              | no          |
+| Cold Archive     | forbidden        | forbidden |    forbidden      | -           |
 
 ### Minimum object size
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.fr-ca.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.fr-ca.md
@@ -54,14 +54,7 @@ Lorsqu'un objet atteint la fin de sa durée de vie selon la configuration de son
 - **versionné** : un marqueur de suppression est créé et devient la version courante. Vous pouvez également choisir le nombre d'anciennes versions que vous souhaitez conserver. Si la version courante de l'objet est la seule version de l'objet et qu'il s'agit également d'un marqueur de suppression, ce dernier sera supprimé.
 - **versioning suspendu** : actuellement, nous ne permettons pas la suspension du versioning si vous avez une configuration de lifecycle en vigueur. De la même manière, nous ne permettons pas le téléchargement d'une configuration de lifecycle si le versioning est suspendu sur le bucket.
 
-> [!warning]
-> 
-> La mise en place de la fonctionnalité se fera en 2 phases :
->
-> - Phase 1 : prise en charge de l'expiration uniquement
-> - Phase 2 : prise en charge des transitions
-
-## Expiration (disponible)
+## Expiration
 
 Les règles de lifecycle sont traitées de manière asynchrone et dans la mesure du possible. La plupart des règles sont appliquées dans les 24 heures, mais cela peut prendre plus de temps dans le cas d'un très grand nombre d'objets ou lors du traitement de nombreux objets. Pendant ce délai, vous continuez à être facturé pour le niveau de stockage actuel de l'objet, même si la règle (par exemple, l'expiration ou la transition) a déjà été déclenchée mais n'est pas encore terminée. Par exemple, si un objet doit être supprimé le 30e jour, mais qu'il n'est traité que le 32e jour, vous pouvez être facturé pour deux jours supplémentaires.
 
@@ -204,7 +197,6 @@ Si la date actuelle est 2024-10-29 et **NoncurrentDays**=5, la règle de lifecyc
 - B v2 est non-courante depuis 2024-10-20 (quand B v3 a été créée) : son âge en tant que version non-courante est 9 jours.
 
 ### Obtenir la date d'expiration programmée
-
 
 Si un objet est programmé pour être supprimé, un appel HEAD-OBJECT renvoie un en-tête de réponse http spécial x-amz-expiration qui contient un timestamp indiquant sa date d'expiration et un identifiant de la règle du lifecycle qui a été appliquée.
 
@@ -393,7 +385,7 @@ Dans un bucket versionné, la configuration suivante effectue ces actions :
 
 ///
 
-## Transition (à venir)
+## Transition
 
 ### Transitions supportées
 
@@ -404,10 +396,11 @@ Dans un bucket versionné, la configuration suivante effectue ces actions :
 
 Les transitions actuellement prises en charge sont les suivantes :
 
-| de/vers          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
+| de/vers          | High Performance | Standard  | Infrequent Access |Cold Archive |
 | ---------------- | ---------------- | --------- | -------------------------- |------------ |
 | High Performance |        -         | oui       |             oui            | non          |
 | Standard         | interdit        | -         |             oui            | non          |
+| Infrequent Access         | interdit        | interdit         |             -            | non          |
 | Cold Archive     | interdit        | interdit |             interdit      | -           |
 
 ### Taille minimale de l'objet

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.fr-fr.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.fr-fr.md
@@ -54,14 +54,8 @@ Lorsqu'un objet atteint la fin de sa durée de vie selon la configuration de son
 - **versionné** : un marqueur de suppression est créé et devient la version courante. Vous pouvez également choisir le nombre d'anciennes versions que vous souhaitez conserver. Si la version courante de l'objet est la seule version de l'objet et qu'il s'agit également d'un marqueur de suppression, ce dernier sera supprimé.
 - **versioning suspendu** : actuellement, nous ne permettons pas la suspension du versioning si vous avez une configuration de lifecycle en vigueur. De la même manière, nous ne permettons pas le téléchargement d'une configuration de lifecycle si le versioning est suspendu sur le bucket.
 
-> [!warning]
-> 
-> La mise en place de la fonctionnalité se fera en 2 phases :
->
-> - Phase 1 : prise en charge de l'expiration uniquement
-> - Phase 2 : prise en charge des transitions
 
-## Expiration (disponible)
+## Expiration
 
 Les règles de lifecycle sont traitées de manière asynchrone et dans la mesure du possible. La plupart des règles sont appliquées dans les 24 heures, mais cela peut prendre plus de temps dans le cas d'un très grand nombre d'objets ou lors du traitement de nombreux objets. Pendant ce délai, vous continuez à être facturé pour le niveau de stockage actuel de l'objet, même si la règle (par exemple, l'expiration ou la transition) a déjà été déclenchée mais n'est pas encore terminée. Par exemple, si un objet doit être supprimé le 30e jour, mais qu'il n'est traité que le 32e jour, vous pouvez être facturé pour deux jours supplémentaires.
 
@@ -392,7 +386,7 @@ Dans un bucket versionné, la configuration suivante effectue ces actions :
 
 ///
 
-## Transition (à venir)
+## Transition
 
 ### Transitions supportées
 
@@ -403,10 +397,11 @@ Dans un bucket versionné, la configuration suivante effectue ces actions :
 
 Les transitions actuellement prises en charge sont les suivantes :
 
-| de/vers          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
+| de/vers          | High Performance | Standard  | Infrequent Access |Cold Archive |
 | ---------------- | ---------------- | --------- | -------------------------- |------------ |
 | High Performance |        -         | oui       |             oui            | non          |
 | Standard         | interdit        | -         |             oui            | non          |
+| Infrequent Access         | interdit        | interdit         |             -            | non          |
 | Cold Archive     | interdit        | interdit |             interdit      | -           |
 
 ### Taille minimale de l'objet

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.fr-fr.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.fr-fr.md
@@ -54,7 +54,6 @@ Lorsqu'un objet atteint la fin de sa durée de vie selon la configuration de son
 - **versionné** : un marqueur de suppression est créé et devient la version courante. Vous pouvez également choisir le nombre d'anciennes versions que vous souhaitez conserver. Si la version courante de l'objet est la seule version de l'objet et qu'il s'agit également d'un marqueur de suppression, ce dernier sera supprimé.
 - **versioning suspendu** : actuellement, nous ne permettons pas la suspension du versioning si vous avez une configuration de lifecycle en vigueur. De la même manière, nous ne permettons pas le téléchargement d'une configuration de lifecycle si le versioning est suspendu sur le bucket.
 
-
 ## Expiration
 
 Les règles de lifecycle sont traitées de manière asynchrone et dans la mesure du possible. La plupart des règles sont appliquées dans les 24 heures, mais cela peut prendre plus de temps dans le cas d'un très grand nombre d'objets ou lors du traitement de nombreux objets. Pendant ce délai, vous continuez à être facturé pour le niveau de stockage actuel de l'objet, même si la règle (par exemple, l'expiration ou la transition) a déjà été déclenchée mais n'est pas encore terminée. Par exemple, si un objet doit être supprimé le 30e jour, mais qu'il n'est traité que le 32e jour, vous pouvez être facturé pour deux jours supplémentaires.

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.it-it.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Smart Storage Management with Lifecycle Rules
 excerpt: Learn how to optimise your storage costs with OVHcloud lifecycle rules
-updated: 2025-05-13
+updated: 2025-06-05
 ---
 
 <style>
@@ -54,14 +54,7 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
-> [!warning]
-> 
-> The release of the feature will be done in 2 phases:
->
-> - Phase 1: support for expiration only
-> - Phase 2: support for transitions
-
-## Expiration (available)
+## Expiration
 
 Lifecycle rules are processed asynchronously and on a best-effort basis. Most rules are applied within 24 hours, but for very large buckets or when processing many objects, it might take longer. During this delay, you continue to be billed for the object's current storage tier, even if the rule (e.g., expiration or transition) has already been triggered but not yet completed. For example, if an object is set to be deleted on day 30 but is only processed on day 32, you may be billed for an additional two days.
 
@@ -393,7 +386,7 @@ In a versioned bucket, the following configuration does the following actions:
 
 ///
 
-## Transition (coming soon)
+## Transition
 
 ### Supported transitions
 
@@ -403,11 +396,12 @@ In a versioned bucket, the following configuration does the following actions:
 
 The following are the currently supported transitions:
 
-| from/to          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
-| ---------------- | ---------------- | --------- | -------------------------- |------------ |
-| High Performance |        -         | yes       |             yes            | no          |
-| Standard         | forbidden        | -         |             yes            | no          |
-| Cold Archive     | forbidden        | forbidden |             forbidden      | -           |
+| from/to          | High Performance | Standard  | Infrequent Access |Cold Archive |
+| ---------------- | ---------------- | --------- | ----------------- |------------ |
+| High Performance |        -         | yes       |    yes            | no          |
+| Standard         | forbidden        | -         |    yes            | no          |
+| Infrequent Access| forbidden        | forbidden |    -              | no          |
+| Cold Archive     | forbidden        | forbidden |    forbidden      | -           |
 
 ### Minimum object size
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.pl-pl.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Smart Storage Management with Lifecycle Rules
 excerpt: Learn how to optimise your storage costs with OVHcloud lifecycle rules
-updated: 2025-05-13
+updated: 2025-06-05
 ---
 
 <style>
@@ -54,14 +54,7 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
-> [!warning]
-> 
-> The release of the feature will be done in 2 phases:
->
-> - Phase 1: support for expiration only
-> - Phase 2: support for transitions
-
-## Expiration (available)
+## Expiration
 
 Lifecycle rules are processed asynchronously and on a best-effort basis. Most rules are applied within 24 hours, but for very large buckets or when processing many objects, it might take longer. During this delay, you continue to be billed for the object's current storage tier, even if the rule (e.g., expiration or transition) has already been triggered but not yet completed. For example, if an object is set to be deleted on day 30 but is only processed on day 32, you may be billed for an additional two days.
 
@@ -393,7 +386,7 @@ In a versioned bucket, the following configuration does the following actions:
 
 ///
 
-## Transition (coming soon)
+## Transition
 
 ### Supported transitions
 
@@ -403,11 +396,12 @@ In a versioned bucket, the following configuration does the following actions:
 
 The following are the currently supported transitions:
 
-| from/to          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
-| ---------------- | ---------------- | --------- | -------------------------- |------------ |
-| High Performance |        -         | yes       |             yes            | no          |
-| Standard         | forbidden        | -         |             yes            | no          |
-| Cold Archive     | forbidden        | forbidden |             forbidden      | -           |
+| from/to          | High Performance | Standard  | Infrequent Access |Cold Archive |
+| ---------------- | ---------------- | --------- | ----------------- |------------ |
+| High Performance |        -         | yes       |    yes            | no          |
+| Standard         | forbidden        | -         |    yes            | no          |
+| Infrequent Access| forbidden        | forbidden |    -              | no          |
+| Cold Archive     | forbidden        | forbidden |    forbidden      | -           |
 
 ### Minimum object size
 

--- a/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.pt-pt.md
+++ b/pages/storage_and_backup/object_storage/s3_bucket_lifecycle/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Object Storage - Smart Storage Management with Lifecycle Rules
 excerpt: Learn how to optimise your storage costs with OVHcloud lifecycle rules
-updated: 2025-05-13
+updated: 2025-06-05
 ---
 
 <style>
@@ -54,14 +54,7 @@ When an object reaches the end of its lifetime based on its lifecycle configurat
 - **versioned**: a delete marker is created and becomes the current version. You can also choose how many old versions you want to keep. If the current object version is the only object version and it is also a delete marker, that delete marker will be removed.
 - **versioning-suspended**: we currently do not allow for the suspension of versioning if you have a lifecycle configuration in effect and vice-versa. We currently do not allow for the upload of a lifecycle configuration if versioning is suspended on the bucket.
 
-> [!warning]
-> 
-> The release of the feature will be done in 2 phases:
->
-> - Phase 1: support for expiration only
-> - Phase 2: support for transitions
-
-## Expiration (available)
+## Expiration
 
 Lifecycle rules are processed asynchronously and on a best-effort basis. Most rules are applied within 24 hours, but for very large buckets or when processing many objects, it might take longer. During this delay, you continue to be billed for the object's current storage tier, even if the rule (e.g., expiration or transition) has already been triggered but not yet completed. For example, if an object is set to be deleted on day 30 but is only processed on day 32, you may be billed for an additional two days.
 
@@ -393,7 +386,7 @@ In a versioned bucket, the following configuration does the following actions:
 
 ///
 
-## Transition (coming soon)
+## Transition
 
 ### Supported transitions
 
@@ -403,11 +396,12 @@ In a versioned bucket, the following configuration does the following actions:
 
 The following are the currently supported transitions:
 
-| from/to          | High Performance | Standard  | Standard Infrequent Access |Cold Archive |
-| ---------------- | ---------------- | --------- | -------------------------- |------------ |
-| High Performance |        -         | yes       |             yes            | no          |
-| Standard         | forbidden        | -         |             yes            | no          |
-| Cold Archive     | forbidden        | forbidden |             forbidden      | -           |
+| from/to          | High Performance | Standard  | Infrequent Access |Cold Archive |
+| ---------------- | ---------------- | --------- | ----------------- |------------ |
+| High Performance |        -         | yes       |    yes            | no          |
+| Standard         | forbidden        | -         |    yes            | no          |
+| Infrequent Access| forbidden        | forbidden |    -              | no          |
+| Cold Archive     | forbidden        | forbidden |    forbidden      | -           |
 
 ### Minimum object size
 


### PR DESCRIPTION
<!--
Hello 👋
Thank you for submitting a Pull Request.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details. As long as your Pull Request is a draft, the OVHcloud Guides Team will not start proofreading it.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

DO NOT USE a fork if you are an OVHcloud employee. Instead, please contact the OVHcloud Guides Team so to be granted /write access to this repository.

Feel free to apply labels on your Pull Request, selecting them from the list to your right.

Before submitting a Pull Request, please ensure you have:

- 📖 Read the OVHcloud Documentation readme: https://github.com/ovh/docs/blob/develop/readme.md
- 🇬🇧 Edited (at least) the en-gb version of a guide.
- 🇫🇷 Edited also the fr-fr version if you are a French speaker.
- 🌐 Edited all the files if you're doing a fix or a minor update (this is not mandatory but recommended).
- 👷‍♀️ Created a small PR, if applicable.
- ✅ Tested every step you're documenting.
- 📝 Used descriptive commit messages.
- 📐 Resized images which width exceeds 1400px.
- 📝 Edited or blurred any sensitive/private information from your text and images (IPs, user IDs, private URLs, etc.).
-->

## What type of Pull Request is this?

<!-- Delete the lines which don't apply: -->
- Update of existing guide(s)

## Description
Following prod of Infrequent Access and Lifecycle transition, removed "available" and "soon" on Lifecycle doc + added new supported storage tier "Infrequent Access" in transitions
<!-- Please provide a short description for your Pull Request, including (if applicable) a ticket reference (no internal URL!) or GitHub issue -->

## Mandatory information

<!-- Delete the line which doesn't apply: -->
- This Pull Request can be merged as soon as possible.

<!-- If you know about the following, please mention it. If you don't know, delete the line.-->
- This Pull Request content should be replicated for the US OVHcloud documentation : NO* <!-- https://support.us.ovhcloud.com/hc/en-us -->
   \* the US should only have the updates regarding the removal of "available" and "soon" and the warning bloc BUT NOT the new "Infrequent Access" storage tiers in the supported transitions