### PR TITLE
Fix global links in KB Web cloud

### DIFF
--- a/pages/web_cloud/domains/dns_zone_dkim/guide.de-de.md
+++ b/pages/web_cloud/domains/dns_zone_dkim/guide.de-de.md
@@ -47,7 +47,7 @@ Der DKIM-Eintrag (**D**omain**K**eys **I**dentified **M**ail) ermöglicht die Si
 - Sie haben über das [OVHcloud Kundencenter](/links/manager) Zugriff auf die Konfiguration des betreffenden Domainnamens oder entsprechenden Verwaltungszugriff bei Ihrem DNS-Anbieter, wenn der Domainname nicht über OVHcloud registriert ist.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 - Sie verfügen über einen der folgenden E-Mail-Dienste:
-    - OVHcloud MX Plan E-Mail, verfügbar mit den Angeboten [Webhosting](/links/web/hosting), [Kostenloses Hosting 100M](https://www.ovhcloud.com/de/domains/free-web-hosting/) oder als separater Dienst
+    - OVHcloud MX Plan E-Mail, verfügbar mit den Angeboten [Webhosting](/links/web/hosting), [Kostenloses Hosting 100M](/links/web/domains-free-hosting) oder als separater Dienst
     - [Hosted Exchange](/links/web/emails-hosted-exchange) oder [Private Exchange](/links/web/emails-hosted-exchange)
     - [E-Mail Pro](/links/web/email-pro)
     - Ein E-Mail-Angebot außerhalb von OVHcloud, das über DKIM verfügt

--- a/pages/web_cloud/domains/dns_zone_dkim/guide.en-asia.md
+++ b/pages/web_cloud/domains/dns_zone_dkim/guide.en-asia.md
@@ -188,7 +188,7 @@ After 24 hours, if your `DKIM` box is red, please refer to the section [“Why d
 
 #### Full DKIM configuration <a name="firststep"></a>
 
-To configure DKIM, go to the website <https://ca.api.ovh.com/console/>, log in using the `Login`{.action} button in the top right-hand corner, and enter your OVHcloud credentials.
+To configure DKIM, go to the website </links/console>, log in using the `Login`{.action} button in the top right-hand corner, and enter your OVHcloud credentials.
 
 > Visit our guide ["First Steps with the OVHcloud APIs"](/pages/manage_and_operate/api/first-steps) if you have never used APIs.
 

--- a/pages/web_cloud/domains/dns_zone_dkim/guide.en-au.md
+++ b/pages/web_cloud/domains/dns_zone_dkim/guide.en-au.md
@@ -188,7 +188,7 @@ After 24 hours, if your `DKIM` box is red, please refer to the section [“Why d
 
 #### Full DKIM configuration <a name="firststep"></a>
 
-To configure DKIM, go to the website <https://ca.api.ovh.com/console/>, log in using the `Login`{.action} button in the top right-hand corner, and enter your OVHcloud credentials.
+To configure DKIM, go to the website </links/console>, log in using the `Login`{.action} button in the top right-hand corner, and enter your OVHcloud credentials.
 
 > Visit our guide ["First Steps with the OVHcloud APIs"](/pages/manage_and_operate/api/first-steps) if you have never used APIs.
 

--- a/pages/web_cloud/domains/dns_zone_dkim/guide.en-ca.md
+++ b/pages/web_cloud/domains/dns_zone_dkim/guide.en-ca.md
@@ -227,7 +227,7 @@ Also, make sure that the domain name you want to use for your emails is active i
 
 #### Full DKIM configuration <a name="firststep"></a>
 
-To configure DKIM, go to the website <https://ca.api.ovh.com/console/>, log in using the `Login`{.action} button in the top right-hand corner, and enter your OVHcloud credentials.
+To configure DKIM, go to the website </links/console>, log in using the `Login`{.action} button in the top right-hand corner, and enter your OVHcloud credentials.
 
 > Visit our guide ["First Steps with the OVHcloud APIs"](/pages/manage_and_operate/api/first-steps) if you have never used APIs.
 

--- a/pages/web_cloud/domains/dns_zone_dkim/guide.en-gb.md
+++ b/pages/web_cloud/domains/dns_zone_dkim/guide.en-gb.md
@@ -47,7 +47,7 @@ The DKIM (**D**omain**K**eys **I**dentified **M**ail) record allows you to sign 
 - You can manage the domain name concerned in the [OVHcloud Control Panel](/links/manager), or via your DNS service provider if it is registered outside of OVHcloud.
 - You have access to the [OVHcloud Control Panel](/links/manager).
 - You have signed up to one of these email offers:
-    - OVHcloud MX Plan Email, available with a [web hosting plan](/links/web/hosting), a [100M free hosting plan](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/), or a separate MX Plan solution
+    - OVHcloud MX Plan Email, available with a [web hosting plan](/links/web/hosting), a [100M free hosting plan](/links/web/domains-free-hosting), or a separate MX Plan solution
     - [Exchange](/links/web/emails-hosted-exchange) or [Private Exchange](/links/web/emails-hosted-exchange)
     - [Email Pro](/links/web/email-pro)
     - An email solution outside of OVHcloud with DKIM support

--- a/pages/web_cloud/domains/dns_zone_dkim/guide.en-ie.md
+++ b/pages/web_cloud/domains/dns_zone_dkim/guide.en-ie.md
@@ -47,7 +47,7 @@ The DKIM (**D**omain**K**eys **I**dentified **M**ail) record allows you to sign 
 - You can manage the domain name concerned in the [OVHcloud Control Panel](/links/manager), or via your DNS service provider if it is registered outside of OVHcloud.
 - You have access to the [OVHcloud Control Panel](/links/manager).
 - You have signed up to one of these email offers:
-    - OVHcloud MX Plan Email, available with a [web hosting plan](/links/web/hosting), a [100M free hosting plan](https://www.ovhcloud.com/en-gb/domains/free-web-hosting/), or a separate MX Plan solution
+    - OVHcloud MX Plan Email, available with a [web hosting plan](/links/web/hosting), a [100M free hosting plan](/links/web/domains-free-hosting), or a separate MX Plan solution
     - [Exchange](/links/web/emails-hosted-exchange) or [Private Exchange](/links/web/emails-hosted-exchange)
     - [Email Pro](/links/web/email-pro)
     - An email solution outside of OVHcloud with DKIM support

--- a/pages/web_cloud/domains/dns_zone_dkim/guide.en-sg.md
+++ b/pages/web_cloud/domains/dns_zone_dkim/guide.en-sg.md
@@ -188,7 +188,7 @@ After 24 hours, if your `DKIM` box is red, please refer to the section [“Why d
 
 #### Full DKIM configuration <a name="firststep"></a>
 
-To configure DKIM, go to the website <https://ca.api.ovh.com/console/>, log in using the `Login`{.action} button in the top right-hand corner, and enter your OVHcloud credentials.
+To configure DKIM, go to the website </links/console>, log in using the `Login`{.action} button in the top right-hand corner, and enter your OVHcloud credentials.
 
 > Visit our guide ["First Steps with the OVHcloud APIs"](/pages/manage_and_operate/api/first-steps) if you have never used APIs.
 

--- a/pages/web_cloud/domains/dns_zone_dkim/guide.en-us.md
+++ b/pages/web_cloud/domains/dns_zone_dkim/guide.en-us.md
@@ -227,7 +227,7 @@ Also, make sure that the domain name you want to use for your emails is active i
 
 #### Full DKIM configuration <a name="firststep"></a>
 
-To configure DKIM, go to the website <https://ca.api.ovh.com/console/>, log in using the `Login`{.action} button in the top right-hand corner, and enter your OVHcloud credentials.
+To configure DKIM, go to the website </links/console>, log in using the `Login`{.action} button in the top right-hand corner, and enter your OVHcloud credentials.
 
 > Visit our guide ["First Steps with the OVHcloud APIs"](/pages/manage_and_operate/api/first-steps) if you have never used APIs.
 

--- a/pages/web_cloud/domains/dns_zone_dkim/guide.es-us.md
+++ b/pages/web_cloud/domains/dns_zone_dkim/guide.es-us.md
@@ -222,7 +222,7 @@ Asimismo, asegúrese de que el dominio que quiera utilizar para el correo electr
 
 #### Configuración completa de DKIM <a name="firststep"></a>
 
-Para configurar el DKIM, acceda al sitio web <https://ca.api.ovh.com/console/>, conéctese con el botón `Login`{.action} en la parte superior derecha e introduzca sus claves OVHcloud.
+Para configurar el DKIM, acceda al sitio web </links/console>, conéctese con el botón `Login`{.action} en la parte superior derecha e introduzca sus claves OVHcloud.
 
 > Si nunca ha utilizado la API, puede consultar nuestra guía "[Cómo utilizar las API de OVHcloud](/pages/manage_and_operate/api/first-steps)".
 

--- a/pages/web_cloud/domains/dns_zone_dkim/guide.fr-ca.md
+++ b/pages/web_cloud/domains/dns_zone_dkim/guide.fr-ca.md
@@ -223,7 +223,7 @@ Assurez-vous également que le nom de domaine que vous souhaitez utiliser pour v
 
 ![email](/pages/assets/screens/control_panel/product-selection/web-cloud/microsoft/exchange/associated-domains/dns-dkim-domain.png){.thumbnail .w-400 .h-600}
 
-Pour configurer le DKIM, rendez-vous sur le site <https://ca.api.ovh.com/console/>, connectez-vous à l'aide du bouton `Login`{.action} en haut à droite et renseignez vos identifiants OVHcloud.
+Pour configurer le DKIM, rendez-vous sur le site </links/console>, connectez-vous à l'aide du bouton `Login`{.action} en haut à droite et renseignez vos identifiants OVHcloud.
 
 > Appuyez-vous sur notre guide [« Découvrez comment utiliser les API OVHcloud »](/pages/manage_and_operate/api/first-steps) si vous n'avez jamais utilisé les API.
 

--- a/pages/web_cloud/domains/dns_zone_dkim/guide.fr-fr.md
+++ b/pages/web_cloud/domains/dns_zone_dkim/guide.fr-fr.md
@@ -47,7 +47,7 @@ L'enregistrement DKIM (**D**omain**K**eys **I**dentified **M**ail) permet de sig
 - Disposer d'un accès à la gestion du nom de domaine concerné depuis l'[espace client OVHcloud](/links/manager) ou auprès de votre prestataire de domaine s'il est enregistré en dehors d'OVHcloud.
 - Être connecté à votre [espace client OVHcloud](/links/manager).
 - Avoir souscrit à une des offres e-mail :
-    - E-mails (MX Plan) OVHcloud (disponible via une [offre d’hébergement Web Cloud](/links/web/hosting)), un [hébergement gratuit 100M](https://www.ovhcloud.com/fr/domains/free-web-hosting/) ou une offre MX Plan commandée séparément.
+    - E-mails (MX Plan) OVHcloud (disponible via une [offre d’hébergement Web Cloud](/links/web/hosting)), un [hébergement gratuit 100M](/links/web/domains-free-hosting) ou une offre MX Plan commandée séparément.
     - [Exchange](/links/web/emails-hosted-exchange) ou [Private Exchange](/links/web/emails-hosted-exchange).
     - [E-mail Pro](/links/web/email-pro).
     - Une offre e-mail hors OVHcloud disposant du DKIM.

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.de-de.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.de-de.md
@@ -60,7 +60,7 @@ Der Transferprozess umfasst mehrere Schritte. Diese erfordern die Kontaktaufnahm
 
 > [!warning]
 >
-> Das genaue Verfahren für den Domaintransfer kann variieren, insbesondere bei bestimmten Ländercode-**TLD**s (**ccTLD**, z.B. .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi) und einigen speziellen **TLD**s (.am, .fm. etc.). Je nach Endung Ihres Domainnamens können zusätzliche Voraussetzungen notwendig sein. Wir empfehlen Ihnen, zunächst die für die betreffende Endung verfügbaren Informationen auf unserer Website zu überprüfen: <https://www.ovhcloud.com/de/domains/tld/>.
+> Das genaue Verfahren für den Domaintransfer kann variieren, insbesondere bei bestimmten Ländercode-**TLD**s (**ccTLD**, z.B. .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi) und einigen speziellen **TLD**s (.am, .fm. etc.). Je nach Endung Ihres Domainnamens können zusätzliche Voraussetzungen notwendig sein. Wir empfehlen Ihnen, zunächst die für die betreffende Endung verfügbaren Informationen auf unserer Website zu überprüfen: </links/web/domains-tld>.
 >
 
 ### Schritt 1: Domaininformationen überprüfen <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-asia.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-asia.md
@@ -60,7 +60,7 @@ The transfer procedure has several steps. These steps will involve various entit
 
 > [!warning]
 >
-> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: <https://www.ovhcloud.com/asia/domains/tld/>.
+> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: </links/web/domains-tld>.
 >
 
 ### Step 1: Check the information associated with the domain <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-au.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-au.md
@@ -60,7 +60,7 @@ The transfer procedure has several steps. These steps will involve various entit
 
 > [!warning]
 >
-> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: <https://www.ovhcloud.com/en-au/domains/tld/>.
+> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: </links/web/domains-tld>.
 >
 
 ### Step 1: Check the information associated with the domain <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-ca.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-ca.md
@@ -60,7 +60,7 @@ The transfer procedure has several steps. These steps will involve various entit
 
 > [!warning]
 >
-> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: <https://www.ovhcloud.com/en-ca/domains/tld/>.
+> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: </links/web/domains-tld>.
 >
 
 ### Step 1: Check the information associated with the domain <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-gb.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-gb.md
@@ -60,7 +60,7 @@ The transfer procedure has several steps. These steps will involve various entit
 
 > [!warning]
 >
-> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: <https://www.ovhcloud.com/en-gb/domains/tld/>.
+> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: </links/web/domains-tld>.
 >
 
 ### Step 1: Check the information associated with the domain <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-ie.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-ie.md
@@ -60,7 +60,7 @@ The transfer procedure has several steps. These steps will involve various entit
 
 > [!warning]
 >
-> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: <https://www.ovhcloud.com/en-ie/domains/tld/>.
+> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: </links/web/domains-tld>.
 >
 
 ### Step 1: Check the information associated with the domain <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-sg.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-sg.md
@@ -60,7 +60,7 @@ The transfer procedure has several steps. These steps will involve various entit
 
 > [!warning]
 >
-> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: <https://www.ovhcloud.com/en-sg/domains/tld/>.
+> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: </links/web/domains-tld>.
 >
 
 ### Step 1: Check the information associated with the domain <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-us.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.en-us.md
@@ -60,7 +60,7 @@ The transfer procedure has several steps. These steps will involve various entit
 
 > [!warning]
 >
-> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: <https://www.ovhcloud.com/en/domains/tld/>.
+> The exact procedure for domain transfer may vary, especially in case of some country-code **TLD**s (**ccTLD**, such as .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) and a few special purpose **TLD**s (.am, .fm, etc.). Depending on your domain name extension, you may have additional requirements. We recommend to first check against the information displayed in the section of the extension concerned, on our website: </links/web/domains-tld>.
 >
 
 ### Step 1: Check the information associated with the domain <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.es-es.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.es-es.md
@@ -61,7 +61,7 @@ El procedimiento de transferencia se desarrolla en varias etapas e involucra a v
 
 > [!warning]
 >
-> El procedimiento exacto de transferencia de dominio puede variar, especialmente en el caso de determinados **TLD** de código de país (**ccTLD**, como .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) y de algunos **TLD** especiales (.am, .fm, etc.). Según la extensión del dominio, es posible que sea necesario cumplir requisitos adicionales. Le recomendamos que compruebe en primer lugar la información mostrada para la extensión en cuestión, en nuestro sitio web: <https://www.ovhcloud.com/es-es/domains/tld/>.
+> El procedimiento exacto de transferencia de dominio puede variar, especialmente en el caso de determinados **TLD** de código de país (**ccTLD**, como .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) y de algunos **TLD** especiales (.am, .fm, etc.). Según la extensión del dominio, es posible que sea necesario cumplir requisitos adicionales. Le recomendamos que compruebe en primer lugar la información mostrada para la extensión en cuestión, en nuestro sitio web: </links/web/domains-tld>.
 >
 
 ### 1. Comprobar la información relativa al dominio <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.es-us.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.es-us.md
@@ -61,7 +61,7 @@ El procedimiento de transferencia se desarrolla en varias etapas e involucra a v
 
 > [!warning]
 >
-> El procedimiento exacto de transferencia de dominio puede variar, especialmente en el caso de determinados **TLD** de código de país (**ccTLD**, como .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) y de algunos **TLD** especiales (.am, .fm, etc.). Según la extensión del dominio, es posible que sea necesario cumplir requisitos adicionales. Le recomendamos que compruebe en primer lugar la información mostrada para la extensión en cuestión, en nuestro sitio web: <https://www.ovhcloud.com/es/domains/tld/>.
+> El procedimiento exacto de transferencia de dominio puede variar, especialmente en el caso de determinados **TLD** de código de país (**ccTLD**, como .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) y de algunos **TLD** especiales (.am, .fm, etc.). Según la extensión del dominio, es posible que sea necesario cumplir requisitos adicionales. Le recomendamos que compruebe en primer lugar la información mostrada para la extensión en cuestión, en nuestro sitio web: </links/web/domains-tld>.
 >
 
 ### 1. Comprobar la información relativa al dominio <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.fr-ca.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.fr-ca.md
@@ -61,7 +61,7 @@ La procédure de transfert comporte plusieurs étapes, impliquant la prise de co
 
 > [!warning]
 >
-> La procédure exacte de transfert de domaine peut varier, en particulier dans le cas de certains **TLD** de code de pays (**ccTLD**, tels que .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) et de quelques **TLD** spéciaux (.am, .fm, etc.). Selon l'extension de votre nom de domaine, des prérequis supplémentaires peuvent être nécessaires. Nous vous recommandons de vérifier d'abord les informations affichées pour l'extension concernée, sur notre site Web: <https://www.ovhcloud.com/fr-ca/domains/tld/>.
+> La procédure exacte de transfert de domaine peut varier, en particulier dans le cas de certains **TLD** de code de pays (**ccTLD**, tels que .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) et de quelques **TLD** spéciaux (.am, .fm, etc.). Selon l'extension de votre nom de domaine, des prérequis supplémentaires peuvent être nécessaires. Nous vous recommandons de vérifier d'abord les informations affichées pour l'extension concernée, sur notre site Web: </links/web/domains-tld>.
 >
 
 ### Étape 1 : vérifier les informations associées au nom de domaine <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.fr-fr.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.fr-fr.md
@@ -61,7 +61,7 @@ La procédure de transfert comporte plusieurs étapes, impliquant la prise de co
 
 > [!warning]
 >
-> La procédure exacte de transfert de domaine peut varier, en particulier dans le cas de certains **TLD** de code de pays (**ccTLD**, tels que .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) et de quelques **TLD** spéciaux (.am, .fm, etc.). Selon l'extension de votre nom de domaine, des prérequis supplémentaires peuvent être nécessaires. Nous vous recommandons de vérifier d'abord les informations affichées pour l'extension concernée, sur notre site Web: <https://www.ovhcloud.com/fr/domains/tld/>.
+> La procédure exacte de transfert de domaine peut varier, en particulier dans le cas de certains **TLD** de code de pays (**ccTLD**, tels que .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) et de quelques **TLD** spéciaux (.am, .fm, etc.). Selon l'extension de votre nom de domaine, des prérequis supplémentaires peuvent être nécessaires. Nous vous recommandons de vérifier d'abord les informations affichées pour l'extension concernée, sur notre site Web: </links/web/domains-tld>.
 >
 
 ### Étape 1 : vérifier les informations associées au nom de domaine <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.it-it.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.it-it.md
@@ -61,7 +61,7 @@ La procedura di trasferimento prevede diversi step, tra cui l'avvio di contatti 
 
 > [!warning]
 >
-> La procedura esatta di trasferimento del dominio può variare, in particolare per alcune **TLD** del codice del paese (**ccTLD**, quali .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, ecc.) e per alcune **TLD** speciali (.am, .fm, ecc.). In base all'estensione del tuo dominio, potrebbero essere necessari requisiti aggiuntivi. Ti consigliamo di verificare le informazioni mostrate per l'estensione in questione dal nostro sito Web: <https://www.ovhcloud.com/it/domains/tld/>.
+> La procedura esatta di trasferimento del dominio può variare, in particolare per alcune **TLD** del codice del paese (**ccTLD**, quali .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, ecc.) e per alcune **TLD** speciali (.am, .fm, ecc.). In base all'estensione del tuo dominio, potrebbero essere necessari requisiti aggiuntivi. Ti consigliamo di verificare le informazioni mostrate per l'estensione in questione dal nostro sito Web: </links/web/domains-tld>.
 >
 
 ### Step 1: verifica le informazioni del proprietario del dominio <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.pl-pl.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.pl-pl.md
@@ -61,7 +61,7 @@ Procedura transferu składa się z kilku etapów, w które włączone są różn
 
 > [!warning]
 >
-> Dokładna procedura transferu domeny może się różnić, w szczególności w przypadku niektórych **TLD** kodu kraju (**ccTLD**, takich jak .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, itp.) oraz niektórych specjalnych **TLD** (.am, .fm, itp.). W zależności od rozszerzenia Twojej domeny, mogą być konieczne dodatkowe wymagania. Zalecamy sprawdzenie w pierwszej kolejności informacji wyświetlanych dla danego rozszerzenia na naszej stronie internetowej: <https://www.ovhcloud.com/pl/domains/tld/>.
+> Dokładna procedura transferu domeny może się różnić, w szczególności w przypadku niektórych **TLD** kodu kraju (**ccTLD**, takich jak .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, itp.) oraz niektórych specjalnych **TLD** (.am, .fm, itp.). W zależności od rozszerzenia Twojej domeny, mogą być konieczne dodatkowe wymagania. Zalecamy sprawdzenie w pierwszej kolejności informacji wyświetlanych dla danego rozszerzenia na naszej stronie internetowej: </links/web/domains-tld>.
 >
 
 ### Etap 1: weryfikacja informacji związanych z domeną <a name="step1"></a>

--- a/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.pt-pt.md
+++ b/pages/web_cloud/domains/transfer_incoming_generic_domain/guide.pt-pt.md
@@ -61,7 +61,7 @@ O procedimento de transferência compreende várias etapas, implicando o contact
 
 > [!warning]
 >
-> O procedimento exato de transferência de domínio pode variar, especialmente no caso de certos **TLD** de código de país (**ccTLD**, tais como .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) e de alguns **TLD** especiais (.am, .fm, etc.). Em função da extensão do domínio, poderá ser necessário realizar requisitos adicionais. Recomendamos que comece por verificar as informações apresentadas para a extensão em causa no nosso website: <https://www.ovhcloud.com/pt/domains/tld/>.
+> O procedimento exato de transferência de domínio pode variar, especialmente no caso de certos **TLD** de código de país (**ccTLD**, tais como .pl, .lu, .hk, .ro, .be, .lt, .dk, .at, .fi, etc.) e de alguns **TLD** especiais (.am, .fm, etc.). Em função da extensão do domínio, poderá ser necessário realizar requisitos adicionais. Recomendamos que comece por verificar as informações apresentadas para a extensão em causa no nosso website: </links/web/domains-tld>.
 >
 
 ### 1 - Verificar a informação relativa ao domínio <a name="step1"></a>

--- a/pages/web_cloud/internet/internet_access/comment_resilier_mon_acces_xdsl/guide.fr-fr.md
+++ b/pages/web_cloud/internet/internet_access/comment_resilier_mon_acces_xdsl/guide.fr-fr.md
@@ -20,7 +20,7 @@ La résiliation sera effective à la prochaine facturation de votre accès à In
 ![espace client Telecom Accès Internet](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-01-fr-internet.png){.thumbnail}
 
 > [!primary]
-> La résiliation d'un [pack SIP Trunk](https://www.ovhtelecom.fr/telephonie/sip-trunk/) doit faire l'objet d'une [demande d'assistance](https://help.ovhcloud.com/csm?id=csm_get_help) via le centre d'aide OVHcloud afin que les équipes du support la mettent en place.
+> La résiliation d'un [pack SIP Trunk](/links/telecom/telephonie-sip-trunk) doit faire l'objet d'une [demande d'assistance](https://help.ovhcloud.com/csm?id=csm_get_help) via le centre d'aide OVHcloud afin que les équipes du support la mettent en place.
 >
 
 ## En pratique

--- a/pages/web_cloud/internet/internet_access/connectivity-api/guide.en-gb.md
+++ b/pages/web_cloud/internet/internet_access/connectivity-api/guide.en-gb.md
@@ -20,7 +20,7 @@ This guide is designed to help developers use our APIs to create their own appli
 
 OVHcloud offers various internet access packages that contain at least one internet access but also VoIP lines, emails and domain names.
 
-You can view offers [here](https://www.ovhcloud.com/fr/internet/).
+You can view offers [here](/links/telecom/offre-internet).
 
 Services can be managed using these API endpoints:
 

--- a/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/guide.en-gb.md
+++ b/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/guide.en-gb.md
@@ -12,7 +12,7 @@ The purpose of this guide is to explain what SMS credits are, how to set up auto
 
 - an OVHcloud account
 - access to the [OVHcloud API](https://api.ovh.com/) (for credit transfers only)
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![SMS Telecom Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -49,7 +49,7 @@ To ensure that you are never short of credit on your account, you can enable aut
 > - a SEPA direct debit payment method is present and validated in your OVHcloud account.
 > - your SMS service must be at least 2 months old.
 
-To enable automatic re-crediting, log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, then go to the `Telecom`{.action} tab. Next, click on the `SMS`{.action} section in the services bar. Choose the SMS account you would like to enable automatic re-credit for.
+To enable automatic re-crediting, log in to the [OVHcloud Control Panel](/links/manager){.external}, then go to the `Telecom`{.action} tab. Next, click on the `SMS`{.action} section in the services bar. Choose the SMS account you would like to enable automatic re-credit for.
 
 Go to the `Options`{.action} menu (1), then `Automatic re-credit`{.action} (2).
 

--- a/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/guide.en-ie.md
+++ b/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/guide.en-ie.md
@@ -12,7 +12,7 @@ The purpose of this guide is to explain what SMS credits are, how to set up auto
 
 - an OVHcloud account
 - access to the [OVHcloud API](https://api.ovh.com/) (for credit transfers only)
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![SMS Telecom Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -49,7 +49,7 @@ To ensure that you are never short of credit on your account, you can enable aut
 > - a SEPA direct debit payment method is present and validated in your OVHcloud account.
 > - your SMS service must be at least 2 months old.
 
-To enable automatic re-crediting, log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}, then go to the `Telecom`{.action} tab. Next, click on the `SMS`{.action} section in the services bar. Choose the SMS account you would like to enable automatic re-credit for.
+To enable automatic re-crediting, log in to the [OVHcloud Control Panel](/links/manager){.external}, then go to the `Telecom`{.action} tab. Next, click on the `SMS`{.action} section in the services bar. Choose the SMS account you would like to enable automatic re-credit for.
 
 Go to the `Options`{.action} menu (1), then `Automatic re-credit`{.action} (2).
 

--- a/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/guide.es-es.md
+++ b/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/guide.es-es.md
@@ -16,7 +16,7 @@ Esta guía explica en qué consiste el crédito de SMS, cómo recargarlo de form
 
 - Disponer de una cuenta de SMS en OVHcloud.
 - Conectarse a la [API de OVHcloud](https://api.ovh.com/) (solo para las transferencias de crédito).
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
 
 ![área de cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -53,7 +53,7 @@ Para garantizar que su cuenta de SMS dispone siempre de crédito, puede activar 
 > - una forma de pago de tipo SEPA está presente y validada en su cuenta de OVHcloud.
 > - su servicio SMS debe tener al menos 2 meses de antigüedad.
 
-Para activar la recarga automática, conéctese al [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, acceda a la pestaña `Telecom`{.action} y abra la sección `SMS`{.action}. Seleccione la cuenta de SMS en la que desea activar la recarga automática.
+Para activar la recarga automática, conéctese al [área de cliente de OVHcloud](/links/manager){.external}, acceda a la pestaña `Telecom`{.action} y abra la sección `SMS`{.action}. Seleccione la cuenta de SMS en la que desea activar la recarga automática.
 
 Acceda al menú `Opciones`{.action} (1) y seleccione la opción `Recarga automática`{.action} (2).
 

--- a/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/guide.fr-fr.md
+++ b/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/guide.fr-fr.md
@@ -12,7 +12,7 @@ Ce guide à pour objectif de vous expliquer ce que sont les crédit SMS, comment
 
 - Disposer d'un compte SMS OVHcloud.
 - Être connecté aux [API OVHcloud](https://api.ovh.com/) (uniquement pour les transferts de crédits).
-- Être connecté à l'[espace client OVHcloud](https://www.ovh.com/auth?onsuccess=https%3A%2F%2Fwww.ovhtelecom.fr%2Fmanager&ovhSubsidiary=fr){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
+- Être connecté à l'[espace client OVHcloud](/links/manager-telecom){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
 
 ![espace client Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-fr-sms.png){.thumbnail}
 
@@ -49,7 +49,7 @@ Afin de n'être jamais à court de crédit sur votre compte, vous pouvez activer
 > - un moyen de paiement de type Prélèvement SEPA est présent et validé sur votre compte OVHcloud;
 > - votre service SMS doit avoir au moins 2 mois d'ancienneté.
 
-Pour activer la recharge automatique, connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}, rendez-vous dans l'onglet `Télécom`{.action} puis cliquez sur la section `SMS`{.action}. Choisissez le compte SMS sur lequel activer la recharge automatique.
+Pour activer la recharge automatique, connectez-vous à votre [espace client OVHcloud](/links/manager){.external}, rendez-vous dans l'onglet `Télécom`{.action} puis cliquez sur la section `SMS`{.action}. Choisissez le compte SMS sur lequel activer la recharge automatique.
 
 Rendez-vous dans le menu `Options`{.action} (1) puis `Recharge automatique`{.action} (2).
 

--- a/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/guide.it-it.md
+++ b/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/guide.it-it.md
@@ -16,7 +16,7 @@ Questa guida ti spiega cosa sono i crediti SMS, come ricaricarli in modo automat
 
 - Disporre di un account SMS OVHcloud attivo
 - Avere accesso alle [API OVHcloud](https://api.ovh.com/)(soltanto per trasferire i crediti)
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}, sezione `Télécom`{.action} > `SMS`{.action}
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}, sezione `Télécom`{.action} > `SMS`{.action}
 
 ![Spazio Cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -53,7 +53,7 @@ Per disporre sempre di credito sufficiente sul tuo account SMS, è possibile e a
 > - sul tuo account OVHcloud è presente e validato un metodo di pagamento di tipo SEPA.
 > - il tuo servizio SMS deve avere almeno 2 mesi di anzianità.
 
-Per attivare la ricarica automatica, accedi allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}, clicca sulla scheda `ADSL e telefono`{.action} e poi sulla sezione `SMS`{.action}. Seleziona l’account SMS su cui attivare la ricarica automatica.
+Per attivare la ricarica automatica, accedi allo [Spazio Cliente OVHcloud](/links/manager){.external}, clicca sulla scheda `ADSL e telefono`{.action} e poi sulla sezione `SMS`{.action}. Seleziona l’account SMS su cui attivare la ricarica automatica.
 
 Clicca sul menu `Opzioni`{.action} (1) e poi su `Ricarica automatica`{.action} (2).
 

--- a/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/guide.pl-pl.md
+++ b/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/guide.pl-pl.md
@@ -16,7 +16,7 @@ Z tego przewodnika dowiesz się, czym są zasilenia SMS, jak je automatycznie do
 
 - Posiadanie aktywnego konta SMS OVHcloud
 - Zalogowanie do [API OVHcloud](https://api.ovh.com/) (tylko na potrzeby przenoszenia zasileń)
-- Zalogowanie do[Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
+- Zalogowanie do[Panelu klienta OVHcloud](/links/manager){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
 
 ![Panel klienta Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -53,7 +53,7 @@ Aby nigdy nie zabrakło Ci zasileń na koncie, możesz aktywować automatyczne d
 > - na Twoim koncie OVHcloud dostępny jest sposób płatności SEPA.
 > - Twoja usługa SMS musi mieć przynajmniej 2 miesięcy stażu pracy.
 
-Aby aktywować automatyczne doładowanie, zaloguj się do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}, przejdź do karty `Telefonia`{.action}, a następnie na pasku usług po lewej stronie kliknij sekcję `SMS`{.action}. Wybierz konto SMS, dla którego chcesz aktywować automatyczne doładowanie.
+Aby aktywować automatyczne doładowanie, zaloguj się do [Panelu klienta OVHcloud](/links/manager){.external}, przejdź do karty `Telefonia`{.action}, a następnie na pasku usług po lewej stronie kliknij sekcję `SMS`{.action}. Wybierz konto SMS, dla którego chcesz aktywować automatyczne doładowanie.
 
 Przejdź do menu `Opcje`{.action} (1), a następnie `Automatyczne ładowanie`{.action} (2).
 

--- a/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/guide.en-gb.md
+++ b/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/guide.en-gb.md
@@ -12,7 +12,7 @@ There are specific rules for sending SMS to the United States. The guide will ex
 
 - An OVHcloud SMS account with SMS credits.
 - Access to the [OVHcloud API](https://api.ovh.com/) (for the API method only)
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![SMS Telecom Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -34,7 +34,7 @@ Setting message templates is free and is carried out by the OVHcloud teams withi
 
 #### 2.1 Via the Control Panel
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account. Click on the `Message and campaign`{.action} tab then click `SMS management`{.action}.
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account. Click on the `Message and campaign`{.action} tab then click `SMS management`{.action}.
 
 Finally, click `Manage templates`{.action}.
 

--- a/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/guide.en-ie.md
+++ b/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/guide.en-ie.md
@@ -12,7 +12,7 @@ There are specific rules for sending SMS to the United States. The guide will ex
 
 - An OVHcloud SMS account with SMS credits.
 - Access to the [OVHcloud API](https://api.ovh.com/) (for the API method only)
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![SMS Telecom Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -34,7 +34,7 @@ Setting message templates is free and is carried out by the OVHcloud teams withi
 
 #### 2.1 Via the Control Panel
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}, then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account. Click on the `Message and campaign`{.action} tab then click `SMS management`{.action}.
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account. Click on the `Message and campaign`{.action} tab then click `SMS management`{.action}.
 
 Finally, click `Manage templates`{.action}.
 

--- a/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/guide.es-es.md
+++ b/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/guide.es-es.md
@@ -16,7 +16,7 @@ El envío de SMS a Estados Unidos está sujeto a normas específicas. Esta guía
 
 - Disponer de una cuenta de SMS en OVHcloud con saldo de SMS.
 - Conectarse a la [API de OVHcloud](https://api.ovh.com/) (solo para el método de envío a través de la API).
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
 
 ![área de cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -38,7 +38,7 @@ La validación de las plantillas de mensajes, realizada por el equipo de OVHclou
 
 #### 2.1. Desde el área de cliente
 
-Conéctese al [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external} en la sección `Telecom`{.action}. Haga clic en `SMS`{.action} y seleccione su cuenta de SMS. A continuación, haga clic en la pestaña `Mensaje y campaña`{.action} y, seguidamente, en `Gestión de SMS`{.action}.
+Conéctese al [área de cliente de OVHcloud](/links/manager){.external} en la sección `Telecom`{.action}. Haga clic en `SMS`{.action} y seleccione su cuenta de SMS. A continuación, haga clic en la pestaña `Mensaje y campaña`{.action} y, seguidamente, en `Gestión de SMS`{.action}.
 
 Por último, haga clic en `Gestionar las plantillas`{.action}.
 

--- a/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/guide.fr-fr.md
+++ b/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/guide.fr-fr.md
@@ -12,7 +12,7 @@ L'envoi de SMS aux Etats-Unis est soumis à des règles spécifiques. Ce guide a
 
 - Disposer d’un compte SMS OVHcloud avec des crédits SMS.
 - Être connecté aux [API OVHcloud](https://api.ovh.com/) (uniquement pour la méthode d'envoi via API).
-- Être connecté à l'[espace client OVHcloud](https://www.ovh.com/auth?onsuccess=https%3A%2F%2Fwww.ovhtelecom.fr%2Fmanager&ovhSubsidiary=fr){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
+- Être connecté à l'[espace client OVHcloud](/links/manager-telecom){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
 
 ![espace client Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-fr-sms.png){.thumbnail}
 
@@ -34,7 +34,7 @@ Vous pouvez demander la validation de plusieurs modèles de messages.
 
 #### 2.1 Depuis l'espace client
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth?onsuccess=https%3A%2F%2Fwww.ovhtelecom.fr%2Fmanager&ovhSubsidiary=fr){.external} puis sélectionnez `Télécom`{.action}. Cliquez ensuite sur `SMS`{.action} et choisissez votre compte SMS. Cliquez sur l'onglet `Message et campagne`{.action} (3) puis sur `Gestion des SMS`{.action}. 
+Connectez-vous à votre [espace client OVHcloud](/links/manager-telecom){.external} puis sélectionnez `Télécom`{.action}. Cliquez ensuite sur `SMS`{.action} et choisissez votre compte SMS. Cliquez sur l'onglet `Message et campagne`{.action} (3) puis sur `Gestion des SMS`{.action}. 
 
 Enfin, cliquez sur `Gérer les modèles`{.action}.
 

--- a/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/guide.it-it.md
+++ b/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/guide.it-it.md
@@ -16,7 +16,7 @@ L’invio di SMS negli Stati Uniti è sottoposto a regole specifiche. Questa gui
 
 - Disporre di un account SMS OVHcloud con crediti SMS.
 - Avere accesso alle [API OVHcloud](https://api.ovh.com/)(solo per il metodo di invio via API)
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}, sezione `Télécom`{.action} > `SMS`{.action}
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}, sezione `Télécom`{.action} > `SMS`{.action}
 
 ![Spazio Cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -38,7 +38,7 @@ La convalida dei modelli di messaggi è gratuita e viene effettuata dai team di 
 
 #### 2.1 Dallo Spazio Cliente OVHcloud
 
-Accedi al tuo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external} e seleziona `Télécom`{.action}. Clicca su `SMS`{.action} e seleziona il tuo account SMS. Clicca sulla scheda `Messagio e campagna`{.action} e poi su `Gestisci gli SMS`{.action}.
+Accedi al tuo [Spazio Cliente OVHcloud](/links/manager){.external} e seleziona `Télécom`{.action}. Clicca su `SMS`{.action} e seleziona il tuo account SMS. Clicca sulla scheda `Messagio e campagna`{.action} e poi su `Gestisci gli SMS`{.action}.
 
 Clicca su `Gestisci i modelli`{.action}.
 

--- a/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/guide.pl-pl.md
+++ b/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/guide.pl-pl.md
@@ -16,7 +16,7 @@ Wysyłanie SMS-ów do Stanów Zjednoczonych podlega szczególnym zasadom. Celem 
 
 - Posiadanie konta SMS OVHcloud z kredytami SMS.
 - Zalogowanie do [API OVHcloud](https://api.ovh.com/) (tylko dla metody wysyłki przez API)
-- Zalogowanie do[Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
+- Zalogowanie do[Panelu klienta OVHcloud](/links/manager){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
 
 ![Panel klienta Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -38,7 +38,7 @@ Zatwierdzenie modeli wiadomości jest wykonywane nieodpłatne przez zespoły OVH
 
 #### 2.1 Za pośrednictwem Panelu klienta
 
-Zaloguj się do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external} i wybierz `Telefonia`{.action}. Następnie kliknij `SMS`{.action} i wybierz Twoje konto SMS. Kliknij kartę `Wiadomość SMS i kampania`{.action}, a następnie `Zarządzanie SMS-ami`{.action}.
+Zaloguj się do [Panelu klienta OVHcloud](/links/manager){.external} i wybierz `Telefonia`{.action}. Następnie kliknij `SMS`{.action} i wybierz Twoje konto SMS. Kliknij kartę `Wiadomość SMS i kampania`{.action}, a następnie `Zarządzanie SMS-ami`{.action}.
 
 Następnie kliknij polecenie `Zarządzanie modelami`{.action}.
 

--- a/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/guide.en-gb.md
+++ b/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/guide.en-gb.md
@@ -10,7 +10,7 @@ You can view and download a log of your sent SMS messages from your OVHcloud Con
 ## Requirements
 
 - An OVHcloud SMS account with at least 1 sent SMS.
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![SMS Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -25,7 +25,7 @@ The log records the date, time, sender, recipient and contents of the sent SMS.
 
 ### Step 1: viewing the log in your Control Panel
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account.
+Log in to the [OVHcloud Control Panel](/links/manager), then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account.
 
 In the tab bar, click `Message and campaign`{.action} then `SMS Management`{.action} to access your unit SMS history or `Campaign Management`{.action} to access your SMS campaign history.
 

--- a/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/guide.en-ie.md
+++ b/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/guide.en-ie.md
@@ -10,7 +10,7 @@ You can view and download a log of your sent SMS messages from your OVHcloud Con
 ## Requirements
 
 - An OVHcloud SMS account with at least 1 sent SMS.
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![VoIP Telecom Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -25,7 +25,7 @@ The log records the date, time, sender, recipient and contents of the sent SMS.
 
 ### Step 1: viewing the log in your Control Panel
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account.
+Log in to the [OVHcloud Control Panel](/links/manager), then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account.
 
 In the tab bar, click `Message and campaign`{.action} then `SMS Management`{.action} to access your unit SMS history or `Campaign Management`{.action} to access your SMS campaign history.
 

--- a/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/guide.es-es.md
+++ b/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/guide.es-es.md
@@ -15,7 +15,7 @@ Esta guía explica cómo consultar y descargar el historial de SMS enviados desd
 ## Requisitos
 
 - Tener una cuenta de SMS de OVHcloud con la que haya enviado al menos un SMS.
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
 
 ![área de cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -30,7 +30,7 @@ El historial de envíos incluye información sobre la fecha, el remitente, el de
 
 ### 1. Consultar el historial en el área de cliente
 
-Conéctese a su [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) y seleccione `Telecom`{.action}. Haga clic en `SMS`{.action} y seleccione su cuenta de SMS.
+Conéctese a su [área de cliente de OVHcloud](/links/manager) y seleccione `Telecom`{.action}. Haga clic en `SMS`{.action} y seleccione su cuenta de SMS.
 
 En la barra de pestañas, haga clic en `Mensage y campaña`{.action} y, seguidamente, en `Gestión de SMS`{.action} para acceder al historial de sus SMS unitarios o en `Gestión de campañas`{.action} para acceder al historial de sus campañas de SMS.
 

--- a/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/guide.fr-fr.md
+++ b/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/guide.fr-fr.md
@@ -11,7 +11,7 @@ Votre espace client OVHcloud vous permet de consulter et télécharger l'histori
 ## Prérequis
 
 - Disposer d’un compte SMS OVHcloud avec au moins 1 SMS envoyé.
-- Être connecté à l'[espace client OVHcloud](https://www.ovh.com/auth?onsuccess=https%3A%2F%2Fwww.ovhtelecom.fr%2Fmanager&ovhSubsidiary=fr){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
+- Être connecté à l'[espace client OVHcloud](/links/manager-telecom){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
 
 ![espace client Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-fr-sms.png){.thumbnail}
 
@@ -26,7 +26,7 @@ L'historique comprend la date, l'heure, l'expéditeur, le destinataire ainsi que
 
 ### Étape 1 : consulter l'historique dans votre espace client
 
-Connectez-vous à votre [espace client](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) puis sélectionnez `Télécom`{.action}. Cliquez ensuite sur `SMS`{.action} et choisissez votre compte SMS.
+Connectez-vous à votre [espace client](/links/manager) puis sélectionnez `Télécom`{.action}. Cliquez ensuite sur `SMS`{.action} et choisissez votre compte SMS.
 
 Dans la barre d'onglets, cliquez sur `SMS`{.action} puis sur `Gestions des SMS`{.action} pour accéder à l'historique de vos SMS unitaires ou sur `Gestions des campagnes`{.action} pour accéder à l'historique de vos campagnes de SMS.
 

--- a/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/guide.it-it.md
+++ b/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/guide.it-it.md
@@ -15,7 +15,7 @@ Dallo Spazio Cliente è possibile consultare e scaricare la cronologia degli SMS
 ## Prerequisiti
 
 - Disporre di un account SMS OVHcloud con almeno 1 SMS inviato
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}, sezione `Télécom`{.action} > `SMS`{.action}
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}, sezione `Télécom`{.action} > `SMS`{.action}
 
 ![Spazio Cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -30,7 +30,7 @@ I dettagli elencati nella cronologia includono la data, l’ora, il mittente, il
 
 ### Step 1: consulta la cronologia dal tuo Spazio Cliente
 
-Accedi al tuo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) e seleziona `Telecom`{.action}. Clicca su `SMS`{.action} e seleziona il tuo account SMS.
+Accedi al tuo [Spazio Cliente OVHcloud](/links/manager) e seleziona `Telecom`{.action}. Clicca su `SMS`{.action} e seleziona il tuo account SMS.
 
 Nella barra delle schede, clicca su `Messaggio e campagna`{.action} e poi su `Gestisci gli SMS`{.action} per accedere allo storico dei tuoi SMS unitari o su `Gestisci le campagne`{.action} per accedere allo storico delle tue campagne di SMS.
 

--- a/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/guide.pl-pl.md
+++ b/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/guide.pl-pl.md
@@ -15,7 +15,7 @@ Historię wysłanych wiadomości SMS możesz sprawdzić i pobrać z poziomu Pane
 ## Wymagania początkowe
 
 - Posiadanie konta SMS OVHcloud, z którego wysłano co najmniej jedną wiadomość SMS
-- Zalogowanie do[Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
+- Zalogowanie do[Panelu klienta OVHcloud](/links/manager){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
 
 ![Panel klienta Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -30,7 +30,7 @@ Historia zawiera informacje o dacie, godzinie, nadawcy, odbiorcy oraz treści wy
 
 ### Etap 1: sprawdzanie historii w Panelu klienta
 
-Zaloguj się do [Panelu klienta](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) i wybierz `Telefonia`{.action}. Następnie kliknij `SMS`{.action} i wybierz Twoje konto SMS.
+Zaloguj się do [Panelu klienta](/links/manager) i wybierz `Telefonia`{.action}. Następnie kliknij `SMS`{.action} i wybierz Twoje konto SMS.
 
 Na pasku kart kliknij `Wiadomość SMS i kampania`{.action}, a następnie `Zarządzanie SMS-ami`{.action}, aby uzyskać dostęp do historii Twoich pojedynczych wiadomości SMS lub `Zarządzanie kampaniami`{.action}.
 

--- a/pages/web_cloud/messaging/sms/gerer_les_sms_avec_reponse/guide.fr-fr.md
+++ b/pages/web_cloud/messaging/sms/gerer_les_sms_avec_reponse/guide.fr-fr.md
@@ -20,7 +20,7 @@ Lexpéditeur du SMS réponse sera un numéro court aléatoire. Son utilisation e
 ## Prérequis
 
 - Disposer d’un compte SMS OVHcloud crédité.
-- Être connecté à l'[espace client OVHcloud](https://www.ovh.com/auth?onsuccess=https%3A%2F%2Fwww.ovhtelecom.fr%2Fmanager&ovhSubsidiary=fr){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
+- Être connecté à l'[espace client OVHcloud](/links/manager-telecom){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
 
 ![espace client Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-fr-sms.png){.thumbnail}
 
@@ -48,7 +48,7 @@ La réponse (si vous l'activez) peut être ensuite :
 
 Avant d'envoyer votre SMS réponse, nous vous conseillons de configurer les options de réception des réponses.
 
-Connectez-vous à votre [espace client](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) puis sélectionnez `Télécom`{.action}. Cliquez ensuite sur `SMS`{.action} et choisissez votre compte SMS.
+Connectez-vous à votre [espace client](/links/manager) puis sélectionnez `Télécom`{.action}. Cliquez ensuite sur `SMS`{.action} et choisissez votre compte SMS.
 
 Dans la barre d'onglets, cliquez sur `Options`{.action} puis sur `Options des réponses`{.action}.
 

--- a/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/guide.en-gb.md
+++ b/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/guide.en-gb.md
@@ -12,7 +12,7 @@ All OVHcloud SMS accounts can use one or more address books. This guide explains
 
 - an active OVHcloud SMS account
 - a spreadsheet or text editor tool
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![SMS Telecom Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -20,7 +20,7 @@ All OVHcloud SMS accounts can use one or more address books. This guide explains
 
 ### Step 1: Create an address book via the OVHcloud Control Panel
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), and go to the `Telecom`{.action} section. Next, select `SMS`{.action}.
+Log in to the [OVHcloud Control Panel](/links/manager), and go to the `Telecom`{.action} section. Next, select `SMS`{.action}.
 
 Click on the SMS account concerned, and select the `Contacts`{.action} tab, then `Address book`{.action}.
 

--- a/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/guide.en-ie.md
+++ b/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/guide.en-ie.md
@@ -12,7 +12,7 @@ All OVHcloud SMS accounts can use one or more address books. This guide explains
 
 - an active OVHcloud SMS account
 - a spreadsheet or text editor tool
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![SMS Telecom Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -20,7 +20,7 @@ All OVHcloud SMS accounts can use one or more address books. This guide explains
 
 ### Step 1: Create an address book via the OVHcloud Control Panel
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), and go to the `Telecom`{.action} section. Next, select `SMS`{.action}.
+Log in to the [OVHcloud Control Panel](/links/manager), and go to the `Telecom`{.action} section. Next, select `SMS`{.action}.
 
 Click on the SMS account concerned, and select the `Contacts`{.action} tab, then `Address book`{.action}.
 

--- a/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/guide.es-es.md
+++ b/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/guide.es-es.md
@@ -16,7 +16,7 @@ Todas las cuentas de SMS de OVHcloud permiten utilizar una o varias agendas de c
 
 - Disponer de una cuenta de SMS en OVHcloud.
 - Tener un programa de hojas de cálculo o un editor de texto.
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
 
 ![área de cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -24,7 +24,7 @@ Todas las cuentas de SMS de OVHcloud permiten utilizar una o varias agendas de c
 
 ### 1. Crear una agenda de contactos en el área de cliente
 
-Conéctese al [área de cliente de OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es), en la pestaña `Telecom`{.action}. A continuación, haga clic en `SMS`{.action} en la columna izquierda
+Conéctese al [área de cliente de OVH](/links/manager), en la pestaña `Telecom`{.action}. A continuación, haga clic en `SMS`{.action} en la columna izquierda
 
 Haga clic en la cuenta de SMS correspondiente y seleccione la pestaña `Contactos`{.action} y luego `Agenda de contactos`{.action}.
 

--- a/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/guide.fr-fr.md
+++ b/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/guide.fr-fr.md
@@ -12,7 +12,7 @@ Tous les comptes SMS OVHcloud peuvent utiliser un ou plusieurs carnets d'adresse
 
 - Disposer d'un compte SMS OVHcloud.
 - Disposer d'un outil de type tableur ou éditeur de texte.
-- Être connecté à l'[espace client OVHcloud](https://www.ovh.com/auth?onsuccess=https%3A%2F%2Fwww.ovhtelecom.fr%2Fmanager&ovhSubsidiary=fr){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
+- Être connecté à l'[espace client OVHcloud](/links/manager-telecom){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
 
 ![espace client Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-fr-sms.png){.thumbnail}
 
@@ -20,7 +20,7 @@ Tous les comptes SMS OVHcloud peuvent utiliser un ou plusieurs carnets d'adresse
 
 ### Étape 1 : créer un carnet d'adresses dans votre espace client
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr), rubrique `Telecom`. Sélectionnez ensuite `SMS`{.action}.
+Connectez-vous à votre [espace client OVHcloud](/links/manager), rubrique `Telecom`. Sélectionnez ensuite `SMS`{.action}.
 
 Cliquez sur le compte SMS souhaité et choisissez l'onglet `Contacts`{.action} puis `Carnet d'adresses`{.action}.
 

--- a/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/guide.it-it.md
+++ b/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/guide.it-it.md
@@ -16,7 +16,7 @@ Tutti gli account SMS OVHcloud possono utilizzare una o più rubriche. Questa gu
 
 - Disporre di un account SMS OVHcloud attivo
 - Disporre di un programma di fogli di calcolo o un editor di testo
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}, sezione `Télécom`{.action} > `SMS`{.action}
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}, sezione `Télécom`{.action} > `SMS`{.action}
 
 ![Spazio Cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -24,7 +24,7 @@ Tutti gli account SMS OVHcloud possono utilizzare una o più rubriche. Questa gu
 
 ### Step 1: crea una rubrica di contatti nel tuo Spazio Cliente
 
-Accedi allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it). Quindi seleziona `SMS`{.action}.
+Accedi allo [Spazio Cliente OVHcloud](/links/manager). Quindi seleziona `SMS`{.action}.
 
 Clicca sull'account SMS interessato e seleziona `Contatti`{.action} > `Rubrica`{.action}.
 

--- a/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/guide.pl-pl.md
+++ b/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/guide.pl-pl.md
@@ -16,7 +16,7 @@ Wszystkie konta OVHcloud mogą używać jednej lub więcej książek adresowych.
 
 - Posiadanie aktywnego konta SMS OVHcloud.
 - Posiadanie arkusza kalkulacyjnego lub edytora tekstu.
-- Zalogowanie do[Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
+- Zalogowanie do[Panelu klienta OVHcloud](/links/manager){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
 
 ![Panel klienta Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -24,7 +24,7 @@ Wszystkie konta OVHcloud mogą używać jednej lub więcej książek adresowych.
 
 ### Etap 1: tworzenie książki adresowej w Panelu klienta
 
-Zaloguj się do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) i przejdź do rubryki `Telefonia`{.action}. Następnie z menu po lewej stronie wybierz `SMS`{.action}.
+Zaloguj się do [Panelu klienta OVHcloud](/links/manager) i przejdź do rubryki `Telefonia`{.action}. Następnie z menu po lewej stronie wybierz `SMS`{.action}.
 
 Kliknij żądane konto SMS i wybierz kartę `Kontakty`{.action}, a następnie `Książka adresowa`{.action}.
 

--- a/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/guide.en-gb.md
+++ b/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/guide.en-gb.md
@@ -14,7 +14,7 @@ To send an SMS campaign to multiple contacts, you can import one or more recipie
 
 - an active OVHcloud SMS account
 - a spreadsheet or text editor tool
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![SMS Telecom Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -64,7 +64,7 @@ You should end up with the result below:
 
 ### Step 2: Importing your list into the OVHcloud Control Panel
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), then select `Telecom`{.action}. Next, select `SMS`{.action}.
+Log in to the [OVHcloud Control Panel](/links/manager), then select `Telecom`{.action}. Next, select `SMS`{.action}.
 
 Select your SMS account, then click on the `Contacts`{.action} tab and `Create a contact`{.action} list.
 

--- a/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/guide.en-ie.md
+++ b/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/guide.en-ie.md
@@ -14,7 +14,7 @@ To send an SMS campaign to multiple contacts, you can import one or more recipie
 
 - an active OVHcloud SMS account
 - a spreadsheet or text editor tool
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![SMS Telecom Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -64,7 +64,7 @@ You should end up with the result below:
 
 ### Step 2: Importing your list into the OVHcloud Control Panel
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), then select `Telecom`{.action}. Next, select `SMS`{.action}.
+Log in to the [OVHcloud Control Panel](/links/manager), then select `Telecom`{.action}. Next, select `SMS`{.action}.
 
 Select your SMS account, then click on the `Contacts`{.action} tab and `Create a contact`{.action} list.
 

--- a/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/guide.es-es.md
+++ b/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/guide.es-es.md
@@ -18,7 +18,7 @@ Para enviar una campaña de SMS a múltiples contactos, puede importar una o má
 
 - Disponer de una cuenta de SMS en OVHcloud.
 - Tener un programa de hojas de cálculo o un editor de texto.
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
 
 ![área de cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -68,7 +68,7 @@ El resultado debería ser como el siguiente:
 
 ### 2. Importar la lista en el área de cliente de OVHcloud
 
-Conéctese al [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) y haga clic en la sección `Telecom`{.action}. A continuación, haga clic en `SMS`{.action}.
+Conéctese al [área de cliente de OVHcloud](/links/manager) y haga clic en la sección `Telecom`{.action}. A continuación, haga clic en `SMS`{.action}.
 
 Seleccione su cuenta de SMS y haga clic en la pestaña `Contactos`{.action} y en `Crear una lista de contactos`{.action}.
 

--- a/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/guide.fr-fr.md
+++ b/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/guide.fr-fr.md
@@ -14,7 +14,7 @@ Afin d'envoyer une campagne de SMS à de multiples contacts, vous pouvez importe
 
 - Disposer d’un compte SMS OVHcloud
 - Disposer d'un outil de type tableur ou éditeur de texte
-- Être connecté à l'[espace client OVHcloud](https://www.ovh.com/auth?onsuccess=https%3A%2F%2Fwww.ovhtelecom.fr%2Fmanager&ovhSubsidiary=fr){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
+- Être connecté à l'[espace client OVHcloud](/links/manager-telecom){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
 
 ![espace client Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-fr-sms.png){.thumbnail}
 
@@ -64,7 +64,7 @@ Vous devriez obtenir le résultat ci-dessous :
 
 ### Étape 2 : importer votre liste dans l'espace client OVHcloud
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) puis sélectionnez `Telecom`{.action}. Sélectionnez ensuite `SMS`{.action}.
+Connectez-vous à votre [espace client OVHcloud](/links/manager) puis sélectionnez `Telecom`{.action}. Sélectionnez ensuite `SMS`{.action}.
 
 Sélectionnez votre compte SMS puis cliquez sur l'onglet `Contacts`{.action} et sur `Créer une liste de contacts`{.action}.
 

--- a/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/guide.it-it.md
+++ b/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/guide.it-it.md
@@ -18,7 +18,7 @@ Per inviare una campagna SMS a contatti multipli, è possibile importare una o p
 
 - Disporre di un account SMS OVHcloud attivo
 - Disporre di un programma di fogli di calcolo o un editor di testo
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}, sezione `Télécom`{.action} > `SMS`{.action}
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}, sezione `Télécom`{.action} > `SMS`{.action}
 
 ![Spazio Cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -68,7 +68,7 @@ Il risultato ottenuto dovrebbe essere di questo tipo:
 
 ### Step 2: importare la tua lista dallo Spazio Cliente OVHcloud
 
-Accedi allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) e seleziona `Telecom`. Quindi seleziona `SMS`{.action}.
+Accedi allo [Spazio Cliente OVHcloud](/links/manager) e seleziona `Telecom`. Quindi seleziona `SMS`{.action}.
 
 Seleziona il tuo account SMS e clicca sulla scheda `Contatti`{.action} e su `Crea una lista di contatti`{.action}.
 

--- a/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/guide.pl-pl.md
+++ b/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/guide.pl-pl.md
@@ -16,7 +16,7 @@ Wszystkie konta SMS OVHcloud mogą używać jednej lub kilku list odbiorców. Z 
 
 - Posiadanie aktywnego konta SMS OVHcloud
 - Posiadanie narzędzia typu arkusz kalkulacyjny lub edytor tekstu
-- Zalogowanie do[Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
+- Zalogowanie do[Panelu klienta OVHcloud](/links/manager){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
 
 ![Panel klienta Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -66,7 +66,7 @@ Otrzymany rezultat powinien wyglądać następująco:
 
 ### Etap 2: zaimportować listę do Panelu klienta OVHcloud
 
-Zaloguj się do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) i wybierz opcję `Telecom`{.action}. Następnie z menu po lewej stronie wybierz `SMS`{.action}.
+Zaloguj się do [Panelu klienta OVHcloud](/links/manager) i wybierz opcję `Telecom`{.action}. Następnie z menu po lewej stronie wybierz `SMS`{.action}.
 
 Wybierz konto SMS, następnie kliknij zakładkę `Kontakty`{.action} i `Utwórz listę kontaktów`{.action}.
 

--- a/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/guide.en-gb.md
+++ b/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/guide.en-gb.md
@@ -11,13 +11,13 @@ OVHcloud provides tools integrated into the OVHcloud Control Panel, for sending 
 ## Requirements
 
 - an OVHcloud SMS account with SMS credits
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![SMS Telecom Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account.
+Log in to the [OVHcloud Control Panel](/links/manager), then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account.
 
 The toolbar and shortcuts will give you access to the main features for sending SMS campaigns.
 

--- a/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/guide.en-ie.md
+++ b/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/guide.en-ie.md
@@ -11,13 +11,13 @@ OVHcloud provides tools integrated into the OVHcloud Control Panel, for sending 
 ## Requirements
 
 - an OVHcloud SMS account with SMS credits
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![SMS Telecom Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
 ## Instructions
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account.
+Log in to the [OVHcloud Control Panel](/links/manager), then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account.
 
 The toolbar and shortcuts will give you access to the main features for sending SMS campaigns.
 

--- a/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/guide.es-es.md
+++ b/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/guide.es-es.md
@@ -15,13 +15,13 @@ OVHcloud ofrece una serie de herramientas, disponibles en el área de cliente, q
 ## Requisitos
 
 - Disponer de una cuenta de SMS en OVHcloud con saldo de SMS.
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
 
 ![área de cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
 ## Procedimiento
 
-Conéctese al [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) y seleccione `Telecom`{.action}. Haga clic en `SMS`{.action} y seleccione su cuenta de SMS.
+Conéctese al [área de cliente de OVHcloud](/links/manager) y seleccione `Telecom`{.action}. Haga clic en `SMS`{.action} y seleccione su cuenta de SMS.
 
 La barra de herramientas y los accesos rápidos le permitirán acceder a las principales funcionalidades para enviar su campaña de SMS.
 

--- a/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/guide.fr-fr.md
+++ b/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/guide.fr-fr.md
@@ -11,13 +11,13 @@ OVHcloud met à votre disposition des outils intégrés à votre espace client a
 ## Prérequis
 
 - Disposer d’un compte SMS OVHcloud avec des crédits SMS.
-- Être connecté à l'[espace client OVHcloud](https://www.ovh.com/auth?onsuccess=https%3A%2F%2Fwww.ovhtelecom.fr%2Fmanager&ovhSubsidiary=fr){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
+- Être connecté à l'[espace client OVHcloud](/links/manager-telecom){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
 
 ![espace client Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-fr-sms.png){.thumbnail}
 
 ## En pratique
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) puis sélectionnez `Télécom`{.action}. Cliquez ensuite sur `SMS`{.action} puis choisissez votre compte SMS .
+Connectez-vous à votre [espace client OVHcloud](/links/manager) puis sélectionnez `Télécom`{.action}. Cliquez ensuite sur `SMS`{.action} puis choisissez votre compte SMS .
 
 La barre d'outils ainsi que les raccourcis vous permettront d'accéder aux fonctionnalités principales pour envoyer votre campagne de SMS.
 

--- a/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/guide.it-it.md
+++ b/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/guide.it-it.md
@@ -15,13 +15,13 @@ OVHcloud mette a tua disposizione strumenti integrati nello Spazio Cliente per l
 ## Prerequisiti
 
 - Disporre di un account SMS OVHcloud con saldo SMS.
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}, sezione `Telecom`{.action} > `SMS`{.action}
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}, sezione `Telecom`{.action} > `SMS`{.action}
 
 ![Spazio Cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
 ## Procedura
 
-Accedi allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) e seleziona `Telecom`{.action}. Clicca su `SMS`{.action} e poi seleziona il tuo account SMS.
+Accedi allo [Spazio Cliente OVHcloud](/links/manager) e seleziona `Telecom`{.action}. Clicca su `SMS`{.action} e poi seleziona il tuo account SMS.
 
 La barra degli strumenti e le scorciatoie ti permetteranno di accedere alle funzionalità principali per inviare la tua campagna di SMS.
 

--- a/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/guide.pl-pl.md
+++ b/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/guide.pl-pl.md
@@ -15,13 +15,13 @@ OVHcloud udostępnia Ci zintegrowane z Panelem klienta narzędzia umożliwiając
 ## Wymagania początkowe
 
 - Posiadanie konta SMS OVHcloud z zasileniami SMS
-- Zalogowanie do[Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
+- Zalogowanie do[Panelu klienta OVHcloud](/links/manager){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
 
 ![Panel klienta Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
 ## W praktyce
 
-Zaloguj się do Panelu [klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) i wybierz `Telefonia`{.action}. Następnie kliknij pozycję `SMS`{.action} po lewej stronie, po czym wybierz Twoje konto SMS.
+Zaloguj się do Panelu [klienta OVHcloud](/links/manager) i wybierz `Telefonia`{.action}. Następnie kliknij pozycję `SMS`{.action} po lewej stronie, po czym wybierz Twoje konto SMS.
 
 Pasek narzędzi oraz skróty ułatwiają dostęp do głównych funkcji służących do wysyłania kampanii SMS.
 

--- a/pages/web_cloud/messaging/sms/smpp-control-panel/guide.en-gb.md
+++ b/pages/web_cloud/messaging/sms/smpp-control-panel/guide.en-gb.md
@@ -17,7 +17,7 @@ In the OVHcloud Control Panel, you can retrieve your SMPP credentials, change yo
 ## Requirements
 
 - an [OVHcloud SMS SMPP account](https://www.ovhcloud.com/en-gb/sms/api-sms/)
-- Access to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) in the `Telecom`{.action} section, then `SMS`{.action}.
+- Access to your [OVHcloud Control Panel](/links/manager) in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ## Instructions
 

--- a/pages/web_cloud/messaging/sms/smpp-control-panel/guide.en-ie.md
+++ b/pages/web_cloud/messaging/sms/smpp-control-panel/guide.en-ie.md
@@ -17,7 +17,7 @@ In the OVHcloud Control Panel, you can retrieve your SMPP credentials, change yo
 ## Requirements
 
 - an [OVHcloud SMS SMPP account](https://www.ovhcloud.com/en-ie/sms/api-sms/)
-- Access to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) in the `Telecom`{.action} section, then `SMS`{.action}.
+- Access to your [OVHcloud Control Panel](/links/manager) in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ## Instructions
 

--- a/pages/web_cloud/messaging/sms/smpp-control-panel/guide.es-es.md
+++ b/pages/web_cloud/messaging/sms/smpp-control-panel/guide.es-es.md
@@ -21,7 +21,7 @@ Desde el área de cliente de OVHcloud podrá encontrar las claves SMPP, cambiar 
 ## Requisitos
 
 - Disponer de [una cuenta SMS SMPP OVHcloud](https://www.ovhcloud.com/es-es/sms/api-sms/).
-- Estar conectado a su [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) en la sección `Telecom`{.action} > `SMS`{.action}.
+- Estar conectado a su [área de cliente de OVHcloud](/links/manager) en la sección `Telecom`{.action} > `SMS`{.action}.
 
 ## Procedimiento
 

--- a/pages/web_cloud/messaging/sms/smpp-control-panel/guide.fr-fr.md
+++ b/pages/web_cloud/messaging/sms/smpp-control-panel/guide.fr-fr.md
@@ -17,7 +17,7 @@ L'espace client OVHcloud vous permet de retrouver vos identifiants SMPP, modifie
 ## Prérequis
 
 - Disposer d’un [compte SMS SMPP OVHcloud](https://www.ovhcloud.com/fr/sms/api-sms/).
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) dans la partie `Télécom`{.action} puis `SMS`{.action}.
+- Être connecté à votre [espace client OVHcloud](/links/manager) dans la partie `Télécom`{.action} puis `SMS`{.action}.
 
 ## En pratique
 

--- a/pages/web_cloud/messaging/sms/smpp-control-panel/guide.it-it.md
+++ b/pages/web_cloud/messaging/sms/smpp-control-panel/guide.it-it.md
@@ -22,7 +22,7 @@ Lo Spazio Cliente OVHcloud permette di recuperare le credenziali SMPP, modificar
 ## Prerequisiti
 
 - Disporre di un [account SMS SMPP OVHcloud](https://www.ovhcloud.com/it/sms/api-sms/)
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) nella sezione `Telecom`{.action} > `SMS`{.action}
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager) nella sezione `Telecom`{.action} > `SMS`{.action}
 
 ## Procedura
 

--- a/pages/web_cloud/messaging/sms/smpp-control-panel/guide.pl-pl.md
+++ b/pages/web_cloud/messaging/sms/smpp-control-panel/guide.pl-pl.md
@@ -21,7 +21,7 @@ W Panelu klienta OVHcloud możesz odnaleźć dane do logowania SMPP, zmienić ha
 ## Wymagania początkowe
 
 - Posiadanie [konta SMS SMPP OVHcloud](https://www.ovhcloud.com/pl/sms/api-sms/)
-- Zalogowanie do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) w części `Telecom`{.action} następnie `SMS`{.action}.
+- Zalogowanie do [Panelu klienta OVHcloud](/links/manager) w części `Telecom`{.action} następnie `SMS`{.action}.
 
 ## W praktyce
 

--- a/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/guide.en-gb.md
+++ b/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/guide.en-gb.md
@@ -11,7 +11,7 @@ This guide will explain how to create and manage API users.
 ## Requirements
 
 - an active OVHcloud SMS account
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![SMS Telecom Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -38,7 +38,7 @@ To better manage credit for your SMS accounts, you can set a limit and quota for
 
 ### Step 1: Create an API user.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account.
+Log in to the [OVHcloud Control Panel](/links/manager), then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account.
 
 Then click on the `API users`{.action} tab. To add a user, click `Actions`{.action}, then `Add`{.action}.
 

--- a/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/guide.en-ie.md
+++ b/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/guide.en-ie.md
@@ -11,7 +11,7 @@ This guide will explain how to create and manage API users.
 ## Requirements
 
 - an active OVHcloud SMS account
-- You must be logged in to [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
+- You must be logged in to [OVHcloud Control Panel](/links/manager){.external}, in the `Telecom`{.action} section, then `SMS`{.action}.
 
 ![SMS Telecom Control Panel](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -38,7 +38,7 @@ To better manage credit for your SMS accounts, you can set a limit and quota for
 
 ### Step 1: Create an API user
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account.
+Log in to the [OVHcloud Control Panel](/links/manager), then select `Telecom`{.action}. Next, click `SMS`{.action} and select your SMS account.
 
 Then click on the `API users`{.action} tab. To add a user, click `Actions`{.action}, then `Add`{.action}.
 

--- a/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/guide.es-es.md
+++ b/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/guide.es-es.md
@@ -15,7 +15,7 @@ Esta guía explica cómo crear y gestionar usuarios de la API de SMS.
 ## Requisitos
 
 - Disponer de una cuenta de SMS en OVHcloud.
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}, en la sección `Telecom`{.action}{.action} > `SMS`{.action}.
 
 ![área de cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -41,7 +41,7 @@ Para gestionar mejor el saldo de su cuenta de SMS, es posible aplicar un límite
 
 ### 1. Crear un usuario de la API
 
-Conéctese al [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) en la sección `Telecom`{.action}. A continuación, haga clic en `SMS`{.action} y seleccione su cuenta de SMS.
+Conéctese al [área de cliente de OVHcloud](/links/manager) en la sección `Telecom`{.action}. A continuación, haga clic en `SMS`{.action} y seleccione su cuenta de SMS.
 
 Por último, abra la pestaña `Usuarios API`{.action}. Para añadir un usuario, haga clic en el botón `Acciones`{.action} y seleccione `Añadir`{.action}.
 

--- a/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/guide.fr-fr.md
+++ b/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/guide.fr-fr.md
@@ -11,7 +11,7 @@ Ce guide vous explique comment créer et gérer des utilisateurs API.
 ## Prérequis
 
 - Disposer d'un compte SMS OVHcloud
-- Être connecté à l'[espace client OVHcloud](https://www.ovh.com/auth?onsuccess=https%3A%2F%2Fwww.ovhtelecom.fr%2Fmanager&ovhSubsidiary=fr){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
+- Être connecté à l'[espace client OVHcloud](/links/manager-telecom){.external}, partie `Télécom`{.action} puis `SMS`{.action}.
 
 ![espace client Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-fr-sms.png){.thumbnail}
 
@@ -38,7 +38,7 @@ Afin de gérer au mieux le crédit de votre compte SMS, il est possible de fixer
 
 ### Étape 1 : créer un utilisateur API
 
-Connectez-vous à votre [espace client](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr), puis sélectionnez `Télécom`{.action}. Cliquez ensuite sur `SMS`{.action} et choisissez votre compte SMS.
+Connectez-vous à votre [espace client](/links/manager), puis sélectionnez `Télécom`{.action}. Cliquez ensuite sur `SMS`{.action} et choisissez votre compte SMS.
 
 Cliquez sur l'onglet `Utilisateurs API`{.action}. Pour ajouter un utilisateur, cliquez sur le bouton `Actions`{.action} puis sur `Ajouter`{.action}.
 

--- a/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/guide.it-it.md
+++ b/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/guide.it-it.md
@@ -15,7 +15,7 @@ Questa guida ti mostra come creare e aggiungere utenti API.
 ## Prerequisiti
 
 - Disporre di un account SMS OVHcloud attivo
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}, sezione `Télécom`{.action} > `SMS`{.action}
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}, sezione `Télécom`{.action} > `SMS`{.action}
 
 ![Spazio Cliente Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -42,7 +42,7 @@ Per gestire al meglio il saldo del tuo account SMS, puoi fissare un limite e una
 
 ### Step 1: crea un utente API
 
-Accedi allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) e seleziona `Telecom`{.action}. Poi clicca su `SMS`{.action} e seleziona il tuo account SMS.
+Accedi allo [Spazio Cliente OVHcloud](/links/manager) e seleziona `Telecom`{.action}. Poi clicca su `SMS`{.action} e seleziona il tuo account SMS.
 
 Infine clicca sulla scheda `Utenti API`{.action}. Per aggiungere un utente, clicca sul pulsante `Azioni`{.action} e poi su `Aggiungi`{.action}.
 

--- a/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/guide.pl-pl.md
+++ b/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/guide.pl-pl.md
@@ -15,7 +15,7 @@ Niniejszy przewodnik wyjaśnia, jak tworzyć użytkowników API i zarządzać ni
 ## Wymagania początkowe
 
 - Posiadanie aktywnego konta SMS OVHcloud
-- Zalogowanie do[Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
+- Zalogowanie do[Panelu klienta OVHcloud](/links/manager){.external}, część `Telefonia`{.action}, następnie `SMS`{.action}.
 
 ![Panel klienta Telecom SMS](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-03-en-sms.png){.thumbnail}
 
@@ -42,7 +42,7 @@ Aby jak najlepiej zarządzać zasileniami konta SMS, możesz ustalić ograniczen
 
 ### Etap 1: utworzenie użytkownika API
 
-Zaloguj się do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) i wybierz opcję `Telefonia`{.action}. Następnie kliknij pozycję `SMS`{.action} po lewej stronie i wybierz Twoje konto SMS.
+Zaloguj się do [Panelu klienta OVHcloud](/links/manager) i wybierz opcję `Telefonia`{.action}. Następnie kliknij pozycję `SMS`{.action} po lewej stronie i wybierz Twoje konto SMS.
 
 Teraz kliknij kartę `Użytkownicy API`{.action}. Aby dodać użytkownika, kliknij przycisk `Działania`{.action}, a następnie `Dodaj`{.action}.
 

--- a/pages/web_cloud/phone_and_fax/fax/fax-faq/guide.fr-fr.md
+++ b/pages/web_cloud/phone_and_fax/fax/fax-faq/guide.fr-fr.md
@@ -10,7 +10,7 @@ Retrouvez ici les questions les plus fréquemment posées sur le service Fax OVH
 
 ### Comment commander des fax ?
 
-Pour envoyer des fax, vous devez d'abord disposer d'une ligne Fax dédiée à cet usage. Choisissez votre offre depuis notre page <https://www.ovhtelecom.fr/fax/> et votre ligne fax sera activée dans l'espace client à l'issue de la commande.<br>
+Pour envoyer des fax, vous devez d'abord disposer d'une ligne Fax dédiée à cet usage. Choisissez votre offre depuis notre page </links/telecom/fax> et votre ligne fax sera activée dans l'espace client à l'issue de la commande.<br>
 Par la suite, vous n'avez pas à commander de fax. Chaque envoi de fax vous sera facturé à hauteur du nombre de destinataires compris dans votre campagne de fax.
 
 ### Pourquoi mon Fax est-il en attente ?

--- a/pages/web_cloud/phone_and_fax/voip/gerer-utiliser-appels-simultanes/guide.fr-fr.md
+++ b/pages/web_cloud/phone_and_fax/voip/gerer-utiliser-appels-simultanes/guide.fr-fr.md
@@ -31,7 +31,7 @@ Votre ligne téléphonique chez OVHcloud vous permet de recevoir et d'émettre d
 
 La page qui s'affiche vous permet de visualiser le nombre d'appels simultanés inclus dans votre offre ou en option sur votre ligne. Selon vos besoins, vous avez la possibilité d'augmenter ou de diminuer ce nombre en utilisant les flèches à droite du nombre actuel d'appels simultanés. Avant d'entamer toute démarche, nous vous recommandons de vous assurer que :
 
-- le téléphone sur lequel est configurée votre ligne est apte à gérer le nombre d'appels simultanés dont vous souhaitez bénéficier. Retrouvez plus d'informations sur les téléphones depuis le lien : <https://www.ovhtelecom.fr/telephonie/comparatif-des-telephones.xml> ;
+- le téléphone sur lequel est configurée votre ligne est apte à gérer le nombre d'appels simultanés dont vous souhaitez bénéficier. Retrouvez plus d'informations sur les téléphones depuis le lien : </links/telecom/telephonie-comparatif-telephones> ;
 - la bande passante de votre connexion internet est suffisamment dimensionnée pour gérer le nombre d'appels simultanés dont vous souhaitez bénéficier. Pour une utilisation optimale, une bande passante comprise entre 70 et 100 Kbit/s est requise par appel simultané.
 
 Dès que vous êtes prêt, modifiez le nombre d'appels simultanés grâce aux flèches, puis suivez les étapes qui s'affichent. Pour chaque ajout, n'oubliez pas de payer le bon de commande qui s'affichera.

--- a/pages/web_cloud/web_hosting/manage-runtime/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/manage-runtime/guide.en-ie.md
@@ -19,7 +19,7 @@ With a Cloud Web hosting plan, you can choose from a range of different coding l
 
 With Cloud Web, you can pick from one or more runtime environments that are best adapted to your project. The runtime environment you choose will depend on the kind of project you want to set up. 
 
-So if you have not done so yet, **please ensure that your project is compatible with your Cloud Web hosting plan**. The available coding languages are listed here: <https://www.ovhcloud.com/en-gb/web-hosting/cloud-web-offer/>.Once you have chosen the exact runtime environments you will use, you can start following the steps below.
+So if you have not done so yet, **please ensure that your project is compatible with your Cloud Web hosting plan**. The available coding languages are listed here: </links/web/hosting-cloud-web-offer>.Once you have chosen the exact runtime environments you will use, you can start following the steps below.
 
 ### Step 1: Access the runtime environment management interface.
 

--- a/pages/web_cloud/web_hosting/manage-runtime/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/manage-runtime/guide.es-es.md
@@ -19,7 +19,7 @@ Cloud Web ofrece la posibilidad de utilizar distintos lenguajes de programación
 
 Para adaptarse a todos los proyectos de forma óptima, los planes de alojamiento Cloud Web le permiten disponer de uno o varios motores de ejecución. Por lo tanto, la elección de uno u otro dependerá de lo que desee instrumentar. 
 
-Así pues, **si aún no lo ha hecho, asegúrese de que su proyecto sea técnicamente compatible con su alojamiento Cloud Web**. Puede consultar los lenguajes compatibles visitando el siguiente enlace: <https://www.ovhcloud.com/es-es/web-hosting/cloud-web-offer/>.Una vez que sepa exactamente qué motor o motores de ejecución debe utilizar, puede realizar las acciones que se detallan a continuación.
+Así pues, **si aún no lo ha hecho, asegúrese de que su proyecto sea técnicamente compatible con su alojamiento Cloud Web**. Puede consultar los lenguajes compatibles visitando el siguiente enlace: </links/web/hosting-cloud-web-offer>.Una vez que sepa exactamente qué motor o motores de ejecución debe utilizar, puede realizar las acciones que se detallan a continuación.
 
 ### Etapa 1:  acceder a la gestión de los motores de ejecución
 

--- a/pages/web_cloud/web_hosting/manage-runtime/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/manage-runtime/guide.fr-fr.md
@@ -19,7 +19,7 @@ Cloud Web met à disposition de multiples langages de développement pour constr
 
 Afin de s'adapter au mieux à votre projet, Cloud Web vous permet de disposer d'un ou de plusieurs moteurs d'exécution. L'utilisation de l'un plutôt qu'un autre dépend alors de ce que vous souhaitez mettre en place. 
 
-Ainsi, si ce n'est pas encore fait, **assurez-vous de la compatibilité technique de votre projet avec votre hébergement Cloud Web**. Les langages sont listés à cette adresse : <https://www.ovhcloud.com/fr/web-hosting/cloud-web-offer/>.Après avoir déterminé avec précision le ou les moteurs d'exécution à utiliser, vous pouvez débuter les manipulations décrites ci-dessous.
+Ainsi, si ce n'est pas encore fait, **assurez-vous de la compatibilité technique de votre projet avec votre hébergement Cloud Web**. Les langages sont listés à cette adresse : </links/web/hosting-cloud-web-offer>.Après avoir déterminé avec précision le ou les moteurs d'exécution à utiliser, vous pouvez débuter les manipulations décrites ci-dessous.
 
 ### Étape 1 : accéder à la gestion des moteurs d'exécution
 

--- a/pages/web_cloud/web_hosting/manage-runtime/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/manage-runtime/guide.it-it.md
@@ -19,7 +19,7 @@ Cloud Web mette a tua disposizione diversi linguaggi di programmazione per conse
 
 Per adattarsi al maggior numero di utilizzi possibile, la soluzione di hosting Cloud Web permette di disporre di uno o più motori di esecuzione, ognuno dei quali risponde a esigenze specifiche di ciascun progetto. 
 
-Per prima cosa, **assicurati che il tuo progetto sia tecnicamente compatibile con il tuo hosting Cloud Web**. La lista dei linguaggi compatibili è disponibile all’indirizzo <https://www.ovhcloud.com/it/web-hosting/cloud-web-offer/> 
+Per prima cosa, **assicurati che il tuo progetto sia tecnicamente compatibile con il tuo hosting Cloud Web**. La lista dei linguaggi compatibili è disponibile all’indirizzo </links/web/hosting-cloud-web-offer> 
 
 Una volta indicati i motori di esecuzione da utilizzare, segui la procedura descritta in questa guida. 
 

--- a/pages/web_cloud/web_hosting/manage-runtime/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/manage-runtime/guide.pl-pl.md
@@ -19,7 +19,7 @@ W ramach Cloud Web udostępniamy różne języki programowania do tworzenia Twoj
 
 W ramach Cloud Web możesz użyć jednego lub kilku frameworków. Wybór odpowiedniego frameworku będzie zatem zależał od efektu, jaki chcesz uzyskać. 
 
-Dlatego, jeśli jeszcze tego nie zrobiłeś **upewnij się, czy Twój projekt jest kompatybilny pod względem technicznym z Twoim hostingiem Cloud Web**. Lista języków programowania znajduje się tutaj: <https://www.ovhcloud.com/pl/web-hosting/cloud-web-offer/>.Po dokładnym wskazaniu frameworku lub frameworków, których będziesz używał, możesz rozpocząć operacje opisane poniżej.
+Dlatego, jeśli jeszcze tego nie zrobiłeś **upewnij się, czy Twój projekt jest kompatybilny pod względem technicznym z Twoim hostingiem Cloud Web**. Lista języków programowania znajduje się tutaj: </links/web/hosting-cloud-web-offer>.Po dokładnym wskazaniu frameworku lub frameworków, których będziesz używał, możesz rozpocząć operacje opisane poniżej.
 
 ### Etap 1: dostęp do zarządzania frameworkami
 

--- a/pages/web_cloud/web_hosting/manage-runtime/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/manage-runtime/guide.pt-pt.md
@@ -19,7 +19,7 @@ A Cloud Web oferece a possibilidade de construir um projeto em diferentes lingua
 
 Para melhor se adaptar ao seu projeto, a Cloud Web permite-lhe dispor de um ou vários motores de execução. A utilização de um ou outro motor de execução dependerá das necessidades específicas de cada projeto. 
 
-Desta forma, em primeiro lugar, **certifique-se de que o seu projeto é tecnicamente compatível com o seu alojamento Cloud Web**. Pode consultar as linguagens compatíveis na seguinte ligação: <https://www.ovhcloud.com/pt/web-hosting/cloud-web-offer/> 
+Desta forma, em primeiro lugar, **certifique-se de que o seu projeto é tecnicamente compatível com o seu alojamento Cloud Web**. Pode consultar as linguagens compatíveis na seguinte ligação: </links/web/hosting-cloud-web-offer> 
 
 Depois de escolher o ou os motores de execução que pretende utilizar, pode efetuar as seguintes ações:
 


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their `/links` values.

*Example: replace all `https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB` links with `/links/manager`*.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.

@Y0Coss no need for the `Fix` label, maybe `Minor Update` and even then, I'll let you be the judge.
