### PR TITLE
Fix global links in KB Ovhcloud labs

### DIFF
--- a/pages/ovhcloud_labs/power_web_hosting/getting-started/guide.en-gb.md
+++ b/pages/ovhcloud_labs/power_web_hosting/getting-started/guide.en-gb.md
@@ -8,14 +8,14 @@ updated: 2021-02-04
 
 You've subscribed to a Web POWER web hosting plan to deploy **Node.js**, **Python** or **Ruby** applications, and you want to begin developing your project.
 
-This guide will explain how to manage your POWER web hosting using the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) and the [OVHcloud APIs](https://api.ovh.com/).
+This guide will explain how to manage your POWER web hosting using the [OVHcloud Control Panel](/links/manager) and the [OVHcloud APIs](https://api.ovh.com/).
 
 **Find out how to get started with a POWER web hosting plan.**
 
 ## Requirements
 
 - one of the 3 POWER web hosting plans: [Node.js](https://labs.ovh.com/managed-nodejs), [Python](https://labs.ovh.com/managed-python) or [Ruby](https://labs.ovh.com/managed-ruby)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/ovhcloud_labs/power_web_hosting/getting-started/guide.en-ie.md
+++ b/pages/ovhcloud_labs/power_web_hosting/getting-started/guide.en-ie.md
@@ -8,14 +8,14 @@ updated: 2021-02-04
 
 You've subscribed to a Web POWER web hosting plan to deploy **Node.js**, **Python** or **Ruby** applications, and you want to begin developing your project.
 
-This guide will explain how to manage your POWER web hosting using the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) and the [OVHcloud APIs](https://api.ovh.com/).
+This guide will explain how to manage your POWER web hosting using the [OVHcloud Control Panel](/links/manager) and the [OVHcloud APIs](https://api.ovh.com/).
 
 **Find out how to get started with a POWER web hosting plan.**
 
 ## Requirements
 
 - one of the 3 POWER web hosting plans: [Node.js](https://labs.ovh.com/managed-nodejs), [Python](https://labs.ovh.com/managed-python) or [Ruby](https://labs.ovh.com/managed-ruby)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/ovhcloud_labs/power_web_hosting/getting-started/guide.fr-fr.md
+++ b/pages/ovhcloud_labs/power_web_hosting/getting-started/guide.fr-fr.md
@@ -14,7 +14,7 @@ Retrouvez ici les principales informations relatives à la gestion de votre héb
 ## Prérequis 
 
 - Disposer d'une des 3 offres d'hébergement web POWER : [Node.js](https://labs.ovh.com/managed-nodejs), [Python](https://labs.ovh.com/managed-python) ou [Ruby](https://labs.ovh.com/managed-ruby).
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external} ou aux [API OVHcloud](https://api.ovh.com/).
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external} ou aux [API OVHcloud](https://api.ovh.com/).
 
 ## En pratique
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-etherpad/guide.en-gb.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-etherpad/guide.en-gb.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - a [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-etherpad/guide.en-ie.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-etherpad/guide.en-ie.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - a [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-etherpad/guide.fr-fr.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-etherpad/guide.fr-fr.md
@@ -13,7 +13,7 @@ Vous avez souscrit à un hébergement web POWER Node.js et vous souhaitez y inst
 ## Prérequis
 
 - Disposer de l'offre d'hébergement web POWER [Node.js](https://labs.ovh.com/managed-nodejs).
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 Si vous n'êtes pas encore familier avec l'utilisation de votre hébergement web POWER, nous vous conseillons de consulter notre guide « [Premiers pas avec un hébergement web POWER](/pages/ovhcloud_labs/power_web_hosting/getting-started) » avant de poursuivre la lecture de ce guide.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-express/guide.en-gb.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-express/guide.en-gb.md
@@ -15,7 +15,7 @@ This guide will explain how to deploy a simple *Hello World* server on Express.
 ## Requirements
 
 - a [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-express/guide.en-ie.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-express/guide.en-ie.md
@@ -15,7 +15,7 @@ This guide will explain how to deploy a simple *Hello World* server on Express.
 ## Requirements
 
 - a [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-express/guide.fr-fr.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-express/guide.fr-fr.md
@@ -13,7 +13,7 @@ Vous avez souscrit à un hébergement web POWER Node.js et vous souhaitez y dép
 ## Prérequis
 
 - Disposer de l'offre d'hébergement web POWER [Node.js](https://labs.ovh.com/managed-nodejs).
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 Si vous n'êtes pas encore familier avec l'utilisation de votre hébergement web POWER, nous vous conseillons de consulter notre guide « [Premiers pas avec un hébergement web POWER](/pages/ovhcloud_labs/power_web_hosting/getting-started) » avant de poursuivre la lecture de ce guide.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-ghost/guide.en-gb.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-ghost/guide.en-gb.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-ghost/guide.en-ie.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-ghost/guide.en-ie.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-ghost/guide.fr-fr.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-ghost/guide.fr-fr.md
@@ -13,7 +13,7 @@ Vous avez souscrit à un hébergement web POWER Node.js et vous souhaitez y dép
 ## Prérequis
 
 - Disposer de l'offre d'hébergement web POWER [Node.js](https://labs.ovh.com/managed-nodejs).
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 Si vous n'êtes pas encore familier avec l'utilisation de votre hébergement web POWER, nous vous conseillons de consulter notre guide « [Premiers pas avec un hébergement web POWER](/pages/ovhcloud_labs/power_web_hosting/getting-started) » avant de poursuivre la lecture de ce guide.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-slideshow/guide.en-gb.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-slideshow/guide.en-gb.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-slideshow/guide.en-ie.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-slideshow/guide.en-ie.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-slideshow/guide.fr-fr.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-slideshow/guide.fr-fr.md
@@ -13,7 +13,7 @@ Vous avez souscrit à un hébergement web POWER Node.js et vous souhaitez y dép
 ## Prérequis
 
 - Disposer de l'offre d'hébergement web POWER [Node.js](https://labs.ovh.com/managed-nodejs).
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 Si vous n'êtes pas encore familier avec l'utilisation de votre hébergement web POWER, nous vous conseillons de consulter notre guide « [Premiers pas avec un hébergement web POWER](/pages/ovhcloud_labs/power_web_hosting/getting-started) » avant de poursuivre la lecture de ce guide.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-strapi/guide.en-gb.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-strapi/guide.en-gb.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-strapi/guide.en-ie.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-strapi/guide.en-ie.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-strapi/guide.fr-fr.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-strapi/guide.fr-fr.md
@@ -13,7 +13,7 @@ Vous avez souscrit à un hébergement web POWER Node.js et vous souhaitez y dép
 ## Prérequis
 
 - Disposer de l'offre d'hébergement web POWER [Node.js](https://labs.ovh.com/managed-nodejs).
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 Si vous n'êtes pas encore familier avec l'utilisation de votre hébergement web POWER, nous vous conseillons de consulter notre guide « [Premiers pas avec un hébergement web POWER](/pages/ovhcloud_labs/power_web_hosting/getting-started) » avant de poursuivre la lecture de ce guide.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-wikijs/guide.en-gb.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-wikijs/guide.en-gb.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-wikijs/guide.en-ie.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-wikijs/guide.en-ie.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-install-wikijs/guide.fr-fr.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-install-wikijs/guide.fr-fr.md
@@ -13,7 +13,7 @@ Vous avez souscrit à un hébergement web POWER Node.js et vous souhaitez y dép
 ## Prérequis
 
 - Disposer de l'offre d'hébergement web POWER [Node.js](https://labs.ovh.com/managed-nodejs).
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 Si vous n'êtes pas encore familier avec l'utilisation de votre hébergement web POWER, nous vous conseillons de consulter notre guide « [Premiers pas avec un hébergement web POWER](/pages/ovhcloud_labs/power_web_hosting/getting-started) » avant de poursuivre la lecture de ce guide.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-using-typescript/guide.en-gb.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-using-typescript/guide.en-gb.md
@@ -35,7 +35,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-using-typescript/guide.en-ie.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-using-typescript/guide.en-ie.md
@@ -35,7 +35,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/nodejs-using-typescript/guide.fr-fr.md
+++ b/pages/ovhcloud_labs/power_web_hosting/nodejs-using-typescript/guide.fr-fr.md
@@ -33,7 +33,7 @@ Vous avez souscrit à un hébergement web POWER Node.js et vous souhaitez y dép
 ## Prérequis
 
 - Disposer de l'offre d'hébergement web POWER [Node.js](https://labs.ovh.com/managed-nodejs).
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 Si vous n'êtes pas encore familier avec l'utilisation de votre hébergement web POWER, nous vous conseillons de consulter notre guide « [Premiers pas avec un hébergement web POWER](/pages/ovhcloud_labs/power_web_hosting/getting-started) » avant de poursuivre la lecture de ce guide.
 

--- a/pages/ovhcloud_labs/power_web_hosting/python-install-django/guide.en-gb.md
+++ b/pages/ovhcloud_labs/power_web_hosting/python-install-django/guide.en-gb.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/python-install-django/guide.en-ie.md
+++ b/pages/ovhcloud_labs/power_web_hosting/python-install-django/guide.en-ie.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Node.js](https://labs.ovh.com/managed-nodejs) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/python-install-django/guide.fr-fr.md
+++ b/pages/ovhcloud_labs/power_web_hosting/python-install-django/guide.fr-fr.md
@@ -13,7 +13,7 @@ Vous avez souscrit à un hébergement web POWER Python et vous souhaitez y dépl
 ## Prérequis
 
 - Disposer de l'offre d'hébergement web POWER [Python](https://labs.ovh.com/managed-python).
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 Si vous n'êtes pas encore familier avec l'utilisation de votre hébergement web POWER, nous vous conseillons de consulter notre guide « [Premiers pas avec un hébergement web POWER](/pages/ovhcloud_labs/power_web_hosting/getting-started) » avant de poursuivre la lecture de ce guide.
 

--- a/pages/ovhcloud_labs/power_web_hosting/python-install-flask/guide.en-gb.md
+++ b/pages/ovhcloud_labs/power_web_hosting/python-install-flask/guide.en-gb.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Python](https://labs.ovh.com/managed-python) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/python-install-flask/guide.en-ie.md
+++ b/pages/ovhcloud_labs/power_web_hosting/python-install-flask/guide.en-ie.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Python](https://labs.ovh.com/managed-python) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/python-install-flask/guide.fr-fr.md
+++ b/pages/ovhcloud_labs/power_web_hosting/python-install-flask/guide.fr-fr.md
@@ -13,7 +13,7 @@ Vous avez souscrit à un hébergement web POWER Python et vous souhaitez y dépl
 ## Prérequis
 
 - Disposer de l'offre d'hébergement web POWER [Python](https://labs.ovh.com/managed-python).
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 Si vous n'êtes pas encore familier avec l'utilisation de votre hébergement web POWER, nous vous conseillons de consulter notre guide « [Premiers pas avec un hébergement web POWER](/pages/ovhcloud_labs/power_web_hosting/getting-started) » avant de poursuivre la lecture de ce guide.
 

--- a/pages/ovhcloud_labs/power_web_hosting/ruby-install-cameleon/guide.en-gb.md
+++ b/pages/ovhcloud_labs/power_web_hosting/ruby-install-cameleon/guide.en-gb.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Ruby](https://labs.ovh.com/managed-ruby) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/ruby-install-cameleon/guide.en-ie.md
+++ b/pages/ovhcloud_labs/power_web_hosting/ruby-install-cameleon/guide.en-ie.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Ruby](https://labs.ovh.com/managed-ruby) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/ruby-install-cameleon/guide.fr-fr.md
+++ b/pages/ovhcloud_labs/power_web_hosting/ruby-install-cameleon/guide.fr-fr.md
@@ -13,7 +13,7 @@ Vous avez souscrit à un hébergement web POWER Ruby et vous voulez y déployer 
 ## Prérequis
 
 - Disposer de l'offre d'hébergement web POWER [Ruby](https://labs.ovh.com/managed-ruby).
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 Si vous n'êtes pas encore familier avec l'utilisation de votre hébergement web POWER, nous vous conseillons de consulter notre guide « [Premiers pas avec un hébergement web POWER](/pages/ovhcloud_labs/power_web_hosting/getting-started) » avant de poursuivre la lecture de ce guide.
 

--- a/pages/ovhcloud_labs/power_web_hosting/ruby-install-rails/guide.en-gb.md
+++ b/pages/ovhcloud_labs/power_web_hosting/ruby-install-rails/guide.en-gb.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Ruby](https://labs.ovh.com/managed-ruby) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/ruby-install-rails/guide.en-ie.md
+++ b/pages/ovhcloud_labs/power_web_hosting/ruby-install-rails/guide.en-ie.md
@@ -15,7 +15,7 @@ This guide will explain how to do it.
 ## Requirements
 
 - A [Ruby](https://labs.ovh.com/managed-ruby) POWER web hosting plan
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 If you have just started to use your Web POWER web hosting plan, we suggest to have a look at our [Getting started with a POWER web hosting plan](/pages/ovhcloud_labs/power_web_hosting/getting-started) guide before going further.
 

--- a/pages/ovhcloud_labs/power_web_hosting/ruby-install-rails/guide.fr-fr.md
+++ b/pages/ovhcloud_labs/power_web_hosting/ruby-install-rails/guide.fr-fr.md
@@ -13,7 +13,7 @@ Vous avez souscrit à un hébergement web POWER Ruby et vous voulez y déployer 
 ## Prérequis
 
 - Disposer de l'offre d'hébergement web POWER [Ruby](https://labs.ovh.com/managed-ruby).
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 Si vous n'êtes pas encore familier avec l'utilisation de votre hébergement web POWER, nous vous conseillons de consulter notre guide « [Premiers pas avec un hébergement web POWER](/pages/ovhcloud_labs/power_web_hosting/getting-started) » avant de poursuivre la lecture de ce guide.
 


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their `/links` values.

*Example: replace all `https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB` links with `/links/manager`*.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.

@Y0Coss no need for the `Fix` label, maybe `Minor Update` and even then, I'll let you be the judge.
