### PR TITLE
Disabling language fallback for email and telecom guides

### DIFF
--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/delegation/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/delegation/meta.yaml
@@ -1,3 +1,12 @@
 id: 7d634d52-8f05-4e37-bd8f-bf7b7cfb589d
 full_slug: email-pro-delegation
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config/meta.yaml
@@ -1,3 +1,12 @@
 id: 16fd1abf-2568-4de6-83b7-8f036d142072
 full_slug: email-pro-getting-started
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/footers/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/footers/meta.yaml
@@ -1,3 +1,12 @@
 id: 71ba973a-b0b8-4757-87d4-f3dbf6270e53
 full_slug: email-pro-automatic-signature
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_android/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_android/meta.yaml
@@ -2,3 +2,12 @@ id: 7a3671a7-0264-49ff-afe2-04ef9402236a
 full_slug: email-pro-android-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_gmail/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_gmail/meta.yaml
@@ -2,3 +2,12 @@ id: 17e09406-d4d4-4d73-b933-fa0cc5059677
 full_slug: email-pro-gmail-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_ios/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_ios/meta.yaml
@@ -2,3 +2,12 @@ id: 9f5efe71-10af-42ab-88f8-22dfad74825e
 full_slug: email-pro-iphone-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_mail_macos/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_mail_macos/meta.yaml
@@ -2,3 +2,12 @@ id: 62efaa1a-4736-447d-9734-28553b1a36ef
 full_slug: email-pro-macos-mailapp-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_2016/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_2016/meta.yaml
@@ -2,3 +2,12 @@ id: 43fd8131-cc5b-408c-88ff-06f1fb166c6c
 full_slug: email-pro-outlook-windows-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_2016_mac/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_2016_mac/meta.yaml
@@ -2,3 +2,12 @@ id: 3d1e4540-bd10-4086-956c-d2cf4292c91f
 full_slug: email-pro-outlook-macos-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_android/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_android/meta.yaml
@@ -2,3 +2,12 @@ id: f3cdddf4-76dc-43d3-99b7-d72f250a69ae
 full_slug: email-pro-outlook-android-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_ios/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_ios/meta.yaml
@@ -1,3 +1,12 @@
 id: E3D1E42E-BBB5-4162-9B62-CCD2D9548442
 full_slug: email-pro-outlook-ios-configuration
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_thunderbird/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_thunderbird/meta.yaml
@@ -2,3 +2,12 @@ id: cc0d4eb1-cb9f-4def-83e9-1ac0743bd2d4
 full_slug: email-pro-thunderbird-windows-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_thunderbird_mac/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_thunderbird_mac/meta.yaml
@@ -2,3 +2,12 @@ id: 417f733d-60e7-4c1c-9863-b9176b4a397b
 full_slug: email-pro-thunderbird-macos-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_windows_10/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_windows_10/meta.yaml
@@ -2,3 +2,12 @@ id: 27517d8b-da79-4a37-b96c-b4653caf2714
 full_slug: email-pro-windows-10-mailapp-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/manage_billing_emailpro/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/manage_billing_emailpro/meta.yaml
@@ -1,3 +1,12 @@
 id: cd82363d-5d6a-446e-8776-6463f8623821
 full_slug: email-pro-billing
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/email_pro/responsibility_model/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/email_pro/responsibility_model/meta.yaml
@@ -2,3 +2,12 @@ id: 28fed495-1e0d-4544-83c1-be86e8f1ae83
 full_slug: email-pro-responsibility-model
 reference_category: web-cloud-email-collaborative-solutions-email-pro-getting-started
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/diagnostic_advanced/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/diagnostic_advanced/meta.yaml
@@ -1,3 +1,8 @@
 id: 753e8732-8be1-44cc-bb8d-3b026a7371f6
 full_slug: exchange-troubleshooting
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain/meta.yaml
@@ -1,3 +1,8 @@
 id: ffbbdbcc-eff3-4197-b645-f940edb83462
 full_slug: email-adding-domain
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_dns_cname/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_dns_cname/meta.yaml
@@ -1,3 +1,8 @@
 id: bbde13f5-a004-4471-9a49-0dd89cdef373
 full_slug: email-cname-record
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted/meta.yaml
@@ -1,3 +1,8 @@
 id: 3866c9d9-3d56-406e-8857-f6c052168548
 full_slug: exchange-hosted-getting-started
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_private/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_private/meta.yaml
@@ -1,3 +1,12 @@
 id: c42ff516-3b6f-4289-855f-a3f75977945d
 full_slug: exchange-private-getting-started
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_veeam_backup/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_veeam_backup/meta.yaml
@@ -1,3 +1,12 @@
 id: 5A5EB3F5-82B2-489A-8C6B-530AF2DB8B41
 full_slug: exchange-veeam-backup
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_delegation/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_delegation/meta.yaml
@@ -1,3 +1,8 @@
 id: 5a8aa607-0a3c-4400-983d-da01373b9f20
 full_slug: email-permissions-delegation
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers/meta.yaml
@@ -1,3 +1,8 @@
 id: 03ddb349-7a25-410b-a0dd-52da2ff96b3e
 full_slug: email-footer
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups/meta.yaml
@@ -1,3 +1,8 @@
 id: 5d0bb7a1-ea66-4ad5-9c4e-3e9f2f3293f3
 full_slug: exchange-contacts-groups
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_resources/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_resources/meta.yaml
@@ -1,3 +1,8 @@
 id: 7b44e62b-4d69-4cea-bdeb-6ec8c677bfd0
 full_slug: exchange-resource-accounts
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_send_connector/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_send_connector/meta.yaml
@@ -1,3 +1,12 @@
 id: 9B2C5F4B-0857-4661-B353-58AB0211780D
 full_slug: exchange-send-connector
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_shared_account/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_shared_account/meta.yaml
@@ -1,3 +1,8 @@
 id: 71e66610-dfc1-480a-b18c-cc831423a678
 full_slug: exchange-shared-account
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_android/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_android/meta.yaml
@@ -2,3 +2,8 @@ id: d67fba5b-4940-4db9-89e0-a7b89f083f99
 full_slug: exchange-android-gmail-app-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_ios/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_ios/meta.yaml
@@ -2,3 +2,8 @@ id: 3b2fd238-24d9-4513-9959-707ccacefd0d
 full_slug: exchange-ios-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos/meta.yaml
@@ -2,3 +2,8 @@ id: 8fad218d-6537-4a7b-bec0-f852033f70b4
 full_slug: exchange-macos-mailapp-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016/meta.yaml
@@ -2,3 +2,8 @@ id: 00f72f77-e770-42af-87cc-e237c52282c9
 full_slug: exchange-outlook-windows-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016_mac/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016_mac/meta.yaml
@@ -2,3 +2,8 @@ id: 32ff7ff8-558e-4aa4-9332-42b3586f2ed8
 full_slug: exchange-outlook-macos-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_thunderbird/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_thunderbird/meta.yaml
@@ -2,3 +2,8 @@ id: ed7204b2-b84f-4f30-ade0-19a8e32c4d06
 full_slug: exchange-thunderbird-windows-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_thunderbird_mac/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_thunderbird_mac/meta.yaml
@@ -2,3 +2,8 @@ id: 15f2ef19-a790-419f-906d-8b3a96cdf0fe
 full_slug: exchange-thunderbird-macos-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_windows_10/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_windows_10/meta.yaml
@@ -2,3 +2,8 @@ id: 5286e657-c9c6-4842-aa78-eb26e64235d5
 full_slug: exchange-mailapp-windows-configuration
 banner: marketplace-support-collaboration
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/manage_2fa_exchange/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/manage_2fa_exchange/meta.yaml
@@ -1,3 +1,12 @@
 id: 92259b02-eca4-45e9-9580-a01e5181d309
 full_slug: exchange-2fa
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/manage_billing_exchange/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/manage_billing_exchange/meta.yaml
@@ -1,3 +1,8 @@
 id: 7adf6743-0b6e-431d-8577-5c77ee246928
 full_slug: exchange-billing
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/office_outlook_license/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/office_outlook_license/meta.yaml
@@ -1,3 +1,8 @@
 id: 177b3543-7f7c-40bf-a171-ce43498b3ab0
 full_slug: exchange-order-outlook-licence
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/raci_dedicated_email_infrastructure/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/raci_dedicated_email_infrastructure/meta.yaml
@@ -2,3 +2,12 @@ id: f88c878c-0179-4c5a-a464-32aef9f9e910
 full_slug: dedicated-email-infrastructure-responsibility-sharing
 reference_category: account-and-service-management-responsibility-sharing
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/responsibility-model/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/responsibility-model/meta.yaml
@@ -2,3 +2,10 @@ id: e6c1c58b-ee40-4817-acbc-2477be0b99a3
 full_slug: exchange-hosted-echange-responsibility-model
 reference_category: web-cloud-email-collaborative-solutions-microsoft-exchange-getting-started
 translation_banner: true
+disable_languages:
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/responsibility_model_private_email_server_exchange/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/responsibility_model_private_email_server_exchange/meta.yaml
@@ -2,3 +2,12 @@ id: 3faa5269-2c91-485e-a409-2fcda0b9afd0
 full_slug: private-email-server-responsibility-sharing
 reference_category: account-and-service-management-responsibility-sharing
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp1/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp1/meta.yaml
@@ -1,3 +1,12 @@
 id: d74e93b4-1775-4876-bd4e-ee83a83e0908
 full_slug: microsoft-office365-csp1
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp2/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp2/meta.yaml
@@ -1,3 +1,12 @@
 id: 76c3c576-1c41-494a-93e7-89915ea5a29c
 full_slug: microsoft-office365-csp2
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_proplus/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_proplus/meta.yaml
@@ -1,3 +1,12 @@
 id: 59f89318-60e2-4a3d-87d5-d57109c24411
 full_slug: microsoft-office365-remote-desktop
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios/meta.yaml
@@ -1,3 +1,12 @@
 id: 8B22E20E-8B99-4346-8365-C651DA8FB40A
 full_slug: zimbra-mail-mobile-app-android-ios
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/migrate_mxplan_to_zimbra/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/migrate_mxplan_to_zimbra/meta.yaml
@@ -1,3 +1,12 @@
 id: 0a46b1b1-339b-4920-bae6-f6fbdd6ee467
 full_slug: zimbra-migrate-mxplan-to-zimbra
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_calendar_sync/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_calendar_sync/meta.yaml
@@ -1,3 +1,12 @@
 id: 8FEABEC1-9156-4FBA-91C5-C0A0BDB52FBF
 full_slug: zimbra-sync-calendar-caldav
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/meta.yaml
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/meta.yaml
@@ -1,3 +1,12 @@
 id: 1839A6D8-4AEB-4AFD-86A3-E1E01A3065A6
 full_slug: zimbra-mail-apps
 translation_banner: true
+disable_languages:
+- fr-ca
+- en-ca
+- en-asia
+- en-au
+- en-sg
+- en-in
+- en-us
+- es-us

--- a/pages/web_cloud/internet/internet_access/end_of_copper_migration_ftth/meta.yaml
+++ b/pages/web_cloud/internet/internet_access/end_of_copper_migration_ftth/meta.yaml
@@ -1,2 +1,4 @@
+disable_languages:
+- fr-ca
 id: d45e61ba-118d-4d98-9ce8-b8e916b8e34c
 full_slug: internet-access-end-of-copper-migration-ftth

--- a/pages/web_cloud/internet/overthebox/offer_migration/meta.yaml
+++ b/pages/web_cloud/internet/overthebox/offer_migration/meta.yaml
@@ -1,2 +1,4 @@
+disable_languages:
+- fr-ca
 id: 113069fa-e4c2-4fe4-9061-51eadd1eb351
 full_slug: overthebox-offer-migration


### PR DESCRIPTION

## What type of Pull Request is this?

- Optimization

## Description

Our email / Office365 / Telecom aren't available for all countries.
As a consequence, the language fallback needs to be disabled for all the related guides.

## Mandatory information

- This Pull Request can be merged as soon as possible.
- This Pull Request content should be replicated for the US OVHcloud documentation : NO 