### PR TITLE
Fix global links in KB Network

### DIFF
--- a/pages/network/additional_ip/additional-IP-cancellation/guide.en-asia.md
+++ b/pages/network/additional_ip/additional-IP-cancellation/guide.en-asia.md
@@ -22,14 +22,14 @@ As any other OVHcloud service, an Additional IP service can be cancelled at any 
 ## Requirements
 
 - An [Additional IP service](/links/network/additional-ip)
-- Access to the [OVHcloud API console](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API console](/links/api)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
 
 ### Cancelling an Additional IP service via the API
 
-Log in to the OVHcloud [API web page](https://ca.api.ovh.com/).
+Log in to the OVHcloud [API web page](/links/api).
 
 You first need to find out the name of the service you need to cancel. Use the following call:
 

--- a/pages/network/additional_ip/additional-IP-cancellation/guide.en-au.md
+++ b/pages/network/additional_ip/additional-IP-cancellation/guide.en-au.md
@@ -22,14 +22,14 @@ As any other OVHcloud service, an Additional IP service can be cancelled at any 
 ## Requirements
 
 - An [Additional IP service](/links/network/additional-ip)
-- Access to the [OVHcloud API console](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API console](/links/api)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
 
 ### Cancelling an Additional IP service via the API
 
-Log in to the OVHcloud [API web page](https://ca.api.ovh.com/).
+Log in to the OVHcloud [API web page](/links/api).
 
 You first need to find out the name of the service you need to cancel. Use the following call:
 

--- a/pages/network/additional_ip/additional-IP-cancellation/guide.en-ca.md
+++ b/pages/network/additional_ip/additional-IP-cancellation/guide.en-ca.md
@@ -22,14 +22,14 @@ As any other OVHcloud service, an Additional IP service can be cancelled at any 
 ## Requirements
 
 - An [Additional IP service](/links/network/additional-ip)
-- Access to the [OVHcloud API console](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API console](/links/api)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
 
 ### Cancelling an Additional IP service via the API
 
-Log in to the OVHcloud [API web page](https://ca.api.ovh.com/).
+Log in to the OVHcloud [API web page](/links/api).
 
 You first need to find out the name of the service you need to cancel. Use the following call:
 

--- a/pages/network/additional_ip/additional-IP-cancellation/guide.en-gb.md
+++ b/pages/network/additional_ip/additional-IP-cancellation/guide.en-gb.md
@@ -22,7 +22,7 @@ As any other OVHcloud service, an Additional IP service can be cancelled at any 
 ## Requirements
 
 - An [Additional IP service](/links/network/additional-ip)
-- Access to the [OVHcloud API console](https://eu.api.ovh.com/)
+- Access to the [OVHcloud API console](/links/api)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions

--- a/pages/network/additional_ip/additional-IP-cancellation/guide.en-ie.md
+++ b/pages/network/additional_ip/additional-IP-cancellation/guide.en-ie.md
@@ -22,7 +22,7 @@ As any other OVHcloud service, an Additional IP service can be cancelled at any 
 ## Requirements
 
 - An [Additional IP service](/links/network/additional-ip)
-- Access to the [OVHcloud API console](https://eu.api.ovh.com/)
+- Access to the [OVHcloud API console](/links/api)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions

--- a/pages/network/additional_ip/additional-IP-cancellation/guide.en-sg.md
+++ b/pages/network/additional_ip/additional-IP-cancellation/guide.en-sg.md
@@ -22,14 +22,14 @@ As any other OVHcloud service, an Additional IP service can be cancelled at any 
 ## Requirements
 
 - An [Additional IP service](/links/network/additional-ip)
-- Access to the [OVHcloud API console](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API console](/links/api)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
 
 ### Cancelling an Additional IP service via the API
 
-Log in to the OVHcloud [API web page](https://ca.api.ovh.com/).
+Log in to the OVHcloud [API web page](/links/api).
 
 You first need to find out the name of the service you need to cancel. Use the following call:
 

--- a/pages/network/additional_ip/additional-IP-cancellation/guide.en-us.md
+++ b/pages/network/additional_ip/additional-IP-cancellation/guide.en-us.md
@@ -22,14 +22,14 @@ As any other OVHcloud service, an Additional IP service can be cancelled at any 
 ## Requirements
 
 - An [Additional IP service](/links/network/additional-ip)
-- Access to the [OVHcloud API console](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API console](/links/api)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
 
 ### Cancelling an Additional IP service via the API
 
-Log in to the OVHcloud [API web page](https://ca.api.ovh.com/).
+Log in to the OVHcloud [API web page](/links/api).
 
 You first need to find out the name of the service you need to cancel. Use the following call:
 

--- a/pages/network/additional_ip/additional-IP-cancellation/guide.fr-ca.md
+++ b/pages/network/additional_ip/additional-IP-cancellation/guide.fr-ca.md
@@ -22,14 +22,14 @@ Comme tous les services OVHcloud, les services Additional IP peuvent être rési
 ## Prérequis
 
 - Disposer d'un [service Additional IP](/links/network/additional-ip).
-- Être connecté à la [console API OVHcloud](https://ca.api.ovh.com/).
+- Être connecté à la [console API OVHcloud](/links/api).
 - Consulter le guide [Premiers pas avec les API OVHcloud](/pages/manage_and_operate/api/first-steps) pour vous familiariser avec l'utilisation des APIv6 OVHcloud.
 
 ## En pratique
 
 ### Résilier un service Additional IP via les API
 
-Connectez-vous sur la page web des [API OVHcloud](https://ca.api.ovh.com/).
+Connectez-vous sur la page web des [API OVHcloud](/links/api).
 
 Vous devez d'abord déterminer le nom du service à résilier. Pour cela, utilisez l'appel API suivant :
 

--- a/pages/network/additional_ip/additional-IP-cancellation/guide.fr-fr.md
+++ b/pages/network/additional_ip/additional-IP-cancellation/guide.fr-fr.md
@@ -22,7 +22,7 @@ Comme tous les services OVHcloud, les services Additional IP peuvent être rési
 ## Prérequis
 
 - Disposer d'un [service Additional IP](/links/network/additional-ip).
-- Être connecté à la [console API OVHcloud](https://eu.api.ovh.com/).
+- Être connecté à la [console API OVHcloud](/links/api).
 - Consulter le guide [Premiers pas avec les API OVHcloud](/pages/manage_and_operate/api/first-steps) pour vous familiariser avec l'utilisation des APIv6 OVHcloud.
 
 ## En pratique

--- a/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.de-de.md
+++ b/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.de-de.md
@@ -14,7 +14,7 @@ Bei der ersten Konfiguration des Content Delivery Network (CDN) müssen zunächs
 
 - Sie nutzen das [OVH Content Delivery Network (CDN)](https://www.ovh.de/cdn/){.external}.
 - Sie haben Zugriff auf die Verwaltung der DNS-Zone Ihrer Domain.
-- Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external}.
+- Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager){.external}.
 
 ## Beschreibung
 
@@ -22,7 +22,7 @@ Bei der ersten Konfiguration des Content Delivery Network (CDN) müssen zunächs
 
 Fügen Sie dem CDN zunächst eine Subdomain Ihrer Wahl hinzu, damit es HTTP(S)-Anfragen für diese Domain akzeptiert.
 
-Gehen Sie dazu im [OVHcloud Kundencenter ](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} in den Bereich `Dedicated`{.action} und dann auf `NAS und CDN`{.action}.
+Gehen Sie dazu im [OVHcloud Kundencenter ](/links/manager){.external} in den Bereich `Dedicated`{.action} und dann auf `NAS und CDN`{.action}.
 
 Klicken Sie auf `Eine Domain zum CDN hinzufügen`{.action}:
 

--- a/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.en-gb.md
+++ b/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.en-gb.md
@@ -13,7 +13,7 @@ When you configure the Content Delivery Network (CDN) for the first time, you ne
 ## Requirements
 
 - an [OVH Content Delivery Network (CDN)](https://www.ovh.co.uk/cdn/){.external} solution
-- access to the [OVH Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}
+- access to the [OVH Control Panel](/links/manager){.external}
 - the permissions needed to manage your domain’s DNS zone
  
  
@@ -24,7 +24,7 @@ When you configure the Content Delivery Network (CDN) for the first time, you ne
 
 The first step of this configuration involves adding your subdomain to the CDN, so that it accepts HTTP(S) requests.
 
-To do this, go to the [OVH Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, click on the `Dedicated`{.action} tab, then go to `NAS and CDN`{.action}.
+To do this, go to the [OVH Control Panel](/links/manager){.external}, click on the `Dedicated`{.action} tab, then go to `NAS and CDN`{.action}.
 
 Next, click `Add a domain to the CDN`{.action}.
 

--- a/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.es-es.md
+++ b/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.es-es.md
@@ -14,7 +14,7 @@ Para empezar a utilizar la solución Content Delivery Network (CDN) de OVH, es n
 
 - Tener contratada la solución [CDN de OVH](https://www.ovh.es/cdn/){.external}.
 - Tener acceso a la gestión de la zona DNS del dominio.
-- Tener acceso al [área de cliente](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}.
+- Tener acceso al [área de cliente](/links/manager){.external}.
 
 ## Procedimiento
 
@@ -22,7 +22,7 @@ Para empezar a utilizar la solución Content Delivery Network (CDN) de OVH, es n
 
 En primer lugar, es necesario añadir el subdominio a la CDN para que esta última acepte las peticiones HTTP(S) relativas al mismo.
 
-Para ello, en el [área de cliente de OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external} acceda a la sección `Dedicado`{.action}. En la columna izquierda, haga clic en `NAS y CDN`{.action} y seleccione el servicio CDN correspondiente.
+Para ello, en el [área de cliente de OVH](/links/manager){.external} acceda a la sección `Dedicado`{.action}. En la columna izquierda, haga clic en `NAS y CDN`{.action} y seleccione el servicio CDN correspondiente.
 
 Haga clic en el atajo `Añadir un dominio a la CDN`{.action}.
 

--- a/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.fr-fr.md
+++ b/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.fr-fr.md
@@ -14,7 +14,7 @@ Lors de la première configuration du Content Delivery Network (CDN), il est né
 
 - Bénéficier du [Content Delivery Network (CDN) d'OVH](https://www.ovh.com/fr/cdn/){.external}.
 - Avoir accès à la gestion de la zone DNS de votre nom de domaine.
-- Avoir accès à votre [espace client OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Avoir accès à votre [espace client OVH](/links/manager){.external}.
 
 ## En pratique
 
@@ -22,7 +22,7 @@ Lors de la première configuration du Content Delivery Network (CDN), il est né
 
 La première étape de cette configuration est l'ajout du sous-domaine de votre choix au CDN pour que celui-ci accepte les requêtes HTTP(S) pour ce domaine.
 
-Pour cela, rendez-vous dans votre [espace client OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external} dans l'onglet `Dédié`{.action}, puis `NAS et CDN`{.action}.
+Pour cela, rendez-vous dans votre [espace client OVH](/links/manager){.external} dans l'onglet `Dédié`{.action}, puis `NAS et CDN`{.action}.
 
 Cliquez ensuite sur `Ajouter un domaine au CDN`{.action} :
 

--- a/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.it-it.md
+++ b/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.it-it.md
@@ -14,13 +14,13 @@ Per iniziare a utilizzare il servizio Content Delivery Network (CDN) di OVH, è 
 
 - Usufruire della [Content Delivery Network (CDN) OVH](https://www.ovh.it/cdn/){.external}
 - Avere accesso alla gestione della zona DNS del dominio
-- Avere accesso allo [Spazio Cliente OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}.
+- Avere accesso allo [Spazio Cliente OVH](/links/manager){.external}.
 
 ## Procedura
 
 ### Aggiungi il dominio sulla CDN
 
-Per prima cosa, è necessario aggiungere un sottodominio alla CDN in modo che possa accettare richieste HTTP(S) per questo dominio: accedi alla sezione `Dedicato`{.action} dello [Spazio Cliente OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external} e clicca su `NAS e CDN`{.action} nel menu a sinistra. 
+Per prima cosa, è necessario aggiungere un sottodominio alla CDN in modo che possa accettare richieste HTTP(S) per questo dominio: accedi alla sezione `Dedicato`{.action} dello [Spazio Cliente OVH](/links/manager){.external} e clicca su `NAS e CDN`{.action} nel menu a sinistra. 
 
 Clicca su `Aggiungi un dominio alla CDN`{.action}:
 

--- a/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.pl-pl.md
+++ b/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.pl-pl.md
@@ -14,7 +14,7 @@ Podczas pierwszej konfiguracji usługi CDN (Content Delivery Network) konieczne 
 
 - Posiadanie usługi [CDN (Content Delivery Network) od OVH](https://www.ovh.pl/cdn/){.external}
 - Dostęp do interfejsu zarządzania strefą DNS Twojej domeny
-- Dostęp do [Panelu klienta OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}
+- Dostęp do [Panelu klienta OVH](/links/manager){.external}
 
 ## W praktyce
 
@@ -22,7 +22,7 @@ Podczas pierwszej konfiguracji usługi CDN (Content Delivery Network) konieczne 
 
 Pierwszy etap konfiguracji polega na dodaniu wybranej przez Ciebie subdomeny do usługi CDN, aby mogła ona przyjmować zapytania HTTP(S) dla tej domeny. 
 
-W tym celu przejdź do [Panelu klienta](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external} > zakładka `Serwery dedykowane`{.action} > `NAS i CDN`{.action}.
+W tym celu przejdź do [Panelu klienta](/links/manager){.external} > zakładka `Serwery dedykowane`{.action} > `NAS i CDN`{.action}.
 
 Następnie kliknij `Dodanie domeny do CDN`{.action}:
 

--- a/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.pt-pt.md
+++ b/pages/network/content_delivery_network_infrastructure/first_domain_name_configuration/guide.pt-pt.md
@@ -14,7 +14,7 @@ Ao configurar a solução Content Delivery Network (CDN) pela primeira vez, deve
 
 - Possuir a solução [Content Delivery Network (CDN) da OVH](https://www.ovh.pt/cdn/){.external}.
 - Ter acesso à gestão da zona DNS do seu nome de domínio.
-- Ter acesso à [Área de Cliente OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}.
+- Ter acesso à [Área de Cliente OVH](/links/manager){.external}.
 
 ## Instruções
 
@@ -22,7 +22,7 @@ Ao configurar a solução Content Delivery Network (CDN) pela primeira vez, deve
 
 O primeiro passo desta configuração é a adição de um subdomínio à sua escolha na CDN para que esta última aceite os pedidos HTTP(S) deste domínio.
 
-Para isso, aceda à [Área de Cliente OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}, na janela `Serviços Dedicados`{.action} selecione a opção `NAS e CDN`{.action}.
+Para isso, aceda à [Área de Cliente OVH](/links/manager){.external}, na janela `Serviços Dedicados`{.action} selecione a opção `NAS e CDN`{.action}.
 
 A seguir, clique em `Adicionar domínio à CDN`{.action}.
 

--- a/pages/network/content_delivery_network_infrastructure/quota/guide.de-de.md
+++ b/pages/network/content_delivery_network_infrastructure/quota/guide.de-de.md
@@ -12,7 +12,7 @@ Mithilfe des Content Delivery Network (CDN) können Sie die Antwortzeiten von We
 
 ## Voraussetzungen
 
-- Sie sind in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} eingeloggt.
+- Sie sind in Ihrem [OVHcloud Kundencenter](/links/manager){.external} eingeloggt.
 
 ## Beschreibung
 
@@ -20,7 +20,7 @@ Mithilfe des Content Delivery Network (CDN) können Sie die Antwortzeiten von We
 
 Bei der Bestellung erhalten Sie **1 TB** Traffic-Quota. Bitte beachten Sie, dass dieses nicht jeden Monat automatisch erneuert wird. Ist das Quota aufgebraucht (egal über welchen Zeitraum), muss neues Quota bestellt werden.
 
-Wenn Sie zusätzliches Quota benötigen, können Sie dieses direkt über Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} bestellen.
+Wenn Sie zusätzliches Quota benötigen, können Sie dieses direkt über Ihr [OVHcloud Kundencenter](/links/manager){.external} bestellen.
 
 ![Quota hinzufügen](images/add_quota.png){.thumbnail}
 

--- a/pages/network/content_delivery_network_infrastructure/quota/guide.en-gb.md
+++ b/pages/network/content_delivery_network_infrastructure/quota/guide.en-gb.md
@@ -12,7 +12,7 @@ With the Content Delivery Network (CDN), you can optimise your website’s respo
 
 ## Requirements
 
-- access to the [OVH Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}
+- access to the [OVH Control Panel](/links/manager){.external}
 
 ## Instructions
 
@@ -20,7 +20,7 @@ With the Content Delivery Network (CDN), you can optimise your website’s respo
 
 When you place an order, it comes with a **1 TB** quota allowance for traffic. It is important to note that this quota is not renewed monthly with your solution. Once you have used up this quota allowance (regardless of duration), you will need to add more quota allowance.
 
-If you need additional quota, you can order it directly via the [OVH Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}:
+If you need additional quota, you can order it directly via the [OVH Control Panel](/links/manager){.external}:
 
 ![Add quota](images/add_quota.png){.thumbnail}
 

--- a/pages/network/content_delivery_network_infrastructure/quota/guide.es-es.md
+++ b/pages/network/content_delivery_network_infrastructure/quota/guide.es-es.md
@@ -14,7 +14,7 @@ Cada conexión al sitio web genera un flujo de datos. Cuando estos datos circula
 
 ## Requisitos
 
-- Tener acceso al [área de cliente](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}.
+- Tener acceso al [área de cliente](/links/manager){.external}.
 
 ## Procedimiento
 
@@ -22,7 +22,7 @@ Cada conexión al sitio web genera un flujo de datos. Cuando estos datos circula
 
 Al contratar la solución CDN, puede disfrutar de **1 TB** de tráfico incluido de forma gratuita. Este volumen de tráfico no se renueva cada mes junto con la solución, sino que, una vez consumido (independientemente del plazo), deberá contratar tráfico adicional.
 
-Es posible adquirir tráfico adicional directamente desde el [área de cliente de OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}.
+Es posible adquirir tráfico adicional directamente desde el [área de cliente de OVH](/links/manager){.external}.
 
 ![Adquirir tráfico](images/add_quota.png){.thumbnail}
 

--- a/pages/network/content_delivery_network_infrastructure/quota/guide.fr-fr.md
+++ b/pages/network/content_delivery_network_infrastructure/quota/guide.fr-fr.md
@@ -12,7 +12,7 @@ Le Content Delivery Network (CDN) vous permet d'optimiser le temps de réponse d
 
 ## Prérequis
 
-- Avoir accès à votre [espace client OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Avoir accès à votre [espace client OVH](/links/manager){.external}.
 
 ## En pratique
 
@@ -20,7 +20,7 @@ Le Content Delivery Network (CDN) vous permet d'optimiser le temps de réponse d
 
 Lors de votre commande, **1 To** de trafic vous est offert. Attention, ce quota n'est pas renouvelé chaque mois avec votre offre. En effet, une fois ce volume consommé (quelle que soit la durée), vous devrez en ajouter à nouveau.
 
-Si vous avez besoin de quota supplémentaire, vous pouvez le commander directement depuis votre [espace client OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external} :
+Si vous avez besoin de quota supplémentaire, vous pouvez le commander directement depuis votre [espace client OVH](/links/manager){.external} :
 
 ![Ajout de quota](images/add_quota.png){.thumbnail}
 

--- a/pages/network/content_delivery_network_infrastructure/quota/guide.it-it.md
+++ b/pages/network/content_delivery_network_infrastructure/quota/guide.it-it.md
@@ -12,7 +12,7 @@ La CDN (Content Delivery Network) è un servizio che permette di ottimizzare i t
 
 ## Prerequisiti
 
-- Avere accesso allo [Spazio Cliente OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}
+- Avere accesso allo [Spazio Cliente OVH](/links/manager){.external}
 
 ## Procedura
 
@@ -20,7 +20,7 @@ La CDN (Content Delivery Network) è un servizio che permette di ottimizzare i t
 
 L’attivazione della CDN OVH permette di usufruire di **1 TB** di traffico incluso. Questa quota non si rinnova mensilmente con il servizio ma, indipendentemente dalla sua durata, una volta consumata è necessario ordinare una quota aggiuntiva.
 
-Il traffico supplementare può essere aggiunto direttamente dallo [Spazio Cliente OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}:
+Il traffico supplementare può essere aggiunto direttamente dallo [Spazio Cliente OVH](/links/manager){.external}:
 
 ![Aggiungere quota](images/add_quota.png){.thumbnail}
 

--- a/pages/network/content_delivery_network_infrastructure/quota/guide.pl-pl.md
+++ b/pages/network/content_delivery_network_infrastructure/quota/guide.pl-pl.md
@@ -12,7 +12,7 @@ CDN (Content Delivery Network) umożliwia optymalizację czasu odpowiedzi Twoich
 
 ## Wymagania początkowe
 
-- Dostęp do [Panelu klienta OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}
+- Dostęp do [Panelu klienta OVH](/links/manager){.external}
 
 ## W praktyce
 
@@ -20,7 +20,7 @@ CDN (Content Delivery Network) umożliwia optymalizację czasu odpowiedzi Twoich
 
 W momencie zamówienia przyznany zostaje Ci limit transferu wynoszący **1 TB**. Pamiętaj, że limit ten **nie jest odnawiany** co miesiąc wraz z odnowieniem Twojej usługi. Po zużyciu całego limitu (niezależnie od czasu, w jakim został on wykorzystany), możesz zamówić nowy pakiet transferu danych.
 
-Jeśli potrzebujesz dodatkowego transferu, możesz zamówić go bezpośrednio w [Panelu klienta](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}:
+Jeśli potrzebujesz dodatkowego transferu, możesz zamówić go bezpośrednio w [Panelu klienta](/links/manager){.external}:
 
 ![Dodatnie limitu transferu](images/add_quota.png){.thumbnail}
 

--- a/pages/network/content_delivery_network_infrastructure/quota/guide.pt-pt.md
+++ b/pages/network/content_delivery_network_infrastructure/quota/guide.pt-pt.md
@@ -12,7 +12,7 @@ A solução CDN da OVH permite-lhe otimizar os tempos de resposta dos seus websi
 
 ## Requisitos
 
-- Ter acesso à [Área de Cliente OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}.
+- Ter acesso à [Área de Cliente OVH](/links/manager){.external}.
 
 ## Instruções
 
@@ -20,7 +20,7 @@ A solução CDN da OVH permite-lhe otimizar os tempos de resposta dos seus websi
 
 Ao contratar a solução CDN, poderá usufruir de **1 TB** de tráfego incluído. Contudo, este limite não é renovado mensalmente juntamente com a sua solução. Uma vez consumido (independentemente do prazo), deverá renovar o tráfego disponível.
 
-Caso necessite de tráfego adicional, poderá adicionar diretamente a partir da [Área de Cliente OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}.
+Caso necessite de tráfego adicional, poderá adicionar diretamente a partir da [Área de Cliente OVH](/links/manager){.external}.
 
 ![Adquirir tráfego](images/add_quota.png){.thumbnail}
 

--- a/pages/network/content_delivery_network_infrastructure/ssl_certificate/guide.es-es.md
+++ b/pages/network/content_delivery_network_infrastructure/ssl_certificate/guide.es-es.md
@@ -6,7 +6,7 @@ updated: 2018-02-22
 
 ## Objetivo
 
-Es posible añadir un [certificado SSL](https://www.ovhcloud.com/es-es/web-hosting/options/ssl/){.external} a su red de distribución de contenidos (CDN, del inglés *content delivery network*) para que los usuarios puedan establecer conexiones seguras incluso pasando por la CDN.
+Es posible añadir un [certificado SSL](/links/web/hosting-options-ssl){.external} a su red de distribución de contenidos (CDN, del inglés *content delivery network*) para que los usuarios puedan establecer conexiones seguras incluso pasando por la CDN.
 
 **Esta guía explica cómo funcionan los certificados SSL Let's Encrypt que ofrece OVH.**
 

--- a/pages/network/content_delivery_network_infrastructure/ssl_certificate/guide.it-it.md
+++ b/pages/network/content_delivery_network_infrastructure/ssl_certificate/guide.it-it.md
@@ -6,7 +6,7 @@ updated: 2018-02-22
 
 ## Obiettivo
 
-È possibile aggiungere un [certificato SSL](https://www.ovhcloud.com/it/web-hosting/options/ssl/){.external} sulla CDN (Content Delivery Network) per consentire agli utenti di stabilire connessioni sicure, anche nei casi in cui il traffico passi attraverso la CDN.
+È possibile aggiungere un [certificato SSL](/links/web/hosting-options-ssl){.external} sulla CDN (Content Delivery Network) per consentire agli utenti di stabilire connessioni sicure, anche nei casi in cui il traffico passi attraverso la CDN.
 
 **Questa guida ti mostra nel dettaglio il funzionamento del certificato SSL <i>Let's Encrypt</i> fornito da OVH.**
 

--- a/pages/network/load_balancer/case_blue_green/guide.fr-fr.md
+++ b/pages/network/load_balancer/case_blue_green/guide.fr-fr.md
@@ -15,7 +15,7 @@ Un déploiement **Blue-Green** permet de s'affranchir du temps d'indisponibilit�
 Pour mettre en oeuvre un déploiement de type **Blue-Green**, vous devez disposer des éléments suivants :
 
 - Posséder une offre [OVHcloud Load balancer](https://www.ovh.com/fr/solutions/load-balancer/) dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Un premier serveur qui porte votre infrastructure de production
 - Un second serveur qui porte une infrastructure similaire dédiée au développement
 

--- a/pages/network/load_balancer/case_http2/guide.fr-ca.md
+++ b/pages/network/load_balancer/case_http2/guide.fr-ca.md
@@ -17,7 +17,7 @@ ALPN (Application-Layer Protocol Negotiation) est une extension TLS qui permet �
 - Disposer d'un [Load Balancer OVHcloud](https://www.ovh.com/ca/fr/solutions/load-balancer/){.external}.
 - Un frontend TCP est créé sur le port 443.
 - Une ferme TCP est créée et des serveurs sont ajoutés.
-- Avoir accès à l'[API OVHcloud](https://ca.api.ovh.com/){.external}.
+- Avoir accès à l'[API OVHcloud](/links/api){.external}.
 
 ## En pratique
 

--- a/pages/network/load_balancer/case_http2/guide.it-it.md
+++ b/pages/network/load_balancer/case_http2/guide.it-it.md
@@ -17,7 +17,7 @@ L’ALPN (Application-Layer Protocol Negotiation) è un'estensione TLS che conse
 - Disporre di un [Load Balancer OVH](https://www.ovh.it/soluzioni/load-balancer/){.external}
 - Aver creato un front-end TCP
 - Aver creato una farm TCP e aver aggiunto i server
-- Avere accesso allo [Spazio Cliente OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}
+- Avere accesso allo [Spazio Cliente OVH](/links/manager){.external}
 
 ## Procedura
 

--- a/pages/network/load_balancer/case_smtp/guide.fr-fr.md
+++ b/pages/network/load_balancer/case_smtp/guide.fr-fr.md
@@ -11,7 +11,7 @@ Ce guide a pour but de vous aider à configurer un service OVHcloud Load Balance
 ## Prérequis
 
 - Posséder une offre [OVHcloud Load balancer](https://www.ovh.com/fr/solutions/load-balancer/) dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Posséder un service SMTP de type postfix installé et configuré sur vos serveurs
 
 ## En pratique

--- a/pages/network/load_balancer/create_balancing/guide.de-de.md
+++ b/pages/network/load_balancer/create_balancing/guide.de-de.md
@@ -12,7 +12,7 @@ Der neue OVH Loadbalancer bietet Ihnen mehrere Lastverteilungstypen für Ihre Di
 
 ## Voraussetzungen
 
-- Sie sind in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} eingeloggt.
+- Sie sind in Ihrem [OVHcloud Kundencenter](/links/manager){.external} eingeloggt.
 - Sie haben eine Serverfarm erstellt.
 
 ## Beschreibung

--- a/pages/network/load_balancer/create_balancing/guide.en-asia.md
+++ b/pages/network/load_balancer/create_balancing/guide.en-asia.md
@@ -12,7 +12,7 @@ The new OVH Load Balancer service offers a variety of load balancing methods for
 
 ## Requirements
 
-- You must be logged in to the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia).
+- You must be logged in to the [OVH Control Panel](/links/manager).
 - You need to have created a server farm.
 
 ## Instructions

--- a/pages/network/load_balancer/create_balancing/guide.en-au.md
+++ b/pages/network/load_balancer/create_balancing/guide.en-au.md
@@ -12,7 +12,7 @@ The new OVH Load Balancer service offers a variety of load balancing methods for
 
 ## Requirements
 
-- You must be logged in to the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au).
+- You must be logged in to the [OVH Control Panel](/links/manager).
 - You need to have created a server farm.
 
 ## Instructions

--- a/pages/network/load_balancer/create_balancing/guide.en-ca.md
+++ b/pages/network/load_balancer/create_balancing/guide.en-ca.md
@@ -12,7 +12,7 @@ The new OVH Load Balancer service offers a variety of load balancing methods for
 
 ## Requirements
 
-- You must be logged in to the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca).
+- You must be logged in to the [OVH Control Panel](/links/manager).
 - You need to have created a server farm.
 
 ## Instructions

--- a/pages/network/load_balancer/create_balancing/guide.en-gb.md
+++ b/pages/network/load_balancer/create_balancing/guide.en-gb.md
@@ -12,7 +12,7 @@ The new OVH Load Balancer service offers a variety of load balancing methods for
 
 ## Requirements
 
-- You must be logged in to the [OVH Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB).
+- You must be logged in to the [OVH Control Panel](/links/manager).
 - You need to have created a server farm.
 
 ## Instructions

--- a/pages/network/load_balancer/create_balancing/guide.en-sg.md
+++ b/pages/network/load_balancer/create_balancing/guide.en-sg.md
@@ -12,7 +12,7 @@ The new OVH Load Balancer service offers a variety of load balancing methods for
 
 ## Requirements
 
-- You must be logged in to the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg).
+- You must be logged in to the [OVH Control Panel](/links/manager).
 - You need to have created a server farm.
 
 ## Instructions

--- a/pages/network/load_balancer/create_balancing/guide.fr-ca.md
+++ b/pages/network/load_balancer/create_balancing/guide.fr-ca.md
@@ -12,7 +12,7 @@ Le nouveau service OVH Load Balancer offre différents types de répartition de 
 
 ## Prérequis
 
-- Être connecté à l'[espace client OVH](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à l'[espace client OVH](/links/manager).
 - Posséder une ferme de serveurs créée.
 
 ## En pratique

--- a/pages/network/load_balancer/create_balancing/guide.fr-fr.md
+++ b/pages/network/load_balancer/create_balancing/guide.fr-fr.md
@@ -13,7 +13,7 @@ Le service OVHcloud Load Balancer offre différents types de répartition de cha
 ## Prérequis
 
 - Posséder une offre [OVHcloud Load balancer](https://www.ovh.com/fr/solutions/load-balancer/) dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Posséder une ferme de serveurs créée.
 
 ## En pratique

--- a/pages/network/load_balancer/create_balancing/guide.it-it.md
+++ b/pages/network/load_balancer/create_balancing/guide.it-it.md
@@ -12,7 +12,7 @@ La nuova soluzione OVH Load Balancer offre diverse tipologie di ripartizione del
 
 ## Prerequisiti
 
-- Avere accesso allo [Spazio Cliente OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Avere accesso allo [Spazio Cliente OVH](/links/manager)
 - Disporre di una server farm
 
 ## Procedura

--- a/pages/network/load_balancer/create_balancing/guide.pl-pl.md
+++ b/pages/network/load_balancer/create_balancing/guide.pl-pl.md
@@ -12,7 +12,7 @@ Nowa usługa Load Balancer oferuje różne typy równoważenia obciążenia (loa
 
 ## Wymagania początkowe
 
-- Dostęp do [Panelu klienta OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}
+- Dostęp do [Panelu klienta OVH](/links/manager){.external}
 - Aktywna usługa Load Balancer
 - Utworzona farma serwerów
 

--- a/pages/network/load_balancer/create_balancing/guide.pt-pt.md
+++ b/pages/network/load_balancer/create_balancing/guide.pt-pt.md
@@ -12,7 +12,7 @@ O novo Load Balancer OVH oferece diferentes tipos de repartição de carga para 
 
 ## Requisitos
 
-- Ter acesso à [Área de Cliente OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}.
+- Ter acesso à [Área de Cliente OVH](/links/manager){.external}.
 - Ter uma Farm de servidores criada.
 
 ## Instruções

--- a/pages/network/load_balancer/create_headers/guide.fr-ca.md
+++ b/pages/network/load_balancer/create_headers/guide.fr-ca.md
@@ -19,7 +19,7 @@ Si vous retrouvez uniquement des IP privées dans vos acces_log, ce guide est fa
 ## Prérequis
 
 - Posséder une offre [OVHcloud Load balancer](https://www.ovh.com/ca/fr/solutions/load-balancer/) dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Posséder un service Web installé et configuré sur vos serveurs
 - Posséder un service Nginx installé et configuré sur vos serveurs
 

--- a/pages/network/load_balancer/create_headers/guide.fr-fr.md
+++ b/pages/network/load_balancer/create_headers/guide.fr-fr.md
@@ -19,7 +19,7 @@ Si vous retrouvez uniquement des IP privées dans vos acces_log, ce guide est fa
 ## Prérequis
 
 - Posséder une offre [OVHcloud Load balancer](https://www.ovh.com/fr/solutions/load-balancer/) dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Posséder un service Web installé et configuré sur vos serveurs
 - Posséder un service Nginx installé et configuré sur vos serveurs
 

--- a/pages/network/load_balancer/create_http_https/guide.fr-ca.md
+++ b/pages/network/load_balancer/create_http_https/guide.fr-ca.md
@@ -19,7 +19,7 @@ Pour rappel, le service OVHcloud Load Balancer est composé de 4 parties éléme
 
 ## Prérequis
 
-- Posséder une offre [OVHcloud Load balancer](https://www.ovhcloud.com/fr-ca/network/load-balancer/) dans votre compte OVHcloud.
+- Posséder une offre [OVHcloud Load balancer](/links/network/load-balancer) dans votre compte OVHcloud.
 - Être connecté à votre [espace client OVHcloud](/links/manager).
 - Posséder une ferme configurée
 - Posséder un frontend configuré

--- a/pages/network/load_balancer/create_http_https/guide.fr-fr.md
+++ b/pages/network/load_balancer/create_http_https/guide.fr-fr.md
@@ -20,7 +20,7 @@ Pour rappel, le service OVHcloud Load Balancer est composé de 4 parties éléme
 ## Prérequis
 
 - Posséder une offre [OVHcloud Load balancer](https://www.ovh.com/fr/solutions/load-balancer/) dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Posséder une ferme configurée
 - Posséder un frontend configuré
 - Posséder un certificat SSL

--- a/pages/network/load_balancer/create_probes/guide.fr-fr.md
+++ b/pages/network/load_balancer/create_probes/guide.fr-fr.md
@@ -22,7 +22,7 @@ Ce service étant encore jeune, l'essentiel de ses fonctionnalités est uniqueme
 ## Prérequis
 
 - Posséder une offre [OVHcloud Load balancer](https://www.ovh.com/fr/solutions/load-balancer/) dans votre compte OVHcloud. Le service doit être correctement configuré, avec un paramétrage des fermes et des serveurs.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 
 ## En pratique
 

--- a/pages/network/load_balancer/create_redirectlocation/guide.en-asia.md
+++ b/pages/network/load_balancer/create_redirectlocation/guide.en-asia.md
@@ -14,7 +14,7 @@ The OVH Load Balancer acts by default as a proxy. It can also be configured to r
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com/asia/solutions/load-balancer/){.external}
-- access to the [OVH Control Panel](https://ca.ovh.com/auth/){.external}, or the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH Control Panel](https://ca.ovh.com/auth/){.external}, or the [OVH API](/links/api){.external}
 
 ## Instructions
 
@@ -67,7 +67,7 @@ Once the front-end has been configured, click `Add`{.action} or `Edit`{.action},
 
 ### Add a custom redirection via the API.
 
-In the [OVH API](https://ca.api.ovh.com/){.external}, redirections are specified in the redirectLocation character chain.
+In the [OVH API](/links/api){.external}, redirections are specified in the redirectLocation character chain.
 
 * If you are creating a new front-end:
 

--- a/pages/network/load_balancer/create_redirectlocation/guide.en-au.md
+++ b/pages/network/load_balancer/create_redirectlocation/guide.en-au.md
@@ -14,7 +14,7 @@ The OVH Load Balancer acts by default as a proxy. It can also be configured to r
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com.au/solutions/load-balancer/){.external}
-- access to the [OVH Control Panel](https://ca.ovh.com/auth/){.external}, or the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH Control Panel](https://ca.ovh.com/auth/){.external}, or the [OVH API](/links/api){.external}
 
 ## Instructions
 
@@ -67,7 +67,7 @@ Once the front-end has been configured, click `Add`{.action} or `Edit`{.action},
 
 ### Add a custom redirection via the API.
 
-In the [OVH API](https://ca.api.ovh.com/){.external}, redirections are specified in the redirectLocation character chain.
+In the [OVH API](/links/api){.external}, redirections are specified in the redirectLocation character chain.
 
 * If you are creating a new front-end:
 

--- a/pages/network/load_balancer/create_redirectlocation/guide.en-ca.md
+++ b/pages/network/load_balancer/create_redirectlocation/guide.en-ca.md
@@ -14,7 +14,7 @@ The OVH Load Balancer acts by default as a proxy. It can also be configured to r
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com/ca/en/solutions/load-balancer/){.external}
-- access to the [OVH Control Panel](https://ca.ovh.com/auth/){.external}, or the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH Control Panel](https://ca.ovh.com/auth/){.external}, or the [OVH API](/links/api){.external}
 
 ## Instructions
 
@@ -67,7 +67,7 @@ Once the front-end has been configured, click `Add`{.action} or `Edit`{.action},
 
 ### Add a custom redirection via the API.
 
-In the [OVH API](https://ca.api.ovh.com/){.external}, redirections are specified in the redirectLocation character chain.
+In the [OVH API](/links/api){.external}, redirections are specified in the redirectLocation character chain.
 
 * If you are creating a new front-end:
 

--- a/pages/network/load_balancer/create_redirectlocation/guide.en-gb.md
+++ b/pages/network/load_balancer/create_redirectlocation/guide.en-gb.md
@@ -14,7 +14,7 @@ The OVH Load Balancer acts by default as a proxy. It can also be configured to r
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.co.uk/solutions/load-balancer/){.external}
-- access to the [OVH Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, or the [OVH API](https://api.ovh.com/){.external}
+- access to the [OVH Control Panel](/links/manager){.external}, or the [OVH API](https://api.ovh.com/){.external}
 
 ## Instructions
 
@@ -35,7 +35,7 @@ Custom redirections can be specified via the OVH Control Panel and via the API, 
 
 ### Add a custom redirection via the OVH Control Panel.
 
-You can define custom redirections from the [OVH Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
+You can define custom redirections from the [OVH Control Panel](/links/manager){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
 
 You can either do this on a new front-end as you create it, or on an existing front-end.
 

--- a/pages/network/load_balancer/create_redirectlocation/guide.en-sg.md
+++ b/pages/network/load_balancer/create_redirectlocation/guide.en-sg.md
@@ -14,7 +14,7 @@ The OVH Load Balancer acts by default as a proxy. It can also be configured to r
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com/sg/solutions/load-balancer/){.external}
-- access to the [OVH Control Panel](https://ca.ovh.com/auth/){.external}, or the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH Control Panel](https://ca.ovh.com/auth/){.external}, or the [OVH API](/links/api){.external}
 
 ## Instructions
 
@@ -67,7 +67,7 @@ Once the front-end has been configured, click `Add`{.action} or `Edit`{.action},
 
 ### Add a custom redirection via the API.
 
-In the [OVH API](https://ca.api.ovh.com/){.external}, redirections are specified in the redirectLocation character chain.
+In the [OVH API](/links/api){.external}, redirections are specified in the redirectLocation character chain.
 
 * If you are creating a new front-end:
 

--- a/pages/network/load_balancer/create_redirectlocation/guide.en-us.md
+++ b/pages/network/load_balancer/create_redirectlocation/guide.en-us.md
@@ -14,7 +14,7 @@ The OVH Load Balancer acts by default as a proxy. It can also be configured to r
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com/world/solutions/load-balancer/){.external}
-- access to the [OVH Control Panel](https://ca.ovh.com/auth/){.external}, or the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH Control Panel](https://ca.ovh.com/auth/){.external}, or the [OVH API](/links/api){.external}
 
 ## Instructions
 
@@ -67,7 +67,7 @@ Once the front-end has been configured, click `Add`{.action} or `Edit`{.action},
 
 ### Add a custom redirection via the API.
 
-In the [OVH API](https://ca.api.ovh.com/){.external}, redirections are specified in the redirectLocation character chain.
+In the [OVH API](/links/api){.external}, redirections are specified in the redirectLocation character chain.
 
 * If you are creating a new front-end:
 

--- a/pages/network/load_balancer/create_redirectlocation/guide.fr-ca.md
+++ b/pages/network/load_balancer/create_redirectlocation/guide.fr-ca.md
@@ -13,8 +13,8 @@ Le service OVH Load Balancer agit par défault comme un mandataire ou "Proxy". I
 
 - Disposer d'un [Load Balancer OVH](https://www.ovh.com/ca/fr/solutions/load-balancer/){.external}.
 - Avoir accès :
-    - à l'[espace client OVH](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}, ou bien
-        - à l'[API OVH](https://ca.api.ovh.com/){.external}.
+    - à l'[espace client OVH](/links/manager){.external}, ou bien
+        - à l'[API OVH](/links/api){.external}.
 
 ## En pratique
 
@@ -35,7 +35,7 @@ Les Redirections personnalisées peuvent être spécifiées via le Manager et vi
 
 ### Ajouter une redirection personnalisée via le Manager
 
-Il est possible de définir une redirection personnalisée depuis l'[espace client](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external} dans la partie `Cloud`{.action}, section `Load Balancer`{.action}.
+Il est possible de définir une redirection personnalisée depuis l'[espace client](/links/manager){.external} dans la partie `Cloud`{.action}, section `Load Balancer`{.action}.
 Cela peut-être effectué tant sur un nouveau Frontend pendant sa création, que sur un Frontend existant.
 
 * Ajout d'un nouveau Frontend
@@ -76,7 +76,7 @@ cliquez sur `Appliquer la configuration`{.action}.
 
 ### Ajouter une redirection personnalisée via l'API
 
-Dans l'[API OVH](https://ca.api.ovh.com/){.external}, les Redirections sont spécifiées dans la chaîne de caractère redirectLocation :
+Dans l'[API OVH](/links/api){.external}, les Redirections sont spécifiées dans la chaîne de caractère redirectLocation :
 
 * création d'un nouveau Frontend
 

--- a/pages/network/load_balancer/create_redirectlocation/guide.fr-fr.md
+++ b/pages/network/load_balancer/create_redirectlocation/guide.fr-fr.md
@@ -11,7 +11,7 @@ Le service OVHcloud Load Balancer agit par défaut comme un mandataire ou « Pro
 ## Prérequis
 
 - Posséder une offre [OVHcloud Load balancer](https://www.ovh.com/fr/solutions/load-balancer/) dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté à l'[API OVHcloud](https://api.ovh.com/){.external}.
 
 ## En pratique
@@ -33,7 +33,7 @@ Les redirections personnalisées peuvent être spécifiées via l'espace client 
 
 ### Ajouter une redirection personnalisée depuis l'espace client OVHcloud
 
-Il est possible de définir une redirection personnalisée depuis l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external} dans la partie `Bare Metal Cloud`{.action} puis `Load Balancer`{.action}.
+Il est possible de définir une redirection personnalisée depuis l'[espace client OVHcloud](/links/manager){.external} dans la partie `Bare Metal Cloud`{.action} puis `Load Balancer`{.action}.
 Cela peut-être effectué tant sur un nouveau frontend pendant sa création, que sur un frontend existant.
 
 #### Ajout d'un nouveau frontend

--- a/pages/network/load_balancer/create_route/guide.en-asia.md
+++ b/pages/network/load_balancer/create_route/guide.en-asia.md
@@ -15,7 +15,7 @@ In some cases, you can go a step further and route, redirect or block traffic ac
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com/asia/solutions/load-balancer/){.external} on a solution that lets you create routes
-- access to the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH API](/links/api){.external}
 
 ## Instructions
 
@@ -43,7 +43,7 @@ This is what is known as an ‘end action’. It means that if the rules are con
 
 ## An introduction to the API.
 
-You can only manage routes via the [OVH API](https://ca.api.ovh.com/){.external}. It is only valid for `http`{.action} and `tcp`{.action} protocols, and the `/ipLoadbalancing/{serviceName}/{protocol}/route/`{.action} pathway exposes the API dedicated to routes.
+You can only manage routes via the [OVH API](/links/api){.external}. It is only valid for `http`{.action} and `tcp`{.action} protocols, and the `/ipLoadbalancing/{serviceName}/{protocol}/route/`{.action} pathway exposes the API dedicated to routes.
 
 The API for routes to the OVH Load Balancer is specially designed for flexibility, power and scalability. It is organised around three main sections:
 

--- a/pages/network/load_balancer/create_route/guide.en-au.md
+++ b/pages/network/load_balancer/create_route/guide.en-au.md
@@ -15,7 +15,7 @@ In some cases, you can go a step further and route, redirect or block traffic ac
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com.au/solutions/load-balancer/){.external} on a solution that lets you create routes
-- access to the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH API](/links/api){.external}
 
 ## Instructions
 
@@ -43,7 +43,7 @@ This is what is known as an ‘end action’. It means that if the rules are con
 
 ## An introduction to the API.
 
-You can only manage routes via the [OVH API](https://ca.api.ovh.com/){.external}. It is only valid for `http`{.action} and `tcp`{.action} protocols, and the `/ipLoadbalancing/{serviceName}/{protocol}/route/`{.action} pathway exposes the API dedicated to routes.
+You can only manage routes via the [OVH API](/links/api){.external}. It is only valid for `http`{.action} and `tcp`{.action} protocols, and the `/ipLoadbalancing/{serviceName}/{protocol}/route/`{.action} pathway exposes the API dedicated to routes.
 
 The API for routes to the OVH Load Balancer is specially designed for flexibility, power and scalability. It is organised around three main sections:
 

--- a/pages/network/load_balancer/create_route/guide.en-ca.md
+++ b/pages/network/load_balancer/create_route/guide.en-ca.md
@@ -15,7 +15,7 @@ In some cases, you can go a step further and route, redirect or block traffic ac
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com/ca/en/solutions/load-balancer/){.external} on a solution that lets you create routes
-- access to the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH API](/links/api){.external}
 
 ## Instructions
 
@@ -43,7 +43,7 @@ This is what is known as an ‘end action’. It means that if the rules are con
 
 ## An introduction to the API.
 
-You can only manage routes via the [OVH API](https://ca.api.ovh.com/){.external}. It is only valid for `http`{.action} and `tcp`{.action} protocols, and the `/ipLoadbalancing/{serviceName}/{protocol}/route/`{.action} pathway exposes the API dedicated to routes.
+You can only manage routes via the [OVH API](/links/api){.external}. It is only valid for `http`{.action} and `tcp`{.action} protocols, and the `/ipLoadbalancing/{serviceName}/{protocol}/route/`{.action} pathway exposes the API dedicated to routes.
 
 The API for routes to the OVH Load Balancer is specially designed for flexibility, power and scalability. It is organised around three main sections:
 

--- a/pages/network/load_balancer/create_route/guide.en-sg.md
+++ b/pages/network/load_balancer/create_route/guide.en-sg.md
@@ -15,7 +15,7 @@ In some cases, you can go a step further and route, redirect or block traffic ac
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com/sg/solutions/load-balancer/){.external} on a solution that lets you create routes
-- access to the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH API](/links/api){.external}
 
 ## Instructions
 
@@ -43,7 +43,7 @@ This is what is known as an ‘end action’. It means that if the rules are con
 
 ## An introduction to the API.
 
-You can only manage routes via the [OVH API](https://ca.api.ovh.com/){.external}. It is only valid for `http`{.action} and `tcp`{.action} protocols, and the `/ipLoadbalancing/{serviceName}/{protocol}/route/`{.action} pathway exposes the API dedicated to routes.
+You can only manage routes via the [OVH API](/links/api){.external}. It is only valid for `http`{.action} and `tcp`{.action} protocols, and the `/ipLoadbalancing/{serviceName}/{protocol}/route/`{.action} pathway exposes the API dedicated to routes.
 
 The API for routes to the OVH Load Balancer is specially designed for flexibility, power and scalability. It is organised around three main sections:
 

--- a/pages/network/load_balancer/create_route/guide.en-us.md
+++ b/pages/network/load_balancer/create_route/guide.en-us.md
@@ -15,7 +15,7 @@ In some cases, you can go a step further and route, redirect or block traffic ac
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com/world/solutions/load-balancer/){.external} on a solution that lets you create routes
-- access to the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH API](/links/api){.external}
 
 ## Instructions
 
@@ -43,7 +43,7 @@ This is what is known as an ‘end action’. It means that if the rules are con
 
 ## An introduction to the API.
 
-You can only manage routes via the [OVH API](https://ca.api.ovh.com/){.external}. It is only valid for `http`{.action} and `tcp`{.action} protocols, and the `/ipLoadbalancing/{serviceName}/{protocol}/route/`{.action} pathway exposes the API dedicated to routes.
+You can only manage routes via the [OVH API](/links/api){.external}. It is only valid for `http`{.action} and `tcp`{.action} protocols, and the `/ipLoadbalancing/{serviceName}/{protocol}/route/`{.action} pathway exposes the API dedicated to routes.
 
 The API for routes to the OVH Load Balancer is specially designed for flexibility, power and scalability. It is organised around three main sections:
 

--- a/pages/network/load_balancer/create_route/guide.fr-ca.md
+++ b/pages/network/load_balancer/create_route/guide.fr-ca.md
@@ -13,7 +13,7 @@ Dans certains cas, il est possible d'aller plus loin, et de router, rediriger ou
 ## Prérequis
 
 - Disposer d'un [Load Balancer OVH](https://www.ovh.com/ca/fr/solutions/load-balancer/){.external} sur une offre autorisant la création des routes
-- Avoir accès à l'[API OVH](https://ca.api.ovh.com/){.external}.
+- Avoir accès à l'[API OVH](/links/api){.external}.
 
 ## En pratique
 
@@ -41,7 +41,7 @@ Il s'agit d'une action « finale ». C'est à dire que si les règles sont valid
 
 ## Présentation de l'API
 
-La gestion des routes n'est accessible qu'au travers de l'[API OVH](https://ca.api.ovh.com/){.external}. Elle est valide uniquement pour les protocoles `http`{.action} et `tcp`{.action}, le chemin `/ipLoadbalancing/{serviceName}/{protocole}/route/`{.action} expose l'API dédiée aux routes.
+La gestion des routes n'est accessible qu'au travers de l'[API OVH](/links/api){.external}. Elle est valide uniquement pour les protocoles `http`{.action} et `tcp`{.action}, le chemin `/ipLoadbalancing/{serviceName}/{protocole}/route/`{.action} expose l'API dédiée aux routes.
 
 L'API des routes de votre service OVH Load Balancer a été pensée spécialement pour être souple, puissante et évolutive. Elle est organisée autour de trois sections principales :
 

--- a/pages/network/load_balancer/create_stickiness/guide.en-asia.md
+++ b/pages/network/load_balancer/create_stickiness/guide.en-asia.md
@@ -17,7 +17,7 @@ This guide provides an introduction to the ways in which you can configure these
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com/asia/solutions/load-balancer/){.external}
-- access to the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia){.external}, or the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH Control Panel](/links/manager){.external}, or the [OVH API](/links/api){.external}
 
 ## Instructions
 

--- a/pages/network/load_balancer/create_stickiness/guide.en-au.md
+++ b/pages/network/load_balancer/create_stickiness/guide.en-au.md
@@ -17,7 +17,7 @@ This guide provides an introduction to the ways in which you can configure these
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com.au/solutions/load-balancer/){.external}
-- access to the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au){.external}, or the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH Control Panel](/links/manager){.external}, or the [OVH API](/links/api){.external}
 
 ## Instructions
 

--- a/pages/network/load_balancer/create_stickiness/guide.en-ca.md
+++ b/pages/network/load_balancer/create_stickiness/guide.en-ca.md
@@ -17,7 +17,7 @@ This guide provides an introduction to the ways in which you can configure these
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com/ca/en/solutions/load-balancer/){.external}
-- access to the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca){.external}, or the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH Control Panel](/links/manager){.external}, or the [OVH API](/links/api){.external}
 
 ## Instructions
 

--- a/pages/network/load_balancer/create_stickiness/guide.en-gb.md
+++ b/pages/network/load_balancer/create_stickiness/guide.en-gb.md
@@ -17,7 +17,7 @@ This guide provides an introduction to the ways in which you can configure these
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.co.uk/solutions/load-balancer/){.external}
-- access to the [OVH Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, or the [OVH API](https://api.ovh.com/){.external}
+- access to the [OVH Control Panel](/links/manager){.external}, or the [OVH API](https://api.ovh.com/){.external}
 
 ## Instructions
 

--- a/pages/network/load_balancer/create_stickiness/guide.en-sg.md
+++ b/pages/network/load_balancer/create_stickiness/guide.en-sg.md
@@ -17,7 +17,7 @@ This guide provides an introduction to the ways in which you can configure these
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com/sg/solutions/load-balancer/){.external}
-- access to the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg){.external}, or the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH Control Panel](/links/manager){.external}, or the [OVH API](/links/api){.external}
 
 ## Instructions
 

--- a/pages/network/load_balancer/create_stickiness/guide.en-us.md
+++ b/pages/network/load_balancer/create_stickiness/guide.en-us.md
@@ -17,7 +17,7 @@ This guide provides an introduction to the ways in which you can configure these
 ## Requirements
 
 - an [OVH Load Balancer](https://www.ovh.com/world/solutions/load-balancer/){.external}
-- access to the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we){.external}, or the [OVH API](https://ca.api.ovh.com/){.external}
+- access to the [OVH Control Panel](/links/manager){.external}, or the [OVH API](/links/api){.external}
 
 ## Instructions
 

--- a/pages/network/load_balancer/create_stickiness/guide.fr-ca.md
+++ b/pages/network/load_balancer/create_stickiness/guide.fr-ca.md
@@ -18,8 +18,8 @@ Cette documentation présente différentes façon de configurer cette options po
 
 - Disposer d'un [Load Balancer OVH](https://www.ovh.com/ca/fr/solutions/load-balancer/){.external}.
 - Avoir accès :
-    - à l'[espace client OVH](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}, ou bien
-    - à l'[API OVH](https://ca.api.ovh.com/){.external}.
+    - à l'[espace client OVH](/links/manager){.external}, ou bien
+    - à l'[API OVH](/links/api){.external}.
 
 ## En pratique
 

--- a/pages/network/load_balancer/create_stickiness/guide.fr-fr.md
+++ b/pages/network/load_balancer/create_stickiness/guide.fr-fr.md
@@ -15,7 +15,7 @@ Chaque session du service OVHcloud Load Balancer est maintenue par un système d
 ## Prérequis
 
 - Disposer d'un [Load Balancer OVHcloud](https://www.ovh.com/fr/solutions/load-balancer/){.external}.
-- Avoir accès à l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}, ou bien
+- Avoir accès à l'[espace client OVHcloud](/links/manager){.external}, ou bien
 - Avoir accès à l'[API OVHcloud](https://api.ovh.com/){.external}.
 
 ## En pratique
@@ -42,7 +42,7 @@ Les éléments suivants auront un impact sur la redirection de trafic :
 
 ### Modifier le mode de suivi de connexion d'une ferme via l'espace client OVHcloud
 
-Dans l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external} rendez-vous dans la partie `Bare Metal Cloud`{.action} puis `Load Balancer`{.action}.
+Dans l'[espace client OVHcloud](/links/manager){.external} rendez-vous dans la partie `Bare Metal Cloud`{.action} puis `Load Balancer`{.action}.
 
 Pour modifier le suivi de connexion d'une ferme, il faut éditer celle-ci en allant dans l'onglet `Ferme de serveurs`{.action} puis cliquez sur le bouton d'édition `...`{.action} à droite  de la ferme voulue et sélectionnez `Modifier`{.action}.
 

--- a/pages/network/load_balancer/howto_route_ipfo/guide.en-asia.md
+++ b/pages/network/load_balancer/howto_route_ipfo/guide.en-asia.md
@@ -13,7 +13,7 @@ updated: 2022-10-06
 
 An Additional IP is an IP address that can be switched from one service to another. In doing so, it helps you avoid a wide range of issues for your infrastructure (hardware failures, overload for your services, maintenance, etc.).
 
-For more information on Additional IPs, you can consult our [webpage](https://www.ovhcloud.com/asia/bare-metal/ip/){.external}.
+For more information on Additional IPs, you can consult our [webpage](/links/bare-metal/ip){.external}.
 
 The OVH Load Balancer solution offers load balancing features for a range of different protocols: HTTP, HTTPS, TCP and UDP. When you link it to an Additional IP, you can switch over your existing infrastructure to a Load Balancer without disturbing or interrupting services for your customers. Effectively, you will not need to change the IP address any longer if you are still using the Additional IP, so you will not need to wait for your DNS zone to propagate any changes.
 
@@ -24,7 +24,7 @@ For more information on the OVH Load Balancer solution, you can read our [Introd
 ## Requirements
 
 - a correctly configured [OVH Load Balancer](https://www.ovh.com/asia/solutions/load-balancer/){.external}
-- an [Additional IP](https://www.ovhcloud.com/asia/bare-metal/ip/){.external}
+- an [Additional IP](/links/bare-metal/ip){.external}
 
 > [!primary]
 >
@@ -126,7 +126,7 @@ From the [OVH API](https://ca.api.ovh.com){.external}, you can use the following
 
 ### Via the OVH Control Panel.
 
-You can define dedicated Additional IPs via the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
+You can define dedicated Additional IPs via the [OVH Control Panel](/links/manager){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
 
 Once you have selected the Load Balancer you want to modify, create a new front-end, or edit an existing one.
 

--- a/pages/network/load_balancer/howto_route_ipfo/guide.en-au.md
+++ b/pages/network/load_balancer/howto_route_ipfo/guide.en-au.md
@@ -13,7 +13,7 @@ updated: 2022-10-06
 
 An Additional IP is an IP address that can be switched from one service to another. In doing so, it helps you avoid a wide range of issues for your infrastructure (hardware failures, overload for your services, maintenance, etc.).
 
-For more information on Additional IPs, you can consult our [webpage](https://www.ovhcloud.com/en-au/bare-metal/ip/){.external}.
+For more information on Additional IPs, you can consult our [webpage](/links/bare-metal/ip){.external}.
 
 The OVH Load Balancer solution offers load balancing features for a range of different protocols: HTTP, HTTPS, TCP and UDP. When you link it to an Additional IP, you can switch over your existing infrastructure to a Load Balancer without disturbing or interrupting services for your customers. Effectively, you will not need to change the IP address any longer if you are still using the Additional IP, so you will not need to wait for your DNS zone to propagate any changes.
 
@@ -24,7 +24,7 @@ For more information on the OVH Load Balancer solution, you can read our [Introd
 ## Requirements
 
 - a correctly configured [OVH Load Balancer](https://www.ovh.com.au/solutions/load-balancer/){.external}
-- an [Additional IP](https://www.ovhcloud.com/en-au/bare-metal/ip/){.external}
+- an [Additional IP](/links/bare-metal/ip){.external}
 
 > [!primary]
 >
@@ -126,7 +126,7 @@ From the [OVH API](https://ca.api.ovh.com){.external}, you can use the following
 
 ### Via the OVH Control Panel.
 
-You can define dedicated Additional IPs via the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
+You can define dedicated Additional IPs via the [OVH Control Panel](/links/manager){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
 
 Once you have selected the Load Balancer you want to modify, create a new front-end, or edit an existing one.
 

--- a/pages/network/load_balancer/howto_route_ipfo/guide.en-ca.md
+++ b/pages/network/load_balancer/howto_route_ipfo/guide.en-ca.md
@@ -13,7 +13,7 @@ updated: 2022-10-06
 
 An Additional IP is an IP address that can be switched from one service to another. In doing so, it helps you avoid a wide range of issues for your infrastructure (hardware failures, overload for your services, maintenance, etc.).
 
-For more information on Additional IPs, you can consult our [webpage](https://www.ovhcloud.com/en-ca/bare-metal/ip/){.external}.
+For more information on Additional IPs, you can consult our [webpage](/links/bare-metal/ip){.external}.
 
 The OVH Load Balancer solution offers load balancing features for a range of different protocols: HTTP, HTTPS, TCP and UDP. When you link it to an Additional IP, you can switch over your existing infrastructure to a Load Balancer without disturbing or interrupting services for your customers. Effectively, you will not need to change the IP address any longer if you are still using the Additional IP, so you will not need to wait for your DNS zone to propagate any changes.
 
@@ -24,7 +24,7 @@ For more information on the OVH Load Balancer solution, you can read our [Introd
 ## Requirements
 
 - a correctly configured [OVH Load Balancer](https://www.ovh.com/ca/en/solutions/load-balancer/){.external}
-- an [Additional IP](https://www.ovhcloud.com/en-ca/bare-metal/ip/){.external}
+- an [Additional IP](/links/bare-metal/ip){.external}
 
 > [!primary]
 >
@@ -126,7 +126,7 @@ From the [OVH API](https://ca.api.ovh.com){.external}, you can use the following
 
 ### Via the OVH Control Panel.
 
-You can define dedicated Additional IPs via the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
+You can define dedicated Additional IPs via the [OVH Control Panel](/links/manager){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
 
 Once you have selected the Load Balancer you want to modify, create a new front-end, or edit an existing one.
 

--- a/pages/network/load_balancer/howto_route_ipfo/guide.en-gb.md
+++ b/pages/network/load_balancer/howto_route_ipfo/guide.en-gb.md
@@ -13,7 +13,7 @@ updated: 2022-10-06
 
 An Additional IP is an IP address that can be switched from one service to another. In doing so, it helps you avoid a wide range of issues for your infrastructure (hardware failures, overload for your services, maintenance, etc.).
 
-For more information on Additional IPs, you can consult our [webpage](https://www.ovhcloud.com/en-gb/bare-metal/ip/){.external}.
+For more information on Additional IPs, you can consult our [webpage](/links/bare-metal/ip){.external}.
 
 The OVH Load Balancer solution offers load balancing features for a range of different protocols: HTTP, HTTPS, TCP and UDP. When you link it to an Additional IP, you can switch over your existing infrastructure to a Load Balancer without disturbing or interrupting services for your customers. Effectively, you will not need to change the IP address any longer if you are still using the Additional IP, so you will not need to wait for your DNS zone to propagate any changes.
 
@@ -24,7 +24,7 @@ For more information on the OVH Load Balancer solution, you can read our [Introd
 ## Requirements
 
 - a correctly configured [OVH Load Balancer](https://www.ovh.co.uk/solutions/load-balancer/){.external}
-- an [Additional IP](https://www.ovhcloud.com/en-gb/bare-metal/ip/){.external}
+- an [Additional IP](/links/bare-metal/ip){.external}
 
 > [!primary]
 >
@@ -126,7 +126,7 @@ From the [OVH API](https://api.ovh.com){.external}, you can use the following ca
 
 ### Via the OVH Control Panel.
 
-You can define dedicated Additional IPs via the [OVH Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
+You can define dedicated Additional IPs via the [OVH Control Panel](/links/manager){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
 
 Once you have selected the Load Balancer you want to modify, create a new front-end, or edit an existing one.
 

--- a/pages/network/load_balancer/howto_route_ipfo/guide.en-sg.md
+++ b/pages/network/load_balancer/howto_route_ipfo/guide.en-sg.md
@@ -13,7 +13,7 @@ updated: 2022-10-06
 
 An Additional IP is an IP address that can be switched from one service to another. In doing so, it helps you avoid a wide range of issues for your infrastructure (hardware failures, overload for your services, maintenance, etc.).
 
-For more information on Additional IPs, you can consult our [webpage](https://www.ovhcloud.com/en-sg/bare-metal/ip/){.external}.
+For more information on Additional IPs, you can consult our [webpage](/links/bare-metal/ip){.external}.
 
 The OVH Load Balancer solution offers load balancing features for a range of different protocols: HTTP, HTTPS, TCP and UDP. When you link it to an Additional IP, you can switch over your existing infrastructure to a Load Balancer without disturbing or interrupting services for your customers. Effectively, you will not need to change the IP address any longer if you are still using the Additional IP, so you will not need to wait for your DNS zone to propagate any changes.
 
@@ -24,7 +24,7 @@ For more information on the OVH Load Balancer solution, you can read our [Introd
 ## Requirements
 
 - a correctly configured [OVH Load Balancer](https://www.ovh.com/sg/solutions/load-balancer/){.external}
-- an [Additional IP](https://www.ovhcloud.com/en-sg/bare-metal/ip/){.external}
+- an [Additional IP](/links/bare-metal/ip){.external}
 
 > [!primary]
 >
@@ -126,7 +126,7 @@ From the [OVH API](https://ca.api.ovh.com){.external}, you can use the following
 
 ### Via the OVH Control Panel.
 
-You can define dedicated Additional IPs via the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
+You can define dedicated Additional IPs via the [OVH Control Panel](/links/manager){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
 
 Once you have selected the Load Balancer you want to modify, create a new front-end, or edit an existing one.
 

--- a/pages/network/load_balancer/howto_route_ipfo/guide.en-us.md
+++ b/pages/network/load_balancer/howto_route_ipfo/guide.en-us.md
@@ -13,7 +13,7 @@ updated: 2022-10-06
 
 An Additional IP is an IP address that can be switched from one service to another. In doing so, it helps you avoid a wide range of issues for your infrastructure (hardware failures, overload for your services, maintenance, etc.).
 
-For more information on Additional IPs, you can consult our [webpage](https://www.ovhcloud.com/en/bare-metal/ip/){.external}.
+For more information on Additional IPs, you can consult our [webpage](/links/bare-metal/ip){.external}.
 
 The OVH Load Balancer solution offers load balancing features for a range of different protocols: HTTP, HTTPS, TCP and UDP. When you link it to an Additional IP, you can switch over your existing infrastructure to a Load Balancer without disturbing or interrupting services for your customers. Effectively, you will not need to change the IP address any longer if you are still using the Additional IP, so you will not need to wait for your DNS zone to propagate any changes.
 
@@ -24,7 +24,7 @@ For more information on the OVH Load Balancer solution, you can read our [Introd
 ## Requirements
 
 - a correctly configured [OVH Load Balancer](https://www.ovh.com/world/solutions/load-balancer/){.external}
-- an [Additional IP](https://www.ovhcloud.com/en/bare-metal/ip/){.external}
+- an [Additional IP](/links/bare-metal/ip){.external}
 
 > [!primary]
 >
@@ -126,7 +126,7 @@ From the [OVH API](https://ca.api.ovh.com){.external}, you can use the following
 
 ### Via the OVH Control Panel.
 
-You can define dedicated Additional IPs via the [OVH Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
+You can define dedicated Additional IPs via the [OVH Control Panel](/links/manager){.external} by going to the `Cloud`{.action} section, then `Load Balancer`{.action}.
 
 Once you have selected the Load Balancer you want to modify, create a new front-end, or edit an existing one.
 

--- a/pages/network/load_balancer/howto_route_ipfo/guide.fr-ca.md
+++ b/pages/network/load_balancer/howto_route_ipfo/guide.fr-ca.md
@@ -13,7 +13,7 @@ updated: 2022-10-06
 
 Une Additional IP est une adresse IP basculable d'un service à l'autre. Elle offre donc la possibilité de disposer d'une infrastructure résistant à une grande diversité de problèmes (pannes matérielles, surcharges de vos services, maintenance...).
 
-Pour plus d'informations sur l'Additional IP nous vous recommandons la lecture du [document de présentation](https://www.ovhcloud.com/fr-ca/bare-metal/ip/){.external}.
+Pour plus d'informations sur l'Additional IP nous vous recommandons la lecture du [document de présentation](/links/bare-metal/ip){.external}.
 
 Le service OVH Load Balancer offre quant à lui des fonctionnalités de répartition de charge sur différents protocoles : HTTP, HTTPS, TCP et UDP. Associé à une Additional IP, il devient possible de basculer votre infrastructure existante vers un Load Balancer sans perturber ou interrompre les services de vos clients. En effet il n'y aura désormais plus de changement d'adresse IP dans la mesure où vous utiliserez toujours l'Additional IP, donc pas de délai de propagation des DNS.
 
@@ -24,7 +24,7 @@ Pour plus d'informations sur le service OVH Load Balancer, nous vous conseillons
 ## Prérequis
 
 - Disposer d'un [Load Balancer OVH](https://www.ovh.com/ca/fr/solutions/load-balancer/){.external} correctement configuré.
-- Disposer d'une [Additional IP](https://www.ovhcloud.com/fr-ca/bare-metal/ip/){.external}.
+- Disposer d'une [Additional IP](/links/bare-metal/ip){.external}.
 
 > [!primary]
 >
@@ -127,7 +127,7 @@ Toujours depuis l'[API OVH](https://ca.api.ovh.com){.external}, l'appel suivant 
 > 
 
 ### Depuis le Manager
-Il est enfin possible de définir vos Additional IPs dédiées depuis l'[espace client](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external} dans la partie `Cloud`{.action}, section `Load Balancer`{.action}.
+Il est enfin possible de définir vos Additional IPs dédiées depuis l'[espace client](/links/manager){.external} dans la partie `Cloud`{.action}, section `Load Balancer`{.action}.
 
 Après avoir sélectionné le Load Balancer que vous souhaitez modifier,
 créez un nouveau Frontend, ou éditez en un existants.

--- a/pages/network/load_balancer/howto_route_ipfo/guide.fr-fr.md
+++ b/pages/network/load_balancer/howto_route_ipfo/guide.fr-fr.md
@@ -13,7 +13,7 @@ updated: 2022-10-06
 
 Une Additional IP est une adresse IP basculable d'un service à l'autre. Elle offre donc la possibilité de disposer d'une infrastructure résistant à une grande diversité de problèmes (pannes matérielles, surcharges de vos services, maintenance...).
 
-Pour plus d'informations sur l'Additional IP, nous vous recommandons la lecture du [document de présentation](https://www.ovhcloud.com/fr/bare-metal/ip/).
+Pour plus d'informations sur l'Additional IP, nous vous recommandons la lecture du [document de présentation](/links/bare-metal/ip).
 
 Le service OVHcloud Load Balancer offre quant à lui des fonctionnalités de répartition de charge sur différents protocoles : HTTP, HTTPS, TCP et UDP. Associé à une Additional IP, il devient possible de basculer votre infrastructure existante vers un Load Balancer sans perturber ou interrompre les services de vos clients. En effet il n'y aura désormais plus de changement d'adresse IP dans la mesure où vous utiliserez toujours l'Additional IP, donc pas de délai de propagation des DNS.
 
@@ -24,7 +24,7 @@ Pour plus d'informations sur le service OVHcloud Load Balancer, nous vous consei
 ## Prérequis
 
 - Disposer d'un [Load Balancer OVHcloud](https://www.ovh.com/fr/solutions/load-balancer/) correctement configuré.
-- Disposer d'une [Additional IP](https://www.ovhcloud.com/fr/bare-metal/ip/).
+- Disposer d'une [Additional IP](/links/bare-metal/ip).
 
 > [!primary]
 >
@@ -131,7 +131,7 @@ Toujours depuis l'[API OVHcloud](https://api.ovh.com){.external}, l'appel suivan
 
 #### Depuis l'espace client OVHcloud
 
-Vous pouvez définir vos Additional IPs dédiées depuis l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}. Rendez-vous dans la partie `Bare metal Cloud`{.action} puis dans `Load Balancer`{.action}.
+Vous pouvez définir vos Additional IPs dédiées depuis l'[espace client OVHcloud](/links/manager){.external}. Rendez-vous dans la partie `Bare metal Cloud`{.action} puis dans `Load Balancer`{.action}.
 
 Après avoir sélectionné le Load Balancer que vous souhaitez modifier, créez un nouveau frontend, ou éditez-en un existant.
 

--- a/pages/network/load_balancer/order_freecertificate/guide.fr-fr.md
+++ b/pages/network/load_balancer/order_freecertificate/guide.fr-fr.md
@@ -17,7 +17,7 @@ Par ailleurs, tous vos certificats sont ainsi centralisés au même endroit et l
 ## Prérequis
 
 - Posséder une offre [OVHcloud Load balancer](https://www.ovh.com/fr/solutions/load-balancer/) dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique
 
@@ -25,7 +25,7 @@ Par ailleurs, tous vos certificats sont ainsi centralisés au même endroit et l
 
 La première étape est de configurer votre frontend pour gérer la terminaison SSL.
 
-Vous pouvez configurer votre terminaison SSL depuis l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external} dans la partie `Bare Metal Cloud`{.action} puis `Load Balancer`{.action}.
+Vous pouvez configurer votre terminaison SSL depuis l'[espace client OVHcloud](/links/manager){.external} dans la partie `Bare Metal Cloud`{.action} puis `Load Balancer`{.action}.
 
 Après avoir sélectionné le Load Balancer que vous souhaitez modifier, créez un nouveau frontend ou éditez-en un existant.
 

--- a/pages/network/load_balancer/retrieve_servers_state/guide.fr-fr.md
+++ b/pages/network/load_balancer/retrieve_servers_state/guide.fr-fr.md
@@ -21,7 +21,7 @@ Ce tutoriel explique comment connaître l'état de santé de chaque serveur pour
 ## Prérequis
 
 - Posséder une offre [OVHcloud Load balancer](https://www.ovh.com/fr/solutions/load-balancer/) dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté à l'[API OVHcloud](https://api.ovh.com/){.external}.
 - Posséder une ferme configurée
 - Posséder un frontend configuré

--- a/pages/network/load_balancer/use-lb/guide.es-es.md
+++ b/pages/network/load_balancer/use-lb/guide.es-es.md
@@ -101,7 +101,7 @@ Para contratar un certificado SSL, abra la pestaña `Certificado SSL`{.action} y
 |Elemento|Función|
 |---|---|
 |Nombre|Puede asignarle un nombre al certificado para poder identificarlo rápidamente|
-|Tipo de certificado|Gratuito (Let's Encrypt), Comodo DV o Comodo EV (más información en la [web de ovh](https://www.ovhcloud.com/es-es/web-hosting/options/ssl/))|
+|Tipo de certificado|Gratuito (Let's Encrypt), Comodo DV o Comodo EV (más información en la [web de ovh](/links/web/hosting-options-ssl))|
 |Fully Qualified Domain Name (FQDN)|Indique el dominio o dominios correspondientes|
 
 Si opta por un certificado Comodo EV, también deberá introducir la información de contacto y jurisdiccional.

--- a/pages/network/load_balancer/use-lb/guide.es-us.md
+++ b/pages/network/load_balancer/use-lb/guide.es-us.md
@@ -8,7 +8,7 @@ updated: 2017-12-01
 Esta guía explica los primeros pasos con el servicio Load Balancer y presenta sus principales funcionalidades.
 
 ## Requisitos
-- Tener acceso al [área de cliente](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+- Tener acceso al [área de cliente](/links/manager).
 - Haber contratado un [Load Balancer](https://www.ovh.com/world/es/soluciones/load-balancer/).
 
 ## Procedimiento
@@ -101,7 +101,7 @@ Para contratar un certificado SSL, abra la pestaña `Certificado SSL`{.action} y
 
 |Elemento|Función|
 |---|---|
-|Tipo de certificado|Gratuito (Let's Encrypt), Comodo DV o Comodo EV (más información en la [web de ovh](https://www.ovhcloud.com/es/web-hosting/options/ssl/))|
+|Tipo de certificado|Gratuito (Let's Encrypt), Comodo DV o Comodo EV (más información en la [web de ovh](/links/web/hosting-options-ssl))|
 |Fully Qualified Domain Name (FQDN)|Indique el dominio o dominios correspondientes|
 
 Si opta por un certificado Comodo EV, también deberá introducir la información de contacto y jurisdiccional.

--- a/pages/network/load_balancer/use-lb/guide.fr-fr.md
+++ b/pages/network/load_balancer/use-lb/guide.fr-fr.md
@@ -11,7 +11,7 @@ Ce guide a pour but de vous aider lors de la première prise en main de votre Lo
 ## Prérequis
 
 - Posséder une offre [OVHcloud Load balancer](https://www.ovh.com/fr/solutions/load-balancer/) dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique
 
@@ -105,7 +105,7 @@ Pour commander un certificat SSL, sélectionnez l'onglet `Certificat SSL`{.actio
 |Élément|Fonction|
 |---|---|
 |Nom|Si vous le souhaitez, vous pouvez nommer votre certificat, afin de l'identifier rapidement quand vous en avez plusieurs|
-|Type de certificat|Gratuit (Let's Encrypt), Comodo DV ou Comodo EV ([Pour plus de détails](https://www.ovhcloud.com/fr/web-hosting/options/ssl/))|
+|Type de certificat|Gratuit (Let's Encrypt), Comodo DV ou Comodo EV ([Pour plus de détails](/links/web/hosting-options-ssl))|
 |Fully Qualified Domain Name (FQDN)|Le(s) domaine(s) concerné(s)|
 
 #### Ajout d'un certificat SSL externe

--- a/pages/network/load_balancer/use-lb/guide.it-it.md
+++ b/pages/network/load_balancer/use-lb/guide.it-it.md
@@ -104,7 +104,7 @@ Per ordinare un certificato SSL, seleziona la scheda `Certificati SSL`{.action},
 |Elemento|Descrizione|
 |---|---|
 |Nome|È possibile assegnare un nome al tuo certificato per identificarlo più facilmente|
-|Tipo di certificato|Gratuito (Let's Encrypt), Comodo DV o Comodo EV (per maggiori dettagli, consulta la pagina <https://www.ovhcloud.com/it/web-hosting/options/ssl/>)|
+|Tipo di certificato|Gratuito (Let's Encrypt), Comodo DV o Comodo EV (per maggiori dettagli, consulta la pagina </links/web/hosting-options-ssl>)|
 |Fully Qualified Domain Name (FQDN)|I domini interessati|
 
 #### Aggiungi un certificato SSL

--- a/pages/network/load_balancer/vrack_and_loadbalancer/guide.en-gb.md
+++ b/pages/network/load_balancer/vrack_and_loadbalancer/guide.en-gb.md
@@ -8,7 +8,7 @@ updated: 2022-04-04
 
 The purpose of this guide is to help you link and configure your Load Balancer in vRack via the APIv6 OVH.
 
-The vRack is a dedicated private network that creates a link between all your cloud products. For more information please visit the page on [vRack](https://www.ovhcloud.com/en-gb/network/vrack/)
+The vRack is a dedicated private network that creates a link between all your cloud products. For more information please visit the page on [vRack](/links/network/vrack)
 
 Before starting, if you haven't read it yet, we advise you to read the general presentation of the [Load Balancer](/pages/network/load_balancer/use_presentation) service.
 

--- a/pages/network/load_balancer/vrack_and_loadbalancer/guide.fr-fr.md
+++ b/pages/network/load_balancer/vrack_and_loadbalancer/guide.fr-fr.md
@@ -15,7 +15,7 @@ Avant de vous lancer, si vous ne l’avez pas encore lue, nous vous conseillons 
 ## Prérequis
 
 - Posséder une offre [OVHcloud Load balancer](https://www.ovh.com/fr/solutions/load-balancer/) dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté à l'[API OVHcloud](https://api.ovh.com/){.external}.
 - Posséder une ferme configurée
 - Posséder un frontend configuré

--- a/pages/network/load_balancer/zones/guide.fr-fr.md
+++ b/pages/network/load_balancer/zones/guide.fr-fr.md
@@ -18,7 +18,7 @@ Via une configuration adéquate, vous pouvez également utiliser plusieurs zones
 ## Prérequis
 
 - Posséder une offre [OVHcloud Load balancer](https://www.ovh.com/fr/solutions/load-balancer/) dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté à l'[API OVHcloud](https://api.ovh.com/).
 
 ## En pratique
@@ -27,7 +27,7 @@ Via une configuration adéquate, vous pouvez également utiliser plusieurs zones
 
 #### Depuis l'espace client OVHcloud
 
-Vous pouvez commander une zone supplémentaire depuis l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) dans la partie `Bare Metal Cloud`{.action}, puis `Load Balancer`{.action}.
+Vous pouvez commander une zone supplémentaire depuis l'[espace client OVHcloud](/links/manager) dans la partie `Bare Metal Cloud`{.action}, puis `Load Balancer`{.action}.
 
 Sélectionnez votre Load Balancer puis, dans l'onglet `Accueil`{.action} et le menu `Configuration`{.action}, cliquez sur `Ajouter`{.action} dans la partie « Zones de disponibilité ».
 

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.de-de.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.de-de.md
@@ -66,6 +66,6 @@ The virtual link is a full mesh IP network between any PoP/*EntryPoint* and any 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-asia.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-asia.md
@@ -66,6 +66,6 @@ The virtual link is a full mesh IP network between any PoP/*EntryPoint* and any 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-au.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-au.md
@@ -66,6 +66,6 @@ The virtual link is a full mesh IP network between any PoP/*EntryPoint* and any 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-ca.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-ca.md
@@ -66,6 +66,6 @@ The virtual link is a full mesh IP network between any PoP/*EntryPoint* and any 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-gb.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-gb.md
@@ -66,6 +66,6 @@ The virtual link is a full mesh IP network between any PoP/*EntryPoint* and any 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-ie.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-ie.md
@@ -66,6 +66,6 @@ The virtual link is a full mesh IP network between any PoP/*EntryPoint* and any 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-sg.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-sg.md
@@ -66,6 +66,6 @@ The virtual link is a full mesh IP network between any PoP/*EntryPoint* and any 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-us.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.en-us.md
@@ -66,6 +66,6 @@ The virtual link is a full mesh IP network between any PoP/*EntryPoint* and any 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.es-es.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.es-es.md
@@ -66,6 +66,6 @@ The virtual link is a full mesh IP network between any PoP/*EntryPoint* and any 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.es-us.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.es-us.md
@@ -66,6 +66,6 @@ The virtual link is a full mesh IP network between any PoP/*EntryPoint* and any 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.fr-ca.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.fr-ca.md
@@ -65,6 +65,6 @@ La liaison virtuelle est un réseau IP à maillage complet entre tout PoP/EntryP
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.fr-fr.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.fr-fr.md
@@ -65,6 +65,6 @@ La liaison virtuelle est un réseau IP à maillage complet entre tout PoP/EntryP
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.it-it.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.it-it.md
@@ -66,6 +66,6 @@ The virtual link is a full mesh IP network between any PoP/*EntryPoint* and any 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.pl-pl.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.pl-pl.md
@@ -66,6 +66,6 @@ The virtual link is a full mesh IP network between any PoP/*EntryPoint* and any 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-concepts-overview/guide.pt-pt.md
+++ b/pages/network/ovhcloud_connect/occ-concepts-overview/guide.pt-pt.md
@@ -66,6 +66,6 @@ The virtual link is a full mesh IP network between any PoP/*EntryPoint* and any 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.de-de.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.de-de.md
@@ -18,11 +18,11 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Direct solution](https://www.ovhcloud.com/de/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -183,6 +183,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-asia.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-asia.md
@@ -18,11 +18,11 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Direct solution](https://www.ovhcloud.com/asia/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -183,6 +183,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-au.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-au.md
@@ -18,11 +18,11 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Direct solution](https://www.ovhcloud.com/en-au/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -183,6 +183,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-ca.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-ca.md
@@ -18,11 +18,11 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Direct solution](https://www.ovhcloud.com/en-ca/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -183,6 +183,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-gb.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-gb.md
@@ -18,11 +18,11 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Direct solution](https://www.ovhcloud.com/en-gb/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -183,6 +183,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-ie.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-ie.md
@@ -18,11 +18,11 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Direct solution](https://www.ovhcloud.com/en-ie/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -183,6 +183,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-sg.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-sg.md
@@ -18,11 +18,11 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Direct solution](https://www.ovhcloud.com/en-sg/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -183,6 +183,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-us.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.en-us.md
@@ -18,11 +18,11 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Direct solution](https://www.ovhcloud.com/en/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -183,6 +183,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.es-es.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.es-es.md
@@ -18,11 +18,11 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Direct solution](https://www.ovhcloud.com/es-es/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -183,6 +183,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.es-us.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.es-us.md
@@ -18,11 +18,11 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Direct solution](https://www.ovhcloud.com/es/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -183,6 +183,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.fr-ca.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.fr-ca.md
@@ -17,12 +17,12 @@ OVHcloud Connect permet d’étendre votre réseau d’entreprise avec votre ré
 >
 
 - Posséder une [offre OVHcloud Connect Direct](https://www.ovhcloud.com/fr-ca/network-security/ovhcloud-connect/)
-- Disposer d'un [vRack OVHcloud](https://www.ovhcloud.com/fr-ca/network/vrack/)
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Disposer d'un [vRack OVHcloud](/links/network/vrack)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique
 
-Connectez-vous à [l’espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}, cliquez sur `Bare Metal Cloud`{.action} puis sélectionnez l'onglet `Network`{.action}. Ensuite, cliquez sur `OVHcloud Connect`{.action} puis sur votre offre.
+Connectez-vous à [l’espace client OVHcloud](/links/manager){.external}, cliquez sur `Bare Metal Cloud`{.action} puis sélectionnez l'onglet `Network`{.action}. Ensuite, cliquez sur `OVHcloud Connect`{.action} puis sur votre offre.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -182,6 +182,6 @@ Pour supprimer une configuration PoP, cliquez sur le bouton `(...)`{.action} sur
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.fr-fr.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.fr-fr.md
@@ -18,11 +18,11 @@ OVHcloud Connect permet d’étendre votre réseau d’entreprise avec votre ré
 
 - Posséder une [offre OVHcloud Connect Direct](https://www.ovhcloud.com/fr/network-security/ovhcloud-connect/)
 - Disposer d'un [vRack OVHcloud](https://www.ovh.com/fr/solutions/vrack/)
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique
 
-Connectez-vous à [l’espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}, cliquez sur `Bare Metal Cloud`{.action} puis sélectionnez l'onglet `Network`{.action}. Ensuite, cliquez sur `OVHcloud Connect`{.action} puis sur votre offre.
+Connectez-vous à [l’espace client OVHcloud](/links/manager){.external}, cliquez sur `Bare Metal Cloud`{.action} puis sélectionnez l'onglet `Network`{.action}. Ensuite, cliquez sur `OVHcloud Connect`{.action} puis sur votre offre.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -182,6 +182,6 @@ Pour supprimer une configuration PoP, cliquez sur le bouton `(...)`{.action} sur
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.it-it.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.it-it.md
@@ -18,11 +18,11 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Direct solution](https://www.ovhcloud.com/it/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -183,6 +183,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.pl-pl.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.pl-pl.md
@@ -18,11 +18,11 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Direct solution](https://www.ovhcloud.com/pl/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -183,6 +183,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.pt-pt.md
+++ b/pages/network/ovhcloud_connect/occ-direct-control-panel/guide.pt-pt.md
@@ -18,11 +18,11 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Direct solution](https://www.ovhcloud.com/pt/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -183,6 +183,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.de-de.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.de-de.md
@@ -214,6 +214,6 @@ When all sub-resources have been deleted, the PoP configuration can be safely re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.en-asia.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.en-asia.md
@@ -214,6 +214,6 @@ When all sub-resources have been deleted, the PoP configuration can be safely re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.en-au.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.en-au.md
@@ -214,6 +214,6 @@ When all sub-resources have been deleted, the PoP configuration can be safely re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.en-ca.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.en-ca.md
@@ -214,6 +214,6 @@ When all sub-resources have been deleted, the PoP configuration can be safely re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.en-gb.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.en-gb.md
@@ -214,6 +214,6 @@ When all sub-resources have been deleted, the PoP configuration can be safely re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.en-ie.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.en-ie.md
@@ -214,6 +214,6 @@ When all sub-resources have been deleted, the PoP configuration can be safely re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.en-sg.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.en-sg.md
@@ -214,6 +214,6 @@ When all sub-resources have been deleted, the PoP configuration can be safely re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.en-us.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.en-us.md
@@ -214,6 +214,6 @@ When all sub-resources have been deleted, the PoP configuration can be safely re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.es-es.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.es-es.md
@@ -214,6 +214,6 @@ When all sub-resources have been deleted, the PoP configuration can be safely re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.es-us.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.es-us.md
@@ -214,6 +214,6 @@ When all sub-resources have been deleted, the PoP configuration can be safely re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.fr-ca.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.fr-ca.md
@@ -17,7 +17,7 @@ La mise en place de l'offre OVHcloud Connect peut se faire directement depuis le
 >
 
 * Posséder une offre [OVHcloud Connect](https://www.ovh.com/fr/solutions/ovhcloud-connect/) dans votre compte OVHcloud.
-* Être connecté aux [API OVHcloud](https://ca.api.ovh.com/){.external}.
+* Être connecté aux [API OVHcloud](/links/api){.external}.
 * Avoir [créé vos credentials pour l'utilisation des API OVHcloud](/pages/manage_and_operate/api/first-steps).
 
 ## En pratique
@@ -227,6 +227,6 @@ Si une configuration DC est partagée entre au moins deux services OVHcloud Conn
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.fr-fr.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.fr-fr.md
@@ -227,6 +227,6 @@ Si une configuration DC est partagée entre au moins deux services OVHcloud Conn
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.it-it.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.it-it.md
@@ -214,6 +214,6 @@ When all sub-resources have been deleted, the PoP configuration can be safely re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.pl-pl.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.pl-pl.md
@@ -214,6 +214,6 @@ When all sub-resources have been deleted, the PoP configuration can be safely re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-howto-api/guide.pt-pt.md
+++ b/pages/network/ovhcloud_connect/occ-howto-api/guide.pt-pt.md
@@ -214,6 +214,6 @@ When all sub-resources have been deleted, the PoP configuration can be safely re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.de-de.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.de-de.md
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.en-asia.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.en-asia.md
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.en-au.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.en-au.md
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.en-ca.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.en-ca.md
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.en-gb.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.en-gb.md
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.en-ie.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.en-ie.md
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.en-sg.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.en-sg.md
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.en-us.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.en-us.md
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.es-es.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.es-es.md
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.es-us.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.es-us.md
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.fr-ca.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.fr-ca.md
@@ -47,6 +47,6 @@ La connexion entre un PoP et un Datacentre bénéficie du backbone OVHcloud, de 
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.fr-fr.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.fr-fr.md
@@ -47,6 +47,6 @@ La connexion entre un PoP et un Datacentre bénéficie du backbone OVHcloud, de 
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.it-it.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.it-it.md
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.pl-pl.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.pl-pl.md
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer2/guide.pt-pt.md
+++ b/pages/network/ovhcloud_connect/occ-layer2/guide.pt-pt.md
@@ -47,6 +47,6 @@ Connections between a PoP and a DC benefit from the OVHcloud backbone. An intern
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.de-de.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.de-de.md
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.en-asia.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.en-asia.md
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.en-au.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.en-au.md
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.en-ca.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.en-ca.md
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.en-gb.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.en-gb.md
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.en-ie.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.en-ie.md
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.en-sg.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.en-sg.md
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.en-us.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.en-us.md
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.es-es.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.es-es.md
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.es-us.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.es-us.md
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.fr-ca.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.fr-ca.md
@@ -126,6 +126,6 @@ L'utilisation de MED est une autre alternative pour obtenir la même topologie.
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.fr-fr.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.fr-fr.md
@@ -126,6 +126,6 @@ L'utilisation de MED est une autre alternative pour obtenir la même topologie.
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.it-it.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.it-it.md
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.pl-pl.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.pl-pl.md
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-layer3/guide.pt-pt.md
+++ b/pages/network/ovhcloud_connect/occ-layer3/guide.pt-pt.md
@@ -125,6 +125,6 @@ Using MED is an alternative to achieve the same topology.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-limits/guide.de-de.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.de-de.md
@@ -60,6 +60,6 @@ updated: 2022-08-25
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-limits/guide.en-asia.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.en-asia.md
@@ -60,6 +60,6 @@ updated: 2022-08-25
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-limits/guide.en-au.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.en-au.md
@@ -60,6 +60,6 @@ updated: 2022-08-25
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-limits/guide.en-ca.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.en-ca.md
@@ -60,6 +60,6 @@ updated: 2022-08-25
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-limits/guide.en-gb.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.en-gb.md
@@ -60,6 +60,6 @@ updated: 2022-08-25
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-limits/guide.en-ie.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.en-ie.md
@@ -60,6 +60,6 @@ updated: 2022-08-25
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-limits/guide.en-sg.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.en-sg.md
@@ -60,6 +60,6 @@ updated: 2022-08-25
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-limits/guide.en-us.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.en-us.md
@@ -60,6 +60,6 @@ updated: 2022-08-25
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-limits/guide.es-es.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.es-es.md
@@ -60,6 +60,6 @@ updated: 2022-08-25
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-limits/guide.es-us.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.es-us.md
@@ -60,6 +60,6 @@ updated: 2022-08-25
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-limits/guide.fr-ca.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.fr-ca.md
@@ -63,6 +63,6 @@ Les problèmes suivants sont présents sur OVHcloud Connect.
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-limits/guide.fr-fr.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.fr-fr.md
@@ -63,6 +63,6 @@ Les problèmes suivants sont présents sur OVHcloud Connect.
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-limits/guide.it-it.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.it-it.md
@@ -60,6 +60,6 @@ updated: 2022-08-25
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-limits/guide.pl-pl.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.pl-pl.md
@@ -60,6 +60,6 @@ updated: 2022-08-25
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-limits/guide.pt-pt.md
+++ b/pages/network/ovhcloud_connect/occ-limits/guide.pt-pt.md
@@ -60,6 +60,6 @@ updated: 2022-08-25
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.de-de.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.de-de.md
@@ -18,7 +18,7 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Provider solution](https://www.ovhcloud.com/de/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -28,11 +28,11 @@ Once you have ordered your OVHcloud Connect Provider solution, you will receive 
 
 Depending on the provider you have chosen, go to their portal to log in via the link provided in the order confirmation email. Then enter your service key and confirm the order presented to you.
 
-Next, check the activation status of your solution in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
+Next, check the activation status of your solution in the [OVHcloud Control Panel](/links/manager). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
 
 ### Step 2: Associating a vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -159,6 +159,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-asia.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-asia.md
@@ -18,7 +18,7 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Provider solution](https://www.ovhcloud.com/asia/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -28,11 +28,11 @@ Once you have ordered your OVHcloud Connect Provider solution, you will receive 
 
 Depending on the provider you have chosen, go to their portal to log in via the link provided in the order confirmation email. Then enter your service key and confirm the order presented to you.
 
-Next, check the activation status of your solution in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
+Next, check the activation status of your solution in the [OVHcloud Control Panel](/links/manager). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
 
 ### Step 2: Associating a vRack
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -159,6 +159,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-au.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-au.md
@@ -18,7 +18,7 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Provider solution](https://www.ovhcloud.com/en-au/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -28,11 +28,11 @@ Once you have ordered your OVHcloud Connect Provider solution, you will receive 
 
 Depending on the provider you have chosen, go to their portal to log in via the link provided in the order confirmation email. Then enter your service key and confirm the order presented to you.
 
-Next, check the activation status of your solution in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
+Next, check the activation status of your solution in the [OVHcloud Control Panel](/links/manager). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
 
 ### Step 2: Associating a vRack
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -159,6 +159,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-ca.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-ca.md
@@ -18,7 +18,7 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Provider solution](https://www.ovhcloud.com/en-ca/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -28,11 +28,11 @@ Once you have ordered your OVHcloud Connect Provider solution, you will receive 
 
 Depending on the provider you have chosen, go to their portal to log in via the link provided in the order confirmation email. Then enter your service key and confirm the order presented to you.
 
-Next, check the activation status of your solution in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
+Next, check the activation status of your solution in the [OVHcloud Control Panel](/links/manager). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
 
 ### Step 2: Associating a vRack
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -159,6 +159,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-gb.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-gb.md
@@ -18,7 +18,7 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Provider solution](https://www.ovhcloud.com/en-gb/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -28,11 +28,11 @@ Once you have ordered your OVHcloud Connect Provider solution, you will receive 
 
 Depending on the provider you have chosen, go to their portal to log in via the link provided in the order confirmation email. Then enter your service key and confirm the order presented to you.
 
-Next, check the activation status of your solution in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
+Next, check the activation status of your solution in the [OVHcloud Control Panel](/links/manager). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
 
 ### Step 2: Associating a vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -159,6 +159,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-ie.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-ie.md
@@ -18,7 +18,7 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Provider solution](https://www.ovhcloud.com/en-ie/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -28,11 +28,11 @@ Once you have ordered your OVHcloud Connect Provider solution, you will receive 
 
 Depending on the provider you have chosen, go to their portal to log in via the link provided in the order confirmation email. Then enter your service key and confirm the order presented to you.
 
-Next, check the activation status of your solution in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
+Next, check the activation status of your solution in the [OVHcloud Control Panel](/links/manager). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
 
 ### Step 2: Associating a vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -159,6 +159,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-sg.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-sg.md
@@ -18,7 +18,7 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Provider solution](https://www.ovhcloud.com/en-sg/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -28,11 +28,11 @@ Once you have ordered your OVHcloud Connect Provider solution, you will receive 
 
 Depending on the provider you have chosen, go to their portal to log in via the link provided in the order confirmation email. Then enter your service key and confirm the order presented to you.
 
-Next, check the activation status of your solution in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
+Next, check the activation status of your solution in the [OVHcloud Control Panel](/links/manager). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
 
 ### Step 2: Associating a vRack
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -159,6 +159,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-us.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.en-us.md
@@ -18,7 +18,7 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Provider solution](https://www.ovhcloud.com/en/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -28,11 +28,11 @@ Once you have ordered your OVHcloud Connect Provider solution, you will receive 
 
 Depending on the provider you have chosen, go to their portal to log in via the link provided in the order confirmation email. Then enter your service key and confirm the order presented to you.
 
-Next, check the activation status of your solution in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
+Next, check the activation status of your solution in the [OVHcloud Control Panel](/links/manager). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
 
 ### Step 2: Associating a vRack
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -159,6 +159,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.es-es.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.es-es.md
@@ -18,7 +18,7 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Provider solution](https://www.ovhcloud.com/es-es/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -28,11 +28,11 @@ Once you have ordered your OVHcloud Connect Provider solution, you will receive 
 
 Depending on the provider you have chosen, go to their portal to log in via the link provided in the order confirmation email. Then enter your service key and confirm the order presented to you.
 
-Next, check the activation status of your solution in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
+Next, check the activation status of your solution in the [OVHcloud Control Panel](/links/manager). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
 
 ### Step 2: Associating a vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -159,6 +159,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.es-us.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.es-us.md
@@ -18,7 +18,7 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Provider solution](https://www.ovhcloud.com/es/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -28,11 +28,11 @@ Once you have ordered your OVHcloud Connect Provider solution, you will receive 
 
 Depending on the provider you have chosen, go to their portal to log in via the link provided in the order confirmation email. Then enter your service key and confirm the order presented to you.
 
-Next, check the activation status of your solution in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
+Next, check the activation status of your solution in the [OVHcloud Control Panel](/links/manager). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
 
 ### Step 2: Associating a vRack
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -159,6 +159,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.fr-ca.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.fr-ca.md
@@ -18,7 +18,7 @@ OVHcloud Connect permet d’étendre votre réseau d’entreprise avec votre ré
 
 - Avoir commandé une [offre OVHcloud Connect Provider](https://www.ovhcloud.com/fr-ca/network-security/ovhcloud-connect/)
 - Disposer d'un [vRack OVHcloud](https://www.ovh.com/fr/solutions/vrack/)
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique
 
@@ -29,11 +29,11 @@ Une fois votre offre OVHcloud Connect Provider commandée, vous recevrez une con
 Selon le fournisseur que vous avez choisi, rendez-vous ensuite sur le portail de celui-ci pour vous identifier, le lien étant fourni dans l'e-mail de confirmation de commande. 
 Renseignez alors votre clé de service et validez la commande qui vous sera présentée.
 
-Vérifiez par la suite dans votre  [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external} le statut d'activation de votre offre. Pour cela, cliquez sur `Bare Metal Cloud`{.action} puis sélectionnez l'onglet `Network`{.action}. Ensuite, cliquez sur `OVHcloud Connect`{.action} puis sur votre offre. Le statut de votre offre passera à « Actif ».
+Vérifiez par la suite dans votre  [espace client OVHcloud](/links/manager){.external} le statut d'activation de votre offre. Pour cela, cliquez sur `Bare Metal Cloud`{.action} puis sélectionnez l'onglet `Network`{.action}. Ensuite, cliquez sur `OVHcloud Connect`{.action} puis sur votre offre. Le statut de votre offre passera à « Actif ».
 
 ### Étape 2 : associer un vRack
 
-Connectez-vous à [l’espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}, cliquez sur `Bare Metal Cloud`{.action} en haut à gauche puis sélectionnez l'onglet `Network`{.action}. Cliquez alors sur `OVHcloud Connect`{.action} puis sur votre offre.
+Connectez-vous à [l’espace client OVHcloud](/links/manager){.external}, cliquez sur `Bare Metal Cloud`{.action} en haut à gauche puis sélectionnez l'onglet `Network`{.action}. Cliquez alors sur `OVHcloud Connect`{.action} puis sur votre offre.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -160,6 +160,6 @@ Pour supprimer une configuration PoP, cliquez sur le bouton `(...)`{.action} sur
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.fr-fr.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.fr-fr.md
@@ -18,7 +18,7 @@ OVHcloud Connect permet d’étendre votre réseau d’entreprise avec votre ré
 
 - Avoir commandé une [offre OVHcloud Connect Provider](https://www.ovhcloud.com/fr/network-security/ovhcloud-connect/)
 - Disposer d'un [vRack OVHcloud](https://www.ovh.com/fr/solutions/vrack/)
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique
 
@@ -29,11 +29,11 @@ Une fois votre offre OVHcloud Connect Provider commandée, vous recevrez une con
 Selon le fournisseur que vous avez choisi, rendez-vous ensuite sur le portail de celui-ci pour vous identifier, le lien étant fourni dans l'e-mail de confirmation de commande. 
 Renseignez alors votre clé de service et validez la commande qui vous sera présentée.
 
-Vérifiez par la suite dans votre  [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external} le statut d'activation de votre offre. Pour cela, cliquez sur `Bare Metal Cloud`{.action} puis sélectionnez l'onglet `Network`{.action}. Ensuite, cliquez sur `OVHcloud Connect`{.action} puis sur votre offre. Le statut de votre offre passera à « Actif ».
+Vérifiez par la suite dans votre  [espace client OVHcloud](/links/manager){.external} le statut d'activation de votre offre. Pour cela, cliquez sur `Bare Metal Cloud`{.action} puis sélectionnez l'onglet `Network`{.action}. Ensuite, cliquez sur `OVHcloud Connect`{.action} puis sur votre offre. Le statut de votre offre passera à « Actif ».
 
 ### Étape 2 : associer un vRack
 
-Connectez-vous à [l’espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}, cliquez sur `Bare Metal Cloud`{.action} en haut à gauche puis sélectionnez l'onglet `Network`{.action}. Cliquez alors sur `OVHcloud Connect`{.action} puis sur votre offre.
+Connectez-vous à [l’espace client OVHcloud](/links/manager){.external}, cliquez sur `Bare Metal Cloud`{.action} en haut à gauche puis sélectionnez l'onglet `Network`{.action}. Cliquez alors sur `OVHcloud Connect`{.action} puis sur votre offre.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -160,6 +160,6 @@ Pour supprimer une configuration PoP, cliquez sur le bouton `(...)`{.action} sur
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.it-it.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.it-it.md
@@ -18,7 +18,7 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Provider solution](https://www.ovhcloud.com/it/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -28,11 +28,11 @@ Once you have ordered your OVHcloud Connect Provider solution, you will receive 
 
 Depending on the provider you have chosen, go to their portal to log in via the link provided in the order confirmation email. Then enter your service key and confirm the order presented to you.
 
-Next, check the activation status of your solution in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
+Next, check the activation status of your solution in the [OVHcloud Control Panel](/links/manager). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
 
 ### Step 2: Associating a vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -159,6 +159,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.pl-pl.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.pl-pl.md
@@ -18,7 +18,7 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Provider solution](https://www.ovhcloud.com/pl/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -28,11 +28,11 @@ Once you have ordered your OVHcloud Connect Provider solution, you will receive 
 
 Depending on the provider you have chosen, go to their portal to log in via the link provided in the order confirmation email. Then enter your service key and confirm the order presented to you.
 
-Next, check the activation status of your solution in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
+Next, check the activation status of your solution in the [OVHcloud Control Panel](/links/manager). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
 
 ### Step 2: Associating a vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -159,6 +159,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.pt-pt.md
+++ b/pages/network/ovhcloud_connect/occ-provider-control-panel/guide.pt-pt.md
@@ -18,7 +18,7 @@ With OVHcloud Connect, you can link your company network to your private OVHclou
 
 - An [OVHcloud Connect Provider solution](https://www.ovhcloud.com/pt/network-security/ovhcloud-connect/)
 - An OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -28,11 +28,11 @@ Once you have ordered your OVHcloud Connect Provider solution, you will receive 
 
 Depending on the provider you have chosen, go to their portal to log in via the link provided in the order confirmation email. Then enter your service key and confirm the order presented to you.
 
-Next, check the activation status of your solution in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
+Next, check the activation status of your solution in the [OVHcloud Control Panel](/links/manager). To do this, go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution. Your solution's status should have changed to “Active”.
 
 ### Step 2: Associating a vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Bare Metal Cloud`{.action} section and click on `Network`{.action}. Next, open `OVHcloud Connect`{.action} and click on your solution.
 
 ![ovhcloud connect selection](images/occ_01.png){.thumbnail}
 
@@ -159,6 +159,6 @@ To delete a PoP configuration, click the `...`{.action} button on the PoP config
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.de-de.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.de-de.md
@@ -163,6 +163,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-asia.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-asia.md
@@ -163,6 +163,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-au.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-au.md
@@ -163,6 +163,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-ca.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-ca.md
@@ -163,6 +163,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-gb.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-gb.md
@@ -163,6 +163,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-ie.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-ie.md
@@ -163,6 +163,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-sg.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-sg.md
@@ -163,6 +163,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-us.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.en-us.md
@@ -163,6 +163,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.es-es.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.es-es.md
@@ -163,6 +163,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.es-us.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.es-us.md
@@ -163,6 +163,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.fr-ca.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.fr-ca.md
@@ -163,6 +163,6 @@ La BGP Area côté client doit être différente de celle côté OVHcloud.
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.fr-fr.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.fr-fr.md
@@ -163,6 +163,6 @@ La BGP Area côté client doit être différente de celle côté OVHcloud.
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.it-it.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.it-it.md
@@ -163,6 +163,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.pl-pl.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.pl-pl.md
@@ -163,6 +163,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.pt-pt.md
+++ b/pages/network/ovhcloud_connect/occ-setup-diagnostics/guide.pt-pt.md
@@ -163,6 +163,6 @@ The BGP Area on the customer side must be different from the OVHcloud side.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.de-de.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.de-de.md
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-asia.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-asia.md
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-au.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-au.md
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-ca.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-ca.md
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-gb.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-gb.md
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-ie.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-ie.md
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-sg.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-sg.md
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-us.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.en-us.md
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.es-es.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.es-es.md
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.es-us.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.es-us.md
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.fr-ca.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.fr-ca.md
@@ -67,6 +67,6 @@ Une fois la commande finalisée, OVHcloud fournira au client une Lettre d'autori
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.fr-fr.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.fr-fr.md
@@ -67,6 +67,6 @@ Une fois la commande finalisée, OVHcloud fournira au client une Lettre d'autori
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.it-it.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.it-it.md
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.pl-pl.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.pl-pl.md
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/network/ovhcloud_connect/occdedicated-faq/guide.pt-pt.md
+++ b/pages/network/ovhcloud_connect/occdedicated-faq/guide.pt-pt.md
@@ -67,6 +67,6 @@ After having subscribed, the customer will receive a Letter of Authorization (LO
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their `/links` values.

*Example: replace all `https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB` links with `/links/manager`*.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.

@Y0Coss no need for the `Fix` label, maybe `Minor Update` and even then, I'll let you be the judge.
