### PR TITLE
Fix global links in Bare metal cloud dedicated servers

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.de-de.md
@@ -16,9 +16,9 @@ updated: 2020-08-17
 - Eine Shell mit Root-Rechten ausführen
 
 > [!warning]
-> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](https://eco.ovhcloud.com/de/about/) eingesetzt wird.
+> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](/links/bare-metal/eco-about) eingesetzt wird.
 >
-> Weitere Informationen finden Sie auf der [Vergleichsseite](https://eco.ovhcloud.com/de/compare/).
+> Weitere Informationen finden Sie auf der [Vergleichsseite](/links/bare-metal/eco-compare).
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-asia.md
@@ -16,9 +16,9 @@ Jumbo frames are Ethernet frames with more than 1500 bytes of payload. They can 
 - run a shell as root
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/asia/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/asia/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-au.md
@@ -16,9 +16,9 @@ Jumbo frames are Ethernet frames with more than 1500 bytes of payload. They can 
 - run a shell as root
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-au/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-au/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-ca.md
@@ -16,9 +16,9 @@ Jumbo frames are Ethernet frames with more than 1500 bytes of payload. They can 
 - run a shell as root
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ca/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ca/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-gb.md
@@ -16,9 +16,9 @@ Jumbo frames are Ethernet frames with more than 1500 bytes of payload. They can 
 - run a shell as root
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-ie.md
@@ -16,9 +16,9 @@ Jumbo frames are Ethernet frames with more than 1500 bytes of payload. They can 
 - run a shell as root
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ie/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ie/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-sg.md
@@ -16,9 +16,9 @@ Jumbo frames are Ethernet frames with more than 1500 bytes of payload. They can 
 - run a shell as root
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-sg/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-sg/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.en-us.md
@@ -16,9 +16,9 @@ Jumbo frames are Ethernet frames with more than 1500 bytes of payload. They can 
 - run a shell as root
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.es-es.md
@@ -16,9 +16,9 @@ Las tramas Jumbo o *Jumbo frames* son tramas Ethernet con una carga útil superi
 - Abrir un *shell* con permisos root.
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es-es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es-es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.es-us.md
@@ -16,9 +16,9 @@ Las tramas Jumbo o *Jumbo frames* son tramas Ethernet con una carga útil superi
 - Abrir un *shell* con permisos root.
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.fr-ca.md
@@ -16,9 +16,9 @@ Les trames Jumbo, ou *Jumbo frames*, sont des trames Ethernet dont la charge uti
 - Ouvrir un shell avec les droits root
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr-ca/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr-ca/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.fr-fr.md
@@ -16,9 +16,9 @@ Les trames Jumbo, ou *Jumbo frames*, sont des trames Ethernet dont la charge uti
 - Ouvrir un shell avec les droits root
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.it-it.md
@@ -16,9 +16,9 @@ I *Jumbo frame* sono frame Ethernet con un payload compreso tra 1500 e 9000 byte
 - Avviare una shell con i permessi di root
 
 > [!warning]
-> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](https://eco.ovhcloud.com/it/about/).
+> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](/links/bare-metal/eco-about).
 >
-> Per maggiori informazioni, consulta la nostra [a confronto](https://eco.ovhcloud.com/it/compare/).
+> Per maggiori informazioni, consulta la nostra [a confronto](/links/bare-metal/eco-compare).
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.pl-pl.md
@@ -16,9 +16,9 @@ Ramki Jumbo, inaczej *Jumbo frames*, to ramki Ethernet o ładowności ponad 1500
 - Otwórz shell z prawami root
 
 > [!warning]
-> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](https://eco.ovhcloud.com/pl/about/).
+> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](/links/bare-metal/eco-about).
 >
-> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](https://eco.ovhcloud.com/pl/compare/).
+> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](/links/bare-metal/eco-compare).
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/VRACK_MTU_Jumbo_Frames/guide.pt-pt.md
@@ -16,9 +16,9 @@ Os quadros Jumbo, ou *Jumbo Frames*, são quadros Ethernet cuja carga útil é s
 - Abrir um shell com direitos root
 
 > [!warning]
-> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](https://eco.ovhcloud.com/pt/about/).
+> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para mais informações, consulte o nosso [comparativo](https://eco.ovhcloud.com/pt/compare/).
+> Para mais informações, consulte o nosso [comparativo](/links/bare-metal/eco-compare).
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/activate-port-firewall-soft-win/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/activate-port-firewall-soft-win/guide.fr-ca.md
@@ -14,7 +14,7 @@ Pour protéger de manière optimale votre système, votre serveur sous Windows S
 >
 > OVHcloud met à votre disposition des services dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d'assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
 >
 
 ## Prérequis

--- a/pages/bare_metal_cloud/dedicated_servers/activate-port-firewall-soft-win/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/activate-port-firewall-soft-win/guide.fr-fr.md
@@ -14,7 +14,7 @@ Pour protéger de manière optimale votre système, votre serveur sous Windows S
 >
 > OVHcloud met à votre disposition des services dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d'assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
 >
 
 ## Prérequis

--- a/pages/bare_metal_cloud/dedicated_servers/adding-secondary-dns-on-dedicated-server/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/adding-secondary-dns-on-dedicated-server/guide.es-es.md
@@ -17,7 +17,7 @@ Si configura su servidor dedicado como servidor DNS, puede utilizar el DNS de OV
 ## Requisitos
 
 - Tener un [servidor dedicado](/links/bare-metal/bare-metal){.external}.
-- Tener un [dominio](/links/web/domains){.external} gestionado administrativa o técnicamente.
+- Tener un [dominio](/links/web/domains) gestionado administrativa o técnicamente.
 - Estar conectado al [área de cliente de OVHcloud](/links/manager){.external}.
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/adding-secondary-dns-on-dedicated-server/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/adding-secondary-dns-on-dedicated-server/guide.es-es.md
@@ -17,7 +17,7 @@ Si configura su servidor dedicado como servidor DNS, puede utilizar el DNS de OV
 ## Requisitos
 
 - Tener un [servidor dedicado](/links/bare-metal/bare-metal){.external}.
-- Tener un [dominio](https://www.ovhcloud.com/es-es/domains/){.external} gestionado administrativa o técnicamente.
+- Tener un [dominio](/links/web/domains){.external} gestionado administrativa o técnicamente.
 - Estar conectado al [área de cliente de OVHcloud](/links/manager){.external}.
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/adding-secondary-dns-on-dedicated-server/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/adding-secondary-dns-on-dedicated-server/guide.es-es.md
@@ -18,7 +18,7 @@ Si configura su servidor dedicado como servidor DNS, puede utilizar el DNS de OV
 
 - Tener un [servidor dedicado](/links/bare-metal/bare-metal){.external}.
 - Tener un [dominio](/links/web/domains) gestionado administrativa o técnicamente.
-- Estar conectado al [área de cliente de OVHcloud](/links/manager){.external}.
+- Estar conectado al [área de cliente de OVHcloud](/links/manager).
 
 > [!warning]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/adding-secondary-dns-on-dedicated-server/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/adding-secondary-dns-on-dedicated-server/guide.es-us.md
@@ -17,7 +17,7 @@ Si configura su servidor dedicado como servidor DNS, puede utilizar el DNS de OV
 ## Requisitos
 
 - Tener un [servidor dedicado](/links/bare-metal/bare-metal).
-- Tener un [dominio](/links/web/domains){.external} gestionado administrativa o técnicamente.
+- Tener un [dominio](/links/web/domains) gestionado administrativa o técnicamente.
 - Estar conectado al [área de cliente de OVHcloud](/links/manager).
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/adding-secondary-dns-on-dedicated-server/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/adding-secondary-dns-on-dedicated-server/guide.es-us.md
@@ -17,7 +17,7 @@ Si configura su servidor dedicado como servidor DNS, puede utilizar el DNS de OV
 ## Requisitos
 
 - Tener un [servidor dedicado](/links/bare-metal/bare-metal).
-- Tener un [dominio](https://www.ovhcloud.com/es/domains/){.external} gestionado administrativa o técnicamente.
+- Tener un [dominio](/links/web/domains){.external} gestionado administrativa o técnicamente.
 - Estar conectado al [área de cliente de OVHcloud](/links/manager).
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.de-de.md
@@ -88,7 +88,7 @@ Sobald die Bearbeitung abgeschlossen ist, wird Ihre IP entsperrt.
 
 #### Entsperren Sie Ihre IP-Adresse über die OVHcloud API
 
-Verbinden Sie sich mit dem [API-Interface von OVHcloud](https://eu.api.ovh.com/) und folgen Sie den nachstehenden Schritten. Weitere Informationen zur Verwendung der OVHcloud API finden Sie in unserer Anleitung "[Erste Schritte mit der OVHcloud API](/pages/manage_and_operate/api/first-steps)".
+Verbinden Sie sich mit dem [API-Interface von OVHcloud](/links/api) und folgen Sie den nachstehenden Schritten. Weitere Informationen zur Verwendung der OVHcloud API finden Sie in unserer Anleitung "[Erste Schritte mit der OVHcloud API](/pages/manage_and_operate/api/first-steps)".
 
 Rufen Sie zunächst die Liste der IPs jedes OVHcloud Dienstes ab (Hosted Private Cloud / VPS / Public Cloud / Dedicated Server):
 

--- a/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.en-asia.md
@@ -84,7 +84,7 @@ Once done, your IP will be unblocked.
 
 #### Unblocking your IP from the OVHcloud API
 
-Log in to the [OVHcloud API interface](https://ca.api.ovh.com/) according to the [relevant guide](/pages/manage_and_operate/api/first-steps) and follow the steps below.
+Log in to the [OVHcloud API interface](/links/api) according to the [relevant guide](/pages/manage_and_operate/api/first-steps) and follow the steps below.
 
 First, retrieve the list of IPs for each OVHcloud service (Dedicated Server/Hosted Private Cloud/VPS/Public Cloud):
 

--- a/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.en-au.md
@@ -84,7 +84,7 @@ Once done, your IP will be unblocked.
 
 #### Unblocking your IP from the OVHcloud API
 
-Log in to the [OVHcloud API interface](https://ca.api.ovh.com/) according to the [relevant guide](/pages/manage_and_operate/api/first-steps) and follow the steps below.
+Log in to the [OVHcloud API interface](/links/api) according to the [relevant guide](/pages/manage_and_operate/api/first-steps) and follow the steps below.
 
 First, retrieve the list of IPs for each OVHcloud service (Dedicated Server/Hosted Private Cloud/VPS/Public Cloud):
 

--- a/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.en-ca.md
@@ -84,7 +84,7 @@ Once done, your IP will be unblocked.
 
 #### Unblocking your IP from the OVHcloud API
 
-Log in to the [OVHcloud API interface](https://ca.api.ovh.com/) according to the [relevant guide](/pages/manage_and_operate/api/first-steps) and follow the steps below.
+Log in to the [OVHcloud API interface](/links/api) according to the [relevant guide](/pages/manage_and_operate/api/first-steps) and follow the steps below.
 
 First, retrieve the list of IPs for each OVHcloud service (Dedicated Server/Hosted Private Cloud/VPS/Public Cloud):
 

--- a/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.en-sg.md
@@ -84,7 +84,7 @@ Once done, your IP will be unblocked.
 
 #### Unblocking your IP from the OVHcloud API
 
-Log in to the [OVHcloud API interface](https://ca.api.ovh.com/) according to the [relevant guide](/pages/manage_and_operate/api/first-steps) and follow the steps below.
+Log in to the [OVHcloud API interface](/links/api) according to the [relevant guide](/pages/manage_and_operate/api/first-steps) and follow the steps below.
 
 First, retrieve the list of IPs for each OVHcloud service (Dedicated Server/Hosted Private Cloud/VPS/Public Cloud):
 

--- a/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.en-us.md
@@ -84,7 +84,7 @@ Once done, your IP will be unblocked.
 
 #### Unblocking your IP from the OVHcloud API
 
-Log in to the [OVHcloud API interface](https://ca.api.ovh.com/) according to the [relevant guide](/pages/manage_and_operate/api/first-steps) and follow the steps below.
+Log in to the [OVHcloud API interface](/links/api) according to the [relevant guide](/pages/manage_and_operate/api/first-steps) and follow the steps below.
 
 First, retrieve the list of IPs for each OVHcloud service (Dedicated Server/Hosted Private Cloud/VPS/Public Cloud):
 

--- a/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.es-es.md
@@ -87,7 +87,7 @@ Una vez realizado el tratamiento, la IP se desbloqueará.
 
 #### Desbloquear la dirección IP desde la API de OVHcloud
 
-Conéctese a la interfaz de la [API de OVHcloud](https://eu.api.ovh.com/) y siga los pasos que se indican a continuación. Para más información sobre el uso de las API de OVHcloud, consulte nuestra guía [Primeros pasos con las API de OVHcloud](/pages/manage_and_operate/api/first-steps).
+Conéctese a la interfaz de la [API de OVHcloud](/links/api) y siga los pasos que se indican a continuación. Para más información sobre el uso de las API de OVHcloud, consulte nuestra guía [Primeros pasos con las API de OVHcloud](/pages/manage_and_operate/api/first-steps).
 
 Descargue en primer lugar la lista de direcciones IP de cada servicio de OVHcloud (Hosted Private Cloud, VPS, Public Cloud, servidor dedicado):
 

--- a/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.es-us.md
@@ -87,7 +87,7 @@ Una vez realizado el tratamiento, la IP se desbloqueará.
 
 #### Desbloquear la dirección IP desde la API de OVHcloud
 
-Conéctese a la interfaz de la [API de OVHcloud](https://ca.api.ovh.com/) y siga los pasos que se indican a continuación. Para más información sobre el uso de las API de OVHcloud, consulte nuestra guía [Primeros pasos con las API de OVHcloud](/pages/manage_and_operate/api/first-steps).
+Conéctese a la interfaz de la [API de OVHcloud](/links/api) y siga los pasos que se indican a continuación. Para más información sobre el uso de las API de OVHcloud, consulte nuestra guía [Primeros pasos con las API de OVHcloud](/pages/manage_and_operate/api/first-steps).
 
 Descargue en primer lugar la lista de direcciones IP de cada servicio de OVHcloud (Hosted Private Cloud, VPS, Public Cloud, servidor dedicado):
 

--- a/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.fr-ca.md
@@ -84,7 +84,7 @@ Une fois le traitement effectué, votre IP sera débloquée.
 
 #### Débloquer votre adresse IP depuis l'API OVHcloud
 
-Connectez-vous à l'interface [API d'OVHcloud](https://ca.api.ovh.com/) et suivez les étapes ci-dessous. Pour plus d'informations sur l'utilisation des API OVHcloud, consultez notre guide « [Premiers pas avec les API OVHcloud](/pages/manage_and_operate/api/first-steps) ».
+Connectez-vous à l'interface [API d'OVHcloud](/links/api) et suivez les étapes ci-dessous. Pour plus d'informations sur l'utilisation des API OVHcloud, consultez notre guide « [Premiers pas avec les API OVHcloud](/pages/manage_and_operate/api/first-steps) ».
 
 Récupérez tout d'abord la liste des IPs de chaque service OVHcloud (Hosted Private Cloud / VPS / Public Cloud / Serveur Dédié) :
 

--- a/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.it-it.md
@@ -88,7 +88,7 @@ Una volta completata l'operazione, il tuo IP verrà sbloccato.
 
 #### Sblocca il tuo indirizzo IP dall'API OVHcloud
 
-Accedi all'interfaccia [API di OVHcloud](https://eu.api.ovh.com/) e segui gli step qui sotto. Per maggiori informazioni sull'utilizzo delle API OVHcloud, consulta la guida Iniziare a [Iniziare a utilizzare le API OVHcloud](/pages/manage_and_operate/api/first-steps).
+Accedi all'interfaccia [API di OVHcloud](/links/api) e segui gli step qui sotto. Per maggiori informazioni sull'utilizzo delle API OVHcloud, consulta la guida Iniziare a [Iniziare a utilizzare le API OVHcloud](/pages/manage_and_operate/api/first-steps).
 
 Per prima cosa recupera la lista degli IP di ogni servizio OVHcloud (Hosted Private Cloud / VPS / Public Cloud / Server Dedicato):
 

--- a/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.pl-pl.md
@@ -86,7 +86,7 @@ Po zakończeniu operacji Twój Destination IP zostanie odblokowany.
 
 #### Odblokuj adres IP z poziomu API OVHcloud
 
-Zaloguj się do interfejsu [API OVHcloud](https://eu.api.ovh.com/) i postępuj zgodnie z poniższymi instrukcjami. Aby uzyskać więcej informacji na temat korzystania z API OVHcloud, zapoznaj się z naszym przewodnikiem "[Pierwsze kroki z API OVHcloud](/pages/manage_and_operate/api/first-steps)".
+Zaloguj się do interfejsu [API OVHcloud](/links/api) i postępuj zgodnie z poniższymi instrukcjami. Aby uzyskać więcej informacji na temat korzystania z API OVHcloud, zapoznaj się z naszym przewodnikiem "[Pierwsze kroki z API OVHcloud](/pages/manage_and_operate/api/first-steps)".
 
 Pobierz listę adresów IP każdej usługi OVHcloud (Hosted Private Cloud / VPS / Public Cloud / Serwer dedykowany):
 

--- a/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/antispam_best_practices/guide.pt-pt.md
@@ -88,7 +88,7 @@ Após o tratamento, o IP será desbloqueado.
 
 #### Desbloquear o endereço IP a partir da API OVHcloud
 
-Ligue-se à interface [API da OVHcloud](https://eu.api.ovh.com/) e siga os passos abaixo. Para mais informações sobre a utilização das API OVHcloud, consulte o nosso guia "[Primeiros passos com as API OVHcloud](/pages/manage_and_operate/api/first-steps)".
+Ligue-se à interface [API da OVHcloud](/links/api) e siga os passos abaixo. Para mais informações sobre a utilização das API OVHcloud, consulte o nosso guia "[Primeiros passos com as API OVHcloud](/pages/manage_and_operate/api/first-steps)".
 
 Em primeiro lugar, obtenha a lista dos endereços IP de cada serviço OVHcloud (Hosted Private Cloud / VPS / Public Cloud / Servidor Dedicado):
 

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.de-de.md
@@ -19,7 +19,7 @@ Auch wenn der Server nicht für Zwecke verwendet wird, die die Verwaltung von re
 
 ## Voraussetzungen
 
-- Sie haben einen [Dedicated Server](/links/bare-metal/bare-metal) oder [VPS](https://www.ovhcloud.com/de/vps/) mit einem Linux-Betriebssystem Ihrem Kunden-Account.
+- Sie haben einen [Dedicated Server](/links/bare-metal/bare-metal) oder [VPS](/links/bare-metal/vps) mit einem Linux-Betriebssystem Ihrem Kunden-Account.
 - Sie verfügen über die Zugangsdaten, die Sie nach der Installation per E-Mail erhalten haben.
 
 ## In der praktischen Anwendung

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-asia.md
@@ -16,7 +16,7 @@ Even if the server is not used for a purpose that requires the administration of
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/en-gb/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Login credentials received via email after the installation
 
 

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-au.md
@@ -16,7 +16,7 @@ Even if the server is not used for a purpose that requires the administration of
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/en-gb/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Login credentials received via email after the installation
 
 

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-ca.md
@@ -16,7 +16,7 @@ Even if the server is not used for a purpose that requires the administration of
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/en-gb/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Login credentials received via email after the installation
 
 

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-gb.md
@@ -16,7 +16,7 @@ Even if the server is not used for a purpose that requires the administration of
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/en-gb/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Login credentials received via email after the installation
 
 

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-ie.md
@@ -16,7 +16,7 @@ Even if the server is not used for a purpose that requires the administration of
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/en-gb/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Login credentials received via email after the installation
 
 

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-sg.md
@@ -16,7 +16,7 @@ Even if the server is not used for a purpose that requires the administration of
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/en-gb/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Login credentials received via email after the installation
 
 

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.en-us.md
@@ -16,7 +16,7 @@ Even if the server is not used for a purpose that requires the administration of
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/en-gb/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Login credentials received via email after the installation
 
 

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.es-es.md
@@ -19,7 +19,7 @@ Aunque el servidor no se utilice para fines que requieran la administración de 
 
 ## Requisitos
 
-- Un [servidor dedicado](/links/bare-metal/bare-metal) o un [VPS](https://www.ovhcloud.com/es-es/vps/) con un sistema operativo Linux en su cuenta de OVHcloud
+- Un [servidor dedicado](/links/bare-metal/bare-metal) o un [VPS](/links/bare-metal/vps) con un sistema operativo Linux en su cuenta de OVHcloud
 - Disponer de las claves de conexión recibidas por correo electrónico tras la instalación.
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.es-us.md
@@ -19,7 +19,7 @@ Aunque el servidor no se utilice para fines que requieran la administración de 
 
 ## Requisitos
 
-- Un [servidor dedicado](/links/bare-metal/bare-metal) o un [VPS](https://www.ovhcloud.com/es/vps/) con un sistema operativo Linux en su cuenta de OVHcloud
+- Un [servidor dedicado](/links/bare-metal/bare-metal) o un [VPS](/links/bare-metal/vps) con un sistema operativo Linux en su cuenta de OVHcloud
 - Disponer de las claves de conexión recibidas por correo electrónico tras la instalación.
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.fr-ca.md
@@ -16,7 +16,7 @@ Même si le serveur n’est pas utilisé à des fins nécessitant l’administra
 
 ## Prérequis
 
-- Un [serveur dédié](/links/bare-metal/bare-metal) ou un [VPS](https://www.ovhcloud.com/fr-ca/vps/) avec un système d'exploitation Linux dans votre compte OVHcloud
+- Un [serveur dédié](/links/bare-metal/bare-metal) ou un [VPS](/links/bare-metal/vps) avec un système d'exploitation Linux dans votre compte OVHcloud
 - Disposer des identifiants de connexion reçus par e-mail suite à l'installation.
 
 ## En pratique
@@ -33,7 +33,7 @@ N'oubliez pas de consulter également nos guides de premiers pas :
 > [!warning]
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
+> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
 >
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.fr-fr.md
@@ -16,7 +16,7 @@ Même si le serveur n’est pas utilisé à des fins nécessitant l’administra
 
 ## Prérequis
 
-- Un [serveur dédié](/links/bare-metal/bare-metal) ou un [VPS](https://www.ovhcloud.com/fr/vps/) avec un système d'exploitation Linux dans votre compte OVHcloud
+- Un [serveur dédié](/links/bare-metal/bare-metal) ou un [VPS](/links/bare-metal/vps) avec un système d'exploitation Linux dans votre compte OVHcloud
 - Disposer des identifiants de connexion reçus par e-mail suite à l'installation.
 
 ## En pratique
@@ -33,7 +33,7 @@ N'oubliez pas de consulter également nos guides de premiers pas :
 > [!warning]
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
+> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
 >
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.it-it.md
@@ -19,7 +19,7 @@ Anche se il server non viene utilizzato per scopi che richiedono l'amministrazio
 
 ## Prerequisiti
 
-- Un [server dedicato](/links/bare-metal/bare-metal) o un [VPS](https://www.ovhcloud.com/it/vps/) con un sistema operativo Linux nel tuo account OVHcloud
+- Un [server dedicato](/links/bare-metal/bare-metal) o un [VPS](/links/bare-metal/vps) con un sistema operativo Linux nel tuo account OVHcloud
 - Disporre delle credenziali di accesso ricevute via email in seguito all’installazione
 
 ## Procedura

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.pl-pl.md
@@ -20,7 +20,7 @@ Nawet jeśli serwer nie jest używany do celów, które wymagają administrowani
 
 ## Wymagania początkowe
 
-- [Serwer dedykowany](/links/bare-metal/bare-metal) lub [VPS](https://www.ovhcloud.com/pl/vps/) z systemem operacyjnym Linux na koncie OVHcloud
+- [Serwer dedykowany](/links/bare-metal/bare-metal) lub [VPS](/links/bare-metal/vps) z systemem operacyjnym Linux na koncie OVHcloud
 - Posiadanie danych do logowania otrzymanych w e-mailu po zakończonej instalacji.
 
 ## W praktyce

--- a/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/changing_root_password_linux_ds/guide.pt-pt.md
@@ -20,7 +20,7 @@ Mesmo que o servidor não seja utilizado para fins que requeiram a administraç�
 
 ## Requisitos
 
-- Um [servidor dedicado](/links/bare-metal/bare-metal) ou um [VPS](https://www.ovhcloud.com/pt/vps/) com um sistema operativo Linux na sua conta OVHcloud
+- Um [servidor dedicado](/links/bare-metal/bare-metal) ou um [VPS](/links/bare-metal/vps) com um sistema operativo Linux na sua conta OVHcloud
 - Ter acesso a credenciais de início de sessão que recebeu por correio eletrónico após a instalação.
 
 ## Instruções

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.de-de.md
@@ -38,9 +38,9 @@ Neben Private IP Addressing ist es mit dem [vRack](https://www.ovh.de/loesungen/
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 > [!warning]
-> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](https://eco.ovhcloud.com/de/about/) eingesetzt wird.
+> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](/links/bare-metal/eco-about) eingesetzt wird.
 >
-> Weitere Informationen finden Sie auf der [Vergleichsseite](https://eco.ovhcloud.com/de/compare/).
+> Weitere Informationen finden Sie auf der [Vergleichsseite](/links/bare-metal/eco-compare).
 
 ## In der praktischen Anwendung
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-asia.md
@@ -38,9 +38,9 @@ As well as private IP addressing, the [vRack](/links/network/vrack){.external} a
 - Access to the OVHcloud [Control Panel](/links/manager){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/asia/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/asia/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-au.md
@@ -38,9 +38,9 @@ As well as private IP addressing, the [vRack](/links/network/vrack){.external} a
 - Access to the OVHcloud [Control Panel](/links/manager){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-au/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-au/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-ca.md
@@ -38,9 +38,9 @@ As well as private IP addressing, the [vRack](/links/network/vrack){.external} a
 - Access to the OVHcloud [Control Panel](/links/manager){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ca/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ca/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-gb.md
@@ -38,9 +38,9 @@ As well as private IP addressing, the [vRack](/links/network/vrack){.external} a
 - Access to the [OVHcloud Control Panel](/links/manager){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-ie.md
@@ -38,9 +38,9 @@ As well as private IP addressing, the [vRack](/links/network/vrack){.external} a
 - Access to the [OVHcloud Control Panel](/links/manager){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ie/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ie/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-sg.md
@@ -38,9 +38,9 @@ As well as private IP addressing, the [vRack](/links/network/vrack){.external} a
 - Access to the [OVHcloud Control Panel](/links/manager){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-sg/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-sg/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-us.md
@@ -33,7 +33,7 @@ As well as private IP addressing, the [vRack](/links/network/vrack){.external} a
 
 - A public block of IP addresses in your account, with a minimum of four addresses
 - Your chosen private IP address range
-- A [vRack compatible server](/links/bare-metal/bare-metal){.external}
+- A [vRack compatible server](/links/bare-metal/bare-metal)
 - A [vRack](/links/network/vrack){.external} service activated in your account
 - Access to the OVHcloud [Control Panel](/links/manager){.external}
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.en-us.md
@@ -33,14 +33,14 @@ As well as private IP addressing, the [vRack](/links/network/vrack){.external} a
 
 - A public block of IP addresses in your account, with a minimum of four addresses
 - Your chosen private IP address range
-- A [vRack compatible server](https://www.ovhcloud.com/en/bare-metal/){.external}
+- A [vRack compatible server](/links/bare-metal/bare-metal){.external}
 - A [vRack](/links/network/vrack){.external} service activated in your account
 - Access to the OVHcloud [Control Panel](/links/manager){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.es-es.md
@@ -38,9 +38,9 @@ Además del direccionamiento IP privado, el [vRack](https://www.ovh.es/solucione
 - Estar conectado al [área de cliente de OVHcloud](/links/manager){.external}.
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es-es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es-es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.es-us.md
@@ -38,9 +38,9 @@ Además del direccionamiento IP privado, el [vRack](https://www.ovh.com/world/es
 - Estar conectado al [área de cliente de OVHcloud](/links/manager){.external}.
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.fr-ca.md
@@ -38,9 +38,9 @@ En plus de l'adressage IP privé, le [vRack](https://www.ovh.com/ca/fr/solutions
 - Être connecté à l'[espace client OVHcloud](/links/manager){.external}.
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr-ca/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr-ca/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.fr-fr.md
@@ -38,9 +38,9 @@ En plus de l'adressage IP privé, le [vRack](https://www.ovh.com/fr/solutions/vr
 - Être connecté à l'[espace client OVHcloud](/links/manager){.external}.
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.it-it.md
@@ -38,9 +38,9 @@ Oltre a consentire un indirizzamento IP privato, la [vRack](https://www.ovh.it/s
 - Essere connesso allo [Spazio Cliente OVHcloud](/links/manager){.external}
 
 > [!warning]
-> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](https://eco.ovhcloud.com/it/about/).
+> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](/links/bare-metal/eco-about).
 >
-> Per maggiori informazioni, consulta la nostra [a confronto](https://eco.ovhcloud.com/it/compare/).
+> Per maggiori informazioni, consulta la nostra [a confronto](/links/bare-metal/eco-compare).
 
 ## Procedura
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.pl-pl.md
@@ -38,9 +38,9 @@ Oprócz prywatnego adresowania IP, [vRack](https://www.ovh.pl/rozwiazania/vrack/
 - Dostęp do [Panelu klienta OVHcloud](/links/manager){.external}
 
 > [!warning]
-> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](https://eco.ovhcloud.com/pl/about/).
+> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](/links/bare-metal/eco-about).
 >
-> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](https://eco.ovhcloud.com/pl/compare/).
+> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](/links/bare-metal/eco-compare).
 
 ## W praktyce
 

--- a/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/configuring-an-ip-block-in-a-vrack/guide.pt-pt.md
@@ -38,9 +38,9 @@ Além do direcionamento IP privado, o [vRack](https://www.ovh.pt/solucoes/vrack/
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager){.external}.
 
 > [!warning]
-> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](https://eco.ovhcloud.com/pt/about/).
+> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para mais informações, consulte o nosso [comparativo](https://eco.ovhcloud.com/pt/compare/).
+> Para mais informações, consulte o nosso [comparativo](/links/bare-metal/eco-compare).
 
 ## Instruções
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.de-de.md
@@ -24,9 +24,9 @@ Bei der [Standardkonfiguration des vRack](/pages/bare_metal_cloud/dedicated_serv
 - Sie haben die [Konfiguration des vRack](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server) abgeschlossen.
 
 > [!warning]
-> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](https://eco.ovhcloud.com/de/about/) eingesetzt wird.
+> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](/links/bare-metal/eco-about) eingesetzt wird.
 >
-> Weitere Informationen finden Sie auf der [Vergleichsseite](https://eco.ovhcloud.com/de/compare/).
+> Weitere Informationen finden Sie auf der [Vergleichsseite](/links/bare-metal/eco-compare).
 
 ## In der praktischen Anwendung
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-asia.md
@@ -20,9 +20,9 @@ The standard [vRack configuration](/pages/bare_metal_cloud/dedicated_servers/vra
 * You must have completed the [vRack configuration guide](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/asia/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/asia/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-au.md
@@ -20,9 +20,9 @@ The standard [vRack configuration](/pages/bare_metal_cloud/dedicated_servers/vra
 * You must have completed the [vRack configuration guide](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-au/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-au/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-ca.md
@@ -20,9 +20,9 @@ The standard [vRack configuration](/pages/bare_metal_cloud/dedicated_servers/vra
 * You must have completed the [vRack configuration guide](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ca/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ca/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-gb.md
@@ -20,9 +20,9 @@ The standard [vRack configuration](/pages/bare_metal_cloud/dedicated_servers/vra
 * You must have completed the [vRack configuration guide](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-ie.md
@@ -20,9 +20,9 @@ The standard [vRack configuration](/pages/bare_metal_cloud/dedicated_servers/vra
 * You must have completed the [vRack configuration guide](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ie/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ie/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-sg.md
@@ -20,9 +20,9 @@ The standard [vRack configuration](/pages/bare_metal_cloud/dedicated_servers/vra
 * You must have completed the [vRack configuration guide](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-sg/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-sg/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.en-us.md
@@ -20,9 +20,9 @@ The standard [vRack configuration](/pages/bare_metal_cloud/dedicated_servers/vra
 * You must have completed the [vRack configuration guide](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.es-es.md
@@ -24,9 +24,9 @@ La [configuración estándar del vRack](/pages/bare_metal_cloud/dedicated_server
 - Haber terminado de [configurar el vRack](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}.
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es-es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es-es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.es-us.md
@@ -24,9 +24,9 @@ La [configuración estándar del vRack](/pages/bare_metal_cloud/dedicated_server
 - Haber terminado de [configurar el vRack](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}.
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.fr-ca.md
@@ -20,9 +20,9 @@ La [configuration standard du vRack](/pages/bare_metal_cloud/dedicated_servers/v
 - Avoir finalisé la [configuration du vRack](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}.
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr-ca/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr-ca/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.fr-fr.md
@@ -20,9 +20,9 @@ La [configuration standard du vRack](/pages/bare_metal_cloud/dedicated_servers/v
 - Avoir finalisé la [configuration du vRack](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}.
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.it-it.md
@@ -24,9 +24,9 @@ La [configurazione standard della vRack](/pages/bare_metal_cloud/dedicated_serve
 - Aver completato la [configurazione della vRack](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}
 
 > [!warning]
-> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](https://eco.ovhcloud.com/it/about/).
+> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](/links/bare-metal/eco-about).
 >
-> Per maggiori informazioni, consulta la nostra [a confronto](https://eco.ovhcloud.com/it/compare/).
+> Per maggiori informazioni, consulta la nostra [a confronto](/links/bare-metal/eco-compare).
 
 ## Procedura
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.pl-pl.md
@@ -20,9 +20,9 @@ updated: 2023-09-12
 - Ukończona [konfiguracja vRack](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}
 
 > [!warning]
-> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](https://eco.ovhcloud.com/pl/about/).
+> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](/links/bare-metal/eco-about).
 >
-> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](https://eco.ovhcloud.com/pl/compare/).
+> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](/links/bare-metal/eco-compare).
 
 ## W praktyce
 

--- a/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/creating-multiple-vlans-in-a-vrack/guide.pt-pt.md
@@ -24,9 +24,9 @@ A [configuração standard do vRack](/pages/bare_metal_cloud/dedicated_servers/v
 - Ter finalizado a [configuração do vRack](/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server){.external}.
 
 > [!warning]
-> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](https://eco.ovhcloud.com/pt/about/).
+> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para mais informações, consulte o nosso [comparativo](https://eco.ovhcloud.com/pt/compare/).
+> Para mais informações, consulte o nosso [comparativo](/links/bare-metal/eco-compare).
 
 ## Instruções
 

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.de-de.md
@@ -60,7 +60,7 @@ Although you could start exploring the examples and schemes of the [new "/reinst
 
 #### OVHcloud workaround <a name="ux-ovh"></a>
 
-As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](https://eu.api.ovh.com/console/) page:
+As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](/links/console) page:
 
 - Click `Authentication`{.action} in the upper left corner.
 - Select `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-asia.md
@@ -60,7 +60,7 @@ Although you could start exploring the examples and schemes of the [new "/reinst
 
 #### OVHcloud workaround <a name="ux-ovh"></a>
 
-As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](https://ca.api.ovh.com/console/) page:
+As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](/links/console) page:
 
 - Click `Authentication`{.action} in the upper left corner.
 - Select `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-au.md
@@ -60,7 +60,7 @@ Although you could start exploring the examples and schemes of the [new "/reinst
 
 #### OVHcloud workaround <a name="ux-ovh"></a>
 
-As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](https://ca.api.ovh.com/console/) page:
+As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](/links/console) page:
 
 - Click `Authentication`{.action} in the upper left corner.
 - Select `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-ca.md
@@ -60,7 +60,7 @@ Although you could start exploring the examples and schemes of the [new "/reinst
 
 #### OVHcloud workaround <a name="ux-ovh"></a>
 
-As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](https://ca.api.ovh.com/console/) page:
+As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](/links/console) page:
 
 - Click `Authentication`{.action} in the upper left corner.
 - Select `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-gb.md
@@ -60,7 +60,7 @@ Although you could start exploring the examples and schemes of the [new "/reinst
 
 #### OVHcloud workaround <a name="ux-ovh"></a>
 
-As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](https://eu.api.ovh.com/console/) page:
+As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](/links/console) page:
 
 - Click `Authentication`{.action} in the upper left corner.
 - Select `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-ie.md
@@ -60,7 +60,7 @@ Although you could start exploring the examples and schemes of the [new "/reinst
 
 #### OVHcloud workaround <a name="ux-ovh"></a>
 
-As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](https://eu.api.ovh.com/console/) page:
+As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](/links/console) page:
 
 - Click `Authentication`{.action} in the upper left corner.
 - Select `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-sg.md
@@ -60,7 +60,7 @@ Although you could start exploring the examples and schemes of the [new "/reinst
 
 #### OVHcloud workaround <a name="ux-ovh"></a>
 
-As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](https://ca.api.ovh.com/console/) page:
+As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](/links/console) page:
 
 - Click `Authentication`{.action} in the upper left corner.
 - Select `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.en-us.md
@@ -60,7 +60,7 @@ Although you could start exploring the examples and schemes of the [new "/reinst
 
 #### OVHcloud workaround <a name="ux-ovh"></a>
 
-As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](https://ca.api.ovh.com/console/) page:
+As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](/links/console) page:
 
 - Click `Authentication`{.action} in the upper left corner.
 - Select `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.es-es.md
@@ -60,7 +60,7 @@ Although you could start exploring the examples and schemes of the [new "/reinst
 
 #### OVHcloud workaround <a name="ux-ovh"></a>
 
-As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](https://eu.api.ovh.com/console/) page:
+As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](/links/console) page:
 
 - Click `Authentication`{.action} in the upper left corner.
 - Select `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.es-us.md
@@ -60,7 +60,7 @@ Although you could start exploring the examples and schemes of the [new "/reinst
 
 #### OVHcloud workaround <a name="ux-ovh"></a>
 
-As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](https://ca.api.ovh.com/console/) page:
+As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](/links/console) page:
 
 - Click `Authentication`{.action} in the upper left corner.
 - Select `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.fr-ca.md
@@ -60,7 +60,7 @@ Même si vous pouvez déjà explorer des exemples et schémas de la [nouvelle ro
 
 #### Contournement pour les comptes OVHcloud <a name="ux-ovh"></a>
 
-Comme mentionné dans la [documentation API OVHcloud](/pages/manage_and_operate/api/first-steps#se-connecter-aux-api-ovhcloud), sur la [page des API OVHcloud](https://ca.api.ovh.com/console/) :
+Comme mentionné dans la [documentation API OVHcloud](/pages/manage_and_operate/api/first-steps#se-connecter-aux-api-ovhcloud), sur la [page des API OVHcloud](/links/console) :
 
 - Cliquez sur `Authentication`{.action} en haut à gauche.
 - Cliquez ensuite `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.fr-fr.md
@@ -60,7 +60,7 @@ Même si vous pouvez déjà explorer des exemples et schémas de la [nouvelle ro
 
 #### Contournement pour les comptes OVHcloud <a name="ux-ovh"></a>
 
-Comme mentionné dans la [documentation API OVHcloud](/pages/manage_and_operate/api/first-steps#se-connecter-aux-api-ovhcloud), sur la [page des API OVHcloud](https://eu.api.ovh.com/console/) :
+Comme mentionné dans la [documentation API OVHcloud](/pages/manage_and_operate/api/first-steps#se-connecter-aux-api-ovhcloud), sur la [page des API OVHcloud](/links/console) :
 
 - Cliquez sur `Authentication`{.action} en haut à gauche.
 - Cliquez ensuite `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.it-it.md
@@ -60,7 +60,7 @@ Although you could start exploring the examples and schemes of the [new "/reinst
 
 #### OVHcloud workaround <a name="ux-ovh"></a>
 
-As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](https://eu.api.ovh.com/console/) page:
+As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](/links/console) page:
 
 - Click `Authentication`{.action} in the upper left corner.
 - Select `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.pl-pl.md
@@ -60,7 +60,7 @@ Although you could start exploring the examples and schemes of the [new "/reinst
 
 #### OVHcloud workaround <a name="ux-ovh"></a>
 
-As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](https://eu.api.ovh.com/console/) page:
+As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](/links/console) page:
 
 - Click `Authentication`{.action} in the upper left corner.
 - Select `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/end-of-life-for-personal-installation-templates/guide.pt-pt.md
@@ -60,7 +60,7 @@ Although you could start exploring the examples and schemes of the [new "/reinst
 
 #### OVHcloud workaround <a name="ux-ovh"></a>
 
-As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](https://eu.api.ovh.com/console/) page:
+As mentioned in the [OVHcloud API documentation](/pages/manage_and_operate/api/first-steps#sign-in-to-ovhcloud-apis), on the [OVHcloud console API](/links/console) page:
 
 - Click `Authentication`{.action} in the upper left corner.
 - Select `Login with OVHcloud SSO`{.action}.

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.de-de.md
@@ -53,7 +53,7 @@ As you can see, no datastore is created on the first disk with the `max` partiti
 >
 > Did you know?
 >
-> [VMware on OVHcloud solutions](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) are based on ESXi with the partitioning layout `small`.
+> [VMware on OVHcloud solutions](/links/hosted-private-cloud/vmware) are based on ESXi with the partitioning layout `small`.
 >
 
 ### How to select the partitioning scheme

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-asia.md
@@ -53,7 +53,7 @@ As you can see, no datastore is created on the first disk with the `max` partiti
 >
 > Did you know?
 >
-> [VMware on OVHcloud solutions](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) are based on ESXi with the partitioning layout `small`.
+> [VMware on OVHcloud solutions](/links/hosted-private-cloud/vmware) are based on ESXi with the partitioning layout `small`.
 >
 
 ### How to select the partitioning scheme

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-au.md
@@ -53,7 +53,7 @@ As you can see, no datastore is created on the first disk with the `max` partiti
 >
 > Did you know?
 >
-> [VMware on OVHcloud solutions](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) are based on ESXi with the partitioning layout `small`.
+> [VMware on OVHcloud solutions](/links/hosted-private-cloud/vmware) are based on ESXi with the partitioning layout `small`.
 >
 
 ### How to select the partitioning scheme

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-ca.md
@@ -53,7 +53,7 @@ As you can see, no datastore is created on the first disk with the `max` partiti
 >
 > Did you know?
 >
-> [VMware on OVHcloud solutions](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) are based on ESXi with the partitioning layout `small`.
+> [VMware on OVHcloud solutions](/links/hosted-private-cloud/vmware) are based on ESXi with the partitioning layout `small`.
 >
 
 ### How to select the partitioning scheme

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-gb.md
@@ -53,7 +53,7 @@ As you can see, no datastore is created on the first disk with the `max` partiti
 >
 > Did you know?
 >
-> [VMware on OVHcloud solutions](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) are based on ESXi with the partitioning layout `small`.
+> [VMware on OVHcloud solutions](/links/hosted-private-cloud/vmware) are based on ESXi with the partitioning layout `small`.
 >
 
 ### How to select the partitioning scheme

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-ie.md
@@ -53,7 +53,7 @@ As you can see, no datastore is created on the first disk with the `max` partiti
 >
 > Did you know?
 >
-> [VMware on OVHcloud solutions](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) are based on ESXi with the partitioning layout `small`.
+> [VMware on OVHcloud solutions](/links/hosted-private-cloud/vmware) are based on ESXi with the partitioning layout `small`.
 >
 
 ### How to select the partitioning scheme

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-sg.md
@@ -53,7 +53,7 @@ As you can see, no datastore is created on the first disk with the `max` partiti
 >
 > Did you know?
 >
-> [VMware on OVHcloud solutions](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) are based on ESXi with the partitioning layout `small`.
+> [VMware on OVHcloud solutions](/links/hosted-private-cloud/vmware) are based on ESXi with the partitioning layout `small`.
 >
 
 ### How to select the partitioning scheme

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.en-us.md
@@ -53,7 +53,7 @@ As you can see, no datastore is created on the first disk with the `max` partiti
 >
 > Did you know?
 >
-> [VMware on OVHcloud solutions](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) are based on ESXi with the partitioning layout `small`.
+> [VMware on OVHcloud solutions](/links/hosted-private-cloud/vmware) are based on ESXi with the partitioning layout `small`.
 >
 
 ### How to select the partitioning scheme

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.es-es.md
@@ -53,7 +53,7 @@ As you can see, no datastore is created on the first disk with the `max` partiti
 >
 > Did you know?
 >
-> [VMware on OVHcloud solutions](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) are based on ESXi with the partitioning layout `small`.
+> [VMware on OVHcloud solutions](/links/hosted-private-cloud/vmware) are based on ESXi with the partitioning layout `small`.
 >
 
 ### How to select the partitioning scheme

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.es-us.md
@@ -53,7 +53,7 @@ As you can see, no datastore is created on the first disk with the `max` partiti
 >
 > Did you know?
 >
-> [VMware on OVHcloud solutions](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) are based on ESXi with the partitioning layout `small`.
+> [VMware on OVHcloud solutions](/links/hosted-private-cloud/vmware) are based on ESXi with the partitioning layout `small`.
 >
 
 ### How to select the partitioning scheme

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.fr-ca.md
@@ -53,7 +53,7 @@ Comme vous pouvez le constater, aucun datastore n'est créé sur le premier disq
 > [!primary]
 >
 > Le saviez-vous ?
-> Les solutions [VMware on OVHcloud](https://www.ovhcloud.com/fr/hosted-private-cloud/vmware/) sont basées sur des installations ESXi avec le schéma de partitionnement `small`.
+> Les solutions [VMware on OVHcloud](/links/hosted-private-cloud/vmware) sont basées sur des installations ESXi avec le schéma de partitionnement `small`.
 >
 
 ### Comment sélectionner le schéma de partitionnement ?

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.fr-fr.md
@@ -53,7 +53,7 @@ Comme vous pouvez le constater, aucun datastore n'est créé sur le premier disq
 > [!primary]
 >
 > Le saviez-vous ?
-> Les solutions [VMware on OVHcloud](https://www.ovhcloud.com/fr/hosted-private-cloud/vmware/) sont basées sur des installations ESXi avec le schéma de partitionnement `small`.
+> Les solutions [VMware on OVHcloud](/links/hosted-private-cloud/vmware) sont basées sur des installations ESXi avec le schéma de partitionnement `small`.
 >
 
 ### Comment sélectionner le schéma de partitionnement ?

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.it-it.md
@@ -53,7 +53,7 @@ As you can see, no datastore is created on the first disk with the `max` partiti
 >
 > Did you know?
 >
-> [VMware on OVHcloud solutions](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) are based on ESXi with the partitioning layout `small`.
+> [VMware on OVHcloud solutions](/links/hosted-private-cloud/vmware) are based on ESXi with the partitioning layout `small`.
 >
 
 ### How to select the partitioning scheme

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.pl-pl.md
@@ -53,7 +53,7 @@ As you can see, no datastore is created on the first disk with the `max` partiti
 >
 > Did you know?
 >
-> [VMware on OVHcloud solutions](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) are based on ESXi with the partitioning layout `small`.
+> [VMware on OVHcloud solutions](/links/hosted-private-cloud/vmware) are based on ESXi with the partitioning layout `small`.
 >
 
 ### How to select the partitioning scheme

--- a/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/esxi-partitioning/guide.pt-pt.md
@@ -53,7 +53,7 @@ As you can see, no datastore is created on the first disk with the `max` partiti
 >
 > Did you know?
 >
-> [VMware on OVHcloud solutions](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) are based on ESXi with the partitioning layout `small`.
+> [VMware on OVHcloud solutions](/links/hosted-private-cloud/vmware) are based on ESXi with the partitioning layout `small`.
 >
 
 ### How to select the partitioning scheme

--- a/pages/bare_metal_cloud/dedicated_servers/faq-esxi/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/faq-esxi/guide.en-gb.md
@@ -36,7 +36,7 @@ In case of difficulties, we recommend that you contact a [specialist provider](/
 
 ### Does OVHcloud have a backup to restore my data?
 
-The Dedicated Server offering is optionally supported by [Backup Storage](https://www.ovhcloud.com/en-gb/bare-metal/backup-storage/). However, the backup is not automatic. More details on how this solution works can be found in our [Use Backup Storage on a Dedicated Server](/pages/bare_metal_cloud/dedicated_servers/services_backup_storage) guide.
+The Dedicated Server offering is optionally supported by [Backup Storage](/links/bare-metal/backup-storage). However, the backup is not automatic. More details on how this solution works can be found in our [Use Backup Storage on a Dedicated Server](/pages/bare_metal_cloud/dedicated_servers/services_backup_storage) guide.
 
 Our dedicated servers are also compatible with our [different backup solutions](https://www.ovhcloud.com/en-gb/storage-solutions/).
 
@@ -79,7 +79,7 @@ Not to our knowledge on this wave of attack.
 
 ### Is the VMware on OVHcloud affected by this incident?
 
-Our customers using [VMware on OVHcloud](https://www.ovhcloud.com/en-gb/hosted-private-cloud/) solutions are not affected by the ransomware. Specifically, the SSL gateway makes it possible to avoid this type of attack by blocking external access to this port (OpenSLP 427).
+Our customers using [VMware on OVHcloud](/links/hosted-private-cloud/hosted-private-cloud) solutions are not affected by the ransomware. Specifically, the SSL gateway makes it possible to avoid this type of attack by blocking external access to this port (OpenSLP 427).
 
 ## Go further
 

--- a/pages/bare_metal_cloud/dedicated_servers/faq-esxi/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/faq-esxi/guide.fr-fr.md
@@ -32,11 +32,11 @@ Cependant, nous ne disposons pas de tous les dispositifs nécessaires pour récu
 L'agence nationale américaine pour la cybersécurité et la sécurité des infrastructures ([CISA](https://www.cisa.gov/uscert/ncas/current-activity/2023/02/07/cisa-releases-esxiargs-ransomware-recovery-script){.external}) a également mis à disposition [un outil](https://github.com/cisagov/ESXiArgs-Recover) pour récupérer les données d'un serveur ESXi ciblé par le ransomware ESXIArgs.<br>
 L'utilisation de cet outil nécessite des compétences avancées en administration de système. Nous vous conseillons de ne l'utiliser qu'en connaissance de cause, OVHcloud ne pouvant vous fournir d'assistance sur son utilisation.
 
-En cas de difficultés, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter nos équipes en [créant un ticket d'assistance](https://help.ovhcloud.com/csm?id=csm_get_help).
+En cas de difficultés, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou de contacter nos équipes en [créant un ticket d'assistance](https://help.ovhcloud.com/csm?id=csm_get_help).
 
 ### OVHcloud dispose-t-il d'une sauvegarde pour restaurer vos données ?
 
-L'offre Serveur Dédié bénéficie en option de l'offre [Backup Storage](https://www.ovhcloud.com/fr/bare-metal/backup-storage/). La sauvegarde n'est cependant pas automatique. Retrouvez plus de détails sur le fonctionnement de cette solution sur notre guide « [Utiliser Backup Storage sur un serveur dédié](/pages/bare_metal_cloud/dedicated_servers/services_backup_storage) ».
+L'offre Serveur Dédié bénéficie en option de l'offre [Backup Storage](/links/bare-metal/backup-storage). La sauvegarde n'est cependant pas automatique. Retrouvez plus de détails sur le fonctionnement de cette solution sur notre guide « [Utiliser Backup Storage sur un serveur dédié](/pages/bare_metal_cloud/dedicated_servers/services_backup_storage) ».
 
 Nos serveurs dédiés sont aussi compatibles avec nos [différentes solutions de sauvegarde](https://www.ovhcloud.com/fr/storage-solutions/).
 
@@ -79,7 +79,7 @@ Pas à notre connaissance sur cette vague d'attaque.
 
 ### Est-ce que l'offre VMware on OVHcloud est concernée par cet incident ?
 
-Nos clients utilisant les solutions [VMware on OVHcloud](https://www.ovhcloud.com/fr/hosted-private-cloud/) ne sont pas concernés par le ransomware. Concrètement, la SSL gateway permet d’éviter cette typologie d’attaque en bloquant l’accès externe à ce port (OpenSLP 427).
+Nos clients utilisant les solutions [VMware on OVHcloud](/links/hosted-private-cloud/hosted-private-cloud) ne sont pas concernés par le ransomware. Concrètement, la SSL gateway permet d’éviter cette typologie d’attaque en bloquant l’accès externe à ce port (OpenSLP 427).
 
 ## Aller plus loin
 

--- a/pages/bare_metal_cloud/dedicated_servers/firewall-Linux-iptable/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall-Linux-iptable/guide.fr-ca.md
@@ -15,7 +15,7 @@ Les pare-feux fonctionnent en définissant des règles qui régissent le trafic 
 >
 > OVHcloud met à votre disposition des services dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d'assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
 >
 
 ## Prérequis

--- a/pages/bare_metal_cloud/dedicated_servers/firewall-Linux-iptable/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall-Linux-iptable/guide.fr-fr.md
@@ -15,7 +15,7 @@ Les pare-feux fonctionnent en définissant des règles qui régissent le trafic 
 >
 > OVHcloud met à votre disposition des services dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d'assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
 >
 
 ## Prérequis

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.de-de.md
@@ -26,7 +26,7 @@ Zum Schutz von Diensten, die über öffentliche IP-Adressen zugänglich sind, bi
 
 ## Voraussetzungen 
 
-- Sie haben eine OVHcloud Dienstleistung abonniert, die über eine dedizierte öffentliche IP-Adresse erreichbar ist ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/de/vps/), [Public Cloud Instanz](https://www.ovhcloud.com/de/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/de/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.).
+- Sie haben eine OVHcloud Dienstleistung abonniert, die über eine dedizierte öffentliche IP-Adresse erreichbar ist ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud Instanz](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/hosted-private-cloud), [Additional IP](/links/network/additional-ip), etc.).
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-asia.md
@@ -26,7 +26,7 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/asia/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-asia.md
@@ -26,13 +26,13 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/asia/vps/), [Public Cloud instance](https://www.ovhcloud.com/asia/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/asia/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/asia/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > The Edge Network Firewall does not support QUIC protocol.

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-au.md
@@ -26,7 +26,7 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-au/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-au.md
@@ -26,13 +26,13 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/en-au/vps/), [Public Cloud instance](https://www.ovhcloud.com/en-au/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/en-au/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-au/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > The Edge Network Firewall does not support QUIC protocol.

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-ca.md
@@ -26,7 +26,7 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-ca/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-ca.md
@@ -26,13 +26,13 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/en-ca/vps/), [Public Cloud instance](https://www.ovhcloud.com/en-ca/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/en-ca/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-ca/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > The Edge Network Firewall does not support QUIC protocol.

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-gb.md
@@ -26,7 +26,7 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-gb/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-gb.md
@@ -26,13 +26,13 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/en-gb/vps/), [Public Cloud instance](https://www.ovhcloud.com/en-gb/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/en-gb/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-gb/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > The Edge Network Firewall does not support QUIC protocol.

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-ie.md
@@ -26,13 +26,13 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/en-ie/vps/), [Public Cloud instance](https://www.ovhcloud.com/en-ie/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/en-ie/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-ie/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > The Edge Network Firewall does not support QUIC protocol.

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-ie.md
@@ -26,7 +26,7 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-ie/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-sg.md
@@ -26,7 +26,7 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-sg/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-sg.md
@@ -26,13 +26,13 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/en-sg/vps/), [Public Cloud instance](https://www.ovhcloud.com/en-sg/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/en-sg/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-sg/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > The Edge Network Firewall does not support QUIC protocol.

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-us.md
@@ -26,13 +26,13 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/en/vps/), [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/en/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > The Edge Network Firewall does not support QUIC protocol.

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.en-us.md
@@ -26,7 +26,7 @@ To protect customer services exposed on public IP addresses, OVHcloud offers a s
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.es-es.md
@@ -28,7 +28,7 @@ Para proteger su infraestructura mundial y los servidores de sus clientes, OVHcl
 
 ## Requisitos
 
-- Un servicio de OVHcloud expuesto en una dirección IP pública dedicada ([Servidor Dedicado](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [instancias de Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/es-es/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.).
+- Un servicio de OVHcloud expuesto en una dirección IP pública dedicada ([Servidor Dedicado](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [instancias de Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.).
 - Tener acceso al [área de cliente de OVHcloud](/links/manager).
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.es-es.md
@@ -28,13 +28,13 @@ Para proteger su infraestructura mundial y los servidores de sus clientes, OVHcl
 
 ## Requisitos
 
-- Un servicio de OVHcloud expuesto en una dirección IP pública dedicada ([Servidor Dedicado](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/es-es/vps/), [instancias de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/es-es/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.).
+- Un servicio de OVHcloud expuesto en una dirección IP pública dedicada ([Servidor Dedicado](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [instancias de Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/es-es/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.).
 - Tener acceso al [área de cliente de OVHcloud](/links/manager).
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es-es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es-es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 > [!warning]
 > Edge Firewall Network no admite el protocolo QUIC.

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.es-us.md
@@ -28,12 +28,12 @@ Para proteger su infraestructura mundial y los servidores de sus clientes, OVHcl
 
 ## Requisitos
 
-- Un servicio de OVHcloud expuesto en una dirección IP pública dedicada ([Servidor Dedicado](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/es/vps/), [instancias de Public Cloud](https://www.ovhcloud.com/es/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/es/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.).
+- Un servicio de OVHcloud expuesto en una dirección IP pública dedicada ([Servidor Dedicado](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [instancias de Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/es/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.).
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 > [!warning]
 > Edge Firewall Network no admite el protocolo QUIC.

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.es-us.md
@@ -28,7 +28,7 @@ Para proteger su infraestructura mundial y los servidores de sus clientes, OVHcl
 
 ## Requisitos
 
-- Un servicio de OVHcloud expuesto en una dirección IP pública dedicada ([Servidor Dedicado](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [instancias de Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/es/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.).
+- Un servicio de OVHcloud expuesto en una dirección IP pública dedicada ([Servidor Dedicado](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [instancias de Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.).
 
 > [!warning]
 > Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.fr-ca.md
@@ -26,13 +26,13 @@ Pour protéger les services des clients exposés sur les adresses IP publiques, 
 
 ## Prérequis
 
-- Un service OVHcloud exposé et utilisant une adresse IP publique dédiée ([Serveur Dédié](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/fr-ca/vps/),[instance Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/fr-ca/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- Un service OVHcloud exposé et utilisant une adresse IP publique dédiée ([Serveur Dédié](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps),[instance Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/fr-ca/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Avoir accès à votre [espace client OVHcloud](/links/manager).
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 > [!warning]
 > Le Edge Firewall Network ne prend pas en charge le protocole QUIC.

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.fr-ca.md
@@ -26,7 +26,7 @@ Pour protéger les services des clients exposés sur les adresses IP publiques, 
 
 ## Prérequis
 
-- Un service OVHcloud exposé et utilisant une adresse IP publique dédiée ([Serveur Dédié](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps),[instance Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/fr-ca/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- Un service OVHcloud exposé et utilisant une adresse IP publique dédiée ([Serveur Dédié](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps),[instance Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Avoir accès à votre [espace client OVHcloud](/links/manager).
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.fr-fr.md
@@ -26,13 +26,13 @@ Pour protéger les services des clients exposés sur les adresses IP publiques, 
 
 ## Prérequis
 
-- Un service OVHcloud exposé et utilisant une adresse IP publique dédiée ([Serveur Dédié](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/fr/vps/),[instance Public Cloud](https://www.ovhcloud.com/fr/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- Un service OVHcloud exposé et utilisant une adresse IP publique dédiée ([Serveur Dédié](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps),[instance Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Avoir accès à votre [espace client OVHcloud](/links/manager).
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 > [!warning]
 > Le Edge Firewall Network ne prend pas en charge le protocole QUIC.

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.fr-fr.md
@@ -26,7 +26,7 @@ Pour protéger les services des clients exposés sur les adresses IP publiques, 
 
 ## Prérequis
 
-- Un service OVHcloud exposé et utilisant une adresse IP publique dédiée ([Serveur Dédié](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps),[instance Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- Un service OVHcloud exposé et utilisant une adresse IP publique dédiée ([Serveur Dédié](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps),[instance Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Avoir accès à votre [espace client OVHcloud](/links/manager).
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.it-it.md
@@ -26,7 +26,7 @@ Per proteggere i servizi clienti esposti agli indirizzi IP pubblici, OVHcloud of
 
 ## Requisiti
 
-- Un servizio OVHcloud esposto su un indirizzo IP pubblico dedicato ([server dedicato](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [istanza Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/it/enterprise/products/hosted-private-cloud), [Additional IP](/links/network/additional-ip), ecc.)
+- Un servizio OVHcloud esposto su un indirizzo IP pubblico dedicato ([server dedicato](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [istanza Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), ecc.)
 - Accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.it-it.md
@@ -26,13 +26,13 @@ Per proteggere i servizi clienti esposti agli indirizzi IP pubblici, OVHcloud of
 
 ## Requisiti
 
-- Un servizio OVHcloud esposto su un indirizzo IP pubblico dedicato ([server dedicato](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/it/vps/), [istanza Public Cloud](https://www.ovhcloud.com/it/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/it/enterprise/products/hosted-private-cloud), [Additional IP](/links/network/additional-ip), ecc.)
+- Un servizio OVHcloud esposto su un indirizzo IP pubblico dedicato ([server dedicato](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [istanza Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/it/enterprise/products/hosted-private-cloud), [Additional IP](/links/network/additional-ip), ecc.)
 - Accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 > [!warning]
-> Questa funzionalità potrebbe non essere disponibile o essere limitata sui server della [**Linea di prodotti Eco**](https://eco.ovhcloud.com/it/about/).
+> Questa funzionalità potrebbe non essere disponibile o essere limitata sui server della [**Linea di prodotti Eco**](/links/bare-metal/eco-about).
 >
-> Per maggiori informazioni, visitate la nostra [pagina di confronto](https://eco.ovhcloud.com/it/compare/).
+> Per maggiori informazioni, visitate la nostra [pagina di confronto](/links/bare-metal/eco-compare).
 
 > [!warning]
 > Edge Firewall Network non supporta il protocollo QUIC.

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.pl-pl.md
@@ -26,7 +26,7 @@ Aby chronić usługi dostępne dla klientów korzystających z publicznych adres
 
 ## Wymagania początkowe
 
-- Usługa OVHcloud udostępniona na dedykowanym publicznym adresie IP ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/pl/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip) itd.)
+- Usługa OVHcloud udostępniona na dedykowanym publicznym adresie IP ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip) itd.)
 - Dostęp do [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.pl-pl.md
@@ -26,13 +26,13 @@ Aby chronić usługi dostępne dla klientów korzystających z publicznych adres
 
 ## Wymagania początkowe
 
-- Usługa OVHcloud udostępniona na dedykowanym publicznym adresie IP ([Dedicated server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/pl/vps/), [Public Cloud instance](https://www.ovhcloud.com/pl/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/pl/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip) itd.)
+- Usługa OVHcloud udostępniona na dedykowanym publicznym adresie IP ([Dedicated server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/pl/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip) itd.)
 - Dostęp do [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> Ta funkcja może być niedostępna lub ograniczona na serwerach [**Eco** product line](https://eco.ovhcloud.com/pl/about/).
+> Ta funkcja może być niedostępna lub ograniczona na serwerach [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Aby uzyskać więcej informacji, odwiedź stronę pod adresem [comparison page](https://eco.ovhcloud.com/pl/compare/).
+> Aby uzyskać więcej informacji, odwiedź stronę pod adresem [comparison page](/links/bare-metal/eco-compare).
 
 > [!warning]
 > Edge Network Firewall nie obsługuje protokołu QUIC.

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.pt-pt.md
@@ -26,7 +26,7 @@ Para proteger os serviços dos clientes expostos aos IPs públicos, a OVHcloud o
 
 ## Requisitos
 
-- Um serviço OVHcloud exposto num endereço IP público dedicado ([Servidor dedicado](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Instância Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/pt/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- Um serviço OVHcloud exposto num endereço IP público dedicado ([Servidor dedicado](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Instância Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Acesso à [Área de Cliente OVHcloud](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/firewall_network/guide.pt-pt.md
@@ -26,13 +26,13 @@ Para proteger os serviços dos clientes expostos aos IPs públicos, a OVHcloud o
 
 ## Requisitos
 
-- Um serviço OVHcloud exposto num endereço IP público dedicado ([Servidor dedicado](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/pt/vps/), [Instância Public Cloud](https://www.ovhcloud.com/pt/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/pt/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- Um serviço OVHcloud exposto num endereço IP público dedicado ([Servidor dedicado](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Instância Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/pt/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Acesso à [Área de Cliente OVHcloud](/links/manager)
 
 > [!warning]
-> Esta funcionalidade poderá estar indisponível ou limitada nos servidores da linha de produto [**Eco**](https://eco.ovhcloud.com/pt/about/).
+> Esta funcionalidade poderá estar indisponível ou limitada nos servidores da linha de produto [**Eco**](/links/bare-metal/eco-about).
 >
-> Visite a nossa [página de comparação](https://eco.ovhcloud.com/pt/compare/) para mais informações.
+> Visite a nossa [página de comparação](/links/bare-metal/eco-compare) para mais informações.
 
 > [!warning]
 > A Edge Firewall Network não suporta o protocolo QUIC.

--- a/pages/bare_metal_cloud/dedicated_servers/getting-started-with-dedicated-server-eco/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/getting-started-with-dedicated-server-eco/guide.fr-ca.md
@@ -87,7 +87,7 @@ Cliquez enfin sur `Confirmer`{.action} pour lancer l'installation du système d'
 > [!warning]
 > OVHcloud met à votre disposition des services dont la configuration et la gestion relèvent de votre responsabilité. Il vous appartient donc d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous avez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](/links/partner) si vous avez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
 >
 
 #### Linux

--- a/pages/bare_metal_cloud/dedicated_servers/getting-started-with-dedicated-server-eco/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/getting-started-with-dedicated-server-eco/guide.fr-fr.md
@@ -87,7 +87,7 @@ Cliquez enfin sur `Confirmer`{.action} pour lancer l'installation du système d'
 > [!warning]
 > OVHcloud met à votre disposition des services dont la configuration et la gestion relèvent de votre responsabilité. Il vous appartient donc d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous avez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](/links/partner) si vous avez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
 >
 
 #### Linux

--- a/pages/bare_metal_cloud/dedicated_servers/hardware-upgrade-HG-Scale/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/hardware-upgrade-HG-Scale/guide.de-de.md
@@ -82,6 +82,6 @@ Möchten Sie gleichzeitig Storage und RAM erweitern? Dann bestellen und bezahlen
  
 Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](/links/partner).
  
-Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
+Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](/links/support).
  
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/bare_metal_cloud/dedicated_servers/hardware-upgrade-HG-Scale/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/hardware-upgrade-HG-Scale/guide.es-es.md
@@ -81,6 +81,6 @@ Si desea programar la mejora de la memoria y el almacenamiento durante la misma 
  
 Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con [partners de OVHcloud](/links/partner).
  
-Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
+Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](/links/support).
  
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/bare_metal_cloud/dedicated_servers/hardware-upgrade-HG-Scale/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/hardware-upgrade-HG-Scale/guide.es-us.md
@@ -81,6 +81,6 @@ Si desea programar la mejora de la memoria y el almacenamiento durante la misma 
  
 Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con [partners de OVHcloud](/links/partner).
  
-Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es/support-levels/).
+Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](/links/support).
  
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/bare_metal_cloud/dedicated_servers/hardware-upgrade-HG-Scale/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/hardware-upgrade-HG-Scale/guide.it-it.md
@@ -82,6 +82,6 @@ Per pianificare un upgrade di memoria e storage durante lo stesso intervento, è
  
 Per prestazioni specializzate (referenziamento, sviluppo, ecc...), contatta i [partner OVHcloud](/links/partner).
  
-Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre soluzioni [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
+Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre soluzioni [offerte di supporto](/links/support).
  
 Contatta la nostra Community di utenti all'indirizzo <https://community.ovh.com/en/>.

--- a/pages/bare_metal_cloud/dedicated_servers/hardware-upgrade-HG-Scale/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/hardware-upgrade-HG-Scale/guide.pl-pl.md
@@ -82,6 +82,6 @@ Jeśli zamierzasz zwiększyć pojemność pamięci i przestrzeni dyskowej w trak
  
 W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj się z [partnerami OVHcloud](/links/partner).
  
-Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](https://www.ovhcloud.com/pl/support-levels/).
+Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](/links/support).
  
 Dołącz do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/bare_metal_cloud/dedicated_servers/hardware-upgrade-HG-Scale/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/hardware-upgrade-HG-Scale/guide.pt-pt.md
@@ -82,6 +82,6 @@ Se pretender programar uma evolução de memória e de armazenamento durante a m
  
 Para serviços especializados (referenciamento, desenvolvimento, etc), contacte os [parceiros OVHcloud](/links/partner).
  
-Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
+Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
  
 Fale com nossa comunidade de utilizadores: <https://community.ovh.com/en/>.

--- a/pages/bare_metal_cloud/dedicated_servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync/guide.fr-ca.md
@@ -14,7 +14,7 @@ Distribué sous licence GNU GPL, rsync (pour  «remote synchronization» ), est 
 
 > [!warning]
 >
-Ce tutoriel vous présente l’utilisation d’une ou de plusieurs solutions OVHcloud avec des outils externes et vous décrit des manipulations réalisées dans un contexte précis. Pensez à les adapter en fonction de votre situation ! Si vous rencontrez des difficultés lors de ces manipulations, nous vous invitons à faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) et/ou à poser vos questions à notre [communauté d'utilisateurs](/links/community). OVHcloud ne sera pas en mesure de vous fournir une assistance.
+Ce tutoriel vous présente l’utilisation d’une ou de plusieurs solutions OVHcloud avec des outils externes et vous décrit des manipulations réalisées dans un contexte précis. Pensez à les adapter en fonction de votre situation ! Si vous rencontrez des difficultés lors de ces manipulations, nous vous invitons à faire appel à un [prestataire spécialisé](/links/partner) et/ou à poser vos questions à notre [communauté d'utilisateurs](/links/community). OVHcloud ne sera pas en mesure de vous fournir une assistance.
 >
 
 ## Prérequis

--- a/pages/bare_metal_cloud/dedicated_servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/how-to-copy-data-from-one-dedicated-server-to-another-using-rsync/guide.fr-fr.md
@@ -14,7 +14,7 @@ Distribué sous licence GNU GPL, rsync (pour  «remote synchronization» ), est 
 
 > [!warning]
 >
-Ce tutoriel vous présente l’utilisation d’une ou de plusieurs solutions OVHcloud avec des outils externes et vous décrit des manipulations réalisées dans un contexte précis. Pensez à les adapter en fonction de votre situation ! Si vous rencontrez des difficultés lors de ces manipulations, nous vous invitons à faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) et/ou à poser vos questions à notre [communauté d'utilisateurs](/links/community). OVHcloud ne sera pas en mesure de vous fournir une assistance.
+Ce tutoriel vous présente l’utilisation d’une ou de plusieurs solutions OVHcloud avec des outils externes et vous décrit des manipulations réalisées dans un contexte précis. Pensez à les adapter en fonction de votre situation ! Si vous rencontrez des difficultés lors de ces manipulations, nous vous invitons à faire appel à un [prestataire spécialisé](/links/partner) et/ou à poser vos questions à notre [communauté d'utilisateurs](/links/community). OVHcloud ne sera pas en mesure de vous fournir une assistance.
 >
 
 ## Prérequis

--- a/pages/bare_metal_cloud/dedicated_servers/hyperv-network-HG-Scale/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/hyperv-network-HG-Scale/guide.es-us.md
@@ -253,7 +253,7 @@ network:
 - Tener un bloque público de direcciones IP reservado en su cuenta, con un mínimo de cuatro direcciones.
 - Haber elegido un rango de direcciones IP privadas.
 - Tener un [servidor compatible con el vRack](/links/bare-metal/bare-metal){.external}.
-- Haber activado un servicio [vRack](https://www.ovhcloud.com/es/network/vrack/){.external}.
+- Haber activado un servicio [vRack](/links/network/vrack){.external}.
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 
 #### Explicaciones

--- a/pages/bare_metal_cloud/dedicated_servers/hyperv-network-HG-Scale/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/hyperv-network-HG-Scale/guide.es-us.md
@@ -253,7 +253,7 @@ network:
 - Tener un bloque público de direcciones IP reservado en su cuenta, con un mínimo de cuatro direcciones.
 - Haber elegido un rango de direcciones IP privadas.
 - Tener un [servidor compatible con el vRack](/links/bare-metal/bare-metal){.external}.
-- Haber activado un servicio [vRack](/links/network/vrack){.external}.
+- Haber activado un servicio [vRack](/links/network/vrack).
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 
 #### Explicaciones

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.de-de.md
@@ -16,7 +16,7 @@ Mit der Einrichtung eines Webservers und verwandter Software kann Ihr Cloud Serv
 
 ## Voraussetzungen
 
-- Sie haben einen [Dedicated Server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/de/vps/) oder eine [Public Cloud Instanz](https://www.ovhcloud.com/de/public-cloud/) in Ihrem Kunden-Account (ausgenommen Windows-Systeme).
+- Sie haben einen [Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps) oder eine [Public Cloud Instanz](/links/public-cloud/public-cloud) in Ihrem Kunden-Account (ausgenommen Windows-Systeme).
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 - Sie haben administrativen Zugriff (sudo) auf Ihren Dienst über SSH.
 

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-asia.md
@@ -12,7 +12,7 @@ Setting up a web server and related software enables your cloud server to host d
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/asia/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access to your service via SSH
 

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-au.md
@@ -12,7 +12,7 @@ Setting up a web server and related software enables your cloud server to host d
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/en-au/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access to your service via SSH
 

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-ca.md
@@ -12,7 +12,7 @@ Setting up a web server and related software enables your cloud server to host d
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/en-ca/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access to your service via SSH
 

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-gb.md
@@ -12,7 +12,7 @@ Setting up a web server and related software enables your cloud server to host d
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/en-gb/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access to your service via SSH
 

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-ie.md
@@ -12,7 +12,7 @@ Setting up a web server and related software enables your cloud server to host d
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/en-ie/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access to your service via SSH
 

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-sg.md
@@ -12,7 +12,7 @@ Setting up a web server and related software enables your cloud server to host d
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/en-sg/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access to your service via SSH
 

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.en-us.md
@@ -12,7 +12,7 @@ Setting up a web server and related software enables your cloud server to host d
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/en/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access to your service via SSH
 

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.es-es.md
@@ -16,7 +16,7 @@ La creación de un servidor web y los programas asociados permiten que su servid
 
 ## Requisitos
 
-- Un [servidor dedicado](/links/bare-metal/bare-metal), un [VPS](https://www.ovhcloud.com/es-es/vps/) o una instancia de [Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud (excepto sistemas Windows)
+- Un [servidor dedicado](/links/bare-metal/bare-metal), un [VPS](/links/bare-metal/vps) o una instancia de [Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud (excepto sistemas Windows)
 - Tienes acceso a tu [área de cliente de OVHcloud](/links/manager)
 - Acceso administrativo al servicio por SSH
 

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.es-us.md
@@ -16,7 +16,7 @@ La creación de un servidor web y los programas asociados permiten que su servid
 
 ## Requisitos
 
-- Un [servidor dedicado](/links/bare-metal/bare-metal), un [VPS](https://www.ovhcloud.com/es/vps/) o una instancia de [Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud (excepto sistemas Windows)
+- Un [servidor dedicado](/links/bare-metal/bare-metal), un [VPS](/links/bare-metal/vps) o una instancia de [Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud (excepto sistemas Windows)
 - Tienes acceso a tu [área de cliente de OVHcloud](/links/manager)
 - Acceso administrativo al servicio por SSH
 

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.fr-ca.md
@@ -12,14 +12,14 @@ La mise en place d'un serveur web et des logiciels associés permet à votre ser
 
 ## Prérequis
 
-- Un [serveur dédié](/links/bare-metal/bare-metal), un [VPS](https://www.ovhcloud.com/fr-ca/vps/) ou une instance [Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud (hors systèmes Windows)
+- Un [serveur dédié](/links/bare-metal/bare-metal), un [VPS](/links/bare-metal/vps) ou une instance [Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud (hors systèmes Windows)
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 - Un accès administratif à votre service via SSH
 
 > [!warning]
 > Ce tutoriel vous présente l’utilisation d’une ou de plusieurs solutions OVHcloud avec des outils externes et vous décrit des manipulations réalisées dans un contexte précis. Il vous faudra peut-être adapter les consignes à votre situation.
 >
-> Nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) ou de vous rapprocher de [notre communauté](/links/community) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
+> Nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou de vous rapprocher de [notre communauté](/links/community) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
 >
 
 ## En pratique

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.fr-fr.md
@@ -12,14 +12,14 @@ La mise en place d'un serveur web et des logiciels associés permet à votre ser
 
 ## Prérequis
 
-- Un [serveur dédié](/links/bare-metal/bare-metal), un [VPS](https://www.ovhcloud.com/fr/vps/) ou une instance [Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud (hors systèmes Windows)
+- Un [serveur dédié](/links/bare-metal/bare-metal), un [VPS](/links/bare-metal/vps) ou une instance [Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud (hors systèmes Windows)
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 - Un accès administratif à votre service via SSH
 
 > [!warning]
 > Ce tutoriel vous présente l’utilisation d’une ou de plusieurs solutions OVHcloud avec des outils externes et vous décrit des manipulations réalisées dans un contexte précis. Il vous faudra peut-être adapter les consignes à votre situation.
 >
-> Nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de vous rapprocher de [notre communauté](/links/community) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
+> Nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou de vous rapprocher de [notre communauté](/links/community) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
 >
 
 ## En pratique

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.it-it.md
@@ -16,7 +16,7 @@ La realizzazione di un server Web e dei software associati permette al tuo serve
 
 ## Prerequisiti
 
-- Un [server dedicato](/links/bare-metal/bare-metal), un [VPS](https://www.ovhcloud.com/it/vps/) o un'istanza [Public Cloud](https://www.ovhcloud.com/it/public-cloud/) nel tuo account OVHcloud (Windows escluso)
+- Un [server dedicato](/links/bare-metal/bare-metal), un [VPS](/links/bare-metal/vps) o un'istanza [Public Cloud](/links/public-cloud/public-cloud) nel tuo account OVHcloud (Windows escluso)
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 - Un accesso amministrativo al tuo servizio tramite SSH
 

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.pl-pl.md
@@ -16,7 +16,7 @@ Uruchomienie serwera www i powiązanych z nim aplikacji pozwala serwerowi cloud 
 
 ## Wymagania początkowe
 
-- Serwer [dedykowany](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/pl/vps/) lub instancja [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na Twoim koncie OVHcloud (z wyłączeniem systemu Windows)
+- Serwer [dedykowany](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps) lub instancja [Public Cloud](/links/public-cloud/public-cloud) na Twoim koncie OVHcloud (z wyłączeniem systemu Windows)
 - Dostęp do [Panelu klienta OVHcloud](/links/manager)
 - Dostęp administracyjny do Twojej usługi przez SSH
 

--- a/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/installing_lamp_debian9_ubuntu18/guide.pt-pt.md
@@ -16,7 +16,7 @@ A implementação de um servidor web e dos softwares associados permite ao seu s
 
 ## Requisitos
 
-- Um [servidor dedicado](/links/bare-metal/bare-metal), um [VPS](https://www.ovhcloud.com/pt/vps/) ou uma instância [Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud (exceto sistemas Windows)
+- Um [servidor dedicado](/links/bare-metal/bare-metal), um [VPS](/links/bare-metal/vps) ou uma instância [Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud (exceto sistemas Windows)
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager)
 - Um acesso administrativo ao seu serviço via SSH
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.de-de.md
@@ -21,9 +21,9 @@ updated: 2021-02-25
 - Sie verfügen über einen IP-Block von 4 oder mehr IP-Adressen.
 
 > [!warning]
-> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](https://eco.ovhcloud.com/de/about/) eingesetzt wird.
+> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](/links/bare-metal/eco-about) eingesetzt wird.
 >
-> Weitere Informationen finden Sie auf der [Vergleichsseite](https://eco.ovhcloud.com/de/compare/).
+> Weitere Informationen finden Sie auf der [Vergleichsseite](/links/bare-metal/eco-compare).
 
 ## In der praktischen Anwendung
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-asia.md
@@ -17,9 +17,9 @@ updated: 2021-02-25
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/asia/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/asia/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-au.md
@@ -17,9 +17,9 @@ updated: 2021-02-25
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-au/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-au/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-ca.md
@@ -17,9 +17,9 @@ updated: 2021-02-25
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ca/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ca/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-gb.md
@@ -17,9 +17,9 @@ updated: 2021-02-25
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-ie.md
@@ -17,9 +17,9 @@ updated: 2021-02-25
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ie/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ie/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-sg.md
@@ -17,9 +17,9 @@ updated: 2021-02-25
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-sg/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-sg/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.en-us.md
@@ -17,9 +17,9 @@ updated: 2021-02-25
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.es-es.md
@@ -23,9 +23,9 @@ Siga el proceso de instalación de Hyper-V, asocie un switch virtual y configure
 - Estar conectado al [área de cliente de OVHcloud](/links/manager).
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es-es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es-es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.es-us.md
@@ -23,9 +23,9 @@ Siga el proceso de instalación de Hyper-V, asocie un switch virtual y configure
 - Estar conectado al [área de cliente de OVHcloud](/links/manager)
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.fr-ca.md
@@ -19,9 +19,9 @@ Suivez le processus d'installation d'Hyper-V, l'association d'un switch virtuel 
 - Etre connecté à l'[espace client OVHcloud](/links/manager).
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr-ca/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr-ca/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.fr-fr.md
@@ -19,9 +19,9 @@ Suivez le processus d'installation d'Hyper-V, l'association d'un switch virtuel 
 - Etre connecté à l'[espace client OVHcloud](/links/manager).
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.it-it.md
@@ -23,9 +23,9 @@ Segui il processo di installazione di Hyper-V, l'associazione di uno switch virt
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager).
 
 > [!warning]
-> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](https://eco.ovhcloud.com/it/about/).
+> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](/links/bare-metal/eco-about).
 >
-> Per maggiori informazioni, consulta la nostra [a confronto](https://eco.ovhcloud.com/it/compare/).
+> Per maggiori informazioni, consulta la nostra [a confronto](/links/bare-metal/eco-compare).
 
 ## Procedura
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.pl-pl.md
@@ -23,9 +23,9 @@ Postępuj zgodnie z instrukcjami procesu instalacji Hyper-V, połączenia wirtua
 - Dostęp do [Panelu klienta OVHcloud](/links/manager).
 
 > [!warning]
-> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](https://eco.ovhcloud.com/pl/about/).
+> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](/links/bare-metal/eco-about).
 >
-> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](https://eco.ovhcloud.com/pl/compare/).
+> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](/links/bare-metal/eco-compare).
 
 ## W praktyce
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipfo-vrack-hyperv/guide.pt-pt.md
@@ -23,9 +23,9 @@ Siga o processo de instalação do Hyper-V, a associação de um switch virtual 
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager).
 
 > [!warning]
-> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](https://eco.ovhcloud.com/pt/about/).
+> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para mais informações, consulte o nosso [comparativo](https://eco.ovhcloud.com/pt/compare/).
+> Para mais informações, consulte o nosso [comparativo](/links/bare-metal/eco-compare).
 
 ## Instruções
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.en-asia.md
@@ -12,7 +12,7 @@ updated: 2024-02-27
 >
 
 In the [OVHcloud Control Panel](/links/manager), it is possible to specify a boot mode among a predefined list: primary disk or rescue.<br>
-With the [OVHcloud API](https://ca.api.ovh.com/), you can define custom scripts.
+With the [OVHcloud API](/links/api), you can define custom scripts.
 
 Using a custom script can be useful in the following use cases:
 
@@ -23,7 +23,7 @@ Using a custom script can be useful in the following use cases:
 ## Requirements
 
 - A [dedicated server](/links/bare-metal/bare-metal) **ready to be booted/rebooted** in your OVHcloud account.
-- Access to the [OVHcloud API](https://ca.api.ovh.com/).
+- Access to the [OVHcloud API](/links/api).
 
 > [!warning]
 >
@@ -83,7 +83,7 @@ You can now reboot your server and it will use your [iPXE](https://ipxe.org/) to
 
 ### Changing boot modes <a name="leaveIpxeScript"></a>
 
-You can now switch back to disk or rescue boot from the [OVHcloud Control Panel](/links/manager) (see our guide on [Activating and using rescue mode](/pages/bare_metal_cloud/dedicated_servers/rescue_mode)), or the [OVHcloud API](https://ca.api.ovh.com/).
+You can now switch back to disk or rescue boot from the [OVHcloud Control Panel](/links/manager) (see our guide on [Activating and using rescue mode](/pages/bare_metal_cloud/dedicated_servers/rescue_mode)), or the [OVHcloud API](/links/api).
 
 #### Switch to disk <a name="switchToDisk"></a>
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.en-au.md
@@ -12,7 +12,7 @@ updated: 2024-02-27
 >
 
 In the [OVHcloud Control Panel](/links/manager), it is possible to specify a boot mode among a predefined list: primary disk or rescue.<br>
-With the [OVHcloud API](https://ca.api.ovh.com/), you can define custom scripts.
+With the [OVHcloud API](/links/api), you can define custom scripts.
 
 Using a custom script can be useful in the following use cases:
 
@@ -23,7 +23,7 @@ Using a custom script can be useful in the following use cases:
 ## Requirements
 
 - A [dedicated server](/links/bare-metal/bare-metal) **ready to be booted/rebooted** in your OVHcloud account.
-- Access to the [OVHcloud API](https://ca.api.ovh.com/).
+- Access to the [OVHcloud API](/links/api).
 
 > [!warning]
 >
@@ -83,7 +83,7 @@ You can now reboot your server and it will use your [iPXE](https://ipxe.org/) to
 
 ### Changing boot modes <a name="leaveIpxeScript"></a>
 
-You can now switch back to disk or rescue boot from the [OVHcloud Control Panel](/links/manager) (see our guide on [Activating and using rescue mode](/pages/bare_metal_cloud/dedicated_servers/rescue_mode)), or the [OVHcloud API](https://ca.api.ovh.com/).
+You can now switch back to disk or rescue boot from the [OVHcloud Control Panel](/links/manager) (see our guide on [Activating and using rescue mode](/pages/bare_metal_cloud/dedicated_servers/rescue_mode)), or the [OVHcloud API](/links/api).
 
 #### Switch to disk <a name="switchToDisk"></a>
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.en-ca.md
@@ -12,7 +12,7 @@ updated: 2024-02-27
 >
 
 In the [OVHcloud Control Panel](/links/manager), it is possible to specify a boot mode among a predefined list: primary disk or rescue.<br>
-With the [OVHcloud API](https://ca.api.ovh.com/), you can define custom scripts.
+With the [OVHcloud API](/links/api), you can define custom scripts.
 
 Using a custom script can be useful in the following use cases:
 
@@ -23,7 +23,7 @@ Using a custom script can be useful in the following use cases:
 ## Requirements
 
 - A [dedicated server](/links/bare-metal/bare-metal) **ready to be booted/rebooted** in your OVHcloud account.
-- Access to the [OVHcloud API](https://ca.api.ovh.com/).
+- Access to the [OVHcloud API](/links/api).
 
 > [!warning]
 >
@@ -83,7 +83,7 @@ You can now reboot your server and it will use your [iPXE](https://ipxe.org/) to
 
 ### Changing boot modes <a name="leaveIpxeScript"></a>
 
-You can now switch back to disk or rescue boot from the [OVHcloud Control Panel](/links/manager) (see our guide on [Activating and using rescue mode](/pages/bare_metal_cloud/dedicated_servers/rescue_mode)), or the [OVHcloud API](https://ca.api.ovh.com/).
+You can now switch back to disk or rescue boot from the [OVHcloud Control Panel](/links/manager) (see our guide on [Activating and using rescue mode](/pages/bare_metal_cloud/dedicated_servers/rescue_mode)), or the [OVHcloud API](/links/api).
 
 #### Switch to disk <a name="switchToDisk"></a>
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.en-sg.md
@@ -12,7 +12,7 @@ updated: 2024-02-27
 >
 
 In the [OVHcloud Control Panel](/links/manager), it is possible to specify a boot mode among a predefined list: primary disk or rescue.<br>
-With the [OVHcloud API](https://ca.api.ovh.com/), you can define custom scripts.
+With the [OVHcloud API](/links/api), you can define custom scripts.
 
 Using a custom script can be useful in the following use cases:
 
@@ -23,7 +23,7 @@ Using a custom script can be useful in the following use cases:
 ## Requirements
 
 - A [dedicated server](/links/bare-metal/bare-metal) **ready to be booted/rebooted** in your OVHcloud account.
-- Access to the [OVHcloud API](https://ca.api.ovh.com/).
+- Access to the [OVHcloud API](/links/api).
 
 > [!warning]
 >
@@ -83,7 +83,7 @@ You can now reboot your server and it will use your [iPXE](https://ipxe.org/) to
 
 ### Changing boot modes <a name="leaveIpxeScript"></a>
 
-You can now switch back to disk or rescue boot from the [OVHcloud Control Panel](/links/manager) (see our guide on [Activating and using rescue mode](/pages/bare_metal_cloud/dedicated_servers/rescue_mode)), or the [OVHcloud API](https://ca.api.ovh.com/).
+You can now switch back to disk or rescue boot from the [OVHcloud Control Panel](/links/manager) (see our guide on [Activating and using rescue mode](/pages/bare_metal_cloud/dedicated_servers/rescue_mode)), or the [OVHcloud API](/links/api).
 
 #### Switch to disk <a name="switchToDisk"></a>
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.en-us.md
@@ -12,7 +12,7 @@ updated: 2024-02-27
 >
 
 In the [OVHcloud Control Panel](/links/manager), it is possible to specify a boot mode among a predefined list: primary disk or rescue.<br>
-With the [OVHcloud API](https://ca.api.ovh.com/), you can define custom scripts.
+With the [OVHcloud API](/links/api), you can define custom scripts.
 
 Using a custom script can be useful in the following use cases:
 
@@ -23,7 +23,7 @@ Using a custom script can be useful in the following use cases:
 ## Requirements
 
 - A [dedicated server](/links/bare-metal/bare-metal) **ready to be booted/rebooted** in your OVHcloud account.
-- Access to the [OVHcloud API](https://ca.api.ovh.com/).
+- Access to the [OVHcloud API](/links/api).
 
 > [!warning]
 >
@@ -83,7 +83,7 @@ You can now reboot your server and it will use your [iPXE](https://ipxe.org/) to
 
 ### Changing boot modes <a name="leaveIpxeScript"></a>
 
-You can now switch back to disk or rescue boot from the [OVHcloud Control Panel](/links/manager) (see our guide on [Activating and using rescue mode](/pages/bare_metal_cloud/dedicated_servers/rescue_mode)), or the [OVHcloud API](https://ca.api.ovh.com/).
+You can now switch back to disk or rescue boot from the [OVHcloud Control Panel](/links/manager) (see our guide on [Activating and using rescue mode](/pages/bare_metal_cloud/dedicated_servers/rescue_mode)), or the [OVHcloud API](/links/api).
 
 #### Switch to disk <a name="switchToDisk"></a>
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.es-us.md
@@ -16,7 +16,7 @@ updated: 2024-02-27
 >
 
 En el [área de cliente de OVHcloud](/links/manager) puede especificar un modo de arranque de una lista predefinida: disco principal o rescue.
-A través de la [API de OVHcloud](https://ca.api.ovh.com/), también puede definir scripts personalizados.
+A través de la [API de OVHcloud](/links/api), también puede definir scripts personalizados.
 
 Utilizar un script personalizado puede ser interesante en los siguientes casos:
 
@@ -26,7 +26,7 @@ Utilizar un script personalizado puede ser interesante en los siguientes casos:
 ## Requisitos
 
 - Un [servidor dedicado](/links/bare-metal/bare-metal) **listo para ser booteado/reiniciado** en su cuenta de OVHcloud.
-- Tener acceso a la [API de OVHcloud](https://ca.api.ovh.com/).
+- Tener acceso a la [API de OVHcloud](/links/api).
 
 > [!warning]
 >
@@ -86,7 +86,7 @@ Ya puede reiniciar el servidor y este utilizará su script [iPXE](https://ipxe.o
 
 ### Otros modos de arranque <a name="leaveIpxeScript"></a>
 
-En cualquier momento puede volver al disco o al modo de rescate desde el [área de cliente de OVHcloud](/links/manager) (consulte nuestra guía "[Activar y utilizar el modo de rescate](/pages/bare_metal_cloud/dedicated_servers/rescue_mode)") o a través de la [API de OVHcloud](https://ca.api.ovh.com/).
+En cualquier momento puede volver al disco o al modo de rescate desde el [área de cliente de OVHcloud](/links/manager) (consulte nuestra guía "[Activar y utilizar el modo de rescate](/pages/bare_metal_cloud/dedicated_servers/rescue_mode)") o a través de la [API de OVHcloud](/links/api).
 
 #### Cambiar a disco <a name="switchToDisk"></a>
 

--- a/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/ipxe-scripts/guide.fr-ca.md
@@ -12,7 +12,7 @@ updated: 2024-02-27
 >
 
 Dans l'[espace client OVHcloud](/links/manager), il est possible de choisir un amorçage parmi une liste prédéfinie restreinte : disque ou rescue principalement.<br>
-Via l’[API OVHcloud](https://ca.api.ovh.com/), vous pouvez aussi définir des scripts personnalisés.
+Via l’[API OVHcloud](/links/api), vous pouvez aussi définir des scripts personnalisés.
 
 Utiliser un script personnalisé peut-être intéressant dans les cas suivants :
 
@@ -22,7 +22,7 @@ Utiliser un script personnalisé peut-être intéressant dans les cas suivants :
 ## Prérequis
 
 - Un [serveur dédié](/links/bare-metal/bare-metal) **prêt à être booté/rebooté** sur votre compte OVHcloud.
-- Avoir accès à l'[API OVHcloud](https://ca.api.ovh.com/).
+- Avoir accès à l'[API OVHcloud](/links/api).
 
 > [!warning]
 >
@@ -82,7 +82,7 @@ Vous pouvez maintenant redémarrer votre serveur et celui-ci utilisera votre scr
 
 ### Autres modes de boot <a name="leaveIpxeScript"></a>
 
-Vous pouvez à tout moment basculer à nouveau sur le disque ou sur le mode rescue à partir de l'[espace client OVHcloud](/links/manager) (consultez notre guide « [Activer et utiliser le mode rescue](/pages/bare_metal_cloud/dedicated_servers/rescue_mode) »), ou via l’[API OVHcloud](https://ca.api.ovh.com/).
+Vous pouvez à tout moment basculer à nouveau sur le disque ou sur le mode rescue à partir de l'[espace client OVHcloud](/links/manager) (consultez notre guide « [Activer et utiliser le mode rescue](/pages/bare_metal_cloud/dedicated_servers/rescue_mode) »), ou via l’[API OVHcloud](/links/api).
 
 #### Basculer sur disque <a name="switchToDisk"></a>
 

--- a/pages/bare_metal_cloud/dedicated_servers/memcache_secure/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/memcache_secure/guide.fr-ca.md
@@ -16,7 +16,7 @@ Par défaut, memcached n'est pas protégé par une authentification. Si le serve
 >
 > OVHcloud met à votre disposition des machines dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
 >
 
 ## Prérequis

--- a/pages/bare_metal_cloud/dedicated_servers/memcache_secure/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/memcache_secure/guide.fr-fr.md
@@ -16,7 +16,7 @@ Par défaut, memcached n'est pas protégé par une authentification. Si le serve
 >
 > OVHcloud met à votre disposition des machines dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
 >
 
 ## Prérequis

--- a/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-asia.md
@@ -45,7 +45,7 @@ Data migration usually involves copying files from one server to another. There 
 
 ### Using the backup storage (available only on OVHcloud and So you Start)
 
-With the [Backup Storage](https://www.ovhcloud.com/asia/bare-metal/backup-storage/) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
+With the [Backup Storage](/links/bare-metal/backup-storage) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
 
 > [!warning]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-au.md
@@ -45,7 +45,7 @@ Data migration usually involves copying files from one server to another. There 
 
 ### Using the backup storage (available only on OVHcloud and So you Start)
 
-With the [Backup Storage](https://www.ovhcloud.com/en-au/bare-metal/backup-storage/) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
+With the [Backup Storage](/links/bare-metal/backup-storage) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
 
 > [!warning]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-ca.md
@@ -45,7 +45,7 @@ Data migration usually involves copying files from one server to another. There 
 
 ### Using the backup storage (available only on OVHcloud and So you Start)
 
-With the [Backup Storage](https://www.ovhcloud.com/en-ca/bare-metal/backup-storage/) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
+With the [Backup Storage](/links/bare-metal/backup-storage) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
 
 > [!warning]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-gb.md
@@ -45,7 +45,7 @@ Data migration usually involves copying files from one server to another. There 
 
 ### Using the backup storage (available only on OVHcloud and So you Start)
 
-With the [Backup Storage](https://www.ovhcloud.com/en-gb/bare-metal/backup-storage/) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
+With the [Backup Storage](/links/bare-metal/backup-storage) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
 
 > [!warning]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-ie.md
@@ -45,7 +45,7 @@ Data migration usually involves copying files from one server to another. There 
 
 ### Using the backup storage (available only on OVHcloud and So you Start)
 
-With the [Backup Storage](https://www.ovhcloud.com/en-ie/bare-metal/backup-storage/) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
+With the [Backup Storage](/links/bare-metal/backup-storage) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
 
 > [!warning]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-sg.md
@@ -45,7 +45,7 @@ Data migration usually involves copying files from one server to another. There 
 
 ### Using the backup storage (available only on OVHcloud and So you Start)
 
-With the [Backup Storage](https://www.ovhcloud.com/en-sg/bare-metal/backup-storage/) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
+With the [Backup Storage](/links/bare-metal/backup-storage) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
 
 > [!warning]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.en-us.md
@@ -45,7 +45,7 @@ Data migration usually involves copying files from one server to another. There 
 
 ### Using the backup storage (available only on OVHcloud and So you Start)
 
-With the [Backup Storage](https://www.ovhcloud.com/en/bare-metal/backup-storage/) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
+With the [Backup Storage](/links/bare-metal/backup-storage) option, you can store data on a service that is external to your server. It is only linked to the service you ordered it from.
 
 > [!warning]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.es-es.md
@@ -50,7 +50,7 @@ La migración de los datos suele implicar copiar archivos de un servidor a otro.
 
 ### Uso del Backup Storage (disponible únicamente en OVHcloud y So you Start)
 
-Con la opción [Backup Storage](https://www.ovhcloud.com/es-es/bare-metal/backup-storage/) de backup, puede almacenar datos en un servicio externo al servidor. Solo está relacionado con el servicio que le ha contratado.
+Con la opción [Backup Storage](/links/bare-metal/backup-storage) de backup, puede almacenar datos en un servicio externo al servidor. Solo está relacionado con el servicio que le ha contratado.
 
 > [!warning]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.es-us.md
@@ -50,7 +50,7 @@ La migración de los datos suele implicar copiar archivos de un servidor a otro.
 
 ### Uso del Backup Storage (disponible únicamente en OVHcloud y So you Start)
 
-Con la opción [Backup Storage](https://www.ovhcloud.com/es/bare-metal/backup-storage/) de backup, puede almacenar datos en un servicio externo al servidor. Solo está relacionado con el servicio que le ha contratado.
+Con la opción [Backup Storage](/links/bare-metal/backup-storage) de backup, puede almacenar datos en un servicio externo al servidor. Solo está relacionado con el servicio que le ha contratado.
 
 > [!warning]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.fr-ca.md
@@ -14,7 +14,7 @@ Vos besoins et les gammes OVHcloud évoluant constamment, il est parfois nécess
 >
 > OVHcloud met à votre disposition des services dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d’assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
 >
 
 ## Prérequis
@@ -44,7 +44,7 @@ La migration des données consiste généralement à copier les fichiers d'un se
 
 ### Utiliser le backup storage (disponible uniquement sur OVHcloud et So you Start)
 
-L'option [Backup Storage](https://www.ovhcloud.com/fr-ca/bare-metal/backup-storage/) vous permet de stocker des données sur un service externalisé à votre serveur. De base, il est lié uniquement au service sur lequel vous l'avez commandé.
+L'option [Backup Storage](/links/bare-metal/backup-storage) vous permet de stocker des données sur un service externalisé à votre serveur. De base, il est lié uniquement au service sur lequel vous l'avez commandé.
 
 > [!warning]
 >
@@ -86,7 +86,7 @@ Pour plus d'informations, consultez notre documentation sur les [domaines et DNS
 
 ## Aller plus loin
 
-Pour bénéficier d'une assistance à la migration de votre serveur, nous vous proposons de contacter [notre réseau de partenaires](https://partner.ovhcloud.com/fr-ca/directory/).
+Pour bénéficier d'une assistance à la migration de votre serveur, nous vous proposons de contacter [notre réseau de partenaires](/links/partner).
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 

--- a/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/migrate_a_server_to_another/guide.fr-fr.md
@@ -14,7 +14,7 @@ Vos besoins et les gammes OVHcloud évoluant constamment, il est parfois nécess
 >
 > OVHcloud met à votre disposition des services dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d’assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
 >
 
 ## Prérequis
@@ -44,7 +44,7 @@ La migration des données consiste généralement à copier les fichiers d'un se
 
 ### Utiliser le backup storage (disponible uniquement sur OVHcloud et So you Start)
 
-L'option [Backup Storage](https://www.ovhcloud.com/fr/bare-metal/backup-storage/) vous permet de stocker des données sur un service externalisé à votre serveur. De base, il est lié uniquement au service sur lequel vous l'avez commandé.
+L'option [Backup Storage](/links/bare-metal/backup-storage) vous permet de stocker des données sur un service externalisé à votre serveur. De base, il est lié uniquement au service sur lequel vous l'avez commandé.
 
 > [!warning]
 >
@@ -86,7 +86,7 @@ Pour plus d'informations, consultez notre documentation sur les [domaines et DNS
 
 ## Aller plus loin
 
-Pour bénéficier d'une assistance à la migration de votre serveur, nous vous proposons de contacter [notre réseau de partenaires](https://partner.ovhcloud.com/fr/directory/).
+Pour bénéficier d'une assistance à la migration de votre serveur, nous vous proposons de contacter [notre réseau de partenaires](/links/partner).
 
 Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.de-de.md
@@ -32,9 +32,9 @@ IP-Adressblöcke in einer Region können innerhalb dieser Region von einem Reche
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 > [!warning]
-> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](https://eco.ovhcloud.com/de/about/) eingesetzt wird.
+> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](/links/bare-metal/eco-about) eingesetzt wird.
 >
-> Weitere Informationen finden Sie auf der [Vergleichsseite](https://eco.ovhcloud.com/de/compare/).
+> Weitere Informationen finden Sie auf der [Vergleichsseite](/links/bare-metal/eco-compare).
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-asia.md
@@ -33,9 +33,9 @@ With this technology, you can switch IP addresses from one solution to another i
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/asia/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/asia/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > If the Additional IP address or one of the block IP addresses has a virtual MAC attached, the target server must support the vMAC functionality.
@@ -83,7 +83,7 @@ Click `Next`{.action}, then `Confirm`{.action}.
 
 ### Moving an IP via the API
 
-Log in to the OVHcloud [API webpage](https://ca.api.ovh.com/).
+Log in to the OVHcloud [API webpage](/links/api).
 
 First, it is best to check if the IP address can be moved.
 <br>To check if the IP can be moved to one of your dedicated servers, use the following call:

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-au.md
@@ -33,9 +33,9 @@ With this technology, you can switch IP addresses from one solution to another i
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-au/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-au/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > If the Additional IP address or one of the block IP addresses has a virtual MAC attached, the target server must support the vMAC functionality.
@@ -83,7 +83,7 @@ Click `Next`{.action}, then `Confirm`{.action}.
 
 ### Moving an IP via the API
 
-Log in to the OVHcloud [API webpage](https://ca.api.ovh.com/).
+Log in to the OVHcloud [API webpage](/links/api).
 
 First, it is best to check if the IP address can be moved.
 <br>To check if the IP can be moved to one of your dedicated servers, use the following call:

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-ca.md
@@ -33,9 +33,9 @@ With this technology, you can switch IP addresses from one solution to another i
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ca/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ca/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > If the Additional IP address or one of the block IP addresses has a virtual MAC attached, the target server must support the vMAC functionality.
@@ -83,7 +83,7 @@ Click `Next`{.action}, then `Confirm`{.action}.
 
 ### Moving an IP via the API
 
-Log in to the OVHcloud [API webpage](https://ca.api.ovh.com/).
+Log in to the OVHcloud [API webpage](/links/api).
 
 First, it is best to check if the IP address can be moved.
 <br>To check if the IP can be moved to one of your dedicated servers, use the following call:

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-gb.md
@@ -33,9 +33,9 @@ With this technology, you can switch IP addresses from one solution to another i
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > If the Additional IP address or one of the block IP addresses has a virtual MAC attached, the target server must support the vMAC functionality.
@@ -83,7 +83,7 @@ Click `Next`{.action}, then `Confirm`{.action}.
 
 ### Moving an IP via the API
 
-Log in to the OVHcloud [API webpage](https://ca.api.ovh.com/).
+Log in to the OVHcloud [API webpage](/links/api).
 
 First, it is best to check if the IP address can be moved.
 <br>To check if the IP can be moved to one of your dedicated servers, use the following call:

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-ie.md
@@ -33,9 +33,9 @@ With this technology, you can switch IP addresses from one solution to another i
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ie/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ie/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > If the Additional IP address or one of the block IP addresses has a virtual MAC attached, the target server must support the vMAC functionality.
@@ -83,7 +83,7 @@ Click `Next`{.action}, then `Confirm`{.action}.
 
 ### Moving an IP via the API
 
-Log in to the OVHcloud [API webpage](https://ca.api.ovh.com/).
+Log in to the OVHcloud [API webpage](/links/api).
 
 First, it is best to check if the IP address can be moved.
 <br>To check if the IP can be moved to one of your dedicated servers, use the following call:

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-sg.md
@@ -33,9 +33,9 @@ With this technology, you can switch IP addresses from one solution to another i
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-sg/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-sg/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > If the Additional IP address or one of the block IP addresses has a virtual MAC attached, the target server must support the vMAC functionality.
@@ -83,7 +83,7 @@ Click `Next`{.action}, then `Confirm`{.action}.
 
 ### Moving an IP via the API
 
-Log in to the OVHcloud [API webpage](https://ca.api.ovh.com/).
+Log in to the OVHcloud [API webpage](/links/api).
 
 First, it is best to check if the IP address can be moved.
 <br>To check if the IP can be moved to one of your dedicated servers, use the following call:

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.en-us.md
@@ -33,9 +33,9 @@ With this technology, you can switch IP addresses from one solution to another i
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 > [!warning]
 > If the Additional IP address or one of the block IP addresses has a virtual MAC attached, the target server must support the vMAC functionality.
@@ -83,7 +83,7 @@ Click `Next`{.action}, then `Confirm`{.action}.
 
 ### Moving an IP via the API
 
-Log in to the OVHcloud [API webpage](https://ca.api.ovh.com/).
+Log in to the OVHcloud [API webpage](/links/api).
 
 First, it is best to check if the IP address can be moved.
 <br>To check if the IP can be moved to one of your dedicated servers, use the following call:

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.es-es.md
@@ -32,9 +32,9 @@ Los bloques de direcciones IP de una región pueden moverse de un datacenter a o
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es-es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es-es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 > [!warning]
 > Si la dirección Additional IP, o una de las direcciones IP del bloque, tiene una MAC virtual asociada, el servidor de destino debe soportar la funcionalidad de las MAC virtuales.

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.es-us.md
@@ -32,9 +32,9 @@ Los bloques de direcciones IP de una región pueden moverse de un datacenter a o
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 > [!warning]
 > Si la dirección Additional IP, o una de las direcciones IP del bloque, tiene una MAC virtual asociada, el servidor de destino debe soportar la funcionalidad de las MAC virtuales.
@@ -82,7 +82,7 @@ Haga clic en `Siguiente`{.action} y, seguidamente, en `Aceptar`{.action}.
 
 ### Mover una IP a través de las API
 
-Conéctese a la página web de las [API de OVHcloud](https://ca.api.ovh.com/).
+Conéctese a la página web de las [API de OVHcloud](/links/api).
 
 En primer lugar, es mejor comprobar si la dirección IP se puede mover correctamente al servidor deseado.
 <br>Para comprobar si la IP puede moverse a uno de sus servidores dedicados, utilice la siguiente llamada:

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.fr-ca.md
@@ -34,9 +34,9 @@ Cette technologie vous permet d’échanger les adresses IP d'une solution à l'
 - Être connecté à l'[espace client OVHcloud](/links/manager){.external}.
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr-ca/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr-ca/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 >
 
 > [!warning]
@@ -86,7 +86,7 @@ Cliquez sur `Suivant`{.action} puis sur `Valider`{.action}.
 
 ### Déplacer une IP via les API
 
-Connectez-vous sur la page web des [API OVHcloud](https://ca.api.ovh.com/).
+Connectez-vous sur la page web des [API OVHcloud](/links/api).
 
 Dans un premier temps, il est préférable de vérifier si l'adresse IP peut bien être déplacée.
 <br>Pour vérifier si l'IP peut être déplacée vers un de vos serveurs dédiés, utilisez l'appel suivant :

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.fr-fr.md
@@ -34,9 +34,9 @@ Cette technologie vous permet d’échanger les adresses IP d'une solution à l'
 - Être connecté à l'[espace client OVHcloud](/links/manager){.external}.
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 >
 
 > [!warning]
@@ -84,7 +84,7 @@ Cliquez sur `Suivant`{.action} puis sur `Valider`{.action}.
 
 ### Déplacer une IP via les API
 
-Connectez-vous sur la page web des [API OVHcloud](https://ca.api.ovh.com/).
+Connectez-vous sur la page web des [API OVHcloud](/links/api).
 
 Dans un premier temps, il est préférable de vérifier si l'adresse IP peut bien être déplacée.
 <br>Pour vérifier si l'IP peut être déplacée vers un de vos serveurs dédiés, utilisez l'appel suivant :

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.it-it.md
@@ -32,9 +32,9 @@ I blocchi di indirizzi IP di una Region possono essere trasferiti da un datacent
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 > [!warning]
-> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](https://eco.ovhcloud.com/it/about/).
+> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](/links/bare-metal/eco-about).
 >
-> Per maggiori informazioni, consulta la nostra [a confronto](https://eco.ovhcloud.com/it/compare/).
+> Per maggiori informazioni, consulta la nostra [a confronto](/links/bare-metal/eco-compare).
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.pl-pl.md
@@ -32,9 +32,9 @@ Bloki adresów IP w regionie mogą być przenoszone między centrami danych w da
 - Dostęp do [panelu klienta OVHcloud](/links/manager)
 
 > [!warning]
-> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](https://eco.ovhcloud.com/pl/about/).
+> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](/links/bare-metal/eco-about).
 >
-> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](https://eco.ovhcloud.com/pl/compare/).
+> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](/links/bare-metal/eco-compare).
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/move-failover-ip/guide.pt-pt.md
@@ -32,9 +32,9 @@ Os blocos de endereços IP numa região podem ser movidos de um datacenter para 
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager).
 
 > [!warning]
-> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](https://eco.ovhcloud.com/pt/about/).
+> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para mais informações, consulte o nosso [comparativo](https://eco.ovhcloud.com/pt/compare/).
+> Para mais informações, consulte o nosso [comparativo](/links/bare-metal/eco-compare).
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.de-de.md
@@ -79,7 +79,7 @@ Das Ihrem Server zugewiesene IPv4-Gateway wird im Tab `Allgemeine Informationen`
 
 #### Über die OVHcloud API <a name="viaapi"></a>
 
-Klicken Sie auf der [OVHcloud API Seite](https://eu.api.ovh.com/console/) oben rechts auf `Login`{.action} ein. Geben Sie auf der nächsten Seite Ihre OVHcloud Kundenkennung ein.
+Klicken Sie auf der [OVHcloud API Seite](/links/console) oben rechts auf `Login`{.action} ein. Geben Sie auf der nächsten Seite Ihre OVHcloud Kundenkennung ein.
 
 Führen Sie den folgenden API-Aufruf unter Angabe des internen Servernamens (Beispiel: `ns3956771.ip-169-254-10.eu`) aus:
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-asia.md
@@ -81,7 +81,7 @@ The IPv4 gateway assigned to your server will appear in the `Network` section of
 
 #### Via the OVHcloud API <a name="viaapi"></a>
 
-On the [OVHcloud API page](https://ca.api.ovh.com/console/), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
+On the [OVHcloud API page](/links/console), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
 
 Execute the following API call, indicating the internal server name (example: `ns3956771.ip-169-254-10.eu`):
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-au.md
@@ -81,7 +81,7 @@ The IPv4 gateway assigned to your server will appear in the `Network` section of
 
 #### Via the OVHcloud API <a name="viaapi"></a>
 
-On the [OVHcloud API page](https://ca.api.ovh.com/console/), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
+On the [OVHcloud API page](/links/console), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
 
 Execute the following API call, indicating the internal server name (example: `ns3956771.ip-169-254-10.eu`):
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-ca.md
@@ -81,7 +81,7 @@ The IPv4 gateway assigned to your server will appear in the `Network` section of
 
 #### Via the OVHcloud API <a name="viaapi"></a>
 
-On the [OVHcloud API page](https://ca.api.ovh.com/console/), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
+On the [OVHcloud API page](/links/console), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
 
 Execute the following API call, indicating the internal server name (example: `ns3956771.ip-169-254-10.eu`):
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-gb.md
@@ -81,7 +81,7 @@ The IPv4 gateway assigned to your server will appear in the `Network` section of
 
 #### Via the OVHcloud API <a name="viaapi"></a>
 
-On the [OVHcloud API page](https://eu.api.ovh.com/console/), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
+On the [OVHcloud API page](/links/console), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
 
 Execute the following API call, indicating the internal server name (example: `ns3956771.ip-169-254-10.eu`):
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-ie.md
@@ -81,7 +81,7 @@ The IPv4 gateway assigned to your server will appear in the `Network` section of
 
 #### Via the OVHcloud API <a name="viaapi"></a>
 
-On the [OVHcloud API page](https://eu.api.ovh.com/console/), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
+On the [OVHcloud API page](/links/console), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
 
 Execute the following API call, indicating the internal server name (example: `ns3956771.ip-169-254-10.eu`):
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-sg.md
@@ -81,7 +81,7 @@ The IPv4 gateway assigned to your server will appear in the `Network` section of
 
 #### Via the OVHcloud API <a name="viaapi"></a>
 
-On the [OVHcloud API page](https://ca.api.ovh.com/console/), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
+On the [OVHcloud API page](/links/console), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
 
 Execute the following API call, indicating the internal server name (example: `ns3956771.ip-169-254-10.eu`):
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.en-us.md
@@ -81,7 +81,7 @@ The IPv4 gateway assigned to your server will appear in the `Network` section of
 
 #### Via the OVHcloud API <a name="viaapi"></a>
 
-On the [OVHcloud API page](https://ca.api.ovh.com/console/), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
+On the [OVHcloud API page](/links/console), click on `Login`{.action} in the top right-hand corner. On the next page, enter your OVHcloud credentials.
 
 Execute the following API call, indicating the internal server name (example: `ns3956771.ip-169-254-10.eu`):
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.es-es.md
@@ -82,7 +82,7 @@ La dirección de la pasarela IPv4 asignada a su servidor se muestra en la secci�
 
 #### A través de la API de OVHcloud <a name="viaapi"></a>
 
-En la [página API de OVHcloud](https://eu.api.ovh.com/console/), haga clic en `Login`{.action}, situado en la esquina superior derecha. En la siguiente página, introduzca su ID de cliente de OVHcloud.
+En la [página API de OVHcloud](/links/console), haga clic en `Login`{.action}, situado en la esquina superior derecha. En la siguiente página, introduzca su ID de cliente de OVHcloud.
 
 Ejecute la siguiente llamada a la API, indicando el nombre interno del servidor (por ejemplo: `ns3956771.ip-169-254-10.eu`):
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.es-us.md
@@ -82,7 +82,7 @@ La dirección de la pasarela IPv4 asignada a su servidor se muestra en la secci�
 
 #### A través de la API de OVHcloud <a name="viaapi"></a>
 
-En la [página API de OVHcloud](https://ca.api.ovh.com/console/), haga clic en `Login`{.action}, situado en la esquina superior derecha. En la siguiente página, introduzca su ID de cliente de OVHcloud.
+En la [página API de OVHcloud](/links/console), haga clic en `Login`{.action}, situado en la esquina superior derecha. En la siguiente página, introduzca su ID de cliente de OVHcloud.
 
 Ejecute la siguiente llamada a la API, indicando el nombre interno del servidor (por ejemplo: `ns3956771.ip-169-254-10.eu`):
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-ca.md
@@ -81,7 +81,7 @@ La gateway IPv4 assignée à votre serveur est affichée dans la section `Résea
 
 #### Via les API OVHcloud <a name="viaapi"></a>
 
-Sur la [page API OVHcloud](https://ca.api.ovh.com/console/), cliquez en haut à droite sur `Login`{.action}. Sur la page suivante, saisissez votre identifiant client OVHcloud.
+Sur la [page API OVHcloud](/links/console), cliquez en haut à droite sur `Login`{.action}. Sur la page suivante, saisissez votre identifiant client OVHcloud.
 
 Exécutez l'appel API suivant, en indiquant le nom interne du serveur (exemple : `ns3956771.ip-169-254-10.eu`) :
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.fr-fr.md
@@ -81,7 +81,7 @@ La gateway IPv4 assignée à votre serveur est affichée dans la section `Résea
 
 #### Via les API OVHcloud <a name="viaapi"></a>
 
-Sur la [page API OVHcloud](https://eu.api.ovh.com/console/), cliquez en haut à droite sur `Login`{.action}. Sur la page suivante, saisissez votre identifiant client OVHcloud.
+Sur la [page API OVHcloud](/links/console), cliquez en haut à droite sur `Login`{.action}. Sur la page suivante, saisissez votre identifiant client OVHcloud.
 
 Exécutez l'appel API suivant, en indiquant le nom interne du serveur (exemple : `ns3956771.ip-169-254-10.eu`) :
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.it-it.md
@@ -81,7 +81,7 @@ L’indirizzo gateway IPv4 assegnato al tuo server è visualizzato nella sezione
 
 #### Tramite le API OVHcloud <a name="viaapi"></a>
 
-Nella [pagina API OVHcloud](https://eu.api.ovh.com/console/), clicca in alto a destra su `Login`{.action}. Nella pagina successiva, inserisci il tuo identificativo cliente OVHcloud.
+Nella [pagina API OVHcloud](/links/console), clicca in alto a destra su `Login`{.action}. Nella pagina successiva, inserisci il tuo identificativo cliente OVHcloud.
 
 Eseguire la chiamata API seguente, indicando il nome interno del server (esempio: `ns3956771.ip-169-254-10.eu`):
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_bridging/guide.pl-pl.md
@@ -81,7 +81,7 @@ Adres bramy IPv4 przypisany do Twojego serwera wyświetla się w sekcji `Sieć` 
 
 #### Za pośrednictwem API OVHcloud <a name="viaapi"></a>
 
-Na [stronie API OVHcloud](https://eu.api.ovh.com/console/) kliknij na `Login`{.action} w prawym górnym rogu. Na następnej stronie wpisz Twój identyfikator klienta OVHcloud.
+Na [stronie API OVHcloud](/links/console) kliknij na `Login`{.action} w prawym górnym rogu. Na następnej stronie wpisz Twój identyfikator klienta OVHcloud.
 
 Wykonaj następujące wywołanie API, wskazując wewnętrzną nazwę serwera (przykład: `ns3956771.ip-169-254-10.eu`):
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.de-de.md
@@ -28,9 +28,9 @@ IP-Aliasing ist eine spezielle Konfiguration im Netzwerk Ihres Servers, mit der 
 - Sie haben administrativen Zugriff (sudo) auf Ihren Server über SSH oder GUI.
 
 > [!warning]
-> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](https://eco.ovhcloud.com/de/about/) eingesetzt wird.
+> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](/links/bare-metal/eco-about) eingesetzt wird.
 >
-> Weitere Informationen finden Sie auf der [Vergleichsseite](https://eco.ovhcloud.com/de/compare/).
+> Weitere Informationen finden Sie auf der [Vergleichsseite](/links/bare-metal/eco-compare).
 
 ## In der praktischen Anwendung
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-asia.md
@@ -29,9 +29,9 @@ IP aliasing is a special network configuration for your OVHcloud dedicated serve
 - Basic networking and administration knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/asia/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/asia/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-au.md
@@ -29,9 +29,9 @@ IP aliasing is a special network configuration for your OVHcloud dedicated serve
 - Basic networking and administration knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-au/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-au/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-ca.md
@@ -29,9 +29,9 @@ IP aliasing is a special network configuration for your OVHcloud dedicated serve
 - Basic networking and administration knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ca/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ca/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-gb.md
@@ -29,9 +29,9 @@ IP aliasing is a special network configuration for your OVHcloud dedicated serve
 - Basic networking and administration knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-ie.md
@@ -29,9 +29,9 @@ IP aliasing is a special network configuration for your OVHcloud dedicated serve
 - Basic networking and administration knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ie/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ie/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-sg.md
@@ -29,9 +29,9 @@ IP aliasing is a special network configuration for your OVHcloud dedicated serve
 - Basic networking and administration knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-sg/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-sg/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.en-us.md
@@ -29,9 +29,9 @@ IP aliasing is a special network configuration for your OVHcloud dedicated serve
 - Basic networking and administration knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en/about/)
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about)
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.es-es.md
@@ -22,9 +22,9 @@ El alias de IP (*IP aliasing* en inglés) es una configuración especial de la r
 - Estar conectado al servidor por SSH (acceso *sudo*).
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es-es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es-es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.es-us.md
@@ -22,9 +22,9 @@ El alias de IP (*IP aliasing* en inglés) es una configuración especial de la r
 - Estar conectado al servidor por SSH (acceso *sudo*).
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.fr-ca.md
@@ -31,9 +31,9 @@ L'alias d'IP (*IP aliasing* en anglais) est une configuration spéciale du rése
 - Être connecté en SSH au serveur ou via remote desktop pour Windows.
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr-ca/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr-ca/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.fr-fr.md
@@ -31,9 +31,9 @@ L'alias d'IP (*IP aliasing* en anglais) est une configuration spéciale du rése
 - Être connecté en SSH au serveur ou via remote desktop pour Windows.
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.it-it.md
@@ -29,9 +29,9 @@ L'alias IP (o IP aliasing) è un tipo di configurazione del tuo server dedicato 
 - Essere connesso al server in SSH (accesso *sudo*)
 
 > [!warning]
-> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](https://eco.ovhcloud.com/it/about/).
+> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](/links/bare-metal/eco-about).
 >
-> Per maggiori informazioni, consulta la nostra [a confronto](https://eco.ovhcloud.com/it/compare/).
+> Per maggiori informazioni, consulta la nostra [a confronto](/links/bare-metal/eco-compare).
 
 ## Procedura
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.pl-pl.md
@@ -29,9 +29,9 @@ Alias IP (po angielsku IP aliasing) to specjalna konfiguracja sieci serwera dedy
 - Zalogowanie się poprzez SSH do serwera (dostęp *sudo*).
 
 > [!warning]
-> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](https://eco.ovhcloud.com/pl/about/).
+> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](/links/bare-metal/eco-about).
 >
-> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](https://eco.ovhcloud.com/pl/compare/).
+> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](/links/bare-metal/eco-compare).
 
 ## W praktyce
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_ipaliasing/guide.pt-pt.md
@@ -29,9 +29,9 @@ O IP aliasing é uma configuração de rede para servidores dedicados que permit
 - Estar ligado ao servidor usando o protocolo SSH.
 
 > [!warning]
-> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](https://eco.ovhcloud.com/pt/about/).
+> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para mais informações, consulte o nosso [comparativo](https://eco.ovhcloud.com/pt/compare/).
+> Para mais informações, consulte o nosso [comparativo](/links/bare-metal/eco-compare).
 
 ## Instruções
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-asia.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/asia/vps/), [Public Cloud instance](https://www.ovhcloud.com/asia/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/asia/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/asia/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-asia.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/asia/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-au.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/en-au/vps/), [Public Cloud instance](https://www.ovhcloud.com/en-au/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/en-au/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-au/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-au.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-au/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-ca.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/en-ca/vps/), [Public Cloud instance](https://www.ovhcloud.com/en-ca/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/en-ca/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-ca/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-ca.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-ca/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-gb.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-gb/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-gb.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/en-gb/vps/), [Public Cloud instance](https://www.ovhcloud.com/en-gb/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/en-gb/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-gb/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-ie.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/en-ie/vps/), [Public Cloud instance](https://www.ovhcloud.com/en-ie/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/en-ie/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-ie/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-ie.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-ie/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-sg.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/en-sg/vps/), [Public Cloud instance](https://www.ovhcloud.com/en-sg/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/en-sg/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-sg/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-sg.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en-sg/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-us.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/en/vps/), [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/en/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.en-us.md
@@ -15,7 +15,7 @@ This guide explains the Network Security Dashboard and provides an overview of c
 
 ## Requirements
 
-- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/en/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- An OVHcloud service exposed on a dedicated public IP address ([Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Public Cloud instance](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.fr-ca.md
@@ -15,7 +15,7 @@ Ce guide a pour but de présenter le tableau de bord de sécurité réseau (*Net
 
 ## Prérequis
 
-- Un service OVHcloud exposé sur une adresse IP publique dédiée ([Serveur dédié](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/fr-ca/vps/), [Instance Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/fr-ca/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- Un service OVHcloud exposé sur une adresse IP publique dédiée ([Serveur dédié](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Instance Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/fr-ca/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.fr-ca.md
@@ -15,7 +15,7 @@ Ce guide a pour but de présenter le tableau de bord de sécurité réseau (*Net
 
 ## Prérequis
 
-- Un service OVHcloud exposé sur une adresse IP publique dédiée ([Serveur dédié](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Instance Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/fr-ca/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- Un service OVHcloud exposé sur une adresse IP publique dédiée ([Serveur dédié](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Instance Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.fr-fr.md
@@ -15,7 +15,7 @@ Ce guide a pour but de présenter le tableau de bord de sécurité réseau (*Net
 
 ## Prérequis
 
-- Un service OVHcloud exposé sur une adresse IP publique dédiée ([Serveur dédié](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Instance Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- Un service OVHcloud exposé sur une adresse IP publique dédiée ([Serveur dédié](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Instance Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](/links/hosted-private-cloud/vmware), [Additional IP](/links/network/additional-ip), etc.)
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_security_dashboard/guide.fr-fr.md
@@ -15,7 +15,7 @@ Ce guide a pour but de présenter le tableau de bord de sécurité réseau (*Net
 
 ## Prérequis
 
-- Un service OVHcloud exposé sur une adresse IP publique dédiée ([Serveur dédié](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/fr/vps/), [Instance Public Cloud](https://www.ovhcloud.com/fr/public-cloud/), [Hosted Private Cloud](https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
+- Un service OVHcloud exposé sur une adresse IP publique dédiée ([Serveur dédié](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps), [Instance Public Cloud](/links/public-cloud/public-cloud), [Hosted Private Cloud](https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/), [Additional IP](/links/network/additional-ip), etc.)
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac/guide.en-asia.md
@@ -15,7 +15,7 @@ Support for the vMAC function is a prerequisite for all actions concerning virtu
 ## Requirements
 
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
-- Access to the OVHcloud [API](https://ca.api.ovh.com/)
+- Access to the OVHcloud [API](/links/api)
 
 > [!primary]
 > If you are not familiar with using the OVHcloud API, please refer to our guide on [Getting started with the OVHcloud API](/pages/manage_and_operate/api/first-steps) .

--- a/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac/guide.en-au.md
@@ -15,7 +15,7 @@ Support for the vMAC function is a prerequisite for all actions concerning virtu
 ## Requirements
 
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
-- Access to the OVHcloud [API](https://ca.api.ovh.com/)
+- Access to the OVHcloud [API](/links/api)
 
 > [!primary]
 > If you are not familiar with using the OVHcloud API, please refer to our guide on [Getting started with the OVHcloud API](/pages/manage_and_operate/api/first-steps) .

--- a/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac/guide.en-ca.md
@@ -15,7 +15,7 @@ Support for the vMAC function is a prerequisite for all actions concerning virtu
 ## Requirements
 
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
-- Access to the OVHcloud [API](https://ca.api.ovh.com/)
+- Access to the OVHcloud [API](/links/api)
 
 > [!primary]
 > If you are not familiar with using the OVHcloud API, please refer to our guide on [Getting started with the OVHcloud API](/pages/manage_and_operate/api/first-steps) .

--- a/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac/guide.en-sg.md
@@ -15,7 +15,7 @@ Support for the vMAC function is a prerequisite for all actions concerning virtu
 ## Requirements
 
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
-- Access to the OVHcloud [API](https://ca.api.ovh.com/)
+- Access to the OVHcloud [API](/links/api)
 
 > [!primary]
 > If you are not familiar with using the OVHcloud API, please refer to our guide on [Getting started with the OVHcloud API](/pages/manage_and_operate/api/first-steps) .

--- a/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac/guide.en-us.md
@@ -15,7 +15,7 @@ Support for the vMAC function is a prerequisite for all actions concerning virtu
 ## Requirements
 
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
-- Access to the OVHcloud [API](https://ca.api.ovh.com/)
+- Access to the OVHcloud [API](/links/api)
 
 > [!primary]
 > If you are not familiar with using the OVHcloud API, please refer to our guide on [Getting started with the OVHcloud API](/pages/manage_and_operate/api/first-steps) .

--- a/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac/guide.es-us.md
@@ -19,7 +19,7 @@ El soporte de esta funcionalidad es un requisito previo para todas las acciones 
 ## Requisitos
 
 - Tener un [servidor dedicado](/links/bare-metal/bare-metal){.external}.
-- Estar conectado a la [API de OVHcloud](https://ca.api.ovh.com/){.external}.
+- Estar conectado a la [API de OVHcloud](/links/api){.external}.
 
 > [!primary]
 > Si no está familiarizado con el uso de la API de OVHcloud, consulte nuestra guía [Primeros pasos con las API de OVHcloud](/pages/manage_and_operate/api/first-steps).

--- a/pages/bare_metal_cloud/dedicated_servers/pfSense_bridging/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pfSense_bridging/guide.fr-ca.md
@@ -24,7 +24,7 @@ La mise en réseau en mode bridge peut être utilisée pour configurer votre mac
 > [!warning]
 > Ce tutoriel vous présente l’utilisation d’une ou de plusieurs solutions OVHcloud avec des outils externes et décrit les actions à réaliser dans un contexte précis. Veuillez noter que ces actions décrites ici doivent être adaptées à votre cas particulier.
 >
-Si vous rencontrez des difficultés lors de l'exécution de ces actions, merci de contacter un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) et/ou d'échanger avec notre [communauté d'utilisateurs](/links/community). OVHcloud ne peut pas vous fournir d’assistance technique à ce sujet.
+Si vous rencontrez des difficultés lors de l'exécution de ces actions, merci de contacter un [prestataire spécialisé](/links/partner) et/ou d'échanger avec notre [communauté d'utilisateurs](/links/community). OVHcloud ne peut pas vous fournir d’assistance technique à ce sujet.
 >
 
 ## En pratique

--- a/pages/bare_metal_cloud/dedicated_servers/pfSense_bridging/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/pfSense_bridging/guide.fr-fr.md
@@ -24,7 +24,7 @@ La mise en réseau en mode bridge peut être utilisée pour configurer votre mac
 > [!warning]
 > Ce tutoriel vous présente l’utilisation d’une ou de plusieurs solutions OVHcloud avec des outils externes et décrit les actions à réaliser dans un contexte précis. Veuillez noter que ces actions décrites ici doivent être adaptées à votre cas particulier.
 >
-Si vous rencontrez des difficultés lors de l'exécution de ces actions, merci de contacter un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) et/ou d'échanger avec notre [communauté d'utilisateurs](/links/community). OVHcloud ne peut pas vous fournir d’assistance technique à ce sujet.
+Si vous rencontrez des difficultés lors de l'exécution de ces actions, merci de contacter un [prestataire spécialisé](/links/partner) et/ou d'échanger avec notre [communauté d'utilisateurs](/links/community). OVHcloud ne peut pas vous fournir d’assistance technique à ce sujet.
 >
 
 ## En pratique

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.de-de.md
@@ -23,7 +23,7 @@ In diesem Fall können Sie sich über den OVHcloud Rescue-Modus mit Ihrem Server
 
 ## Voraussetzungen
 
-- Sie haben einen [Dedicated Server](/links/bare-metal/bare-metal) oder einen [VPS](https://www.ovhcloud.com/de/vps/) in Ihrem Kunden-Account.
+- Sie haben einen [Dedicated Server](/links/bare-metal/bare-metal) oder einen [VPS](/links/bare-metal/vps) in Ihrem Kunden-Account.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-asia.md
@@ -20,7 +20,7 @@ To recover access to a server that you log in to with an SSH key, refer to our g
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/asia/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-au.md
@@ -20,7 +20,7 @@ To recover access to a server that you log in to with an SSH key, refer to our g
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/en-au/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-ca.md
@@ -20,7 +20,7 @@ To recover access to a server that you log in to with an SSH key, refer to our g
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/en-ca/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-gb.md
@@ -20,7 +20,7 @@ To recover access to a server that you log in to with an SSH key, refer to our g
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/en-gb/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-ie.md
@@ -20,7 +20,7 @@ To recover access to a server that you log in to with an SSH key, refer to our g
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/en-ie/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-sg.md
@@ -20,7 +20,7 @@ To recover access to a server that you log in to with an SSH key, refer to our g
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/en-sg/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.en-us.md
@@ -20,7 +20,7 @@ To recover access to a server that you log in to with an SSH key, refer to our g
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](https://www.ovhcloud.com/en/vps/) with a Linux-based OS in your OVHcloud account
+- A [dedicated server](/links/bare-metal/bare-metal) or a [VPS](/links/bare-metal/vps) with a Linux-based OS in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.es-es.md
@@ -23,7 +23,7 @@ En ese caso, puede conectarse a su servidor a través del modo de rescate de OVH
 
 ## Requisitos
 
-- Tener un [servidor dedicado](/links/bare-metal/bare-metal) o un [VPS](https://www.ovhcloud.com/es-es/vps/) en su cuenta de OVHcloud
+- Tener un [servidor dedicado](/links/bare-metal/bare-metal) o un [VPS](/links/bare-metal/vps) en su cuenta de OVHcloud
 - Estar conectado a su [área de cliente de OVHcloud](/links/manager)
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.es-us.md
@@ -23,7 +23,7 @@ En ese caso, puede conectarse a su servidor a través del modo de rescate de OVH
 
 ## Requisitos
 
-- Tener un [servidor dedicado](/links/bare-metal/bare-metal) o un [VPS](https://www.ovhcloud.com/es/vps/) en su cuenta de OVHcloud
+- Tener un [servidor dedicado](/links/bare-metal/bare-metal) o un [VPS](/links/bare-metal/vps) en su cuenta de OVHcloud
 - Estar conectado a su [área de cliente de OVHcloud](/links/manager)
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.fr-ca.md
@@ -19,7 +19,7 @@ Dans ce cas, vous pouvez vous connecter à votre serveur via le mode rescue d’
 
 ## Prérequis
 
-- Disposer d'un [serveur dédié](/links/bare-metal/bare-metal) ou d'un [VPS](https://www.ovhcloud.com/fr-ca/vps/) dans votre compte OVHcloud
+- Disposer d'un [serveur dédié](/links/bare-metal/bare-metal) ou d'un [VPS](/links/bare-metal/vps) dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 > [!primary]
@@ -38,7 +38,7 @@ N'oubliez pas de consulter également nos guides de premiers pas :
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
+> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
 >
 
 <a name="step1"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.fr-fr.md
@@ -19,7 +19,7 @@ Dans ce cas, vous pouvez vous connecter à votre serveur via le mode rescue d’
 
 ## Prérequis
 
-- Disposer d'un [serveur dédié](/links/bare-metal/bare-metal) ou d'un [VPS](https://www.ovhcloud.com/fr/vps/) dans votre compte OVHcloud
+- Disposer d'un [serveur dédié](/links/bare-metal/bare-metal) ou d'un [VPS](/links/bare-metal/vps) dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 > [!primary]
@@ -38,7 +38,7 @@ N'oubliez pas de consulter également nos guides de premiers pas :
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
+> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
 >
 
 <a name="step1"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.it-it.md
@@ -24,7 +24,7 @@ In questo caso, è possibile accedere al server tramite la modalità Rescue di O
 
 ## Prerequisiti
 
-- Disporre di un [server dedicato](/links/bare-metal/bare-metal) o di un [VPS](https://www.ovhcloud.com/it/vps/) nel proprio account OVHcloud
+- Disporre di un [server dedicato](/links/bare-metal/bare-metal) o di un [VPS](/links/bare-metal/vps) nel proprio account OVHcloud
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.pl-pl.md
@@ -24,7 +24,7 @@ W takim przypadku możesz zalogować się do Twojego serwera za pomocą trybu Re
 
 ## Wymagania początkowe
 
-- Posiadanie [serwera dedykowanego](/links/bare-metal/bare-metal) lub [VPS](https://www.ovhcloud.com/pl/vps/) na koncie OVHcloud
+- Posiadanie [serwera dedykowanego](/links/bare-metal/bare-metal) lub [VPS](/links/bare-metal/vps) na koncie OVHcloud
 - Dostęp do [Panelu klienta OVHcloud](/links/manager)
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/replacing-user-password/guide.pt-pt.md
@@ -23,7 +23,7 @@ Neste caso, pode ligar-se ao seu servidor através do modo rescue da OVHcloud, q
 
 ## Requisitos
 
-- Ter um [servidor dedicado](/links/bare-metal/bare-metal) ou um [VPS](https://www.ovhcloud.com/pt/vps/) na sua conta OVHcloud
+- Ter um [servidor dedicado](/links/bare-metal/bare-metal) ou um [VPS](/links/bare-metal/vps) na sua conta OVHcloud
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager)
 
 > [!primary]

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.de-de.md
@@ -16,7 +16,7 @@ Der Rescue-Modus stellt einen permanenten Zugriff auf Ihre Daten bereit, auch we
 
 ## Voraussetzungen
 
-- Sie haben einen [Dedicated Server](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/de/vps/) oder eine [Public Cloud Instanz](https://www.ovhcloud.com/de/public-cloud/) in Ihrem Kunden-Account (ausgenommen Windows-Systeme).
+- Sie haben einen [Dedicated Server](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps) oder eine [Public Cloud Instanz](/links/public-cloud/public-cloud) in Ihrem Kunden-Account (ausgenommen Windows-Systeme).
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-asia.md
@@ -12,7 +12,7 @@ With rescue mode, you can always access your data, even if the server's OS or th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/asia/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-au.md
@@ -12,7 +12,7 @@ With rescue mode, you can always access your data, even if the server's OS or th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/en-au/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-ca.md
@@ -12,7 +12,7 @@ With rescue mode, you can always access your data, even if the server's OS or th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/en-ca/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-gb.md
@@ -12,7 +12,7 @@ With rescue mode, you can always access your data, even if the server's OS or th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/en-gb/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-ie.md
@@ -12,7 +12,7 @@ With rescue mode, you can always access your data, even if the server's OS or th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/en-ie/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-sg.md
@@ -12,7 +12,7 @@ With rescue mode, you can always access your data, even if the server's OS or th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/en-sg/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.en-us.md
@@ -12,7 +12,7 @@ With rescue mode, you can always access your data, even if the server's OS or th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](https://www.ovhcloud.com/en/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account (excluding Windows systems)
+- A [dedicated server](/links/bare-metal/bare-metal), a [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account (excluding Windows systems)
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.es-es.md
@@ -16,7 +16,7 @@ El modo de rescate permite acceder a sus datos de forma permanente, aunque el si
 
 ## Requisitos
 
-- Un [servidor dedicado](/links/bare-metal/bare-metal), un [VPS](https://www.ovhcloud.com/es-es/vps/) o una instancia de [Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud (excepto sistemas Windows)
+- Un [servidor dedicado](/links/bare-metal/bare-metal), un [VPS](/links/bare-metal/vps) o una instancia de [Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud (excepto sistemas Windows)
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager).
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.es-us.md
@@ -16,7 +16,7 @@ El modo de rescate permite acceder a sus datos de forma permanente, aunque el si
 
 ## Requisitos
 
-- Un [servidor dedicado](/links/bare-metal/bare-metal), un [VPS](https://www.ovhcloud.com/es/vps/) o una instancia de [Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud (excepto sistemas Windows)
+- Un [servidor dedicado](/links/bare-metal/bare-metal), un [VPS](/links/bare-metal/vps) o una instancia de [Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud (excepto sistemas Windows)
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager).
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.fr-ca.md
@@ -12,14 +12,14 @@ Le mode Rescue permet d'accéder à vos données en permanence, même si le syst
 
 ## Prérequis
 
-- Un [serveur dédié](/links/bare-metal/bare-metal), un [VPS](https://www.ovhcloud.com/fr-ca/vps/) ou une instance [Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud (hors systèmes Windows)
+- Un [serveur dédié](/links/bare-metal/bare-metal), un [VPS](/links/bare-metal/vps) ou une instance [Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud (hors systèmes Windows)
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 > [!warning]
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Ce tutoriel a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) ou de vous rapprocher de [notre communauté](/links/community) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
+> Ce tutoriel a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou de vous rapprocher de [notre communauté](/links/community) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
 >
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.fr-fr.md
@@ -12,14 +12,14 @@ Le mode Rescue permet d'accéder à vos données en permanence, même si le syst
 
 ## Prérequis
 
-- Un [serveur dédié](/links/bare-metal/bare-metal), un [VPS](https://www.ovhcloud.com/fr/vps/) ou une instance [Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud (hors systèmes Windows)
+- Un [serveur dédié](/links/bare-metal/bare-metal), un [VPS](/links/bare-metal/vps) ou une instance [Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud (hors systèmes Windows)
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 > [!warning]
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Ce tutoriel a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de vous rapprocher de [notre communauté](/links/community) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
+> Ce tutoriel a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou de vous rapprocher de [notre communauté](/links/community) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place de services sur un serveur.
 >
 
 ## Instructions

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.it-it.md
@@ -16,7 +16,7 @@ La modalità Rescue permette di accedere ai tuoi dati in modo permanente, anche 
 
 ## Prerequisiti
 
-- Un [server dedicato](/links/bare-metal/bare-metal), un [VPS](https://www.ovhcloud.com/it/vps/) o un'istanza [Public Cloud](https://www.ovhcloud.com/it/public-cloud/) nel tuo account OVHcloud (Windows escluso)
+- Un [server dedicato](/links/bare-metal/bare-metal), un [VPS](/links/bare-metal/vps) o un'istanza [Public Cloud](/links/public-cloud/public-cloud) nel tuo account OVHcloud (Windows escluso)
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.pl-pl.md
@@ -16,7 +16,7 @@ Tryb Rescue pozwala na stały dostęp do Twoich danych, nawet jeśli system oper
 
 ## Wymagania początkowe
 
-- Serwer [dedykowany](/links/bare-metal/bare-metal), [VPS](https://www.ovhcloud.com/pl/vps/) lub instancja [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na Twoim koncie OVHcloud (z wyłączeniem systemu Windows)
+- Serwer [dedykowany](/links/bare-metal/bare-metal), [VPS](/links/bare-metal/vps) lub instancja [Public Cloud](/links/public-cloud/public-cloud) na Twoim koncie OVHcloud (z wyłączeniem systemu Windows)
 - Dostęp do [Panelu client OVHcloud](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/restore-bdd-rescue/guide.pt-pt.md
@@ -16,7 +16,7 @@ O modo Rescue permite aceder aos seus dados de forma permanente, mesmo que o sis
 
 ## Requisitos
 
-- Um [servidor dedicado](/links/bare-metal/bare-metal), um [VPS](https://www.ovhcloud.com/pt/vps/) ou uma instância [Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud (exceto sistemas Windows)
+- Um [servidor dedicado](/links/bare-metal/bare-metal), um [VPS](/links/bare-metal/vps) ou uma instância [Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud (exceto sistemas Windows)
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.de-de.md
@@ -25,7 +25,7 @@ In diesem Tutorial lernen Sie, wie Sie einen OVHcloud Storage Server nach Ihren 
 ### Sie benötigen:
 
 - einen [OVHcloud Storage Server](https://www.ovhcloud.com/de/bare-metal/storage/){.external}
-- eine Produktionsinfrastruktur ([VPS](https://www.ovhcloud.com/de/vps/){.external}, [Dedicated Server](/links/bare-metal/bare-metal){.external}, [Public Cloud](https://www.ovhcloud.com/de/public-cloud/){.external}, ...)
+- eine Produktionsinfrastruktur ([VPS](/links/bare-metal/vps){.external}, [Dedicated Server](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, ...)
 - eine SSH-Verbindung zwischen dem Storage Server und der Produktionsinfrastruktur
 - empfohlen: ein privates Netzwerk zwischen Ihren Servern ([OVHcloud vRack](https://www.ovh.de/loesungen/vrack/){.external})
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.de-de.md
@@ -25,7 +25,7 @@ In diesem Tutorial lernen Sie, wie Sie einen OVHcloud Storage Server nach Ihren 
 ### Sie benötigen:
 
 - einen [OVHcloud Storage Server](https://www.ovhcloud.com/de/bare-metal/storage/){.external}
-- eine Produktionsinfrastruktur ([VPS](/links/bare-metal/vps){.external}, [Dedicated Server](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, ...)
+- eine Produktionsinfrastruktur ([VPS](/links/bare-metal/vps), [Dedicated Server](/links/bare-metal/bare-metal), [Public Cloud](/links/public-cloud/public-cloud), etc.)
 - eine SSH-Verbindung zwischen dem Storage Server und der Produktionsinfrastruktur
 - empfohlen: ein privates Netzwerk zwischen Ihren Servern ([OVHcloud vRack](https://www.ovh.de/loesungen/vrack/){.external})
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-asia.md
@@ -15,7 +15,7 @@ In this guide, we will show you how to configure an OVHcloud Storage Server to s
 ## Requirements
 
 - an [OVHcloud Storage Server](https://www.ovhcloud.com/asia/bare-metal/storage/){.external}
-- a production infrastructure ([VPS](/links/bare-metal/vps){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.)
+- a production infrastructure ([VPS](/links/bare-metal/vps), [Dedicated Servers](/links/bare-metal/bare-metal), [Public Cloud](/links/public-cloud/public-cloud), etc.)
 - an SSH connection between the Storage Servers and production infrastructure
 - a private network between your servers ([OVHcloud vRack](/links/network/vrack){.external}) is recommended
 - To follow this guide you need knowledge of: Linux administration, logging in via SSH, connecting to/backing up databases, installing operating systems (here we’re using Debian 9.4).

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-asia.md
@@ -15,7 +15,7 @@ In this guide, we will show you how to configure an OVHcloud Storage Server to s
 ## Requirements
 
 - an [OVHcloud Storage Server](https://www.ovhcloud.com/asia/bare-metal/storage/){.external}
-- a production infrastructure ([VPS](https://www.ovhcloud.com/asia/vps/){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](https://www.ovhcloud.com/asia/public-cloud/){.external}, etc.)
+- a production infrastructure ([VPS](/links/bare-metal/vps){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.)
 - an SSH connection between the Storage Servers and production infrastructure
 - a private network between your servers ([OVHcloud vRack](/links/network/vrack){.external}) is recommended
 - To follow this guide you need knowledge of: Linux administration, logging in via SSH, connecting to/backing up databases, installing operating systems (here we’re using Debian 9.4).

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-au.md
@@ -15,7 +15,7 @@ In this guide, we will show you how to configure an OVHcloud Storage Server to s
 ## Requirements
 
 - an [OVHcloud Storage Server](https://www.ovhcloud.com/en-au/bare-metal/storage/){.external}
-- a production infrastructure ([VPS](/links/bare-metal/vps){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.)
+- a production infrastructure ([VPS](/links/bare-metal/vps), [Dedicated Servers](/links/bare-metal/bare-metal), [Public Cloud](/links/public-cloud/public-cloud), etc.)
 - an SSH connection between the Storage Servers and production infrastructure
 - a private network between your servers ([OVHcloud vRack](/links/network/vrack){.external}) is recommended
 - To follow this guide you need knowledge of: Linux administration, logging in via SSH, connecting to/backing up databases, installing operating systems (here we’re using Debian 9.4).

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-au.md
@@ -15,7 +15,7 @@ In this guide, we will show you how to configure an OVHcloud Storage Server to s
 ## Requirements
 
 - an [OVHcloud Storage Server](https://www.ovhcloud.com/en-au/bare-metal/storage/){.external}
-- a production infrastructure ([VPS](https://www.ovhcloud.com/en-au/vps/){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](https://www.ovhcloud.com/en-au/public-cloud/){.external}, etc.)
+- a production infrastructure ([VPS](/links/bare-metal/vps){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.)
 - an SSH connection between the Storage Servers and production infrastructure
 - a private network between your servers ([OVHcloud vRack](/links/network/vrack){.external}) is recommended
 - To follow this guide you need knowledge of: Linux administration, logging in via SSH, connecting to/backing up databases, installing operating systems (here we’re using Debian 9.4).

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-ca.md
@@ -15,7 +15,7 @@ In this guide, we will show you how to configure an OVHcloud Storage Server to s
 ## Requirements
 
 - an [OVHcloud Storage Server](https://www.ovhcloud.com/en-ca/bare-metal/storage/){.external}
-- a production infrastructure ([VPS](/links/bare-metal/vps){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.)
+- a production infrastructure ([VPS](/links/bare-metal/vps), [Dedicated Servers](/links/bare-metal/bare-metal), [Public Cloud](/links/public-cloud/public-cloud), etc.)
 - an SSH connection between the Storage Servers and production infrastructure
 - a private network between your servers ([OVHcloud vRack](/links/network/vrack){.external}) is recommended
 - To follow this guide you need knowledge of: Linux administration, logging in via SSH, connecting to/backing up databases, installing operating systems (here we’re using Debian 9.4).

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-ca.md
@@ -15,7 +15,7 @@ In this guide, we will show you how to configure an OVHcloud Storage Server to s
 ## Requirements
 
 - an [OVHcloud Storage Server](https://www.ovhcloud.com/en-ca/bare-metal/storage/){.external}
-- a production infrastructure ([VPS](https://www.ovhcloud.com/en-ca/vps/){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](https://www.ovhcloud.com/en-ca/public-cloud/){.external}, etc.)
+- a production infrastructure ([VPS](/links/bare-metal/vps){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.)
 - an SSH connection between the Storage Servers and production infrastructure
 - a private network between your servers ([OVHcloud vRack](/links/network/vrack){.external}) is recommended
 - To follow this guide you need knowledge of: Linux administration, logging in via SSH, connecting to/backing up databases, installing operating systems (here we’re using Debian 9.4).

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-gb.md
@@ -15,7 +15,7 @@ In this guide, we will show you how to configure an OVHcloud Storage Server to s
 ## Requirements
 
 - an [OVHcloud Storage Server](https://www.ovhcloud.com/en-gb/bare-metal/storage/){.external}
-- a production infrastructure ([VPS](https://www.ovhcloud.com/en-gb/vps/){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](https://www.ovhcloud.com/en-gb/public-cloud/){.external}, etc.)
+- a production infrastructure ([VPS](/links/bare-metal/vps){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.)
 - an SSH connection between the Storage Servers and production infrastructure
 - a private network between your servers ([OVHcloud vRack](/links/network/vrack){.external}) is recommended
 - To follow this guide you need knowledge of: Linux administration, logging in via SSH, connecting to/backing up databases, installing operating systems (here we’re using Debian 9.4).

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-gb.md
@@ -15,7 +15,7 @@ In this guide, we will show you how to configure an OVHcloud Storage Server to s
 ## Requirements
 
 - an [OVHcloud Storage Server](https://www.ovhcloud.com/en-gb/bare-metal/storage/){.external}
-- a production infrastructure ([VPS](/links/bare-metal/vps){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.)
+- a production infrastructure ([VPS](/links/bare-metal/vps), [Dedicated Servers](/links/bare-metal/bare-metal), [Public Cloud](/links/public-cloud/public-cloud), etc.)
 - an SSH connection between the Storage Servers and production infrastructure
 - a private network between your servers ([OVHcloud vRack](/links/network/vrack){.external}) is recommended
 - To follow this guide you need knowledge of: Linux administration, logging in via SSH, connecting to/backing up databases, installing operating systems (here we’re using Debian 9.4).

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-sg.md
@@ -15,7 +15,7 @@ In this guide, we will show you how to configure an OVHcloud Storage Server to s
 ## Requirements
 
 - an [OVHcloud Storage Server](https://www.ovhcloud.com/en-sg/bare-metal/storage/){.external}
-- a production infrastructure ([VPS](https://www.ovhcloud.com/en-sg/vps/){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](https://www.ovhcloud.com/en-sg/public-cloud/){.external}, etc.)
+- a production infrastructure ([VPS](/links/bare-metal/vps){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.)
 - an SSH connection between the Storage Servers and production infrastructure
 - a private network between your servers ([OVHcloud vRack](/links/network/vrack){.external}) is recommended
 - To follow this guide you need knowledge of: Linux administration, logging in via SSH, connecting to/backing up databases, installing operating systems (here we’re using Debian 9.4).

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-sg.md
@@ -15,7 +15,7 @@ In this guide, we will show you how to configure an OVHcloud Storage Server to s
 ## Requirements
 
 - an [OVHcloud Storage Server](https://www.ovhcloud.com/en-sg/bare-metal/storage/){.external}
-- a production infrastructure ([VPS](/links/bare-metal/vps){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.)
+- a production infrastructure ([VPS](/links/bare-metal/vps), [Dedicated Servers](/links/bare-metal/bare-metal), [Public Cloud](/links/public-cloud/public-cloud), etc.)
 - an SSH connection between the Storage Servers and production infrastructure
 - a private network between your servers ([OVHcloud vRack](/links/network/vrack){.external}) is recommended
 - To follow this guide you need knowledge of: Linux administration, logging in via SSH, connecting to/backing up databases, installing operating systems (here we’re using Debian 9.4).

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-us.md
@@ -15,7 +15,7 @@ In this guide, we will show you how to configure an OVHcloud Storage Server to s
 ## Requirements
 
 - an [OVHcloud Storage Server](https://www.ovhcloud.com/en/bare-metal/storage/){.external}
-- a production infrastructure ([VPS](/links/bare-metal/vps){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.)
+- a production infrastructure ([VPS](/links/bare-metal/vps), [Dedicated Servers](/links/bare-metal/bare-metal), [Public Cloud](/links/public-cloud/public-cloud), etc.)
 - an SSH connection between the Storage Servers and production infrastructure
 - a private network between your servers ([OVHcloud vRack](https://www.ovh.com/world/solutions/vrack/){.external}) is recommended
 - To follow this guide you need knowledge of: Linux administration, logging in via SSH, connecting to/backing up databases, installing operating systems (here we’re using Debian 9.4).

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.en-us.md
@@ -15,7 +15,7 @@ In this guide, we will show you how to configure an OVHcloud Storage Server to s
 ## Requirements
 
 - an [OVHcloud Storage Server](https://www.ovhcloud.com/en/bare-metal/storage/){.external}
-- a production infrastructure ([VPS](https://www.ovhcloud.com/en/vps/){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](https://www.ovhcloud.com/en/public-cloud/){.external}, etc.)
+- a production infrastructure ([VPS](/links/bare-metal/vps){.external}, [Dedicated Servers](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.)
 - an SSH connection between the Storage Servers and production infrastructure
 - a private network between your servers ([OVHcloud vRack](https://www.ovh.com/world/solutions/vrack/){.external}) is recommended
 - To follow this guide you need knowledge of: Linux administration, logging in via SSH, connecting to/backing up databases, installing operating systems (here we’re using Debian 9.4).

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.es-es.md
@@ -25,7 +25,7 @@ Esta guía explica cómo configurar un servidor de almacenamiento de OVHcloud pa
 ### Hardware y software necesarios
 
 - Un [servidor de almacenamiento](https://www.ovhcloud.com/es-es/bare-metal/storage/){.external} de OVHcloud.
-- Una infraestructura de producción ([VPS](/links/bare-metal/vps){.external}, [servidor dedicado](/links/bare-metal/bare-metal){.external}, [instancia de Public Cloud](/links/public-cloud/public-cloud){.external}…).
+- Una infraestructura de producción ([VPS](/links/bare-metal/vps), [servidor dedicado](/links/bare-metal/bare-metal), [instancia de Public Cloud](/links/public-cloud/public-cloud), etc.).
 - Conexión SSH configurada entre el servidor de almacenamiento y la infraestructura de producción.
 - Una [red privada](https://www.ovh.es/soluciones/vrack/){.external} entre los servidores (recomendado).
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.es-es.md
@@ -25,7 +25,7 @@ Esta guía explica cómo configurar un servidor de almacenamiento de OVHcloud pa
 ### Hardware y software necesarios
 
 - Un [servidor de almacenamiento](https://www.ovhcloud.com/es-es/bare-metal/storage/){.external} de OVHcloud.
-- Una infraestructura de producción ([VPS](https://www.ovhcloud.com/es-es/vps/){.external}, [servidor dedicado](/links/bare-metal/bare-metal){.external}, [instancia de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/){.external}…).
+- Una infraestructura de producción ([VPS](/links/bare-metal/vps){.external}, [servidor dedicado](/links/bare-metal/bare-metal){.external}, [instancia de Public Cloud](/links/public-cloud/public-cloud){.external}…).
 - Conexión SSH configurada entre el servidor de almacenamiento y la infraestructura de producción.
 - Una [red privada](https://www.ovh.es/soluciones/vrack/){.external} entre los servidores (recomendado).
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.es-us.md
@@ -25,7 +25,7 @@ Esta guía explica cómo configurar un servidor de almacenamiento de OVHcloud pa
 ### Hardware y software necesarios
 
 - Un [servidor de almacenamiento](https://www.ovhcloud.com/es/bare-metal/storage/){.external} de OVHcloud.
-- Una infraestructura de producción ([VPS](https://www.ovhcloud.com/es/vps/){.external}, [servidor dedicado](/links/bare-metal/bare-metal){.external}, [instancia de Public Cloud](https://www.ovhcloud.com/es/public-cloud/){.external}…).
+- Una infraestructura de producción ([VPS](/links/bare-metal/vps){.external}, [servidor dedicado](/links/bare-metal/bare-metal){.external}, [instancia de Public Cloud](/links/public-cloud/public-cloud){.external}…).
 - Conexión SSH configurada entre el servidor de almacenamiento y la infraestructura de producción.
 - Una [red privada](https://www.ovh.com/world/es/soluciones/vrack/){.external} entre los servidores (recomendado).
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.es-us.md
@@ -25,7 +25,7 @@ Esta guía explica cómo configurar un servidor de almacenamiento de OVHcloud pa
 ### Hardware y software necesarios
 
 - Un [servidor de almacenamiento](https://www.ovhcloud.com/es/bare-metal/storage/){.external} de OVHcloud.
-- Una infraestructura de producción ([VPS](/links/bare-metal/vps){.external}, [servidor dedicado](/links/bare-metal/bare-metal){.external}, [instancia de Public Cloud](/links/public-cloud/public-cloud){.external}…).
+- Una infraestructura de producción ([VPS](/links/bare-metal/vps), [servidor dedicado](/links/bare-metal/bare-metal), [instancia de Public Cloud](/links/public-cloud/public-cloud), etc.).
 - Conexión SSH configurada entre el servidor de almacenamiento y la infraestructura de producción.
 - Una [red privada](https://www.ovh.com/world/es/soluciones/vrack/){.external} entre los servidores (recomendado).
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.fr-ca.md
@@ -25,7 +25,7 @@ Dans ce tutoriel, vous configurerez un serveur de stockage OVHcloud pour répond
 ### Ce que vous devez avoir
 
 - Un [serveur de stockage OVHcloud](https://www.ovhcloud.com/fr-ca/bare-metal/storage/){.external}.
-- Une infrastructure de production ([VPS](https://www.ovhcloud.com/fr-ca/vps/){.external}, [serveurs dédiés](/links/bare-metal/bare-metal){.external}, [Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/){.external}…).
+- Une infrastructure de production ([VPS](/links/bare-metal/vps){.external}, [serveurs dédiés](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}…).
 - Une connexion SSH configurée entre le serveur de stockage et l'infrastructure de production.
 - Conseillé : un réseau privé entre vos serveurs ([OVHcloud vRack](https://www.ovh.com/ca/fr/solutions/vrack/){.external}).
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.fr-ca.md
@@ -25,7 +25,7 @@ Dans ce tutoriel, vous configurerez un serveur de stockage OVHcloud pour répond
 ### Ce que vous devez avoir
 
 - Un [serveur de stockage OVHcloud](https://www.ovhcloud.com/fr-ca/bare-metal/storage/){.external}.
-- Une infrastructure de production ([VPS](/links/bare-metal/vps){.external}, [serveurs dédiés](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}…).
+- Une infrastructure de production ([VPS](/links/bare-metal/vps), [serveurs dédiés](/links/bare-metal/bare-metal), [Public Cloud](/links/public-cloud/public-cloud), etc.).
 - Une connexion SSH configurée entre le serveur de stockage et l'infrastructure de production.
 - Conseillé : un réseau privé entre vos serveurs ([OVHcloud vRack](https://www.ovh.com/ca/fr/solutions/vrack/){.external}).
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.fr-fr.md
@@ -25,7 +25,7 @@ Dans ce tutoriel, vous configurerez un serveur de stockage OVHcloud pour répond
 ### Ce que vous devez avoir
 
 - Un [serveur de stockage OVHcloud](https://www.ovhcloud.com/fr/bare-metal/storage/){.external}.
-- Une infrastructure de production ([VPS](https://www.ovhcloud.com/fr/vps/){.external}, [serveurs dédiés](/links/bare-metal/bare-metal){.external}, [Public Cloud](https://www.ovhcloud.com/fr/public-cloud/){.external}…).
+- Une infrastructure de production ([VPS](/links/bare-metal/vps){.external}, [serveurs dédiés](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}…).
 - Une connexion SSH configurée entre le serveur de stockage et l'infrastructure de production.
 - Conseillé : un réseau privé entre vos serveurs ([OVHcloud vRack](https://www.ovh.com/fr/solutions/vrack/){.external}).
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.fr-fr.md
@@ -25,7 +25,7 @@ Dans ce tutoriel, vous configurerez un serveur de stockage OVHcloud pour répond
 ### Ce que vous devez avoir
 
 - Un [serveur de stockage OVHcloud](https://www.ovhcloud.com/fr/bare-metal/storage/){.external}.
-- Une infrastructure de production ([VPS](/links/bare-metal/vps){.external}, [serveurs dédiés](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}…).
+- Une infrastructure de production ([VPS](/links/bare-metal/vps), [serveurs dédiés](/links/bare-metal/bare-metal), [Public Cloud](/links/public-cloud/public-cloud), etc.).
 - Une connexion SSH configurée entre le serveur de stockage et l'infrastructure de production.
 - Conseillé : un réseau privé entre vos serveurs ([OVHcloud vRack](https://www.ovh.com/fr/solutions/vrack/){.external}).
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.it-it.md
@@ -25,7 +25,7 @@ OVHcloud offre una [gamma di server dedicati](https://www.ovhcloud.com/it/bare-m
 ### Hardware e software necessari
 
 - Un [server di storage OVHcloud](https://www.ovhcloud.com/it/bare-metal/storage/){.external}
-- Un’infrastruttura di produzione ([VPS](https://www.ovhcloud.com/it/vps/){.external}, [server dedicati](/links/bare-metal/bare-metal){.external}, [Public Cloud](https://www.ovhcloud.com/it/public-cloud/){.external}...)
+- Un’infrastruttura di produzione ([VPS](/links/bare-metal/vps){.external}, [server dedicati](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}...)
 - Una connessione SSH configurata tra il server di storage e l’infrastruttura di produzione
 - Una rete privata [vRack](https://www.ovh.it/soluzioni/vrack/){.external} tra i tuoi server (consigliato)
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.it-it.md
@@ -25,7 +25,7 @@ OVHcloud offre una [gamma di server dedicati](https://www.ovhcloud.com/it/bare-m
 ### Hardware e software necessari
 
 - Un [server di storage OVHcloud](https://www.ovhcloud.com/it/bare-metal/storage/){.external}
-- Un’infrastruttura di produzione ([VPS](/links/bare-metal/vps){.external}, [server dedicati](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}...)
+- Un’infrastruttura di produzione ([VPS](/links/bare-metal/vps), [server dedicati](/links/bare-metal/bare-metal), [Public Cloud](/links/public-cloud/public-cloud), ecc.)
 - Una connessione SSH configurata tra il server di storage e l’infrastruttura di produzione
 - Una rete privata [vRack](https://www.ovh.it/soluzioni/vrack/){.external} tra i tuoi server (consigliato)
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.pl-pl.md
@@ -25,7 +25,7 @@ Niniejszy przewodnik wyjaśnia, jak skonfigurować odpowiadający Twoim potrzebo
 ### Powinieneś posiadać:
 
 - [Serwer Storage OVHcloud](https://www.ovhcloud.com/pl/bare-metal/storage/){.external}
-- Infrastrukturę produkcyjną ([VPS](https://www.ovhcloud.com/pl/vps/){.external}, [serwery dedykowane](/links/bare-metal/bare-metal){.external}, [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/){.external}…)
+- Infrastrukturę produkcyjną ([VPS](/links/bare-metal/vps){.external}, [serwery dedykowane](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}…)
 - Połączenie SSH skonfigurowane między serwerem kopii zapasowych a infrastrukturą produkcyjną
 - Zalecane: sieć prywatna między serwerami ([OVHcloud vRack](https://www.ovh.pl/rozwiazania/vrack/){.external})
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.pl-pl.md
@@ -25,7 +25,7 @@ Niniejszy przewodnik wyjaśnia, jak skonfigurować odpowiadający Twoim potrzebo
 ### Powinieneś posiadać:
 
 - [Serwer Storage OVHcloud](https://www.ovhcloud.com/pl/bare-metal/storage/){.external}
-- Infrastrukturę produkcyjną ([VPS](/links/bare-metal/vps){.external}, [serwery dedykowane](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}…)
+- Infrastrukturę produkcyjną ([VPS](/links/bare-metal/vps), [serwery dedykowane](/links/bare-metal/bare-metal), [Public Cloud](/links/public-cloud/public-cloud), itp.)
 - Połączenie SSH skonfigurowane między serwerem kopii zapasowych a infrastrukturą produkcyjną
 - Zalecane: sieć prywatna między serwerami ([OVHcloud vRack](https://www.ovh.pl/rozwiazania/vrack/){.external})
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.pt-pt.md
@@ -25,7 +25,7 @@ Neste tutorial, ficará a saber como configurar um servidor de armazenamento da 
 ### O que precisa de ter
 
 - Um [servidor de armazenamento OVHcloud](https://www.ovhcloud.com/pt/bare-metal/storage/){.external}.
-- Uma infraestrutura de produção ([VPS](https://www.ovhcloud.com/pt/vps/){.external}, [servidores dedicados](/links/bare-metal/bare-metal){.external}, [Public Cloud](https://www.ovhcloud.com/pt/public-cloud/){.external}, etc.).
+- Uma infraestrutura de produção ([VPS](/links/bare-metal/vps){.external}, [servidores dedicados](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.).
 - Um acesso SSH configurado entre o servidor de armazenamento e a infraestrutura de produção.
 - Recomendação: uma rede privada entre os servidores ([vRack OVHcloud](https://www.ovh.pt/solucoes/vrack/){.external}).
 

--- a/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/save_datas_database_on_storage_ds/guide.pt-pt.md
@@ -25,7 +25,7 @@ Neste tutorial, ficará a saber como configurar um servidor de armazenamento da 
 ### O que precisa de ter
 
 - Um [servidor de armazenamento OVHcloud](https://www.ovhcloud.com/pt/bare-metal/storage/){.external}.
-- Uma infraestrutura de produção ([VPS](/links/bare-metal/vps){.external}, [servidores dedicados](/links/bare-metal/bare-metal){.external}, [Public Cloud](/links/public-cloud/public-cloud){.external}, etc.).
+- Uma infraestrutura de produção ([VPS](/links/bare-metal/vps), [servidores dedicados](/links/bare-metal/bare-metal), [Public Cloud](/links/public-cloud/public-cloud), etc.).
 - Um acesso SSH configurado entre o servidor de armazenamento e a infraestrutura de produção.
 - Recomendação: uma rede privada entre os servidores ([vRack OVHcloud](https://www.ovh.pt/solucoes/vrack/){.external}).
 

--- a/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.en-asia.md
@@ -13,7 +13,7 @@ Enabling Intel Software Guard Extensions (SGX) on your server allows you to run 
 ## Requirements
 
 - A dedicated server compatible with the [SGX option](https://www.ovhcloud.com/asia/bare-metal/intel-software-guard-extensions/) in your OVHcloud account
-- Access to the [OVHcloud Control Panel](/links/manager) or the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud Control Panel](/links/manager) or the [OVHcloud API](/links/api)
 - Login credentials received via email after the installation
 - Ubuntu 18.04 or equivalent installed on the server
 
@@ -61,7 +61,7 @@ Continue with [Step 3](#sgx-softwares) of the instructions below.
 
 #### Step 1: Logging in to the API console
 
-On the [OVHcloud API page](https://ca.api.ovh.com/) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
+On the [OVHcloud API page](/links/api) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
 
 #### Step 2: Enabling SGX
 

--- a/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.en-au.md
@@ -13,7 +13,7 @@ Enabling Intel Software Guard Extensions (SGX) on your server allows you to run 
 ## Requirements
 
 - A dedicated server compatible with the [SGX option](https://www.ovhcloud.com/en-au/bare-metal/intel-software-guard-extensions/) in your OVHcloud account
-- Access to the [OVHcloud Control Panel](/links/manager) or the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud Control Panel](/links/manager) or the [OVHcloud API](/links/api)
 - Login credentials received via email after the installation
 - Ubuntu 18.04 or equivalent installed on the server
 
@@ -61,7 +61,7 @@ Continue with [Step 3](#sgx-softwares) of the instructions below.
 
 #### Step 1: Logging in to the API console
 
-On the [OVHcloud API page](https://ca.api.ovh.com/) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
+On the [OVHcloud API page](/links/api) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
 
 #### Step 2: Enabling SGX
 

--- a/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.en-ca.md
@@ -13,7 +13,7 @@ Enabling Intel Software Guard Extensions (SGX) on your server allows you to run 
 ## Requirements
 
 - A dedicated server compatible with the [SGX option](https://www.ovhcloud.com/en-ca/bare-metal/intel-software-guard-extensions/) in your OVHcloud account
-- Access to the [OVHcloud Control Panel](/links/manager) or the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud Control Panel](/links/manager) or the [OVHcloud API](/links/api)
 - Login credentials received via email after the installation
 - Ubuntu 18.04 or equivalent installed on the server
 
@@ -61,7 +61,7 @@ Continue with [Step 3](#sgx-softwares) of the instructions below.
 
 #### Step 1: Logging in to the API console
 
-On the [OVHcloud API page](https://ca.api.ovh.com/) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
+On the [OVHcloud API page](/links/api) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
 
 #### Step 2: Enabling SGX
 

--- a/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.en-sg.md
@@ -13,7 +13,7 @@ Enabling Intel Software Guard Extensions (SGX) on your server allows you to run 
 ## Requirements
 
 - A dedicated server compatible with the [SGX option](https://www.ovhcloud.com/en-sg/bare-metal/intel-software-guard-extensions/) in your OVHcloud account
-- Access to the [OVHcloud Control Panel](/links/manager) or the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud Control Panel](/links/manager) or the [OVHcloud API](/links/api)
 - Login credentials received via email after the installation
 - Ubuntu 18.04 or equivalent installed on the server
 
@@ -61,7 +61,7 @@ Continue with [Step 3](#sgx-softwares) of the instructions below.
 
 #### Step 1: Logging in to the API console
 
-On the [OVHcloud API page](https://ca.api.ovh.com/) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
+On the [OVHcloud API page](/links/api) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
 
 #### Step 2: Enabling SGX
 

--- a/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.en-us.md
@@ -13,7 +13,7 @@ Enabling Intel Software Guard Extensions (SGX) on your server allows you to run 
 ## Requirements
 
 - A dedicated server compatible with the [SGX option](https://www.ovhcloud.com/en/bare-metal/intel-software-guard-extensions/) in your OVHcloud account
-- Access to the [OVHcloud Control Panel](/links/manager) or the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud Control Panel](/links/manager) or the [OVHcloud API](/links/api)
 - Login credentials received via email after the installation
 - Ubuntu 18.04 or equivalent installed on the server
 
@@ -61,7 +61,7 @@ Continue with [Step 3](#sgx-softwares) of the instructions below.
 
 #### Step 1: Logging in to the API console
 
-On the [OVHcloud API page](https://ca.api.ovh.com/) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
+On the [OVHcloud API page](/links/api) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
 
 #### Step 2: Enabling SGX
 

--- a/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.es-us.md
@@ -17,7 +17,7 @@ La tecnología Intel SGX proporciona funciones avanzadas de seguridad mediante e
 
 - Tener un servidor dedicado compatible con la opción [SGX](https://www.ovhcloud.com/es/bare-metal/intel-software-guard-extensions/){.external}
 - Disponer de las claves de conexión recibidas por correo electrónico tras la instalación
-- Tener acceso al [área de cliente de OVHcloud](/links/manager) o a la [API de OVHcloud](https://ca.api.ovh.com/)
+- Tener acceso al [área de cliente de OVHcloud](/links/manager) o a la [API de OVHcloud](/links/api)
 - Tener instalado Ubuntu 18.04 o similar en el servidor
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/sgx-enable-and-use/guide.fr-ca.md
@@ -13,7 +13,7 @@ La technologie Intel SGX fournit des fonctions de sécurité avancées de chiffr
 
 - Avoir un serveur dédié compatible avec l’option [SGX](https://www.ovhcloud.com/fr-ca/bare-metal/intel-software-guard-extensions/){.external}
 - Disposer des identifiants de connexion reçus par e-mail suite à l'installation
-- Avoir accès à l'[espace client OVHcloud](/links/manager) ou l’[API OVHcloud](https://ca.api.ovh.com/)
+- Avoir accès à l'[espace client OVHcloud](/links/manager) ou l’[API OVHcloud](/links/api)
 - Ubuntu 18.04 ou équivalent installé sur le serveur
 
 ## En pratique

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.de-de.md
@@ -17,9 +17,9 @@ Das [vRack](/links/network/vrack) ist ein privates Netzwerk, mit dem Sie das Rou
 - Sie verfügen über fortgeschrittene Netzwerkkenntnisse.
 
 > [!warning]
-> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](https://eco.ovhcloud.com/de/about/) eingesetzt wird.
+> Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](/links/bare-metal/eco-about) eingesetzt wird.
 >
-> Weitere Informationen finden Sie auf der [Vergleichsseite](https://eco.ovhcloud.com/de/compare/).
+> Weitere Informationen finden Sie auf der [Vergleichsseite](/links/bare-metal/eco-compare).
 
 ## Beschreibung
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-asia.md
@@ -17,9 +17,9 @@ The [vRack](/links/network/vrack) is a private network that allows you to config
 - Basic network knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/asia/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/asia/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-au.md
@@ -17,9 +17,9 @@ The [vRack](/links/network/vrack){.external} is a private network that allows yo
 - Basic network knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-au/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-au/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-ca.md
@@ -17,9 +17,9 @@ The [vRack](/links/network/vrack) is a private network that allows you to config
 - Basic network knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ca/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ca/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-gb.md
@@ -17,9 +17,9 @@ The [vRack](/links/network/vrack) is a private network that allows you to config
 - Basic network knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-gb/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-gb/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-ie.md
@@ -17,9 +17,9 @@ The [vRack](/links/network/vrack) is a private network that allows you to config
 - Basic network knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-ie/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-ie/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-sg.md
@@ -17,9 +17,9 @@ The [vRack](/links/network/vrack) is a private network that allows you to config
 - Basic network knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en-sg/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en-sg/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.en-us.md
@@ -17,9 +17,9 @@ The [vRack](/links/network/vrack) is a private network that allows you to config
 - Basic network knowledge
 
 > [!warning]
-> This feature might be unavailable or limited on servers of the [**Eco** product line](https://eco.ovhcloud.com/en/about/).
+> This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about).
 >
-> Please visit our [comparison page](https://eco.ovhcloud.com/en/compare/) for more information.
+> Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.es-es.md
@@ -17,9 +17,9 @@ El [vRack](/links/network/vrack) es una red privada que permite configurar el di
 - Tener conocimientos avanzados de redes.
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es-es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es-es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.es-us.md
@@ -17,9 +17,9 @@ El [vRack](/links/network/vrack) es una red privada que permite configurar el di
 - Tener conocimientos avanzados de redes.
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 ## Procedimiento
 
@@ -43,7 +43,7 @@ En el ejemplo anterior, la dirección IP está anunciada en **Roubaix**. Puede v
 
 ### 2. Modificar el anuncio del bloque de IP
 
-Conéctese a la [API de OVHcloud](https://ca.api.ovh.com/console/) con su ID de cliente y contraseña. Utilice las siguientes llamadas a la API para modificar el anuncio del bloque de IP:
+Conéctese a la [API de OVHcloud](/links/console) con su ID de cliente y contraseña. Utilice las siguientes llamadas a la API para modificar el anuncio del bloque de IP:
 
 > [!api]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.fr-ca.md
@@ -17,9 +17,9 @@ Le [vRack](/links/network/vrack) est un réseau privé vous permettant de config
 - Disposer de connaissances avancées en réseau.
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr-ca/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr-ca/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.fr-fr.md
@@ -17,9 +17,9 @@ Le [vRack](/links/network/vrack) est un réseau privé vous permettant de config
 - Disposer de connaissances avancées en réseau.
 
 > [!warning]
-> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](https://eco.ovhcloud.com/fr/about/).
+> Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about).
 >
-> Consultez notre [comparatif](https://eco.ovhcloud.com/fr/compare/) pour plus d’informations.
+> Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.it-it.md
@@ -17,9 +17,9 @@ La [vRack](/links/network/vrack) è una rete privata che permette di configurare
 - Possedere competenze avanzate di rete
 
 > [!warning]
-> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](https://eco.ovhcloud.com/it/about/).
+> Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](/links/bare-metal/eco-about).
 >
-> Per maggiori informazioni, consulta la nostra [a confronto](https://eco.ovhcloud.com/it/compare/).
+> Per maggiori informazioni, consulta la nostra [a confronto](/links/bare-metal/eco-compare).
 
 ## Procedura
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.pl-pl.md
@@ -17,9 +17,9 @@ Rozwiązanie [vRack](/links/network/vrack) umożliwia konfigurację sieci międz
 - Posiadanie zaawansowanej wiedzy w zakresie sieci
 
 > [!warning]
-> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](https://eco.ovhcloud.com/pl/about/).
+> Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](/links/bare-metal/eco-about).
 >
-> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](https://eco.ovhcloud.com/pl/compare/).
+> Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](/links/bare-metal/eco-compare).
 
 ## W praktyce
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_change_zone_announce/guide.pt-pt.md
@@ -17,9 +17,9 @@ O [vRack](/links/network/vrack) é uma rede privada que lhe permite configurar o
 - Ter conhecimentos avançados de rede.
 
 > [!warning]
-> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](https://eco.ovhcloud.com/pt/about/).
+> Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para mais informações, consulte o nosso [comparativo](https://eco.ovhcloud.com/pt/compare/).
+> Para mais informações, consulte o nosso [comparativo](/links/bare-metal/eco-compare).
 
 ## Instruções
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server/guide.es-es.md
@@ -21,9 +21,9 @@ El vRack (rack virtual) de OVHcloud permite agrupar virtualmente varios servidor
 - Tener un rango de direcciones IP privadas.
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es-es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es-es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/vrack_configuring_on_dedicated_server/guide.es-us.md
@@ -21,9 +21,9 @@ El vRack (rack virtual) de OVHcloud permite agrupar virtualmente varios servidor
 - Tener un rango de direcciones IP privadas.
 
 > [!warning]
-> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](https://eco.ovhcloud.com/es-es/about/).
+> Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about).
 >
-> Para más información, consulte nuestra [comparativa](https://eco.ovhcloud.com/es-es/compare/).
+> Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).
 
 ## Procedimiento
 


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their /links values.

Example: replace all https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB links with /links/manager.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.