### PR TITLE
Fix global links in Bare metal cloud managed bare metal

### DIFF
--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.de-de.md
@@ -13,7 +13,7 @@ Bei einer Hosted Managed Bare Metal-Lösung können Sie stündlich abgerechnete 
 ## Voraussetzungen
 
 - Sie verfügen über eine [Managed Bare Metal](https://www.ovhcloud.com/de/managed-bare-metal/) Infrastruktur.
-- [Dem Benutzer die Berechtigung "Hinzufügen von Ressourcen"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) für das betreffende Rechenzentrum über das [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} erteilen.
+- [Dem Benutzer die Berechtigung "Hinzufügen von Ressourcen"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) für das betreffende Rechenzentrum über das [OVHcloud Kundencenter](/links/manager){.external} erteilen.
 - Sie haben Zugriff zum vSphere-Client.
 
 ## In der praktischen Anwendung

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-asia.md
@@ -13,7 +13,7 @@ With our [Managed Bare Metal solutions](https://www.ovhcloud.com/asia/managed-ba
 ## Requirements
 
 - a [Managed Bare Metal](https://www.ovhcloud.com/asia/managed-bare-metal/){.external} solution
-- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia){.external})
+- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](/links/manager){.external})
 - access to the vSphere client
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-au.md
@@ -13,7 +13,7 @@ With our [Managed Bare Metal solutions](https://www.ovhcloud.com/en-au/managed-b
 ## Requirements
 
 - a [Managed Bare Metal](https://www.ovhcloud.com/en-au/managed-bare-metal/){.external} solution
-- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au){.external})
+- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](/links/manager){.external})
 - access to the vSphere client
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-ca.md
@@ -13,7 +13,7 @@ With our [Managed Bare Metal solutions](https://www.ovhcloud.com/en-ca/managed-b
 ## Requirements
 
 - a [Managed Bare Metal](https://www.ovhcloud.com/en-ca/managed-bare-metal/){.external} solution
-- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca){.external})
+- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](/links/manager){.external})
 - access to the vSphere client
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-gb.md
@@ -13,7 +13,7 @@ With our [Managed Bare Metal solutions](https://www.ovhcloud.com/en-gb/managed-b
 ## Requirements
 
 - a [Managed Bare Metal](https://www.ovhcloud.com/en-gb/managed-bare-metal/){.external} solution
-- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external})
+- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](/links/manager){.external})
 - access to the vSphere client
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-ie.md
@@ -13,7 +13,7 @@ With our [Managed Bare Metal solutions](https://www.ovhcloud.com/en-ie/managed-b
 ## Requirements
 
 - a [Managed Bare Metal](https://www.ovhcloud.com/en-ie/managed-bare-metal/){.external} solution
-- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external})
+- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](/links/manager){.external})
 - access to the vSphere client
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-sg.md
@@ -13,7 +13,7 @@ With our [Managed Bare Metal solutions](https://www.ovhcloud.com/en-sg/managed-b
 ## Requirements
 
 - a [Managed Bare Metal](https://www.ovhcloud.com/en-sg/managed-bare-metal/){.external} solution
-- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg){.external})
+- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](/links/manager){.external})
 - access to the vSphere client
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.en-us.md
@@ -13,7 +13,7 @@ With our [Managed Bare Metal solutions](https://www.ovhcloud.com/en/managed-bare
 ## Requirements
 
 - a [Managed Bare Metal](https://www.ovhcloud.com/en/managed-bare-metal/){.external} solution
-- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we){.external})
+- [the "Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} right for the datacentre concerned (this right is granted via the [OVHcloud Control Panel](/links/manager){.external})
 - access to the vSphere client
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.es-es.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.es-es.md
@@ -13,7 +13,7 @@ La solución [Managed Bare Metal](https://www.ovhcloud.com/es-es/managed-bare-me
 ## Requisitos
 
 * Tener contratado un servicio [Managed Bare Metal](https://www.ovhcloud.com/es-es/managed-bare-metal/){.external}.
-* [Conceder al usuario el permiso "Adición de recursos"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) para el datacenter correspondiente desde el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}.
+* [Conceder al usuario el permiso "Adición de recursos"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) para el datacenter correspondiente desde el [área de cliente de OVHcloud](/links/manager){.external}.
 * Estar conectado al cliente vSphere.
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.es-us.md
@@ -13,7 +13,7 @@ La solución [Managed Bare Metal](https://www.ovhcloud.com/es/managed-bare-metal
 ## Requisitos
 
 * Tener contratado un servicio [Managed Bare Metal](https://www.ovhcloud.com/es/managed-bare-metal/){.external}.
-* [Conceder al usuario el permiso "Adición de recursos"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) para el datacenter correspondiente desde el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}.
+* [Conceder al usuario el permiso "Adición de recursos"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) para el datacenter correspondiente desde el [área de cliente de OVHcloud](/links/manager){.external}.
 * Estar conectado al cliente vSphere.
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.fr-ca.md
@@ -13,7 +13,7 @@ L'offre [Managed Bare Metal](https://www.ovhcloud.com/fr-ca/managed-bare-metal/)
 ## Prérequis
 
 * Posséder une offre [Managed Bare Metal](https://www.ovhcloud.com/fr-ca/managed-bare-metal/){.external}.
-* [Donner le droit "Ajout de ressources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) pour le datacenter concerné à l'utilisateur depuis l'[espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}.
+* [Donner le droit "Ajout de ressources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) pour le datacenter concerné à l'utilisateur depuis l'[espace client OVHcloud](/links/manager){.external}.
 * Être connecté au client vSphere.
 
 ## En pratique

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.fr-fr.md
@@ -13,7 +13,7 @@ L'offre [Managed Bare Metal](https://www.ovhcloud.com/fr/managed-bare-metal/){.e
 ## Prérequis
 
 * Posséder une offre [Managed Bare Metal](https://www.ovhcloud.com/fr/managed-bare-metal/){.external}.
-* [Donner le droit "Ajout de ressources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) pour le datacenter concerné à l'utilisateur depuis l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+* [Donner le droit "Ajout de ressources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) pour le datacenter concerné à l'utilisateur depuis l'[espace client OVHcloud](/links/manager){.external}.
 * Être connecté au client vSphere.
 
 ## En pratique

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.it-it.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.it-it.md
@@ -13,7 +13,7 @@ Il servizio [Managed Bare Metal](https://www.ovhcloud.com/it/managed-bare-metal/
 ## Prerequisiti
 
 * Disporre di una soluzione [Managed Bare Metal](https://www.ovhcloud.com/it/managed-bare-metal/){.external}
-* [Attribuire il permesso "Aggiunta di risorse"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) per il datacenter in questione all'utente dallo[Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}.
+* [Attribuire il permesso "Aggiunta di risorse"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) per il datacenter in questione all'utente dallo[Spazio Cliente OVHcloud](/links/manager){.external}.
 * Essere connesso al client vSphere
 
 ## Procedura

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.pl-pl.md
@@ -13,7 +13,7 @@ Oferta [Managed Bare Metal](https://www.ovhcloud.com/pl/managed-bare-metal/){.ex
 ## Wymagania początkowe
 
 * Posiadanie oferty [Managed Bare Metal](https://www.ovhcloud.com/pl/managed-bare-metal/){.external}
-* [Przydzielenie użytkownikowi uprawnienia "Dodawanie zasobów"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} w wybranym centrum danych, korzystając z [Panelu klienta](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}
+* [Przydzielenie użytkownikowi uprawnienia "Dodawanie zasobów"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} w wybranym centrum danych, korzystając z [Panelu klienta](/links/manager){.external}
 * Połączenie z klientem vSphere
 
 ## W praktyce

--- a/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/adding_hourly_resources/guide.pt-pt.md
@@ -13,7 +13,7 @@ A solução [Managed Bare Metal](https://www.ovhcloud.com/pt/managed-bare-metal/
 ## Requisitos
 
 * Dispor do serviço [Managed Bare Metal](https://www.ovhcloud.com/pt/managed-bare-metal/){.external}.
-* Dar ao utilizador a autorização [“Adição de recursos”](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} quanto ao datacenter em causa a partir da [Área de Cliente OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}.
+* Dar ao utilizador a autorização [“Adição de recursos”](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} quanto ao datacenter em causa a partir da [Área de Cliente OVH](/links/manager){.external}.
 * Estabelecer uma ligação ao cliente vSphere.
 
 ## Instruções

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.de-de.md
@@ -12,7 +12,7 @@ Diese Anleitung erläutert die Verwaltung der Nutzerrechte für das Managed Bare
 ## Voraussetzungen
 
 * Sie nutzen ein [Managed Bare Metal](https://www.ovhcloud.com/de/managed-bare-metal/){.external} Angebot.
-* Sie sind in Ihrem [OVHcloud Kunden Center](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} angemeldet.
+* Sie sind in Ihrem [OVHcloud Kunden Center](/links/manager){.external} angemeldet.
 
 ## Beschreibung
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-asia.md
@@ -13,7 +13,7 @@ The purpose of this guide is to explain the user rights management regarding the
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-au.md
@@ -13,7 +13,7 @@ The purpose of this guide is to explain the user rights management regarding the
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-ca.md
@@ -13,7 +13,7 @@ The purpose of this guide is to explain the user rights management regarding the
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-gb.md
@@ -13,7 +13,7 @@ The purpose of this guide is to explain the user rights management regarding the
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-ie.md
@@ -13,7 +13,7 @@ The purpose of this guide is to explain the user rights management regarding the
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-sg.md
@@ -13,7 +13,7 @@ The purpose of this guide is to explain the user rights management regarding the
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.en-us.md
@@ -13,7 +13,7 @@ The purpose of this guide is to explain the user rights management regarding the
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.es-es.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.es-es.md
@@ -12,7 +12,7 @@ El servicio Managed Bare Metal de OVHcloud permite gestionar los permisos de usu
 ## Requisitos
 
 * Tener contratado un servicio [Managed Bare Metal](https://www.ovhcloud.com/es-es/managed-bare-metal/){.external}.
-* Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}.
+* Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.es-us.md
@@ -12,7 +12,7 @@ El servicio Managed Bare Metal de OVHcloud permite gestionar los permisos de usu
 ## Requisitos
 
 * Tener contratado un servicio [Managed Bare Metal](https://www.ovhcloud.com/es/managed-bare-metal/){.external}.
-* Haber iniciado sesión en el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}.
+* Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.fr-ca.md
@@ -12,7 +12,7 @@ Ce guide a pour objectif d'expliquer les détails de la gestion de droits utilis
 ## Prérequis
 
 * Posséder une offre [Managed Bare Metal](https://www.ovhcloud.com/fr-ca/managed-bare-metal/){.external}.
-* Etre connecter à l'[espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}.
+* Etre connecter à l'[espace client OVHcloud](/links/manager){.external}.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.fr-fr.md
@@ -12,7 +12,7 @@ Ce guide a pour objectif d'expliquer les détails de la gestion de droits utilis
 ## Prérequis
 
 * Posséder une offre [Managed Bare Metal](https://www.ovhcloud.com/fr/managed-bare-metal/){.external}.
-* Etre connecter à l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+* Etre connecter à l'[espace client OVHcloud](/links/manager){.external}.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.it-it.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.it-it.md
@@ -12,11 +12,11 @@ Il servizio Managed Bare Metal di OVHcloud permette di assegnare agli utenti per
 ## Prerequisiti
 
 * Disporre di una soluzione [Managed Bare Metal](https://www.ovhcloud.com/it/managed-bare-metal/){.external}
-* Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}
+* Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}
 
 ## Procedura
 
-Accedi allo [Spazio Cliente](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external} e, nella sezione `Bare Metal Cloud`{.action}, clicca su `Managed Bare Metal`{.action} nella colonna a sinistra e seleziona il servizio su cui apportare la modifica.
+Accedi allo [Spazio Cliente](/links/manager){.external} e, nella sezione `Bare Metal Cloud`{.action}, clicca su `Managed Bare Metal`{.action} nella colonna a sinistra e seleziona il servizio su cui apportare la modifica.
 
 Clicca sulla scheda `Utenti`{.action} e poi sui tre puntini in corrispondenza dell’utente in questione.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.pl-pl.md
@@ -12,7 +12,7 @@ Celem niniejszego przewodnika jest wyjaśnienie, na czym polega zarządzanie pra
 ## Wymagania początkowe
 
 - Wykupienie usługi [Managed Bare Metal](https://www.ovhcloud.com/pl/managed-bare-metal/).
-- Dostęp do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl).
+- Dostęp do [Panelu klienta OVHcloud](/links/manager).
 
 ## W praktyce
 

--- a/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/change-user-rights/guide.pt-pt.md
@@ -12,7 +12,7 @@ Este manual tem como objetivo explicar os detalhes da gestão dos direitos de ut
 ## Requisitos
 
 * Dispor do serviço [Managed Bare Metal](https://www.ovhcloud.com/pt/managed-bare-metal/){.external}.
-* Ter acesso à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}.
+* Ter acesso à [Área de Cliente OVHcloud](/links/manager){.external}.
 
 ## Instruções
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.de-de.md
@@ -13,14 +13,14 @@ Die Berechtigungen und Passwörter von Nutzern des vSphere Clients werden im OVH
 
 ## Voraussetzungen
 
-- Sie sind in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} angemeldet.
+- Sie sind in Ihrem [OVHcloud Kundencenter](/links/manager){.external} angemeldet.
 - Im OVHcloud Kundencenter wurde ein Nutzeraccount für Sie angelegt. Bitte entnehmen Sie [dieser Anleitung](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#benutzer) weitere Informationen.
 
 ## Praktische Anwendung
 
 ### Passwort ändern
 
-Melden Sie sich in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} an, gehen Sie in den Bereich `Bare Metal Cloud`{.action} (1), klicken Sie auf `Managed Bare Metal`{.action} (2) und wählen Sie Ihren Server aus der Liste aus (3). Klicken Sie dann auf den Reiter `Nutzer`{.action} (4).
+Melden Sie sich in Ihrem [OVHcloud Kundencenter](/links/manager){.external} an, gehen Sie in den Bereich `Bare Metal Cloud`{.action} (1), klicken Sie auf `Managed Bare Metal`{.action} (2) und wählen Sie Ihren Server aus der Liste aus (3). Klicken Sie dann auf den Reiter `Nutzer`{.action} (4).
 
 ![Zugang zum Kundencenter](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-asia.md
@@ -12,14 +12,14 @@ vSphere client user permissions and passwords are managed from the OVHcloud Cont
 
 ## Requirements
 
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account created from the OVHcloud Control Panel. For more information, read [this guide](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#users-tab)
 
 ## Instructions
 
 ### Change Password
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
 
 ![control panel](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-au.md
@@ -12,14 +12,14 @@ vSphere client user permissions and passwords are managed from the OVHcloud Cont
 
 ## Requirements
 
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account created from the OVHcloud Control Panel. For more information, read [this guide](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#users-tab)
 
 ## Instructions
 
 ### Change Password
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
 
 ![control panel](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-ca.md
@@ -12,14 +12,14 @@ vSphere client user permissions and passwords are managed from the OVHcloud Cont
 
 ## Requirements
 
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account created from the OVHcloud Control Panel. For more information, read [this guide](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#users-tab)
 
 ## Instructions
 
 ### Change Password
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
 
 ![control panel](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-gb.md
@@ -12,14 +12,14 @@ vSphere client user permissions and passwords are managed from the OVHcloud Cont
 
 ## Requirements
 
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account created from the OVHcloud Control Panel. For more information, read [this guide](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#users-tab)
 
 ## Instructions
 
 ### Change Password
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
 
 ![control panel](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-ie.md
@@ -12,14 +12,14 @@ vSphere client user permissions and passwords are managed from the OVHcloud Cont
 
 ## Requirements
 
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account created from the OVHcloud Control Panel. For more information, read [this guide](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#users-tab)
 
 ## Instructions
 
 ### Change Password
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
 
 ![control panel](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-sg.md
@@ -12,14 +12,14 @@ vSphere client user permissions and passwords are managed from the OVHcloud Cont
 
 ## Requirements
 
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account created from the OVHcloud Control Panel. For more information, read [this guide](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#users-tab)
 
 ## Instructions
 
 ### Change Password
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
 
 ![control panel](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.en-us.md
@@ -12,14 +12,14 @@ vSphere client user permissions and passwords are managed from the OVHcloud Cont
 
 ## Requirements
 
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account created from the OVHcloud Control Panel. For more information, read [this guide](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#users-tab)
 
 ## Instructions
 
 ### Change Password
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click `Managed Bare Metal`{.action} (2) and select your server from the list (3). Click the `Users`{.action} (4) tab.
 
 ![control panel](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.es-es.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.es-es.md
@@ -13,14 +13,14 @@ Es posible gestionar los permisos y contraseñas de los usuarios del cliente vSp
 
 ## Requisitos
 
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 - Haber creado una cuenta de usuario desde el área de cliente de OVHcloud. Para más información, consulte [esta guía](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#usuarios)
 
 ## Procedimiento
 
 ### Cambiar la contraseña
 
-Conéctese al [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, acceda al menú `Servidores`{.action} y, en la sección `Managed Bare Metal`{.action}, seleccione su servidor en la lista. A continuación, haga clic en la pestaña `Usuarios` (4).
+Conéctese al [área de cliente de OVHcloud](/links/manager){.external}, acceda al menú `Servidores`{.action} y, en la sección `Managed Bare Metal`{.action}, seleccione su servidor en la lista. A continuación, haga clic en la pestaña `Usuarios` (4).
 
 ![acceso área de cliente](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.es-us.md
@@ -13,14 +13,14 @@ Es posible gestionar los permisos y contraseñas de los usuarios del cliente vSp
 
 ## Requisitos
 
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 - Haber creado una cuenta de usuario desde el área de cliente de OVHcloud. Para más información, consulte [esta guía](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#usuarios)
 
 ## Procedimiento
 
 ### Cambiar la contraseña
 
-Conéctese al [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}, acceda al menú `Servidores`{.action} y, en la sección `Managed Bare Metal`{.action}, seleccione su servidor en la lista. A continuación, haga clic en la pestaña `Usuarios` (4).
+Conéctese al [área de cliente de OVHcloud](/links/manager){.external}, acceda al menú `Servidores`{.action} y, en la sección `Managed Bare Metal`{.action}, seleccione su servidor en la lista. A continuación, haga clic en la pestaña `Usuarios` (4).
 
 ![acceso área de cliente](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.fr-ca.md
@@ -13,14 +13,14 @@ La gestion des autorisations et mots de passe des utilisateurs du client vSphere
 
 ## Prérequis
 
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}
 - Disposer d'un compte utilisateur créé depuis l'espace client OVHcloud. Pour plus d'informations, consultez [ce guide](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#utilisateurs).
   
 ## En pratique
 
 ### Modifier le mot de passe
 
-Connectez-vous à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}, accédez à la section `Bare Metal Cloud`{.action} (1), cliquez sur `Managed Bare Metal`{.action} (2) et sélectionnez votre serveur dans la liste (3). Cliquez alors sur l'onglet `Utilisateurs`{.action} (4).
+Connectez-vous à votre [espace client OVHcloud](/links/manager){.external}, accédez à la section `Bare Metal Cloud`{.action} (1), cliquez sur `Managed Bare Metal`{.action} (2) et sélectionnez votre serveur dans la liste (3). Cliquez alors sur l'onglet `Utilisateurs`{.action} (4).
 
 ![acces espace client](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.fr-fr.md
@@ -13,14 +13,14 @@ La gestion des autorisations et mots de passe des utilisateurs du client vSphere
 
 ## Prérequis
 
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}
 - Disposer d'un compte utilisateur créé depuis l'espace client OVHcloud. Pour plus d'informations, consultez [ce guide](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#utilisateurs).
 
 ## En pratique
 
 ### Modifier le mot de passe
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}, accédez à la section `Bare Metal Cloud`{.action} (1), cliquez sur `Managed Bare Metal`{.action} (2) et sélectionnez votre serveur dans la liste (3). Cliquez alors sur l'onglet `Utilisateurs`{.action} (4).
+Connectez-vous à votre [espace client OVHcloud](/links/manager){.external}, accédez à la section `Bare Metal Cloud`{.action} (1), cliquez sur `Managed Bare Metal`{.action} (2) et sélectionnez votre serveur dans la liste (3). Cliquez alors sur l'onglet `Utilisateurs`{.action} (4).
 
 ![acces espace client](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.it-it.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.it-it.md
@@ -13,14 +13,14 @@ Le autorizzazioni e le password associate agli utenti del client vSphere possono
 
 ## Prerequisiti
 
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}
 - Disporre di un account utente creato dallo Spazio Cliente OVHcloud. Per maggiori informazioni, consulta [questa guida](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#utenti)
   
 ## Procedura
 
 ### Modifica la password
 
-Accedi allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external} e, nella sezione `Bare Metal Cloud`{.action}  (1), clicca su `Managed Bare Metal`{.action} (2), seleziona il server dalla lista (3) e clicca sulla scheda `Utenti`{.action}(4).
+Accedi allo [Spazio Cliente OVHcloud](/links/manager){.external} e, nella sezione `Bare Metal Cloud`{.action}  (1), clicca su `Managed Bare Metal`{.action} (2), seleziona il server dalla lista (3) e clicca sulla scheda `Utenti`{.action}(4).
 
 ![Accesso allo Spazio Cliente](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.pl-pl.md
@@ -13,14 +13,14 @@ Uprawnieniami i hasłami użytkowników klienta vSphere zarządzasz w Panelu kli
 
 ## Wymagania początkowe
 
-- Zalogowanie do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}
+- Zalogowanie do [Panelu klienta OVHcloud](/links/manager){.external}
 - Posiadanie aktywnego użytkownika utworzonego w Panelu klienta OVHcloud. Aby uzyskać więcej informacji, zapoznaj się z [przewodnikiem](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#uzytkownicy)
 
 ## W praktyce
 
 ### Zmień hasło
 
-Zaloguj się do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}, przejdź do sekcji `Bare Metal Cloud`{.action} (1), kliknij `Managed Bare Metal`{.action} (2) i wybierz serwer z listy (3). Teraz kliknij zakładkę [Użytkownicy](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external} (4).
+Zaloguj się do [Panelu klienta OVHcloud](/links/manager){.external}, przejdź do sekcji `Bare Metal Cloud`{.action} (1), kliknij `Managed Bare Metal`{.action} (2) i wybierz serwer z listy (3). Teraz kliknij zakładkę [Użytkownicy](/links/manager){.external} (4).
 
 ![dostęp do Panelu klienta](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/changer-user-password/guide.pt-pt.md
@@ -13,14 +13,14 @@ A gestão das autorizações e palavras-passe dos utilizadores cliente vSphere r
 
 ## Requisitos
 
-- Estar ligado à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}.
+- Estar ligado à [Área de Cliente OVHcloud](/links/manager){.external}.
 - Dispor de uma conta de utilizador criada a partir da Área de Cliente OVHcloud. Para mais informações, [consulte este manual](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#utilizadores)
 
 ## Instruções
 
 ### Alterar palavra-passe
 
-Aceda à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}, dirija-se à secção `Bare Metal Cloud`{.action} (1), clique em `Managed Bare Metal`{.action} (2) e selecione o seu servidor na lista (3). De seguida, clique no separador `Utilizadores`{.action} (4).
+Aceda à [Área de Cliente OVHcloud](/links/manager){.external}, dirija-se à secção `Bare Metal Cloud`{.action} (1), clique em `Managed Bare Metal`{.action} (2) e selecione o seu servidor na lista (3). De seguida, clique no separador `Utilizadores`{.action} (4).
 
 ![acces espace client](images/userpassword1.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-asia.md
@@ -13,7 +13,7 @@ Cloning a VM creates a copy of the source VM.
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 - a VM in your cluster
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-au.md
@@ -13,7 +13,7 @@ Cloning a VM creates a copy of the source VM.
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 - a VM in your cluster
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-ca.md
@@ -13,7 +13,7 @@ Cloning a VM creates a copy of the source VM.
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 - a VM in your cluster
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-gb.md
@@ -13,7 +13,7 @@ Cloning a VM creates a copy of the source VM.
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 - a VM in your cluster
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-ie.md
@@ -13,7 +13,7 @@ Cloning a VM creates a copy of the source VM.
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 - a VM in your cluster
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-sg.md
@@ -13,7 +13,7 @@ Cloning a VM creates a copy of the source VM.
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 - a VM in your cluster
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/clone-a-vm/guide.en-us.md
@@ -13,7 +13,7 @@ Cloning a VM creates a copy of the source VM.
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 - a VM in your cluster
 
 ## Instructions

--- a/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-asia.md
@@ -13,7 +13,7 @@ You can create an alert on all items in your Managed Bare Metal: the datacentre 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-au.md
@@ -13,7 +13,7 @@ You can create an alert on all items in your Managed Bare Metal: the datacentre 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-ca.md
@@ -13,7 +13,7 @@ You can create an alert on all items in your Managed Bare Metal: the datacentre 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-gb.md
@@ -13,7 +13,7 @@ You can create an alert on all items in your Managed Bare Metal: the datacentre 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-ie.md
@@ -13,7 +13,7 @@ You can create an alert on all items in your Managed Bare Metal: the datacentre 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-sg.md
@@ -13,7 +13,7 @@ You can create an alert on all items in your Managed Bare Metal: the datacentre 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/create-an-alert/guide.en-us.md
@@ -13,7 +13,7 @@ You can create an alert on all items in your Managed Bare Metal: the datacentre 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-asia.md
@@ -13,7 +13,7 @@ You can take a snapshot of a virtual machine. Once you have taken the snapshot, 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-au.md
@@ -13,7 +13,7 @@ You can take a snapshot of a virtual machine. Once you have taken the snapshot, 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-ca.md
@@ -13,7 +13,7 @@ You can take a snapshot of a virtual machine. Once you have taken the snapshot, 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-gb.md
@@ -13,7 +13,7 @@ You can take a snapshot of a virtual machine. Once you have taken the snapshot, 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-ie.md
@@ -13,7 +13,7 @@ You can take a snapshot of a virtual machine. Once you have taken the snapshot, 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-sg.md
@@ -13,7 +13,7 @@ You can take a snapshot of a virtual machine. Once you have taken the snapshot, 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/creating-snapshots/guide.en-us.md
@@ -13,7 +13,7 @@ You can take a snapshot of a virtual machine. Once you have taken the snapshot, 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we))
+- a user account with access to [vSphere](/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface) (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-asia.md
@@ -13,7 +13,7 @@ In the vSphere interface, you have multiple possibilities to deploy a virtual ma
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-au.md
@@ -13,7 +13,7 @@ In the vSphere interface, you have multiple possibilities to deploy a virtual ma
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-ca.md
@@ -13,7 +13,7 @@ In the vSphere interface, you have multiple possibilities to deploy a virtual ma
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-gb.md
@@ -13,7 +13,7 @@ In the vSphere interface, you have multiple possibilities to deploy a virtual ma
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-ie.md
@@ -13,7 +13,7 @@ In the vSphere interface, you have multiple possibilities to deploy a virtual ma
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-sg.md
@@ -13,7 +13,7 @@ In the vSphere interface, you have multiple possibilities to deploy a virtual ma
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/deploy-a-vm/guide.en-us.md
@@ -13,7 +13,7 @@ In the vSphere interface, you have multiple possibilities to deploy a virtual ma
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-asia.md
@@ -13,7 +13,7 @@ To ensure continuity of service and avoid data loss, OVHcloud automatically take
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-au.md
@@ -13,7 +13,7 @@ To ensure continuity of service and avoid data loss, OVHcloud automatically take
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-ca.md
@@ -13,7 +13,7 @@ To ensure continuity of service and avoid data loss, OVHcloud automatically take
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-gb.md
@@ -13,7 +13,7 @@ To ensure continuity of service and avoid data loss, OVHcloud automatically take
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-ie.md
@@ -13,7 +13,7 @@ To ensure continuity of service and avoid data loss, OVHcloud automatically take
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-sg.md
@@ -13,7 +13,7 @@ To ensure continuity of service and avoid data loss, OVHcloud automatically take
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/hourly-snapshots/guide.en-us.md
@@ -13,7 +13,7 @@ To ensure continuity of service and avoid data loss, OVHcloud automatically take
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.de-de.md
@@ -13,7 +13,7 @@ Unser Managed Bare Metal Angebot entspricht nicht mehr Ihren Anforderungen? Oder
 ## Voraussetzungen
 
 - Sie verfügen über eine [Managed Bare Metal](https://www.ovhcloud.com/de/managed-bare-metal/) Infrastruktur.
-- Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
+- Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 ## In der praktischen Anwendung
 
@@ -24,7 +24,7 @@ Unser Managed Bare Metal Angebot entspricht nicht mehr Ihren Anforderungen? Oder
 
 ### Schritt 1: Beantragen Sie die Kündigung in Ihrem OVHcloud Kundencenter
 
-Melden Sie sich in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} an, gehen Sie in den Bereich `Bare Metal Cloud`{.action} (1), klicken Sie auf `Managed Bare Metal`{.action} (2) und wählen Sie die Managed Bare Metal aus der Liste aus (3), die Sie kündigen möchten.
+Melden Sie sich in Ihrem [OVHcloud Kundencenter](/links/manager){.external} an, gehen Sie in den Bereich `Bare Metal Cloud`{.action} (1), klicken Sie auf `Managed Bare Metal`{.action} (2) und wählen Sie die Managed Bare Metal aus der Liste aus (3), die Sie kündigen möchten.
 
 Klicken Sie im Reiter “Allgemeine Informationen” in der Tabelle “Dienstverwaltung” auf den Button `...`{.action} (4) rechts neben dem Datum der Verlängerung. Klicken Sie dann auf `Dienst löschen`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-asia.md
@@ -13,7 +13,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -24,7 +24,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 
 ### Step 1: Request termination from the OVHcloud Control Panel
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
 
 In the "Service management" section of the "General Information" tab, click the button `...`{.action} (4) to the right of the renewal date. Finally, click on `Delete the service`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-au.md
@@ -13,7 +13,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -24,7 +24,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 
 ### Step 1: Request termination from the OVHcloud Control Panel
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
 
 In the "Service management" section of the "General Information" tab, click the button `...`{.action} (4) to the right of the renewal date. Finally, click on `Delete the service`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-ca.md
@@ -13,7 +13,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -24,7 +24,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 
 ### Step 1: Request termination from the OVHcloud Control Panel
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
 
 In the "Service management" section of the "General Information" tab, click the button `...`{.action} (4) to the right of the renewal date. Finally, click on `Delete the service`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-gb.md
@@ -13,7 +13,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -24,7 +24,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 
 ### Step 1: Request termination from the OVHcloud Control Panel
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
 
 In the "Service management" section of the "General Information" tab, click the button `...`{.action} (4) to the right of the renewal date. Finally, click on `Delete the service`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-ie.md
@@ -13,7 +13,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -24,7 +24,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 
 ### Step 1: Request termination from the OVHcloud Control Panel
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
 
 In the "Service management" section of the "General Information" tab, click the button `...`{.action} (4) to the right of the renewal date. Finally, click on `Delete the service`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-sg.md
@@ -13,7 +13,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -24,7 +24,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 
 ### Step 1: Request termination from the OVHcloud Control Panel
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
 
 In the "Service management" section of the "General Information" tab, click the button `...`{.action} (4) to the right of the renewal date. Finally, click on `Delete the service`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.en-us.md
@@ -13,7 +13,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -24,7 +24,7 @@ If your Managed Bare Metal offer no longer suits you, or if you have ordered a n
 
 ### Step 1: Request termination from the OVHcloud Control Panel
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
+Log in to your [OVHcloud Control Panel](/links/manager){.external}, go to `Bare Metal Cloud`{.action} (1), click on `Managed Bare Metal`{.action} (2) and select your offer from the list (3).
 
 In the "Service management" section of the "General Information" tab, click the button `...`{.action} (4) to the right of the renewal date. Finally, click on `Delete the service`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.es-es.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.es-es.md
@@ -12,7 +12,7 @@ Es posible solicitar la baja de su infraestructura Managed Bare Metal en cualqui
 
 ## Requisitos
 
-- Estar conectado al [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, en el menú `Servidores`{.action} > `Managed Bare Metal`{.action}.
+- Estar conectado al [área de cliente de OVHcloud](/links/manager){.external}, en el menú `Servidores`{.action} > `Managed Bare Metal`{.action}.
 - Haber contratado una solución [Managed Bare Metal](https://www.ovhcloud.com/es-es/managed-bare-metal/){.external}.
 
 ## Procedimiento
@@ -24,7 +24,7 @@ Es posible solicitar la baja de su infraestructura Managed Bare Metal en cualqui
 
 ### 1\. Solicitar la baja del servicio desde el área de cliente de OVHcloud
 
-Conéctese al [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, acceda al menú `Servidores`{.action} (1), haga clic en la sección `Managed Bare Metal`{.action} (2) y seleccione su servicio en la lista (3).
+Conéctese al [área de cliente de OVHcloud](/links/manager){.external}, acceda al menú `Servidores`{.action} (1), haga clic en la sección `Managed Bare Metal`{.action} (2) y seleccione su servicio en la lista (3).
 
 En la columna «Gestión del servicio», haga clic en el botón con forma de tres puntos `...`{.action} (4) que aparece junto a la fecha de renovación. Por último, haga clic en `Eliminar el servicio`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.es-us.md
@@ -12,7 +12,7 @@ Es posible solicitar la baja de su infraestructura Managed Bare Metal en cualqui
 
 ## Requisitos
 
-- Estar conectado al [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}, en el menú `Servidores`{.action} > `Managed Bare Metal`{.action}.
+- Estar conectado al [área de cliente de OVHcloud](/links/manager){.external}, en el menú `Servidores`{.action} > `Managed Bare Metal`{.action}.
 - Haber contratado una solución [Managed Bare Metal](https://www.ovhcloud.com/es/managed-bare-metal/){.external}.
 
 ## Procedimiento
@@ -24,7 +24,7 @@ Es posible solicitar la baja de su infraestructura Managed Bare Metal en cualqui
 
 ### 1\. Solicitar la baja del servicio desde el área de cliente de OVHcloud
 
-Conéctese al [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}, acceda al menú `Servidores`{.action} (1), haga clic en la sección `Managed Bare Metal`{.action} (2) y seleccione su servicio en la lista (3).
+Conéctese al [área de cliente de OVHcloud](/links/manager){.external}, acceda al menú `Servidores`{.action} (1), haga clic en la sección `Managed Bare Metal`{.action} (2) y seleccione su servicio en la lista (3).
 
 En la columna «Gestión del servicio», haga clic en el botón con forma de tres puntos `...`{.action} (4) que aparece junto a la fecha de renovación. Por último, haga clic en `Eliminar el servicio`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.fr-ca.md
@@ -12,7 +12,7 @@ Si votre offre Managed Bare Metal ne vous convient plus, ou que vous avez comman
 
 ## Prérequis
 
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}.
 - Posséder un produit [Managed Bare Metal](https://www.ovhcloud.com/fr-ca/managed-bare-metal/){.external}.
 
 ## En pratique
@@ -24,7 +24,7 @@ Si votre offre Managed Bare Metal ne vous convient plus, ou que vous avez comman
 
 ### Étape 1 : demander la résiliation depuis l'espace client OVHcloud
 
-Connectez-vous à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}, accédez à la section `Bare Metal Cloud`{.action} (1), cliquez sur `Managed Bare Metal`{.action} (2) et sélectionnez votre offre dans la liste (3).
+Connectez-vous à votre [espace client OVHcloud](/links/manager){.external}, accédez à la section `Bare Metal Cloud`{.action} (1), cliquez sur `Managed Bare Metal`{.action} (2) et sélectionnez votre offre dans la liste (3).
 
 Dans le tableau « Gestion du service » de l'onglet « Informations Générales », cliquez sur le bouton `...`{.action} (4) à droite de la date de renouvellement. Cliquez enfin sur `Supprimer le service`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.fr-fr.md
@@ -12,7 +12,7 @@ Si votre offre Managed Bare Metal ne vous convient plus, ou que vous avez comman
 
 ## Prérequis
 
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}.
 - Posséder un produit [Managed Bare Metal](https://www.ovhcloud.com/fr/managed-bare-metal/){.external}.
 
 ## En pratique
@@ -24,7 +24,7 @@ Si votre offre Managed Bare Metal ne vous convient plus, ou que vous avez comman
 
 ### Étape 1 : demander la résiliation depuis l'espace client OVHcloud
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}, accédez à la section `Bare Metal Cloud`{.action} (1), cliquez sur `Managed Bare Metal`{.action} (2) et sélectionnez votre offre dans la liste (3).
+Connectez-vous à votre [espace client OVHcloud](/links/manager){.external}, accédez à la section `Bare Metal Cloud`{.action} (1), cliquez sur `Managed Bare Metal`{.action} (2) et sélectionnez votre offre dans la liste (3).
 
 Dans le tableau « Gestion du service » de l'onglet `Informations Générales`{.action}, cliquez sur le bouton `...`{.action} (4) à droite de la date de renouvellement. Cliquez enfin sur `Supprimer le service`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.it-it.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.it-it.md
@@ -12,7 +12,7 @@ Se il servizio Managed Bare Metal utilizzato non è più in grado di rispondere 
 
 ## Prerequisiti
 
-- Essere connesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}, sezione `Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action}.
+- Essere connesso allo [Spazio Cliente OVHcloud](/links/manager){.external}, sezione `Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action}.
 - Disporre di un servizio [Managed Bare Metal](https://www.ovhcloud.com/it/managed-bare-metal/){.external} attivo
 
 ## Procedura
@@ -24,7 +24,7 @@ Se il servizio Managed Bare Metal utilizzato non è più in grado di rispondere 
 
 ### Step 1: richiedi la disattivazione del servizio dallo Spazio Cliente OVHcloud
 
-Accedi allo [Spazio Cliente](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external} e, nella sezione `Bare Metal Cloud`{.action} (1), clicca su `Managed Bare Metal`{.action} (2) e seleziona il servizio nella lista (3).
+Accedi allo [Spazio Cliente](/links/manager){.external} e, nella sezione `Bare Metal Cloud`{.action} (1), clicca su `Managed Bare Metal`{.action} (2) e seleziona il servizio nella lista (3).
 
 Nel riquadro “Gestisci il servizio” disponibile nella scheda “Informazioni generali”, clicca sul pulsante `...`{.action}  (4) in corrispondenza della data di rinnovo e seleziona l’opzione `Elimina il servizio`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.pl-pl.md
@@ -12,7 +12,7 @@ Jeśli usługa Managed Bare Metal nie jest już dla Ciebie odpowiednia lub jeśl
 
 ## Wymagania początkowe
 
-- Dostęp do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external} i sekcji `Bare Metal Cloud`{.action}, a następnie `Managed Bare Metal`{.action}
+- Dostęp do [Panelu klienta OVHcloud](/links/manager){.external} i sekcji `Bare Metal Cloud`{.action}, a następnie `Managed Bare Metal`{.action}
 - Posiadanie usługi [Managed Bare Metal](https://www.ovhcloud.com/pl/managed-bare-metal/){.external}
 
 ## W praktyce
@@ -24,7 +24,7 @@ Jeśli usługa Managed Bare Metal nie jest już dla Ciebie odpowiednia lub jeśl
 
 ### Etap 1: złóż dyspozycję zakończenia usługi w Panelu klienta 
 
-Zaloguj się do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}, przejdź do sekcji `Bare Metal Cloud`{.action} (1), kliknij `Managed Bare Metal`{.action} (2) i wybierz serwer z listy (3).
+Zaloguj się do [Panelu klienta OVHcloud](/links/manager){.external}, przejdź do sekcji `Bare Metal Cloud`{.action} (1), kliknij `Managed Bare Metal`{.action} (2) i wybierz serwer z listy (3).
 
 W tabeli “Zarządzanie usługami” w zakładce “Informacje ogólne” kliknij przycisk `...`{.action} (4) po prawej stronie od daty odnowienia. Na koniec kliknij `Usuń usługę`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/how-to-cancel/guide.pt-pt.md
@@ -12,7 +12,7 @@ Se a sua oferta de Managed Bare Metal já não lhe convier, ou se encomendou uma
 
 ## Requisitos
 
-- Estar ligado à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external} e aceder à secção `Bare Metal Cloud`{.action} e, depois, `Managed Bare Metal`{.action}.
+- Estar ligado à [Área de Cliente OVHcloud](/links/manager){.external} e aceder à secção `Bare Metal Cloud`{.action} e, depois, `Managed Bare Metal`{.action}.
 - Ter um produto [Managed Bare Metal](https://www.ovhcloud.com/pt/managed-bare-metal/){.external}.
 
 ## Instruções
@@ -24,7 +24,7 @@ Se a sua oferta de Managed Bare Metal já não lhe convier, ou se encomendou uma
 
 ### 1 - Solicitar a rescisão através da Área de Cliente OVHcloud
 
-Aceda à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}, dirija-se à secção `Bare Metal Cloud`{.action} (1), clique em `Managed Bare Metal`{.action} (2) e selecione a sua oferta na lista (3).
+Aceda à [Área de Cliente OVHcloud](/links/manager){.external}, dirija-se à secção `Bare Metal Cloud`{.action} (1), clique em `Managed Bare Metal`{.action} (2) e selecione a sua oferta na lista (3).
 
 Na tabela «Gestão do serviço» do separador «Informações gerais», clique no botão `...`{.action} (4) à direita da data de renovação. Clique em `Eliminar o serviço`{.action} (5).
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.de-de.md
@@ -12,7 +12,7 @@ IP-Blöcke können verwendet werden, um Ihre Dienste über das Internet zugängl
 
 ## Voraussetzungen
 
-- Sie sind in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} eingeloggt.
+- Sie sind in Ihrem [OVHcloud Kundencenter](/links/manager){.external} eingeloggt.
 - Sie verfügen über eine [Managed Bare Metal Infrastruktur](https://www.ovhcloud.com/de/managed-bare-metal/){.external} in Ihrem OVHcloud Account.
 
 ## In der praktischen Anwendung
@@ -86,7 +86,7 @@ Verwenden Sie anschließend diesen API-Aufruf, um die IP in den IP-Parkplatz zu 
 > Dieser Aufruf trennt das Netzwerk auf den VMs, die die betreffenden IPs verwenden.
 >
 
-Sie können die Migration Ihres IP-Blocks über Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} im Bereich `Bare Metal Cloud`{.action} unter `Managed Bare Metal`{.action} nachverfolgen. Klicken Sie auf Ihren Managed Bare Metal Dienst und dann auf den Tab `Operationen`{.action}.
+Sie können die Migration Ihres IP-Blocks über Ihr [OVHcloud Kundencenter](/links/manager){.external} im Bereich `Bare Metal Cloud`{.action} unter `Managed Bare Metal`{.action} nachverfolgen. Klicken Sie auf Ihren Managed Bare Metal Dienst und dann auf den Tab `Operationen`{.action}.
 
 Die Referenz der Operation lautet “removeIpRipeBlock”.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-asia.md
@@ -13,7 +13,7 @@ An IP address block can be used to make your services available over the Interne
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -84,7 +84,7 @@ Then use this API call to move the IP addresses to "IP parking":
 > This call cuts the network on VMs that use the IPs in question.
 >
 
-You can track the IP block movement from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia){.external} in the `Bare Metal Cloud`{.action} part and then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service and then click the `Operations`{.action} tab.
+You can track the IP block movement from your [OVHcloud Control Panel](/links/manager){.external} in the `Bare Metal Cloud`{.action} part and then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service and then click the `Operations`{.action} tab.
 
 The operation name is removeIpRipeBlock.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-au.md
@@ -13,7 +13,7 @@ An IP address block can be used to make your services available over the Interne
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -84,7 +84,7 @@ Then use this API call to move the IP addresses to "IP parking":
 > This call cuts the network on VMs that use the IPs in question.
 >
 
-You can track the IP block movement from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au){.external} in the `Bare Metal Cloud`{.action} part and then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service and then click the `Operations`{.action} tab.
+You can track the IP block movement from your [OVHcloud Control Panel](/links/manager){.external} in the `Bare Metal Cloud`{.action} part and then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service and then click the `Operations`{.action} tab.
 
 The operation name is removeIpRipeBlock.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-ca.md
@@ -13,7 +13,7 @@ An IP address block can be used to make your services available over the Interne
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -84,7 +84,7 @@ Then use this API call to move the IP addresses to "IP parking":
 > This call cuts the network on VMs that use the IPs in question.
 >
 
-You can track the IP block movement from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca){.external} in the `Bare Metal Cloud`{.action} part and then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service and then click the `Operations`{.action} tab.
+You can track the IP block movement from your [OVHcloud Control Panel](/links/manager){.external} in the `Bare Metal Cloud`{.action} part and then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service and then click the `Operations`{.action} tab.
 
 The operation name is removeIpRipeBlock.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-gb.md
@@ -12,7 +12,7 @@ IP blocks can be used to make your services accessible online.
 
 ## Requirements
 
-* access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}
+* access to the [OVHcloud Control Panel](/links/manager){.external}
 * a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/){.external} on your OVHcloud account
 
 ## Instructions
@@ -86,7 +86,7 @@ Next, use this API call to move the IP into the IP parking space:
 > This call cuts the network on the VMs that use the IPs concerned.
 >
 
-You can track the movement of your IP block via the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external} in the `Bare Metal Cloud`{.action} section, then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service, then on the `Operations`{.action} tab.
+You can track the movement of your IP block via the [OVHcloud Control Panel](/links/manager){.external} in the `Bare Metal Cloud`{.action} section, then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service, then on the `Operations`{.action} tab.
 
 The operation reference is “removeIpRipeBlock”.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-ie.md
@@ -13,7 +13,7 @@ An IP address block can be used to make your services available over the Interne
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -84,7 +84,7 @@ Then use this API call to move the IP addresses to "IP parking":
 > This call cuts the network on VMs that use the IPs in question.
 >
 
-You can track the IP block movement from your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external} in the `Bare Metal Cloud`{.action} part and then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service and then click the `Operations`{.action} tab.
+You can track the IP block movement from your [OVHcloud Control Panel](/links/manager){.external} in the `Bare Metal Cloud`{.action} part and then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service and then click the `Operations`{.action} tab.
 
 The operation name is removeIpRipeBlock.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-sg.md
@@ -13,7 +13,7 @@ An IP address block can be used to make your services available over the Interne
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -84,7 +84,7 @@ Then use this API call to move the IP addresses to "IP parking":
 > This call cuts the network on VMs that use the IPs in question.
 >
 
-You can track the IP block movement from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg){.external} in the `Bare Metal Cloud`{.action} part and then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service and then click the `Operations`{.action} tab.
+You can track the IP block movement from your [OVHcloud Control Panel](/links/manager){.external} in the `Bare Metal Cloud`{.action} part and then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service and then click the `Operations`{.action} tab.
 
 The operation name is removeIpRipeBlock.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.en-us.md
@@ -13,7 +13,7 @@ An IP address block can be used to make your services available over the Interne
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
@@ -84,7 +84,7 @@ Then use this API call to move the IP addresses to "IP parking":
 > This call cuts the network on VMs that use the IPs in question.
 >
 
-You can track the IP block movement from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we){.external} in the `Bare Metal Cloud`{.action} part and then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service and then click the `Operations`{.action} tab.
+You can track the IP block movement from your [OVHcloud Control Panel](/links/manager){.external} in the `Bare Metal Cloud`{.action} part and then `Managed Bare Metal`{.action}. Click on your Managed Bare Metal service and then click the `Operations`{.action} tab.
 
 The operation name is removeIpRipeBlock.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.es-es.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.es-es.md
@@ -12,7 +12,7 @@ Los bloques de IP permiten que sus servicios estén accesibles online.
 
 ## Requisitos
 
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 - Disponer de una [infraestructura Managed Bare Metal](https://www.ovhcloud.com/es-es/managed-bare-metal/){.external} en su cuenta de OVHcloud.
 
 ## Procedimiento
@@ -93,7 +93,7 @@ A continuación utilice la siguiente llamada para mover la IP en el parking de I
 > Esta llamada interrumpe la red en las MV que utilizan las IP en cuestión.
 >
 
-Podrá seguir la migración del bloque de IP desde su [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) en el menú `Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action}. Haga clic en su servicio y, a continuación, en la pestaña `Operaciones`{.action}.
+Podrá seguir la migración del bloque de IP desde su [área de cliente de OVHcloud](/links/manager) en el menú `Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action}. Haga clic en su servicio y, a continuación, en la pestaña `Operaciones`{.action}.
 
 La referencia de la operación es «removeIpRipeBlock».
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.es-us.md
@@ -12,7 +12,7 @@ Los bloques de IP permiten que sus servicios estén accesibles online.
 
 ## Requisitos
 
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 - Disponer de una [infraestructura Managed Bare Metal](https://www.ovhcloud.com/es/managed-bare-metal/){.external} en su cuenta de OVHcloud.
 
 ## Procedimiento
@@ -93,7 +93,7 @@ A continuación utilice la siguiente llamada para mover la IP en el parking de I
 > Esta llamada interrumpe la red en las MV que utilizan las IP en cuestión.
 >
 
-Podrá seguir la migración del bloque de IP desde su [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) en el menú `Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action}. Haga clic en su servicio y, a continuación, en la pestaña `Operaciones`{.action}.
+Podrá seguir la migración del bloque de IP desde su [área de cliente de OVHcloud](/links/manager) en el menú `Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action}. Haga clic en su servicio y, a continuación, en la pestaña `Operaciones`{.action}.
 
 La referencia de la operación es «removeIpRipeBlock».
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.fr-ca.md
@@ -12,7 +12,7 @@ Un bloc IP peut vous servir à rendre vos services accessibles sur Internet.
 
 ## Prérequis
 
-* Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}.
+* Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 * Posséder une [infrastructure Managed Bare Metal](https://www.ovhcloud.com/fr-ca/managed-bare-metal/){.external} sur votre compte OVHcloud.
 
 ## En pratique
@@ -86,7 +86,7 @@ Utilisez ensuite cet appel API pour déplacer l'IP dans le parking des IPS :
 > Cet appel coupe le réseau sur les VMs qui utilisent les IPs en question.
 >
 
-Vous pourrez suivre le déplacement du bloc IP depuis votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}. Cliquez sur votre service Managed Bare Metal puis sur l'onglet `Operations`{.action}.
+Vous pourrez suivre le déplacement du bloc IP depuis votre [espace client OVHcloud](/links/manager){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}. Cliquez sur votre service Managed Bare Metal puis sur l'onglet `Operations`{.action}.
 
 La référence de l'opération est « removeIpRipeBlock ».
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.fr-fr.md
@@ -12,7 +12,7 @@ Un bloc IP peut vous servir à rendre vos services accessibles sur Internet.
 
 ## Prérequis
 
-* Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+* Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 * Posséder une [infrastructure Managed Bare Metal](https://www.ovhcloud.com/fr/managed-bare-metal/){.external} sur votre compte OVHcloud.
 
 ## En pratique
@@ -86,7 +86,7 @@ Utilisez ensuite cet appel API pour déplacer l'IP dans le parking des IPS :
 > Cet appel coupe le réseau sur les VMs qui utilisent les IPs en question.
 >
 
-Vous pourrez suivre le déplacement du bloc IP depuis votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}. Cliquez sur votre service Managed Bare Metal puis sur l'onglet `Operations`{.action}.
+Vous pourrez suivre le déplacement du bloc IP depuis votre [espace client OVHcloud](/links/manager){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}. Cliquez sur votre service Managed Bare Metal puis sur l'onglet `Operations`{.action}.
 
 La référence de l'opération est « removeIpRipeBlock ».
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.it-it.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.it-it.md
@@ -12,7 +12,7 @@ Un blocco IP Un blocco IP può essere utilizzato per rendere i tuoi servizi acce
 
 ## Prerequisiti
 
-* Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}
+* Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}
 * Disporre di un’[infrastruttura Managed Bare Metal](https://www.ovhcloud.com/it/managed-bare-metal/){.external} sul proprio account OVHcloud
 
 ## Procedura
@@ -86,7 +86,7 @@ Dopodiché utilizza questa chiamata API per spostare l’IP nel Parking degli IP
 > Questa chiamata interrompe la rete sulle VM che utilizzano gli IP in questione.
 >
 
-È possibile seguire la migrazione del blocco IP dal tuo[Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external} nella sezione`Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action}. Clicca sul tuo servizio Managed Bare Metal, quindi sulla scheda `Operazioni`{.action}.
+È possibile seguire la migrazione del blocco IP dal tuo[Spazio Cliente OVHcloud](/links/manager){.external} nella sezione`Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action}. Clicca sul tuo servizio Managed Bare Metal, quindi sulla scheda `Operazioni`{.action}.
 
 Il riferimento dell’operazione è « removeIpRipeBlock ».
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.pl-pl.md
@@ -12,8 +12,8 @@ Blok IP umożliwia udostępnianie witryn w Internecie.
 
 ## Wymagania początkowe
 
-* Dostęp do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}.
-* Posiadanie [infrastruktury Managed Bare Metal](https://www.ovhcloud.com/pl/public-cloud/){.external} na koncie OVHcloud.
+* Dostęp do [Panelu klienta OVHcloud](/links/manager){.external}.
+* Posiadanie [infrastruktury Managed Bare Metal](/links/public-cloud/public-cloud){.external} na koncie OVHcloud.
 
 ## W praktyce
 
@@ -86,7 +86,7 @@ Następnie użyj tego wywołania API, aby przenieść IP na “parking adresów 
 > To wywołanie odcina dostęp do sieci maszynom wirtualnym, które wykorzystują dane adresy IP.
 >
 
-Możesz śledzić przenoszenie bloku IP z poziomu Twojego [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external} w sekcji `Bare Metal Cloud`{.action}, a następnie `Managed Bare Metal`{.action}. Kliknij Twoją usługę Managed Bare Metal, a następnie kartę `Operacje`{.action}.
+Możesz śledzić przenoszenie bloku IP z poziomu Twojego [Panelu klienta OVHcloud](/links/manager){.external} w sekcji `Bare Metal Cloud`{.action}, a następnie `Managed Bare Metal`{.action}. Kliknij Twoją usługę Managed Bare Metal, a następnie kartę `Operacje`{.action}.
 
 Odnośnik do operacji to “removeIpRipeBlock”.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.pl-pl.md
@@ -13,7 +13,7 @@ Blok IP umożliwia udostępnianie witryn w Internecie.
 ## Wymagania początkowe
 
 * Dostęp do [Panelu klienta OVHcloud](/links/manager){.external}.
-* Posiadanie [infrastruktury Managed Bare Metal](/links/public-cloud/public-cloud){.external} na koncie OVHcloud.
+* Posiadanie [infrastruktury Managed Bare Metal](https://www.ovhcloud.com/pl/managed-bare-metal/){.external} na koncie OVHcloud.
 
 ## W praktyce
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ip-block-addition/guide.pt-pt.md
@@ -12,7 +12,7 @@ Um bloco IP pode servir para tornar os seus serviços acessíveis na Internet.
 
 ## Requisitos
 
-* Ter acesso à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}.
+* Ter acesso à [Área de Cliente OVHcloud](/links/manager){.external}.
 * Dispor de uma [infraestrutura Managed Bare Metal](https://www.ovhcloud.com/pt/managed-bare-metal/){.external} na sua conta OVHcloud.
 
 ## Instruções
@@ -86,7 +86,7 @@ De seguida, utilize esta chamada API para mover o IP no “IP parking”:
 > Esta chamada associa a rede nas VM que utilizam os IP em questão.
 >
 
-Poderá acompanhar a transferência do bloco IP na sua [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external} na secção `Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action}. Clique no seu serviço Managed Bare Metal e, depois, no separador `Operações`{.action}.
+Poderá acompanhar a transferência do bloco IP na sua [Área de Cliente OVHcloud](/links/manager){.external} na secção `Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action}. Clique no seu serviço Managed Bare Metal e, depois, no separador `Operações`{.action}.
 
 A referência da operação é “removeIpRipeBlock”.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.de-de.md
@@ -12,14 +12,14 @@ Das OVHcloud Kundencenter bietet zahlreiche Optionen für die Konfiguration Ihre
 
 ## Voraussetzungen
 
-- Sie sind in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} eingeloggt und befinden sich unter `Bare Metal Cloud`{.action} im Bereich `Managed Bare Metal`{.action}.
+- Sie sind in Ihrem [OVHcloud Kundencenter](/links/manager){.external} eingeloggt und befinden sich unter `Bare Metal Cloud`{.action} im Bereich `Managed Bare Metal`{.action}.
 - Sie verfügen über eine [Managed Bare Metal](https://www.ovhcloud.com/de/managed-bare-metal/){.external} Infrastruktur.
 
 ## In der praktischen Anwendung
 
 ### Tab "Allgemeine Informationen"
 
-Unter dem Menüpunkt `Bare Metal Cloud`{.action} im Bereich `Managed Bare Metal`{.action} Ihres [OVHcloud Kundencenters](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} finden Sie eine allgemeine Übersicht.
+Unter dem Menüpunkt `Bare Metal Cloud`{.action} im Bereich `Managed Bare Metal`{.action} Ihres [OVHcloud Kundencenters](/links/manager){.external} finden Sie eine allgemeine Übersicht.
 
 ![Allgemeine Informationen](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-asia.md
@@ -13,13 +13,13 @@ The OVHcloud Managed Bare Metal Control Panel enables you to easily manage the n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### General information tab
 
-Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
+Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](/links/manager), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
 
 ![General information](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-au.md
@@ -13,13 +13,13 @@ The OVHcloud Managed Bare Metal Control Panel enables you to easily manage the n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### General information tab
 
-Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
+Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](/links/manager), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
 
 ![General information](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-ca.md
@@ -13,13 +13,13 @@ The OVHcloud Managed Bare Metal Control Panel enables you to easily manage the n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### General information tab
 
-Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
+Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](/links/manager), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
 
 ![General information](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-gb.md
@@ -13,13 +13,13 @@ The OVHcloud Managed Bare Metal Control Panel enables you to easily manage the n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### General information tab
 
-Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
+Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](/links/manager), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
 
 ![General information](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-ie.md
@@ -13,13 +13,13 @@ The OVHcloud Managed Bare Metal Control Panel enables you to easily manage the n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### General information tab
 
-Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
+Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](/links/manager), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
 
 ![General information](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-sg.md
@@ -13,13 +13,13 @@ The OVHcloud Managed Bare Metal Control Panel enables you to easily manage the n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### General information tab
 
-Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
+Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](/links/manager), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
 
 ![General information](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.en-us.md
@@ -13,13 +13,13 @@ The OVHcloud Managed Bare Metal Control Panel enables you to easily manage the n
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### General information tab
 
-Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
+Once you have navigated to the "Bare Metal Cloud" section of your [OVHcloud Control Panel](/links/manager), and selected your service under `Managed Bare Metal`{.action} in the left-hand navigation bar, you will have access to a general overview of your Managed Bare Metal service:
 
 ![General information](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.es-es.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.es-es.md
@@ -12,14 +12,14 @@ El área de cliente de OVHcloud ofrece múltiples opciones de configuración de 
 
 ## Requisitos
 
-- Estar conectado al [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, en la sección `Bare Metal Cloud`{.action}, y dentro, en `Managed Bare Metal`{.action}.
+- Estar conectado al [área de cliente de OVHcloud](/links/manager){.external}, en la sección `Bare Metal Cloud`{.action}, y dentro, en `Managed Bare Metal`{.action}.
 - Haber contratado un servicio [Managed Bare Metal OVHcloud](https://www.ovhcloud.com/es-es/managed-bare-metal/){.external}.
 
 ## Procedimiento
 
 ### Información general
 
-Una vez en la sección `Bare Metal Cloud`{.action} del [área de cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, haga clic en `Managed Bare Metal`{.action} y aparecerá la información general de su Managed Bare Metal.
+Una vez en la sección `Bare Metal Cloud`{.action} del [área de cliente OVHcloud](/links/manager){.external}, haga clic en `Managed Bare Metal`{.action} y aparecerá la información general de su Managed Bare Metal.
 
 ![Información general](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.es-us.md
@@ -12,14 +12,14 @@ El área de cliente de OVHcloud ofrece múltiples opciones de configuración de 
 
 ## Requisitos
 
-- Estar conectado al [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}, en la sección `Bare Metal Cloud`{.action}, y dentro, en `Managed Bare Metal`{.action}.
+- Estar conectado al [área de cliente de OVHcloud](/links/manager){.external}, en la sección `Bare Metal Cloud`{.action}, y dentro, en `Managed Bare Metal`{.action}.
 - Haber contratado un servicio [Managed Bare Metal OVHcloud](https://www.ovhcloud.com/es/managed-bare-metal/){.external}.
 
 ## Procedimiento
 
 ### Información general
 
-Una vez en la sección `Bare Metal Cloud`{.action} del [área de cliente OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}, haga clic en `Managed Bare Metal`{.action} y aparecerá la información general de su Managed Bare Metal.
+Una vez en la sección `Bare Metal Cloud`{.action} del [área de cliente OVHcloud](/links/manager){.external}, haga clic en `Managed Bare Metal`{.action} y aparecerá la información general de su Managed Bare Metal.
 
 ![Información general](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.fr-ca.md
@@ -12,14 +12,14 @@ L'espace client OVHcloud vous propose de nombreuses options de paramétrage de v
 
 ## Prérequis
 
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}.
 - Posséder un produit [Managed Bare Metal](https://www.ovhcloud.com/fr-ca/managed-bare-metal/){.external}.
 
 ## En pratique
 
 ### Onglet général
 
-Une fois dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action} de votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}, vous aurez accès à un aperçu général de votre Managed Bare Metal :
+Une fois dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action} de votre [espace client OVHcloud](/links/manager){.external}, vous aurez accès à un aperçu général de votre Managed Bare Metal :
 
 ![Informations générales](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.fr-fr.md
@@ -12,14 +12,14 @@ L'espace client OVHcloud vous propose de nombreuses options de paramétrage de v
 
 ## Prérequis
 
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}.
 - Posséder un produit [Managed Bare Metal](https://www.ovhcloud.com/fr/managed-bare-metal/){.external}.
 
 ## En pratique
 
 ### Onglet général
 
-Une fois dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action} de votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}, vous aurez accès à un aperçu général de votre Managed Bare Metal :
+Une fois dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action} de votre [espace client OVHcloud](/links/manager){.external}, vous aurez accès à un aperçu général de votre Managed Bare Metal :
 
 ![Informations générales](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.it-it.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.it-it.md
@@ -12,14 +12,14 @@ Lo Spazio Cliente OVHcloud propone numerose opzioni di configurazione della tua 
 
 ## Prerequisiti
 
-- Essere connesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}, sezione `Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action}.
+- Essere connesso allo [Spazio Cliente OVHcloud](/links/manager){.external}, sezione `Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action}.
 - Disporre di un servizio [Managed Bare Metal](https://www.ovhcloud.com/it/managed-bare-metal/){.external} attivo
 
 ## Procedura
 
 ### Informazioni generali
 
-Accedendo alla sezione `Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action} del tuo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}, visualizzi le informazioni relative alla tua piattaforma:
+Accedendo alla sezione `Bare Metal Cloud`{.action} > `Managed Bare Metal`{.action} del tuo [Spazio Cliente OVHcloud](/links/manager){.external}, visualizzi le informazioni relative alla tua piattaforma:
 
 ![Informazioni generali](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.pl-pl.md
@@ -12,14 +12,14 @@ Panel klienta OVHcloud oferuje liczne opcje konfiguracji Twojej infrastruktury M
 
 ## Wymagania początkowe
 
-- Dostęp do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external} i przejście do sekcji `Bare Metal Cloud`{.action}, a następnie `Managed Bare Metal`{.action}
+- Dostęp do [Panelu klienta OVHcloud](/links/manager){.external} i przejście do sekcji `Bare Metal Cloud`{.action}, a następnie `Managed Bare Metal`{.action}
 - Posiadanie usługi [Managed Bare Metal](https://www.ovhcloud.com/pl/managed-bare-metal/){.external}
 
 ## W praktyce
 
 ### Karta ogólna
 
-W sekcji `Managed Bare Metal`{.action} znajdującej się w części `Bare Metal Cloud`{.action} [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external} masz dostęp do ogólnego podglądu infrastruktury Managed Bare Metal:
+W sekcji `Managed Bare Metal`{.action} znajdującej się w części `Bare Metal Cloud`{.action} [Panelu klienta OVHcloud](/links/manager){.external} masz dostęp do ogólnego podglądu infrastruktury Managed Bare Metal:
 
 ![Informacje ogólne](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud/guide.pt-pt.md
@@ -12,14 +12,14 @@ A Área de Cliente OVHcloud oferece-lhe várias opções de personalização da 
 
 ## Requisitos
 
-- Estar ligado à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external} e aceder à secção `Bare Metal Cloud`{.action} e, depois, `Managed Bare Metal`{.action}.
+- Estar ligado à [Área de Cliente OVHcloud](/links/manager){.external} e aceder à secção `Bare Metal Cloud`{.action} e, depois, `Managed Bare Metal`{.action}.
 - Ter um produto [Managed Bare Metal](https://www.ovhcloud.com/pt/managed-bare-metal/){.external}.
 
 ## Instruções
 
 ### Separador geral
 
-Depois de aceder à secção  `Bare Metal Cloud`{.action} e `Managed Bare Metal`{.action} da [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}, visualizará um panorama geral da sua Managed Bare Metal:
+Depois de aceder à secção  `Bare Metal Cloud`{.action} e `Managed Bare Metal`{.action} da [Área de Cliente OVHcloud](/links/manager){.external}, visualizará um panorama geral da sua Managed Bare Metal:
 
 ![Informações gerais](images/controlpanel1-e.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.de-de.md
@@ -13,7 +13,7 @@ Wenn Sie Ihre virtuelle Maschine erstellt haben, stehen deren Ressourcen nicht p
 ## Voraussetzungen
 
 - Sie haben eine virtuelle Maschine auf einer [Managed Bare Metal Infrastruktur](https://www.ovhcloud.com/de/managed-bare-metal/) erstellt.
-- Sie haben einen Benutzeraccount mit Zugriff auf vSphere (erstellt im [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)).
+- Sie haben einen Benutzeraccount mit Zugriff auf vSphere (erstellt im [OVHcloud Kundencenter](/links/manager)).
 
 ## In der praktischen Anwendung
 

--- a/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-asia.md
@@ -13,7 +13,7 @@ Once you have created your virtual machine (VM), its resources are not permanent
 ## Requirements
 
 - a virtual machine, created on a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-au.md
@@ -13,7 +13,7 @@ Once you have created your virtual machine (VM), its resources are not permanent
 ## Requirements
 
 - a virtual machine, created on a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-ca.md
@@ -13,7 +13,7 @@ Once you have created your virtual machine (VM), its resources are not permanent
 ## Requirements
 
 - a virtual machine, created on a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-gb.md
@@ -13,7 +13,7 @@ Once you have created your virtual machine (VM), its resources are not permanent
 ## Requirements
 
 - a virtual machine, created on a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-ie.md
@@ -13,7 +13,7 @@ Once you have created your virtual machine (VM), its resources are not permanent
 ## Requirements
 
 - a virtual machine, created on a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-sg.md
@@ -13,7 +13,7 @@ Once you have created your virtual machine (VM), its resources are not permanent
 ## Requirements
 
 - a virtual machine, created on a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/modify-hardware-configuration-of-vm/guide.en-us.md
@@ -13,7 +13,7 @@ Once you have created your virtual machine (VM), its resources are not permanent
 ## Requirements
 
 - a virtual machine, created on a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.de-de.md
@@ -24,7 +24,7 @@ Windows VMs, die von einem Template aus eingerichtet werden, verwenden automatis
 ## Voraussetzungen
 
 - Sie haben Zugriff auf den Web Client (HTML5).
-- [Sie haben die Windows Lizenzen](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-lizenz) über Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)  aktiviert.
+- [Sie haben die Windows Lizenzen](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-lizenz) über Ihr [OVHcloud Kundencenter](/links/manager)  aktiviert.
 
 ## In der praktischen Anwendung
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-asia.md
@@ -20,7 +20,7 @@ Windows VMs deployed from a template automatically use the SPLA licences provide
 ## Requirements
 
 - Web client access (HTML5)
-- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia){.external}, in the `Windows licence`{.action} tab for the datacentre)
+- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](/links/manager){.external}, in the `Windows licence`{.action} tab for the datacentre)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-au.md
@@ -20,7 +20,7 @@ Windows VMs deployed from a template automatically use the SPLA licences provide
 ## Requirements
 
 - Web client access (HTML5)
-- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au){.external}, in the `Windows licence`{.action} tab for the datacentre)
+- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](/links/manager){.external}, in the `Windows licence`{.action} tab for the datacentre)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-ca.md
@@ -20,7 +20,7 @@ Windows VMs deployed from a template automatically use the SPLA licences provide
 ## Requirements
 
 - Web client access (HTML5)
-- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca){.external}, in the `Windows licence`{.action} tab for the datacentre)
+- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](/links/manager){.external}, in the `Windows licence`{.action} tab for the datacentre)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-gb.md
@@ -20,7 +20,7 @@ Windows VMs deployed from a template automatically use the SPLA licences provide
 ## Requirements
 
 - Web client access (HTML5)
-- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, in the `Windows licence`{.action} tab for the datacentre)
+- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](/links/manager){.external}, in the `Windows licence`{.action} tab for the datacentre)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-ie.md
@@ -20,7 +20,7 @@ Windows VMs deployed from a template automatically use the SPLA licences provide
 ## Requirements
 
 - Web client access (HTML5)
-- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}, in the `Windows licence`{.action} tab for the datacentre)
+- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](/links/manager){.external}, in the `Windows licence`{.action} tab for the datacentre)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-sg.md
@@ -20,7 +20,7 @@ Windows VMs deployed from a template automatically use the SPLA licences provide
 ## Requirements
 
 - Web client access (HTML5)
-- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg){.external}, in the `Windows licence`{.action} tab for the datacentre)
+- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](/links/manager){.external}, in the `Windows licence`{.action} tab for the datacentre)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.en-us.md
@@ -20,7 +20,7 @@ Windows VMs deployed from a template automatically use the SPLA licences provide
 ## Requirements
 
 - Web client access (HTML5)
-- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we){.external}, in the `Windows licence`{.action} tab for the datacentre)
+- [active Windows licences](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#windows-licence-tab) (activate via the [OVHcloud Control Panel](/links/manager){.external}, in the `Windows licence`{.action} tab for the datacentre)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.es-es.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.es-es.md
@@ -22,7 +22,7 @@ Las MV Windows desplegadas a partir de una plantilla utilizan automáticamente l
 ## Requisitos
 
 - Tener acceso al cliente web (HTML5).
-- Haber activado las [licencias de Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licencia-windows) desde el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external} (en la pestaña `Licencia Widows`{.action} de la plataforma). 
+- Haber activado las [licencias de Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licencia-windows) desde el [área de cliente de OVHcloud](/links/manager){.external} (en la pestaña `Licencia Widows`{.action} de la plataforma). 
 
 Desde un navegador de internet, vaya a la página de inicio de su Managed Bare Metal y haga clic en `OVH Templates`{.action}.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.es-us.md
@@ -22,7 +22,7 @@ Las MV Windows desplegadas a partir de una plantilla utilizan automáticamente l
 ## Requisitos
 
 - Tener acceso al cliente web (HTML5).
-- Haber activado las [licencias de Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licencia-windows) desde el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external} (en la pestaña `Licencia Widows`{.action} de la plataforma). 
+- Haber activado las [licencias de Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licencia-windows) desde el [área de cliente de OVHcloud](/links/manager){.external} (en la pestaña `Licencia Widows`{.action} de la plataforma). 
 
 Desde un navegador de internet, vaya a la página de inicio de su Managed Bare Metal y haga clic en `OVH Templates`{.action}.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.fr-ca.md
@@ -20,7 +20,7 @@ Les VM Windows déployées à partir d'un template utilisent automatiquement les
 ## Prérequis
 
 - Avoir accès au client Web (HTML5)
-- [Avoir activé les licences Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licence-windows) depuis votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}
+- [Avoir activé les licences Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licence-windows) depuis votre [espace client OVHcloud](/links/manager){.external}
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.fr-fr.md
@@ -20,7 +20,7 @@ Les VM Windows déployées à partir d'un template utilisent automatiquement les
 ## Prérequis
 
 - Avoir accès au client Web (HTML5)
-- [Avoir activé les licences Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licence-windows) depuis votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}
+- [Avoir activé les licences Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licence-windows) depuis votre [espace client OVHcloud](/links/manager){.external}
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.it-it.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.it-it.md
@@ -24,7 +24,7 @@ Le VM Windows implementate a partire da un template utilizzano automaticamente l
 ## Prerequisiti
 
 - Avere accesso al client Web (HTML5)
-- [Avere attivato le licenze di Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licenze-windows){.external} dal tuo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external} (scheda `Licenza Windows`{.action} del datacenter) 
+- [Avere attivato le licenze di Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licenze-windows){.external} dal tuo [Spazio Cliente OVHcloud](/links/manager){.external} (scheda `Licenza Windows`{.action} del datacenter) 
 
 ## Procedura
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.pl-pl.md
@@ -18,7 +18,7 @@ OVH oferuje szablony Windows i SQL Server (w formacie OVF), które możesz wdro�
 ## Wymagania początkowe
 
 - Dostęp do klienta sieciowego lub do grubego klienta w zależności od używanej wersji
-- [Aktywowanie licencji Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licencja-windows) w [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external} (zakładka `Licencje Windows`{.action} w odpowiednim centrum danych) 
+- [Aktywowanie licencji Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licencja-windows) w [Panelu klienta OVHcloud](/links/manager){.external} (zakładka `Licencje Windows`{.action} w odpowiednim centrum danych) 
 
 ## W praktyce
 

--- a/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/ovf_template/guide.pt-pt.md
@@ -18,7 +18,7 @@ A OVH disponibiliza templates Windows e SQL server (em formato OVF) que pode usa
 ## Requisitos
 
 - Ter acesso ao web client ou ao thick client, consoante a versão utilizada.
-- [Ter ativado as licenças Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licence-windows){.external} na [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external} (separador `Licença Windows`{.action} do datacenter). 
+- [Ter ativado as licenças Windows](/pages/bare_metal_cloud/managed_bare_metal/manager-ovhcloud#licence-windows){.external} na [Área de Cliente OVHcloud](/links/manager){.external} (separador `Licença Windows`{.action} do datacenter). 
 
 ## Instruções
 

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.de-de.md
@@ -13,7 +13,7 @@ Das OVHcloud Network Plugin wurde entwickelt,  um alle IP-Adressen effizient zu 
 ## Voraussetzungen
 
 - Sie nutzen ein Angebot der Art [Managed Bare Metal](https://www.ovhcloud.com/de/managed-bare-metal/){.external}.
-- Sie sind in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) angemeldet.
+- Sie sind in Ihrem [OVHcloud Kundencenter](/links/manager) angemeldet.
 - Sie haben einen mit Ihrer Managed Bare Metal verbundenen IP-Block.
 - Sie haben Zugang zum vSphere Interface.
 
@@ -48,7 +48,7 @@ Die neue “Reverse-IP” wird dann in der Tabelle angezeigt.
 
 > [!primary]
 >
-> Diese Konfiguration können Sie auch in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) vornehmen. 
+> Diese Konfiguration können Sie auch in Ihrem [OVHcloud Kundencenter](/links/manager) vornehmen. 
 > 
 
 ## Weiterführende Informationen

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-asia.md
@@ -49,7 +49,7 @@ The new reverse will then be displayed in the table.
 
 > [!primary]
 >
-> This configuration process is also accessible via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) and the [OVHcloud APIs](https://ca.api.ovh.com/){.external}. 
+> This configuration process is also accessible via the [OVHcloud Control Panel](/links/manager) and the [OVHcloud APIs](/links/api){.external}. 
 > 
 
 ## Go further

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-au.md
@@ -49,7 +49,7 @@ The new reverse will then be displayed in the table.
 
 > [!primary]
 >
-> This configuration process is also accessible via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) and the [OVHcloud APIs](https://ca.api.ovh.com/){.external}. 
+> This configuration process is also accessible via the [OVHcloud Control Panel](/links/manager) and the [OVHcloud APIs](/links/api){.external}. 
 > 
 
 ## Go further

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-ca.md
@@ -49,7 +49,7 @@ The new reverse will then be displayed in the table.
 
 > [!primary]
 >
-> This configuration process is also accessible via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) and the [OVHcloud APIs](https://ca.api.ovh.com/){.external}. 
+> This configuration process is also accessible via the [OVHcloud Control Panel](/links/manager) and the [OVHcloud APIs](/links/api){.external}. 
 > 
 
 ## Go further

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-gb.md
@@ -49,7 +49,7 @@ The new reverse will then be displayed in the table.
 
 > [!primary]
 >
-> This configuration process is also accessible via the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) and the [OVHcloud APIs](https://api.ovh.com/){.external}. 
+> This configuration process is also accessible via the [OVHcloud Control Panel](/links/manager) and the [OVHcloud APIs](https://api.ovh.com/){.external}. 
 > 
 
 ## Go further

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-ie.md
@@ -49,7 +49,7 @@ The new reverse will then be displayed in the table.
 
 > [!primary]
 >
-> This configuration process is also accessible via the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) and the [OVHcloud APIs](https://api.ovh.com/){.external}. 
+> This configuration process is also accessible via the [OVHcloud Control Panel](/links/manager) and the [OVHcloud APIs](https://api.ovh.com/){.external}. 
 > 
 
 ## Go further

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-sg.md
@@ -49,7 +49,7 @@ The new reverse will then be displayed in the table.
 
 > [!primary]
 >
-> This configuration process is also accessible via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) and the [OVHcloud APIs](https://ca.api.ovh.com/){.external}. 
+> This configuration process is also accessible via the [OVHcloud Control Panel](/links/manager) and the [OVHcloud APIs](/links/api){.external}. 
 > 
 
 ## Go further

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.en-us.md
@@ -49,7 +49,7 @@ The new reverse will then be displayed in the table.
 
 > [!primary]
 >
-> This configuration process is also accessible via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) and the [OVHcloud APIs](https://ca.api.ovh.com/){.external}. 
+> This configuration process is also accessible via the [OVHcloud Control Panel](/links/manager) and the [OVHcloud APIs](/links/api){.external}. 
 > 
 
 ## Go further

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.es-es.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.es-es.md
@@ -13,7 +13,7 @@ OVHcloud ha desarrollado para sus clientes el plugin OVHcloud Network para ofrec
 ## Requisitos
 
 - Tener una solución [Managed Bare Metal](https://www.ovhcloud.com/es-es/managed-bare-metal/){.external}.
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es).
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 - Tener un bloque de direcciones IP asociado a su Managed Bare Metal.
 - Tener acceso a la interfaz vSphere.
 
@@ -48,7 +48,7 @@ El registro inverso aparecerá en la tabla.
 
 > [!primary]
 >
-> Este proceso de configuración también está disponible desde su [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es). 
+> Este proceso de configuración también está disponible desde su [área de cliente de OVHcloud](/links/manager). 
 > 
 
 ## Más información

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.es-us.md
@@ -13,7 +13,7 @@ OVHcloud ha desarrollado para sus clientes el plugin OVHcloud Network para ofrec
 ## Requisitos
 
 - Tener una solución [Managed Bare Metal](https://www.ovhcloud.com/es/managed-bare-metal/){.external}.
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 - Tener un bloque de direcciones IP asociado a su Managed Bare Metal.
 - Tener acceso a la interfaz vSphere.
 
@@ -48,7 +48,7 @@ El registro inverso aparecerá en la tabla.
 
 > [!primary]
 >
-> Este proceso de configuración también está disponible desde su [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws). 
+> Este proceso de configuración también está disponible desde su [área de cliente de OVHcloud](/links/manager). 
 > 
 
 ## Más información

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.fr-ca.md
@@ -13,7 +13,7 @@ Le plugin OVHcloud Network a été développé pour permettre une gestion plus c
 ## Prérequis
 
 - Disposer d'une offre [Managed Bare Metal](https://www.ovhcloud.com/fr-ca/managed-bare-metal/){.external}.
-- Être connecté à [l'espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à [l'espace client OVHcloud](/links/manager).
 - Un bloc d'adresse IP lié à votre Managed Bare Metal.
 - Accès à l'interface vSphere.
 
@@ -48,7 +48,7 @@ Le nouveau  « reverse » sera alors affiché dans le tableau.
 
 > [!primary]
 >
-> Ce processus de configuration est également accessible sur votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc). 
+> Ce processus de configuration est également accessible sur votre [espace client OVHcloud](/links/manager). 
 > 
 
 ## Aller plus loin

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.fr-fr.md
@@ -13,7 +13,7 @@ Le plugin OVHcloud Network a été développé pour permettre une gestion plus c
 ## Prérequis
 
 - Disposer d'une offre [Managed Bare Metal](https://www.ovhcloud.com/fr/managed-bare-metal/){.external}.
-- Être connecté à [l'espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à [l'espace client OVHcloud](/links/manager).
 - Un bloc d'adresse IP lié à votre Managed Bare Metal.
 - Accès à l'interface vSphere.
 
@@ -48,7 +48,7 @@ Le nouveau  « reverse » sera alors affiché dans le tableau.
 
 > [!primary]
 >
-> Ce processus de configuration est également accessible sur votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr). 
+> Ce processus de configuration est également accessible sur votre [espace client OVHcloud](/links/manager). 
 > 
 
 ## Aller plus loin

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.it-it.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.it-it.md
@@ -13,7 +13,7 @@ Il plugin OVHcloud Network è stato sviluppato per consentire una gestione più 
 ## Prerequisiti
 
 - Disporre di una soluzione [Managed Bare Metal](https://www.ovhcloud.com/it/managed-bare-metal/){.external}
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 - Disporre di un blocco di indirizzi IP associato al Managed Bare Metal
 - Avere accesso all’interfaccia vSphere
 
@@ -46,7 +46,7 @@ Inserisci il “reverse” e clicca su `Confirm`{.action}: il nuovo valore appar
 
 > [!primary]
 >
-> Questo processo di configurazione è disponibile anche nello [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it). 
+> Questo processo di configurazione è disponibile anche nello [Spazio Cliente OVHcloud](/links/manager). 
 > 
 
 ## Per saperne di più

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.pl-pl.md
@@ -37,7 +37,7 @@ W części **IP Blocks** wyszczególnione są wszystkie adresy IP Twojego bloku.
 
 Aby zaktualizować informacje we wtyczce OVH, że Twoje publiczne adresy IP są już używane, konieczne jest wysłanie zapytania ARP (_arping_) z maszyny lub maszyn wirtualnych używających tych adresów. Uwaga: niektóre konfiguracje z wirtualną zaporą nie umożliwiają pobierania adresów MAC, jeśli protokół ARP nie został wskazany jako autoryzowany.
 
-Możesz następnie skonfigurować Twoje rewersy DNS dla IP, na przykład dla serwera e-mail. Ustawienie to jest dostępne również w [Panelu klienta](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external} oraz w interfejsie [API OVH](https://api.ovh.com/){.external}. Kliknij trzy kropki po lewej stronie adresu IP, a następnie `Edit Reverse`{.action}.
+Możesz następnie skonfigurować Twoje rewersy DNS dla IP, na przykład dla serwera e-mail. Ustawienie to jest dostępne również w [Panelu klienta](/links/manager){.external} oraz w interfejsie [API OVH](https://api.ovh.com/){.external}. Kliknij trzy kropki po lewej stronie adresu IP, a następnie `Edit Reverse`{.action}.
 
 ![Przycisk Edition Reverse](images/network_04.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.pl-pl.md
@@ -37,7 +37,7 @@ W części **IP Blocks** wyszczególnione są wszystkie adresy IP Twojego bloku.
 
 Aby zaktualizować informacje we wtyczce OVH, że Twoje publiczne adresy IP są już używane, konieczne jest wysłanie zapytania ARP (_arping_) z maszyny lub maszyn wirtualnych używających tych adresów. Uwaga: niektóre konfiguracje z wirtualną zaporą nie umożliwiają pobierania adresów MAC, jeśli protokół ARP nie został wskazany jako autoryzowany.
 
-Możesz następnie skonfigurować Twoje rewersy DNS dla IP, na przykład dla serwera e-mail. Ustawienie to jest dostępne również w [Panelu klienta](/links/manager){.external} oraz w interfejsie [API OVH](https://api.ovh.com/){.external}. Kliknij trzy kropki po lewej stronie adresu IP, a następnie `Edit Reverse`{.action}.
+Możesz następnie skonfigurować Twoje rewersy DNS dla IP, na przykład dla serwera e-mail. Ustawienie to jest dostępne również w [Panelu klienta](/links/manager){.external} oraz w interfejsie [API OVHcloud](/links/api){.external}. Kliknij trzy kropki po lewej stronie adresu IP, a następnie `Edit Reverse`{.action}.
 
 ![Przycisk Edition Reverse](images/network_04.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/plugin_ovh_network/guide.pt-pt.md
@@ -13,7 +13,7 @@ O plugin OVHcloud Network foi concebido para permitir uma gestão mais orientada
 ## Requisitos
 
 - Dispor de uma oferta [Managed Bare Metal](https://www.ovhcloud.com/pt/managed-bare-metal/){.external}.
-- Ter acesso à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt).
+- Ter acesso à [Área de Cliente OVHcloud](/links/manager).
 - Um bloco de endereços IP associado ao seu Managed Bare Metal.
 - Aceder à interface vSphere.
 
@@ -48,7 +48,7 @@ O novo “reverse” será então apresentado na tabela.
 
 > [!primary]
 >
-> Este processo de configuração também é acessível na sua [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt). 
+> Este processo de configuração também é acessível na sua [Área de Cliente OVHcloud](/links/manager). 
 > 
 
 ## Quer saber mais?

--- a/pages/bare_metal_cloud/managed_bare_metal/service-migration-vdc/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/service-migration-vdc/guide.en-gb.md
@@ -22,7 +22,7 @@ There are two aspects to migrating an infrastructure to a new vDC:
 ## Requirements
 
 - a PCC infrastructure
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/service-migration-vdc/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/service-migration-vdc/guide.fr-fr.md
@@ -22,7 +22,7 @@ La migration d'une infrastructure vers un nouveau vDC comporte deux aspects:
 ## Prérequis
 
 * Une infrastructure PCC
-* Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}.
+* Être connecté à votre [espace client OVHcloud](/links/manager){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/managed_bare_metal/service-migration/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/service-migration/guide.en-gb.md
@@ -21,7 +21,7 @@ There are two aspects to migrating an infrastructure to a Managed Bare Metal sol
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/service-migration/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/service-migration/guide.fr-fr.md
@@ -20,7 +20,7 @@ La migration d'un service Managed Bare Metal comprend deux aspects :
 
 ## Prérequis
 
-* Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}.
+* Être connecté à votre [espace client OVHcloud](/links/manager){.external} dans la partie `Bare Metal Cloud`{.action} puis `Managed Bare Metal`{.action}.
 * Posséder un produit [Managed Bare Metal](https://www.ovhcloud.com/fr/managed-bare-metal/){.external}.
 
 ## En pratique

--- a/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-asia.md
@@ -14,7 +14,7 @@ The OVHcloud vRack feature makes it possible to connect different cloud services
 
 ### OVHcloud Control Panel
 
-After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)) and the "datacenter" will be automatically included into a vRack.
+After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](/links/manager)) and the "datacenter" will be automatically included into a vRack.
 
 ![Data centre](images/vRackDatacenter.PNG){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-au.md
@@ -14,7 +14,7 @@ The OVHcloud vRack feature makes it possible to connect different cloud services
 
 ### OVHcloud Control Panel
 
-After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)) and the "datacenter" will be automatically included into a vRack.
+After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](/links/manager)) and the "datacenter" will be automatically included into a vRack.
 
 ![Data centre](images/vRackDatacenter.PNG){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-ca.md
@@ -14,7 +14,7 @@ The OVHcloud vRack feature makes it possible to connect different cloud services
 
 ### OVHcloud Control Panel
 
-After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)) and the "datacenter" will be automatically included into a vRack.
+After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](/links/manager)) and the "datacenter" will be automatically included into a vRack.
 
 ![Data centre](images/vRackDatacenter.PNG){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-gb.md
@@ -14,7 +14,7 @@ The OVHcloud vRack feature makes it possible to connect different cloud services
 
 ### OVHcloud Control Panel
 
-After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)) and the "datacenter" will be automatically included into a vRack.
+After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](/links/manager)) and the "datacenter" will be automatically included into a vRack.
 
 ![Data centre](images/vRackDatacenter.PNG){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-ie.md
@@ -14,7 +14,7 @@ The OVHcloud vRack feature makes it possible to connect different cloud services
 
 ### OVHcloud Control Panel
 
-After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)) and the "datacenter" will be automatically included into a vRack.
+After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](/links/manager)) and the "datacenter" will be automatically included into a vRack.
 
 ![Data centre](images/vRackDatacenter.PNG){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-sg.md
@@ -14,7 +14,7 @@ The OVHcloud vRack feature makes it possible to connect different cloud services
 
 ### OVHcloud Control Panel
 
-After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)) and the "datacenter" will be automatically included into a vRack.
+After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](/links/manager)) and the "datacenter" will be automatically included into a vRack.
 
 ![Data centre](images/vRackDatacenter.PNG){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/using-vrack/guide.en-us.md
@@ -14,7 +14,7 @@ The OVHcloud vRack feature makes it possible to connect different cloud services
 
 ### OVHcloud Control Panel
 
-After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)) and the "datacenter" will be automatically included into a vRack.
+After your [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/) is delivered, it will be displayed in the section `vRack` (under "Bare Metal Cloud" in your [OVHcloud Control Panel](/links/manager)) and the "datacenter" will be automatically included into a vRack.
 
 ![Data centre](images/vRackDatacenter.PNG){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.de-de.md
@@ -11,14 +11,14 @@ Der Zugang zum vCenter kann eingeschränkt werden. Dazu wird nur bestimmten IP A
 
 ## Voraussetzungen
 
-* Sie sind in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} eingeloggt.
+* Sie sind in Ihrem [OVHcloud Kundencenter](/links/manager){.external} eingeloggt.
 * Sie verfügen über eine [Managed Bare Metal Infrastruktur](https://www.ovhcloud.com/de/managed-bare-metal/){.external} in Ihrem OVHcloud Account.
 
 ## Praktische Anwendung
 
 Wenn die [ Regeln für den Zugang zum vCenter Einschränkungen vorsehen](/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy), müssen die IPs hinzugefügt werden, die sich mit dem Dienst verbinden dürfen.
 
-Dies erfolgt im [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external-link}. Klicken Sie im Abschnitt `Bare Metal Cloud` auf die Rubrik `Managed Bare Metal`. Wählen Sie die Infrastruktur aus. Klicken Sie dann auf den Tab `Sicherheit` und danach auf `Neuen IP-Bereich hinzufügen`{.action}.
+Dies erfolgt im [OVHcloud Kundencenter](/links/manager){.external-link}. Klicken Sie im Abschnitt `Bare Metal Cloud` auf die Rubrik `Managed Bare Metal`. Wählen Sie die Infrastruktur aus. Klicken Sie dann auf den Tab `Sicherheit` und danach auf `Neuen IP-Bereich hinzufügen`{.action}.
 
 ![vCenter](images/restrictIP.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-asia.md
@@ -13,7 +13,7 @@ Access to your Managed Bare Metal can be restricted by allowing only certain IP 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-au.md
@@ -13,7 +13,7 @@ Access to your Managed Bare Metal can be restricted by allowing only certain IP 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-ca.md
@@ -13,7 +13,7 @@ Access to your Managed Bare Metal can be restricted by allowing only certain IP 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-gb.md
@@ -13,7 +13,7 @@ Access to your Managed Bare Metal can be restricted by allowing only certain IP 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-ie.md
@@ -13,7 +13,7 @@ Access to your Managed Bare Metal can be restricted by allowing only certain IP 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-sg.md
@@ -13,7 +13,7 @@ Access to your Managed Bare Metal can be restricted by allowing only certain IP 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.en-us.md
@@ -13,7 +13,7 @@ Access to your Managed Bare Metal can be restricted by allowing only certain IP 
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.es-es.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.es-es.md
@@ -11,14 +11,14 @@ Es posible limitar el acceso al vCenter autorizando solo la conexión de determi
 
 ## Requisitos
 
-* Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}.
+* Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 * Disponer de una [infraestructura Managed Bare Metal](https://www.ovhcloud.com/es-es/managed-bare-metal/){.external} en su cuenta de OVHcloud.
 
 ## Procedimiento
 
 Cuando [la política de acceso al vCenter está restringida](/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy), es necesario añadir las direcciones IP autorizadas a conectarse al servicio.
 
-Esta operación se realiza desde el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external-link}. En el menú `Servidores`, acceda a la sección `Managed Bare Metal`. Seleccione la infraestructura y, a continuación, abra la pestaña `Seguridad`. Por último, haga clic en `Añadir un nuevo rango de direcciones IP`{.action}.
+Esta operación se realiza desde el [área de cliente de OVHcloud](/links/manager){.external-link}. En el menú `Servidores`, acceda a la sección `Managed Bare Metal`. Seleccione la infraestructura y, a continuación, abra la pestaña `Seguridad`. Por último, haga clic en `Añadir un nuevo rango de direcciones IP`{.action}.
 
 ![vCenter](images/restrictIP.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.es-us.md
@@ -11,14 +11,14 @@ Es posible limitar el acceso al vCenter autorizando solo la conexión de determi
 
 ## Requisitos
 
-* Haber iniciado sesión en el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}.
+* Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 * Disponer de una [infraestructura Managed Bare Metal](https://www.ovhcloud.com/es/managed-bare-metal/){.external} en su cuenta de OVHcloud.
 
 ## Procedimiento
 
 Cuando [la política de acceso al vCenter está restringida](/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy), es necesario añadir las direcciones IP autorizadas a conectarse al servicio.
 
-Esta operación se realiza desde el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external-link}. En el menú `Servidores`, acceda a la sección `Managed Bare Metal`. Seleccione la infraestructura y, a continuación, abra la pestaña `Seguridad`. Por último, haga clic en `Añadir un nuevo rango de direcciones IP`{.action}.
+Esta operación se realiza desde el [área de cliente de OVHcloud](/links/manager){.external-link}. En el menú `Servidores`, acceda a la sección `Managed Bare Metal`. Seleccione la infraestructura y, a continuación, abra la pestaña `Seguridad`. Por último, haga clic en `Añadir un nuevo rango de direcciones IP`{.action}.
 
 ![vCenter](images/restrictIP.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.fr-ca.md
@@ -11,14 +11,14 @@ Il est possible de restreindre l'accès au vCenter en autorisant uniquement cert
 
 ## Prérequis
 
-* Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}.
+* Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 * Posséder une [infrastructure Managed Bare Metal](https://www.ovhcloud.com/fr-ca/managed-bare-metal/){.external} sur votre compte OVHcloud.
 
 ## En pratique
 
 Lorsque [la politique d'accès au vCenter est restreinte](/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy), il est nécessaire d'ajouter les IPs qui seront autorisées à se connecter au service.
 
-L'opération se réalise dans [l'espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external-link}. Dans la section `Bare Metal Cloud`, cliquez sur la rubrique `Managed Bare Metal`. Sélectionnez l'infrastructure puis rendez-vous dans l'onglet `Sécurité` et enfin cliquez sur `Ajouter une nouvelle plage d'adresses IP`{.action}.
+L'opération se réalise dans [l'espace client OVHcloud](/links/manager){.external-link}. Dans la section `Bare Metal Cloud`, cliquez sur la rubrique `Managed Bare Metal`. Sélectionnez l'infrastructure puis rendez-vous dans l'onglet `Sécurité` et enfin cliquez sur `Ajouter une nouvelle plage d'adresses IP`{.action}.
 
 ![vCenter](images/restrictIP.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.fr-fr.md
@@ -11,14 +11,14 @@ Il est possible de restreindre l'accès au vCenter en autorisant uniquement cert
 
 ## Prérequis
 
-* Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+* Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 * Posséder une [infrastructure Managed Bare Metal](https://www.ovhcloud.com/fr/managed-bare-metal/){.external} sur votre compte OVHcloud.
 
 ## En pratique
 
 Lorsque [la politique d'accès au vCenter est restreinte](/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy), il est nécessaire d'ajouter les IPs qui seront autorisées à se connecter au service.
 
-L'opération se réalise dans [l'espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external-link}. Dans la section `Bare Metal Cloud`, cliquez sur la rubrique `Managed Bare Metal`. Sélectionnez l'infrastructure puis rendez-vous dans l'onglet `Sécurité` et enfin cliquez sur `Ajouter une nouvelle plage d'adresses IP`{.action}.
+L'opération se réalise dans [l'espace client OVHcloud](/links/manager){.external-link}. Dans la section `Bare Metal Cloud`, cliquez sur la rubrique `Managed Bare Metal`. Sélectionnez l'infrastructure puis rendez-vous dans l'onglet `Sécurité` et enfin cliquez sur `Ajouter une nouvelle plage d'adresses IP`{.action}.
 
 ![vCenter](images/restrictIP.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.it-it.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.it-it.md
@@ -11,14 +11,14 @@ Impostare restrizioni di accesso al vCenter consente di limitare la connessione 
 
 ## Prerequisiti
 
-* Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}
+* Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}
 * Disporre di un’[infrastruttura Managed Bare Metal](https://www.ovhcloud.com/it/managed-bare-metal/){.external} sul proprio account OVHcloud
 
 ## Procedura
 
 Se la [politica di accesso al vCenter è configurata come limitata](/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy), è necessario aggiungere gli IP che saranno autorizzati a connettersi al servizio.
 
-Questa operazione può essere effettuata dallo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external-link}: nella sezione `Bare Metal Cloud`, clicca su `Managed Bare Metal` nella colonna a sinistra. Seleziona l’infrastruttura, clicca sulla scheda `Sicurezza` e poi su `Aggiungi una nuova classe di indirizzi IP`{.action}.
+Questa operazione può essere effettuata dallo [Spazio Cliente OVHcloud](/links/manager){.external-link}: nella sezione `Bare Metal Cloud`, clicca su `Managed Bare Metal` nella colonna a sinistra. Seleziona l’infrastruttura, clicca sulla scheda `Sicurezza` e poi su `Aggiungi una nuova classe di indirizzi IP`{.action}.
 
 ![vCenter](images/restrictIP.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.pl-pl.md
@@ -11,14 +11,14 @@ Możesz ograniczyć dostęp do vCenter, pozwalając na łączenie się z nim tyl
 
 ## Wymagania początkowe
 
-* Dostęp do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}.
+* Dostęp do [Panelu klienta OVHcloud](/links/manager){.external}.
 * Posiadanie [infrastruktury Managed Bare Metal](https://www.ovhcloud.com/pl/managed-bare-metal/){.external} na koncie OVHcloud.
 
 ## W praktyce
 
 Kiedy polityka dostępu do vCenter jest ograniczona, konieczne jest dodanie adresów IP, które będą mogły łączyć się z usługą.
 
-Operacja ta przeprowadzana jest w [Panelu klienta](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external-link}. W sekcji `Bare Metal Cloud`, kliknij sekcję `Managed Bare Metal`. Wybierz infrastrukturę, przejdź do zakładki `Bezpieczeństwo`, po czym kliknij `Dodaj nowy zakres adresów IP`{.action}.
+Operacja ta przeprowadzana jest w [Panelu klienta](/links/manager){.external-link}. W sekcji `Bare Metal Cloud`, kliknij sekcję `Managed Bare Metal`. Wybierz infrastrukturę, przejdź do zakładki `Bezpieczeństwo`, po czym kliknij `Dodaj nowy zakres adresów IP`{.action}.
 
 ![vCenter](images/restrictIP.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-authorise-ip-access/guide.pt-pt.md
@@ -11,14 +11,14 @@ updated: 2020-11-18
 
 ## Requisitos
 
-* Ter acesso à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}.
+* Ter acesso à [Área de Cliente OVHcloud](/links/manager){.external}.
 * Dispor de uma [infraestrutura Managed Bare Metal](https://www.ovhcloud.com/pt/managed-bare-metal/){.external} na sua conta OVHcloud.
 
 ## Instruções
 
 Quando [a política de acesso ao vCenter é limitada](/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy), é necessário adicionar os IP que serão autorizados a ligar-se ao serviço.
 
-A operação pode ser realizada a partir da [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external-link}. Na secção `Bare Metal Cloud`, clique na opção `Managed Bare Metal`. Selecione a infraestrutura e aceda ao separador `Segurança` e clique em `Adicionar um novo intervalo de endereços IP`{.action}.
+A operação pode ser realizada a partir da [Área de Cliente OVHcloud](/links/manager){.external-link}. Na secção `Bare Metal Cloud`, clique na opção `Managed Bare Metal`. Selecione a infraestrutura e aceda ao separador `Segurança` e clique em `Adicionar um novo intervalo de endereços IP`{.action}.
 
 ![vCenter](images/restrictIP.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.de-de.md
@@ -13,11 +13,11 @@ Um die Sicherheit Ihrer Managed Bare Metal Infrastruktur zu verbessern, können 
 ## Voraussetzungen
 
 - Sie nutzen ein Angebot der Art [Managed Bare Metal](https://www.ovhcloud.com/de/managed-bare-metal/){.external}.
-- Sie sind in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) angemeldet.
+- Sie sind in Ihrem [OVHcloud Kundencenter](/links/manager) angemeldet.
 
 ## Praktische Anwendung
 
-Melden Sie sich in Ihrem  [OVHcloud  Kundencenter an](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de). Gehen Sie in die Rubrik `Bare Metal Cloud`{.action} und wählen Sie dort Ihren Dienst unter `Managed Bare Metal`{.action} in der linken Navigationsleiste.
+Melden Sie sich in Ihrem  [OVHcloud  Kundencenter an](/links/manager). Gehen Sie in die Rubrik `Bare Metal Cloud`{.action} und wählen Sie dort Ihren Dienst unter `Managed Bare Metal`{.action} in der linken Navigationsleiste.
 
 Klicken Sie auf der Startseite des Dienstes auf `Sicherheit`{.action} und danach auf `Zugangseinstellungen für vCenter bearbeiten`{.action}.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-asia.md
@@ -13,7 +13,7 @@ To enhance security for your Managed Bare Metal infrastructure, you can restrict
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-au.md
@@ -13,7 +13,7 @@ To enhance security for your Managed Bare Metal infrastructure, you can restrict
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-ca.md
@@ -13,7 +13,7 @@ To enhance security for your Managed Bare Metal infrastructure, you can restrict
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-gb.md
@@ -13,7 +13,7 @@ To enhance security for your Managed Bare Metal infrastructure, you can restrict
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-ie.md
@@ -13,7 +13,7 @@ To enhance security for your Managed Bare Metal infrastructure, you can restrict
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-sg.md
@@ -13,7 +13,7 @@ To enhance security for your Managed Bare Metal infrastructure, you can restrict
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.en-us.md
@@ -13,7 +13,7 @@ To enhance security for your Managed Bare Metal infrastructure, you can restrict
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.es-es.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.es-es.md
@@ -13,11 +13,11 @@ Es posible restringir y gestionar el acceso al vCenter para mejorar la seguridad
 ## Requisitos
 
 - Tener una solución [Managed Bare Metal](https://www.ovhcloud.com/es-es/managed-bare-metal/){.external}.
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es).
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 
 ## Procedimiento
 
-Desde el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es), acceda a la sección `Servidores`{.action} y, en el menú de la izquierda, seleccione su servicio en la columna `Managed Bare Metal.`{.action}
+Desde el [área de cliente de OVHcloud](/links/manager), acceda a la sección `Servidores`{.action} y, en el menú de la izquierda, seleccione su servicio en la columna `Managed Bare Metal.`{.action}
 
 Desde la página principal del servicio, haga clic en la pestaña `Seguridad`{.action} y, a continuación, en `Modificar la política de acceso al vCenter`{.action}.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.es-us.md
@@ -13,11 +13,11 @@ Es posible restringir y gestionar el acceso al vCenter para mejorar la seguridad
 ## Requisitos
 
 - Tener una solución [Managed Bare Metal](https://www.ovhcloud.com/es/managed-bare-metal/){.external}.
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 
 ## Procedimiento
 
-Desde el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws), acceda a la sección `Servidores`{.action} y, en el menú de la izquierda, seleccione su servicio en la columna `Managed Bare Metal.`{.action}
+Desde el [área de cliente de OVHcloud](/links/manager), acceda a la sección `Servidores`{.action} y, en el menú de la izquierda, seleccione su servicio en la columna `Managed Bare Metal.`{.action}
 
 Desde la página principal del servicio, haga clic en la pestaña `Seguridad`{.action} y, a continuación, en `Modificar la política de acceso al vCenter`{.action}.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.fr-ca.md
@@ -13,11 +13,11 @@ Pour améliorer la sécurité de votre infrastructure Managed Bare Metal, vous p
 ## Prérequis
 
 - Disposer d'une offre [Managed Bare Metal](https://www.ovhcloud.com/fr-ca/managed-bare-metal/){.external}.
-- Être connecté à [l'espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à [l'espace client OVHcloud](/links/manager).
 
 ## En pratique
 
-Connectez-vous à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc), dirigez-vous dans la section`Bare Metal Cloud`{.action}, puis sélectionnez votre service sous `Managed Bare Metal`{.action} dans la barre de navigation de gauche.
+Connectez-vous à votre [espace client OVHcloud](/links/manager), dirigez-vous dans la section`Bare Metal Cloud`{.action}, puis sélectionnez votre service sous `Managed Bare Metal`{.action} dans la barre de navigation de gauche.
 
 À partir de la page principale du service, cliquez sur l'onglet `Sécurité`{.action}, puis sur `Modifier la politique d'accès vCenter`{.action}.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.fr-fr.md
@@ -13,11 +13,11 @@ Pour améliorer la sécurité de votre infrastructure Managed Bare Metal, vous p
 ## Prérequis
 
 - Disposer d'une offre [Managed Bare Metal](https://www.ovhcloud.com/fr/managed-bare-metal/){.external}.
-- Être connecté à [l'espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à [l'espace client OVHcloud](/links/manager).
 
 ## En pratique
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr), dirigez-vous dans la section`Bare Metal Cloud`{.action}, puis sélectionnez votre service sous `Managed Bare Metal`{.action} dans la barre de navigation de gauche.
+Connectez-vous à votre [espace client OVHcloud](/links/manager), dirigez-vous dans la section`Bare Metal Cloud`{.action}, puis sélectionnez votre service sous `Managed Bare Metal`{.action} dans la barre de navigation de gauche.
 
 À partir de la page principale du service, cliquez sur l'onglet `Sécurité`{.action}, puis sur `Modifier la politique d'accès vCenter`{.action}.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.it-it.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.it-it.md
@@ -13,11 +13,11 @@ Per aumentare la sicurezza di un’infrastruttura Managed Bare Metal, è possibi
 ## Prerequisiti
 
 - Disporre di una soluzione [Managed Bare Metal](https://www.ovhcloud.com/it/managed-bare-metal/){.external}
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 ## Procedura
 
-Accedi allo [Spazio Cliente](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) e, nella sezione `Bare Metal Cloud`{.action}, clicca su `Managed Bare Metal`{.action} nella colonna a sinistra e seleziona il servizio in questione.
+Accedi allo [Spazio Cliente](/links/manager) e, nella sezione `Bare Metal Cloud`{.action}, clicca su `Managed Bare Metal`{.action} nella colonna a sinistra e seleziona il servizio in questione.
 
 Nella pagina principale, clicca sulla scheda `Sicurezza`{.action} e poi su `Modifica la politica di accesso al vCenter`{.action}.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.pl-pl.md
@@ -13,11 +13,11 @@ Aby zwiększyć bezpieczeństwo infrastruktury Managed Bare Metal, można ograni
 ## Wymagania początkowe
 
 - Wykupienie usługi [Managed Bare Metal](https://www.ovhcloud.com/pl/managed-bare-metal/){.external}.
-- Dostęp do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl).
+- Dostęp do [Panelu klienta OVHcloud](/links/manager).
 
 ## W praktyce
 
-Zaloguj się do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl), przejdź do sekcji `Bare Metal Cloud`{.action}, a następnie wybierz swoją usługę w sekcji `Managed Bare Metal`{.action} na pasku nawigacji po lewej stronie.
+Zaloguj się do [Panelu klienta OVHcloud](/links/manager), przejdź do sekcji `Bare Metal Cloud`{.action}, a następnie wybierz swoją usługę w sekcji `Managed Bare Metal`{.action} na pasku nawigacji po lewej stronie.
 
 Na stronie głównej serwisu kliknij zakładkę `Bezpieczeństwo`{.action}, a następnie `Zmień politykę dostępu do vCenter`{.action}.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vcenter-modify-access-policy/guide.pt-pt.md
@@ -13,11 +13,11 @@ Para melhorar a segurança da sua infraestrutura Managed Bare Metal, pode limita
 ## Requisitos
 
 - Dispor de uma oferta [Managed Bare Metal](https://www.ovhcloud.com/pt/managed-bare-metal/){.external}.
-- Ter acesso à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt).
+- Ter acesso à [Área de Cliente OVHcloud](/links/manager).
 
 ## Instruções
 
-Aceda à sua [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt), vá à secção `Bare Metal Cloud`{.action} e selecione o seu serviço em `Managed Bare Metal`{.action} no menu à esquerda.
+Aceda à sua [Área de Cliente OVHcloud](/links/manager), vá à secção `Bare Metal Cloud`{.action} e selecione o seu serviço em `Managed Bare Metal`{.action} no menu à esquerda.
 
 Na página principal do serviço, clique no separador `Segurança`{.action} e em `Alterar a política de acesso ao vCenter`{.action}.
 

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-asia.md
@@ -15,7 +15,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account with access to vSphere and the permission ["Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) for the pertinent data centre
 - [vSphere High Availability (HA)](/pages/bare_metal_cloud/managed_bare_metal/vmware_ha_high_availability) enabled
 - [Distributed Resource Scheduler (DRS)](/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler) enabled
@@ -30,7 +30,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 
 ### Activating the backup option
 
-The first step is to order the service from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
+The first step is to order the service from the [OVHcloud Control Panel](/links/manager). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
 
 ![Enable backup](images/veeam-managed-bare-metal.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-au.md
@@ -15,7 +15,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account with access to vSphere and the permission ["Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) for the pertinent data centre
 - [vSphere High Availability (HA)](/pages/bare_metal_cloud/managed_bare_metal/vmware_ha_high_availability) enabled
 - [Distributed Resource Scheduler (DRS)](/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler) enabled
@@ -30,7 +30,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 
 ### Activating the backup option
 
-The first step is to order the service from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
+The first step is to order the service from the [OVHcloud Control Panel](/links/manager). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
 
 ![Enable backup](images/veeam-managed-bare-metal.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-ca.md
@@ -15,7 +15,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account with access to vSphere and the permission ["Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) for the pertinent data centre
 - [vSphere High Availability (HA)](/pages/bare_metal_cloud/managed_bare_metal/vmware_ha_high_availability) enabled
 - [Distributed Resource Scheduler (DRS)](/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler) enabled
@@ -30,7 +30,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 
 ### Activating the backup option
 
-The first step is to order the service from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
+The first step is to order the service from the [OVHcloud Control Panel](/links/manager). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
 
 ![Enable backup](images/veeam-managed-bare-metal.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-gb.md
@@ -15,7 +15,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account with access to vSphere and the permission ["Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) for the pertinent data centre
 - [vSphere High Availability (HA)](/pages/bare_metal_cloud/managed_bare_metal/vmware_ha_high_availability) enabled
 - [Distributed Resource Scheduler (DRS)](/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler) enabled
@@ -30,7 +30,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 
 ### Activating the backup option
 
-The first step is to order the service from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
+The first step is to order the service from the [OVHcloud Control Panel](/links/manager). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
 
 ![Enable backup](images/veeam-managed-bare-metal.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-ie.md
@@ -15,7 +15,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account with access to vSphere and the permission ["Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) for the pertinent data centre
 - [vSphere High Availability (HA)](/pages/bare_metal_cloud/managed_bare_metal/vmware_ha_high_availability) enabled
 - [Distributed Resource Scheduler (DRS)](/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler) enabled
@@ -30,7 +30,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 
 ### Activating the backup option
 
-The first step is to order the service from the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
+The first step is to order the service from the [OVHcloud Control Panel](/links/manager). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
 
 ![Enable backup](images/veeam-managed-bare-metal.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-sg.md
@@ -15,7 +15,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account with access to vSphere and the permission ["Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) for the pertinent data centre
 - [vSphere High Availability (HA)](/pages/bare_metal_cloud/managed_bare_metal/vmware_ha_high_availability) enabled
 - [Distributed Resource Scheduler (DRS)](/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler) enabled
@@ -30,7 +30,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 
 ### Activating the backup option
 
-The first step is to order the service from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
+The first step is to order the service from the [OVHcloud Control Panel](/links/manager). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
 
 ![Enable backup](images/veeam-managed-bare-metal.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.en-us.md
@@ -15,7 +15,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- access to the [OVHcloud Control Panel](/links/manager)
 - a user account with access to vSphere and the permission ["Add resources"](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights) for the pertinent data centre
 - [vSphere High Availability (HA)](/pages/bare_metal_cloud/managed_bare_metal/vmware_ha_high_availability) enabled
 - [Distributed Resource Scheduler (DRS)](/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler) enabled
@@ -30,7 +30,7 @@ Backups are performed using a virtual machine (VM) within your [Managed Bare Met
 
 ### Activating the backup option
 
-The first step is to order the service from the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
+The first step is to order the service from the [OVHcloud Control Panel](/links/manager). To do this, go to the `Managed Bare Metal`{.action} section of the `Bare Metal Cloud`{.action} tab. Click on the relevant vSphere infrastructure, then select the data centre. Click on the `Backup`{.action} tab.
 
 ![Enable backup](images/veeam-managed-bare-metal.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service/guide.fr-fr.md
@@ -15,7 +15,7 @@ Les sauvegardes sont réalisées à l'aide d'une machine virtuelle (VM) située 
 ## Prérequis
 
 * Posséder une offre [Managed Bare Metal](https://www.ovhcloud.com/fr/managed-bare-metal/){.external}.
-* [Donner le droit « Ajout de ressources »](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} pour le datacenter concerné à l'utilisateur depuis l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+* [Donner le droit « Ajout de ressources »](/pages/bare_metal_cloud/managed_bare_metal/change-user-rights){.external} pour le datacenter concerné à l'utilisateur depuis l'[espace client OVHcloud](/links/manager){.external}.
 * Être connecté au client vSphere.
 * Avoir activé la [haute disponibilité (HA)](/pages/bare_metal_cloud/managed_bare_metal/vmware_ha_high_availability){.external}.
 * Avoir activé le [Distributed Ressource Scheduler (DRS)](/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler){.external} sur le ou les clusters.
@@ -30,7 +30,7 @@ Les sauvegardes sont réalisées à l'aide d'une machine virtuelle (VM) située 
 
 ### Activer le service
 
-La première étape consiste à activer le service depuis l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}. Pour cela, rendez-vous dans la partie `Managed Bare Metal`{.action} de l'onglet `Bare Metal Cloud`{.action}. Cliquez sur l'infrastructure vSphere concernée, puis sur le datacenter souhaité. Choisissez l'onglet `Backup`{.action}.
+La première étape consiste à activer le service depuis l'[espace client OVHcloud](/links/manager){.external}. Pour cela, rendez-vous dans la partie `Managed Bare Metal`{.action} de l'onglet `Bare Metal Cloud`{.action}. Cliquez sur l'infrastructure vSphere concernée, puis sur le datacenter souhaité. Choisissez l'onglet `Backup`{.action}.
 
 ![Activer le backup](images/veeam-managed-bare-metal.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_managed_backup_restoration/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_managed_backup_restoration/guide.en-asia.md
@@ -10,7 +10,7 @@ updated: 2021-03-29
 
 ## Requirements
 
-- Access to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API](/links/api)
 - [Veeam Managed Backup enabled](/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service) on your Hosted Private Cloud solution
 
 ## Instructions
@@ -21,7 +21,7 @@ If you are not familiar with OVHcloud APIs, please refer to our [Getting started
 
 First, you need to target the backups you want to restore.
 
-Log in to [https://ca.api.ovh.com/](https://ca.api.ovh.com/) and use the following call:
+Log in to [https://ca.api.ovh.com/](/links/api) and use the following call:
 
 > [!api]
 >
@@ -55,7 +55,7 @@ Take note of the BackupRepository reference, this will allow you to restore back
 
 The API call will restore the last valid restore points for each backup in the storage folder.
 
-Log in to [https://ca.api.ovh.com/](https://ca.api.ovh.com/) and use the following call:
+Log in to [https://ca.api.ovh.com/](/links/api) and use the following call:
 
 > [!api]
 >

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_managed_backup_restoration/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_managed_backup_restoration/guide.en-au.md
@@ -10,7 +10,7 @@ updated: 2021-03-29
 
 ## Requirements
 
-- Access to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API](/links/api)
 - [Veeam Managed Backup enabled](/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service) on your Hosted Private Cloud solution
 
 ## Instructions
@@ -21,7 +21,7 @@ If you are not familiar with OVHcloud APIs, please refer to our [Getting started
 
 First, you need to target the backups you want to restore.
 
-Log in to [https://ca.api.ovh.com/](https://ca.api.ovh.com/) and use the following call:
+Log in to [https://ca.api.ovh.com/](/links/api) and use the following call:
 
 > [!api]
 >
@@ -55,7 +55,7 @@ Take note of the BackupRepository reference, this will allow you to restore back
 
 The API call will restore the last valid restore points for each backup in the storage folder.
 
-Log in to [https://ca.api.ovh.com/](https://ca.api.ovh.com/) and use the following call:
+Log in to [https://ca.api.ovh.com/](/links/api) and use the following call:
 
 > [!api]
 >

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_managed_backup_restoration/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_managed_backup_restoration/guide.en-sg.md
@@ -10,7 +10,7 @@ updated: 2021-03-29
 
 ## Requirements
 
-- Access to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API](/links/api)
 - [Veeam Managed Backup enabled](/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service) on your Hosted Private Cloud solution
 
 ## Instructions
@@ -21,7 +21,7 @@ If you are not familiar with OVHcloud APIs, please refer to our [Getting started
 
 First, you need to target the backups you want to restore.
 
-Log in to [https://ca.api.ovh.com/](https://ca.api.ovh.com/) and use the following call:
+Log in to [https://ca.api.ovh.com/](/links/api) and use the following call:
 
 > [!api]
 >
@@ -55,7 +55,7 @@ Take note of the BackupRepository reference, this will allow you to restore back
 
 The API call will restore the last valid restore points for each backup in the storage folder.
 
-Log in to [https://ca.api.ovh.com/](https://ca.api.ovh.com/) and use the following call:
+Log in to [https://ca.api.ovh.com/](/links/api) and use the following call:
 
 > [!api]
 >

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_managed_backup_restoration/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_managed_backup_restoration/guide.en-us.md
@@ -10,7 +10,7 @@ updated: 2021-03-29
 
 ## Requirements
 
-- Access to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API](/links/api)
 - [Veeam Managed Backup enabled](/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service) on your Hosted Private Cloud solution
 
 ## Instructions
@@ -21,7 +21,7 @@ If you are not familiar with OVHcloud APIs, please refer to our [Getting started
 
 First, you need to target the backups you want to restore.
 
-Log in to [https://ca.api.ovh.com/](https://ca.api.ovh.com/) and use the following call:
+Log in to [https://ca.api.ovh.com/](/links/api) and use the following call:
 
 > [!api]
 >
@@ -55,7 +55,7 @@ Take note of the BackupRepository reference, this will allow you to restore back
 
 The API call will restore the last valid restore points for each backup in the storage folder.
 
-Log in to [https://ca.api.ovh.com/](https://ca.api.ovh.com/) and use the following call:
+Log in to [https://ca.api.ovh.com/](/links/api) and use the following call:
 
 > [!api]
 >

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_managed_backup_restoration/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_managed_backup_restoration/guide.es-us.md
@@ -14,7 +14,7 @@ updated: 2021-03-29
 
 ## Requisitos
 
-- Estar conectado a la [API de OVHcloud.](https://ca.api.ovh.com/)
+- Estar conectado a la [API de OVHcloud.](/links/api)
 - [Veeam Managed Backup activado](/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service) en su Managed Bare Metal
 
 ## Procedimiento
@@ -25,7 +25,7 @@ Si no está familiarizado con el funcionamiento de las API de OVHcloud, consulte
 
 En primer lugar, debe identificar los backups que desea restaurar.
 
-Conéctese a [https://ca.api.ovh.com/](https://ca.api.ovh.com/) y utilice la siguiente llamada:
+Conéctese a [https://ca.api.ovh.com/](/links/api) y utilice la siguiente llamada:
 
 > [!api]
 >
@@ -59,7 +59,7 @@ Tenga en cuenta que el backup repository permite restaurar las copias de segurid
 
 La llamada a la API restaurará los últimos puntos de restauración válidos de cada backup presente en el directorio de almacenamiento.
 
-Conéctese a [https://ca.api.ovh.com/](https://ca.api.ovh.com/) y utilice la siguiente llamada:
+Conéctese a [https://ca.api.ovh.com/](/links/api) y utilice la siguiente llamada:
 
 > [!api]
 >

--- a/pages/bare_metal_cloud/managed_bare_metal/veeam_managed_backup_restoration/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/veeam_managed_backup_restoration/guide.fr-ca.md
@@ -10,7 +10,7 @@ updated: 2021-03-29
 
 ## Prérequis
 
-- Être connecté aux [API OVHcloud](https://ca.api.ovh.com/)
+- Être connecté aux [API OVHcloud](/links/api)
 - [Veeam Managed Backup activé](/pages/bare_metal_cloud/managed_bare_metal/veeam_backup_as_a_service) sur votre offre Managed Bare Metal
 
 ## En pratique
@@ -21,7 +21,7 @@ Si vous n'êtes pas habitué au fonctionnement des API OVHcloud, consultez notre
 
 Il vous faut dans un premier temps cibler les sauvegardes à restaurer.
 
-Connectez-vous sur [https://ca.api.ovh.com/](https://ca.api.ovh.com/) et utilisez l'appel suivant :
+Connectez-vous sur [https://ca.api.ovh.com/](/links/api) et utilisez l'appel suivant :
 
 > [!api]
 >
@@ -55,7 +55,7 @@ Prenez note du dossier de stockage (BackupRepository), celui-ci vous permettra d
 
 L'appel API va restaurer les derniers points de restauration valides de chaque sauvegarde présente sur le dossier de stockage.
 
-Connectez-vous sur [https://ca.api.ovh.com/](https://ca.api.ovh.com/) et utilisez l'appel suivant :
+Connectez-vous sur [https://ca.api.ovh.com/](/links/api) et utilisez l'appel suivant :
 
 > [!api]
 >

--- a/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-asia.md
@@ -13,7 +13,7 @@ The feature Distributed Resource Scheduler (DRS) is available in a VMware cluste
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-au.md
@@ -13,7 +13,7 @@ The feature Distributed Resource Scheduler (DRS) is available in a VMware cluste
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-ca.md
@@ -13,7 +13,7 @@ The feature Distributed Resource Scheduler (DRS) is available in a VMware cluste
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-gb.md
@@ -13,7 +13,7 @@ The feature Distributed Resource Scheduler (DRS) is available in a VMware cluste
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-ie.md
@@ -13,7 +13,7 @@ The feature Distributed Resource Scheduler (DRS) is available in a VMware cluste
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-sg.md
@@ -13,7 +13,7 @@ The feature Distributed Resource Scheduler (DRS) is available in a VMware cluste
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vmware_drs_distributed_ressource_scheduler/guide.en-us.md
@@ -13,7 +13,7 @@ The feature Distributed Resource Scheduler (DRS) is available in a VMware cluste
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.de-de.md
@@ -13,11 +13,11 @@ Ein Name, Vorname, eine Telefonnummer und E-Mail-Adresse können mit dem vSphere
 ## Voraussetzungen
 
 - Sie verfügen über eine [Managed Bare Metal](https://www.ovhcloud.com/de/managed-bare-metal/) Infrastruktur.
-- Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
+- Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 ## In der praktischen Anwendung
 
-Loggen Sie sich in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) ein und wählen Sie dann den Bereich `Bare Metal Cloud`. Klicken Sie im linken Menü auf `Managed Bare Metal` und wählen Sie die betreffende Infrastruktur aus.
+Loggen Sie sich in Ihrem [OVHcloud Kundencenter](/links/manager) ein und wählen Sie dann den Bereich `Bare Metal Cloud`. Klicken Sie im linken Menü auf `Managed Bare Metal` und wählen Sie die betreffende Infrastruktur aus.
 
 ![vSphere-Nutzer](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-asia.md
@@ -13,11 +13,11 @@ You can associate a name, first name, phone number, and email address with a vSp
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
+In your [OVHcloud Control Panel](/links/manager) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
 
 ![user vsphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-au.md
@@ -13,11 +13,11 @@ You can associate a name, first name, phone number, and email address with a vSp
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
+In your [OVHcloud Control Panel](/links/manager) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
 
 ![user vsphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-ca.md
@@ -13,11 +13,11 @@ You can associate a name, first name, phone number, and email address with a vSp
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
+In your [OVHcloud Control Panel](/links/manager) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
 
 ![user vsphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-gb.md
@@ -13,11 +13,11 @@ You can associate a name, first name, phone number, and email address with a vSp
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-In your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
+In your [OVHcloud Control Panel](/links/manager) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
 
 ![user vsphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-ie.md
@@ -13,11 +13,11 @@ You can associate a name, first name, phone number, and email address with a vSp
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-In your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
+In your [OVHcloud Control Panel](/links/manager) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
 
 ![user vsphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-sg.md
@@ -13,11 +13,11 @@ You can associate a name, first name, phone number, and email address with a vSp
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
+In your [OVHcloud Control Panel](/links/manager) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
 
 ![user vsphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.en-us.md
@@ -13,11 +13,11 @@ You can associate a name, first name, phone number, and email address with a vSp
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/)
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
-In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
+In your [OVHcloud Control Panel](/links/manager) go to the section `Bare Metal Cloud`. Click on `Managed Bare Metal` in the service bar on the left and select your infrastructure.
 
 ![user vsphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.es-es.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.es-es.md
@@ -13,11 +13,11 @@ Es posible asociar un nombre, un apellido, un número de teléfono y una direcci
 ## Requisitos
 
 - Tener una solución [Managed Bare Metal](https://www.ovhcloud.com/es-es/managed-bare-metal/){.external}.
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es).
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 
 ## Procedimiento
 
-Conéctese al [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) y acceda a la sección `Servidores`. En la barra de servicios de la izquierda, haga clic en `Managed Bare Metal` y seleccione la infraestructura correspondiente.
+Conéctese al [área de cliente de OVHcloud](/links/manager) y acceda a la sección `Servidores`. En la barra de servicios de la izquierda, haga clic en `Managed Bare Metal` y seleccione la infraestructura correspondiente.
 
 ![Usuario vSphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.es-us.md
@@ -13,11 +13,11 @@ Es posible asociar un nombre, un apellido, un número de teléfono y una direcci
 ## Requisitos
 
 - Tener una solución [Managed Bare Metal](https://www.ovhcloud.com/es/managed-bare-metal/){.external}.
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 
 ## Procedimiento
 
-Conéctese al [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) y acceda a la sección `Servidores`. En la barra de servicios de la izquierda, haga clic en `Managed Bare Metal` y seleccione la infraestructura correspondiente.
+Conéctese al [área de cliente de OVHcloud](/links/manager) y acceda a la sección `Servidores`. En la barra de servicios de la izquierda, haga clic en `Managed Bare Metal` y seleccione la infraestructura correspondiente.
 
 ![Usuario vSphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.fr-ca.md
@@ -13,11 +13,11 @@ Il est possible d'associer un nom, prénom, numéro de téléphone et adresse e-
 ## Prérequis
 
 - Disposer d'une offre [Managed Bare Metal](https://www.ovhcloud.com/fr-ca/managed-bare-metal/).
-- Être connecté à [l'espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à [l'espace client OVHcloud](/links/manager).
 
 ## En pratique
 
-Connectez-vous à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc) et dirigez-vous dans la section `Bare Metal Cloud`. Cliquez sur `Managed Bare Metal` dans la barre de services à gauche puis sélectionnez l'infrastructure concernée.
+Connectez-vous à votre [espace client OVHcloud](/links/manager) et dirigez-vous dans la section `Bare Metal Cloud`. Cliquez sur `Managed Bare Metal` dans la barre de services à gauche puis sélectionnez l'infrastructure concernée.
 
 ![utilisateur vsphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.fr-fr.md
@@ -13,11 +13,11 @@ Il est possible d'associer un nom, prénom, numéro de téléphone et adresse e-
 ## Prérequis
 
 - Disposer d'une offre [Managed Bare Metal](https://www.ovhcloud.com/fr/managed-bare-metal/).
-- Être connecté à [l'espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à [l'espace client OVHcloud](/links/manager).
 
 ## En pratique
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) et dirigez-vous dans la section `Bare Metal Cloud`. Cliquez sur `Managed Bare Metal` dans la barre de services à gauche puis sélectionnez l'infrastructure concernée.
+Connectez-vous à votre [espace client OVHcloud](/links/manager) et dirigez-vous dans la section `Bare Metal Cloud`. Cliquez sur `Managed Bare Metal` dans la barre de services à gauche puis sélectionnez l'infrastructure concernée.
 
 ![utilisateur vsphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.it-it.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.it-it.md
@@ -13,11 +13,11 @@ All’utente vSphere di un servizio Managed Bare Metal è possibile associare co
 ## Prerequisiti
 
 - Disporre di una soluzione [Managed Bare Metal](https://www.ovhcloud.com/it/managed-bare-metal/){.external}
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 ## Procedura
 
-Accedi allo [Spazio Cliente](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) e, nella sezione `Bare Metal Cloud`, clicca su `Managed Bare Metal` nella colonna a sinistra e seleziona il servizio in questione.
+Accedi allo [Spazio Cliente](/links/manager) e, nella sezione `Bare Metal Cloud`, clicca su `Managed Bare Metal` nella colonna a sinistra e seleziona il servizio in questione.
 
 ![Utente vSphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.pl-pl.md
@@ -13,11 +13,11 @@ Możliwe jest powiązanie imienia, nazwiska, numeru telefonu i adresu e-mail z u
 ## Wymagania początkowe
 
 - Wykupienie usługi [Managed Bare Metal](https://www.ovhcloud.com/pl/managed-bare-metal/).
-- Dostęp do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl).
+- Dostęp do [Panelu klienta OVHcloud](/links/manager).
 
 ## W praktyce
 
-Zaloguj się do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) i przejdź do sekcji `Bare Metal Cloud`. Kliknij `Managed Bare Metal` na pasku usług po lewej stronie, po czym wybierz odpowiednią infrastrukturę.
+Zaloguj się do [Panelu klienta OVHcloud](/links/manager) i przejdź do sekcji `Bare Metal Cloud`. Kliknij `Managed Bare Metal` na pasku usług po lewej stronie, po czym wybierz odpowiednią infrastrukturę.
 
 ![Użytkownik vsphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-edit-user/guide.pt-pt.md
@@ -13,11 +13,11 @@ updated: 2020-11-18
 ## Requisitos
 
 - Dispor de uma oferta [Managed Bare Metal](https://www.ovhcloud.com/pt/managed-bare-metal/).
-- Ter acesso à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt).
+- Ter acesso à [Área de Cliente OVHcloud](/links/manager).
 
 ## Instruções
 
-Aceda à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt) e selecione a secção `Bare Metal Cloud`. Clique em `Managed Bare Metal` na barra de serviços à esquerda e selecione a infraestrutura correspondente.
+Aceda à [Área de Cliente OVHcloud](/links/manager) e selecione a secção `Bare Metal Cloud`. Clique em `Managed Bare Metal` na barra de serviços à esquerda e selecione a infraestrutura correspondente.
 
 ![utilizador vsphere](images/addMailOnUser01.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-asia.md
@@ -11,7 +11,7 @@ updated: 2020-11-18
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/asia/managed-bare-metal/) of which you are an administrative contact (to receive login credentials)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-au.md
@@ -11,7 +11,7 @@ updated: 2020-11-18
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-au/managed-bare-metal/) of which you are an administrative contact (to receive login credentials)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-ca.md
@@ -11,7 +11,7 @@ updated: 2020-11-18
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ca/managed-bare-metal/) of which you are an administrative contact (to receive login credentials)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-gb.md
@@ -11,7 +11,7 @@ updated: 2020-11-18
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-gb/managed-bare-metal/) of which you are an administrative contact (to receive login credentials)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-ie.md
@@ -11,7 +11,7 @@ updated: 2020-11-18
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-ie/managed-bare-metal/) of which you are an administrative contact (to receive login credentials)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-sg.md
@@ -11,7 +11,7 @@ updated: 2020-11-18
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en-sg/managed-bare-metal/) of which you are an administrative contact (to receive login credentials)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere-interface/guide.en-us.md
@@ -11,7 +11,7 @@ updated: 2020-11-18
 ## Requirements
 
 - a [Managed Bare Metal infrastructure](https://www.ovhcloud.com/en/managed-bare-metal/) of which you are an administrative contact (to receive login credentials)
-- a user account with access to vSphere (created in the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we))
+- a user account with access to vSphere (created in the [OVHcloud Control Panel](/links/manager))
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.de-de.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.de-de.md
@@ -12,7 +12,7 @@ Um die Integrität Ihrer Infrastruktur zu gewährleisten, empfehlen wir, den Zug
 
 ## Voraussetzungen
 
-- Sie sind in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} angemeldet.
+- Sie sind in Ihrem [OVHcloud Kundencenter](/links/manager){.external} angemeldet.
 
 ## Beschreibung
 
@@ -20,13 +20,13 @@ Um die Integrität Ihrer Infrastruktur zu gewährleisten, empfehlen wir, den Zug
 
 Unser erster Tipp ist die IP-basierte Zugangsbeschränkung. Wir empfehlen Ihnen, immer mit einem Whitelisting-System zu arbeiten. Hierbei wird grundsätzlich allen IP-Adressen der Zugriff verwehrt und Sie können manuell die Adressen hinzufügen, denen Sie Zugriff auf Ihre Infrastruktur gewähren möchten.
 
-Sie können die Einstellungen direkt in Ihrem [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} vornehmen. Gehen Sie dazu in Ihrem Managed Bare Metal Bereich auf `Sicherheit`{.action}. Es wird eine Tabelle angezeigt, die alle gesperrten und freigegebenen IP-Adressen auflistet. Um eine weitere IP hinzuzufügen, klicken Sie rechts auf `IP-Adressen hinzufügen`{.action}.
+Sie können die Einstellungen direkt in Ihrem [OVHcloud Kundencenter](/links/manager){.external} vornehmen. Gehen Sie dazu in Ihrem Managed Bare Metal Bereich auf `Sicherheit`{.action}. Es wird eine Tabelle angezeigt, die alle gesperrten und freigegebenen IP-Adressen auflistet. Um eine weitere IP hinzuzufügen, klicken Sie rechts auf `IP-Adressen hinzufügen`{.action}.
 
 ![IPs hinzufügen](images/adding_ip.png){.thumbnail}
 
 ### Spezifische Nutzer anlegen
 
-Wir empfehlen, personalisierte Zugänge für diejenigen Nutzer einzurichten, die Zugriff auf Ihre Infrastruktur erhalten sollen. Diese Einstellungen können Sie ebenfalls über Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} vornehmen. Klicken Sie dazu bitte auf den Tab `Benutzer`{.action}. Um einen neuen Nutzer hinzuzufügen, klicken Sie rechts auf den Button: `Benutzer erstellen`{.action}.
+Wir empfehlen, personalisierte Zugänge für diejenigen Nutzer einzurichten, die Zugriff auf Ihre Infrastruktur erhalten sollen. Diese Einstellungen können Sie ebenfalls über Ihr [OVHcloud Kundencenter](/links/manager){.external} vornehmen. Klicken Sie dazu bitte auf den Tab `Benutzer`{.action}. Um einen neuen Nutzer hinzuzufügen, klicken Sie rechts auf den Button: `Benutzer erstellen`{.action}.
 
 ![Nutzer](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ Anschließend können Sie die Rechte für jeden Nutzer verwalten, indem Sie in d
 
 Wenn der Nutzer den Client nicht mehr verwendet, sollte die Sitzung entsprechend geschlossen werden. Es ist möglich, eine maximale Sitzungsdauer festzulegen, um die Verbindungszeit der Nutzer einzuschränken.
 
-Diese Einstellungen können Sie im [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de){.external} vornehmen. Gehen Sie hierzu in Ihrem Managed Bare Metal Bereich auf `Sicherheit`{.action}. Klicken Sie dann rechts auf den Button `Sitzungstimeout ändern`{.action}.
+Diese Einstellungen können Sie im [OVHcloud Kundencenter](/links/manager){.external} vornehmen. Gehen Sie hierzu in Ihrem Managed Bare Metal Bereich auf `Sicherheit`{.action}. Klicken Sie dann rechts auf den Button `Sitzungstimeout ändern`{.action}.
 
 ![Sitzungstimeout](images/security-expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-asia.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-asia.md
@@ -12,7 +12,7 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 ## Requirements
 
-- You must be logged in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia){.external}.
+- You must be logged in to the [OVHcloud Control Panel](/links/manager){.external}.
 
 ## Instructions
 
@@ -20,13 +20,13 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 This first method involves restricting access based on the user's IP address. For this purpose, we recommend continuing to work with a registration system that uses whitelisting. This technique refuses access by default for all IP addresses. You can then manually add the IPs that require access to your infrastructure.
 
-You can do this directly in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
+You can do this directly in your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
 
 ![Add IP](images/adding_ip.png){.thumbnail}
 
 ### Create specific users
 
-We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
+We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](/links/manager){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
 
 ![Users](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ You can then manage each user’s rights by clicking on the cogwheel icons at th
 
 When users finish a session, we recommend closing the session accordingly. To limit connection time, you can set a session expiry duration.
 
-To do this, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
+To do this, go to your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
 
 ![Session expiry](images/expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-au.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-au.md
@@ -12,7 +12,7 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 ## Requirements
 
-- You must be logged in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au){.external}.
+- You must be logged in to the [OVHcloud Control Panel](/links/manager){.external}.
 
 ## Instructions
 
@@ -20,13 +20,13 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 This first method involves restricting access based on the user's IP address. For this purpose, we recommend continuing to work with a registration system that uses whitelisting. This technique refuses access by default for all IP addresses. You can then manually add the IPs that require access to your infrastructure.
 
-You can do this directly in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
+You can do this directly in your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
 
 ![Add IP](images/adding_ip.png){.thumbnail}
 
 ### Create specific users
 
-We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
+We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](/links/manager){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
 
 ![Users](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ You can then manage each user’s rights by clicking on the cogwheel icons at th
 
 When users finish a session, we recommend closing the session accordingly. To limit connection time, you can set a session expiry duration.
 
-To do this, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
+To do this, go to your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
 
 ![Session expiry](images/expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-ca.md
@@ -12,7 +12,7 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 ## Requirements
 
-- You must be logged in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca){.external}.
+- You must be logged in to the [OVHcloud Control Panel](/links/manager){.external}.
 
 ## Instructions
 
@@ -20,13 +20,13 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 This first method involves restricting access based on the user's IP address. For this purpose, we recommend continuing to work with a registration system that uses whitelisting. This technique refuses access by default for all IP addresses. You can then manually add the IPs that require access to your infrastructure.
 
-You can do this directly in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
+You can do this directly in your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
 
 ![Add IP](images/adding_ip.png){.thumbnail}
 
 ### Create specific users
 
-We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
+We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](/links/manager){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
 
 ![Users](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ You can then manage each user’s rights by clicking on the cogwheel icons at th
 
 When users finish a session, we recommend closing the session accordingly. To limit connection time, you can set a session expiry duration.
 
-To do this, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
+To do this, go to your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
 
 ![Session expiry](images/expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-gb.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-gb.md
@@ -12,7 +12,7 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 ## Requirements
 
-- You must be logged in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}.
+- You must be logged in to the [OVHcloud Control Panel](/links/manager){.external}.
 
 ## Instructions
 
@@ -20,13 +20,13 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 This first method involves restricting access based on the user's IP address. For this purpose, we recommend continuing to work with a registration system that uses whitelisting. This technique refuses access by default for all IP addresses. You can then manually add the IPs that require access to your infrastructure.
 
-You can do this directly in your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
+You can do this directly in your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
 
 ![Add IP](images/adding_ip.png){.thumbnail}
 
 ### Create specific users
 
-We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
+We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](/links/manager){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
 
 ![Users](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ You can then manage each user’s rights by clicking on the cogwheel icons at th
 
 When users finish a session, we recommend closing the session accordingly. To limit connection time, you can set a session expiry duration.
 
-To do this, go to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
+To do this, go to your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
 
 ![Session expiry](images/expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-ie.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-ie.md
@@ -12,7 +12,7 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 ## Requirements
 
-- You must be logged in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}.
+- You must be logged in to the [OVHcloud Control Panel](/links/manager){.external}.
 
 ## Instructions
 
@@ -20,13 +20,13 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 This first method involves restricting access based on the user's IP address. For this purpose, we recommend continuing to work with a registration system that uses whitelisting. This technique refuses access by default for all IP addresses. You can then manually add the IPs that require access to your infrastructure.
 
-You can do this directly in your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
+You can do this directly in your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
 
 ![Add IP](images/adding_ip.png){.thumbnail}
 
 ### Create specific users
 
-We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
+We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](/links/manager){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
 
 ![Users](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ You can then manage each user’s rights by clicking on the cogwheel icons at th
 
 When users finish a session, we recommend closing the session accordingly. To limit connection time, you can set a session expiry duration.
 
-To do this, go to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
+To do this, go to your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
 
 ![Session expiry](images/expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-sg.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-sg.md
@@ -12,7 +12,7 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 ## Requirements
 
-- You must be logged in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg){.external}.
+- You must be logged in to the [OVHcloud Control Panel](/links/manager){.external}.
 
 ## Instructions
 
@@ -20,13 +20,13 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 This first method involves restricting access based on the user's IP address. For this purpose, we recommend continuing to work with a registration system that uses whitelisting. This technique refuses access by default for all IP addresses. You can then manually add the IPs that require access to your infrastructure.
 
-You can do this directly in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
+You can do this directly in your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
 
 ![Add IP](images/adding_ip.png){.thumbnail}
 
 ### Create specific users
 
-We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
+We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](/links/manager){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
 
 ![Users](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ You can then manage each user’s rights by clicking on the cogwheel icons at th
 
 When users finish a session, we recommend closing the session accordingly. To limit connection time, you can set a session expiry duration.
 
-To do this, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
+To do this, go to your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
 
 ![Session expiry](images/expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.en-us.md
@@ -12,7 +12,7 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 ## Requirements
 
-- You must be logged in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we){.external}.
+- You must be logged in to the [OVHcloud Control Panel](/links/manager){.external}.
 
 ## Instructions
 
@@ -20,13 +20,13 @@ To ensure optimal security for your system, we recommend limiting access to it. 
 
 This first method involves restricting access based on the user's IP address. For this purpose, we recommend continuing to work with a registration system that uses whitelisting. This technique refuses access by default for all IP addresses. You can then manually add the IPs that require access to your infrastructure.
 
-You can do this directly in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
+You can do this directly in your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. In this section, you will see a table listing all authorised or denied IP addresses. To add new ones, click `Add IPs`{.action} on the right-hand side:
 
 ![Add IP](images/adding_ip.png){.thumbnail}
 
 ### Create specific users
 
-We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
+We highly recommend creating personal accounts for each user that requires access to your infrastructure. You can also do this in your [OVHcloud Control Panel](/links/manager){.external}, in the `Users`{.action} tab. To add new users, click the `Create User`{.external} button on the right-hand side.
 
 ![Users](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ You can then manage each user’s rights by clicking on the cogwheel icons at th
 
 When users finish a session, we recommend closing the session accordingly. To limit connection time, you can set a session expiry duration.
 
-To do this, go to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
+To do this, go to your [OVHcloud Control Panel](/links/manager){.external}. Go to the Managed Bare Metal section, then `Security`{.action}. Next, click the `Change expiry duration`{.action} button, situated on the right-hand side of the screen. In the following window, you can choose the time (in minutes) before a session expires.
 
 ![Session expiry](images/expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.es-es.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.es-es.md
@@ -12,7 +12,7 @@ Restringir el acceso a su infraestructura es una medida recomendable para garant
 
 ## Requisitos
 
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 
 ## Procedimiento
 
@@ -20,13 +20,13 @@ Restringir el acceso a su infraestructura es una medida recomendable para garant
 
 En primer lugar, debe restringir los accesos por IP. Le aconsejamos que utilice siempre un sistema de lista blanca. Esta técnica consiste en prohibir el acceso por defecto a todas las direcciones IP e indicar las direcciones que sí pueden acceder a la infraestructura.
 
-Puede realizar esta operación directamente desde el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}. Una vez conectado a su Managed Bare Metal, abra la pestaña `Seguridad`{.action}. Se mostrará una tabla en la que podrá consultar las direcciones IP autorizadas o denegadas. Para añadir nuevas direcciones IP, haga clic en el botón `Añadir IP`{.action}, situado a la derecha.
+Puede realizar esta operación directamente desde el [área de cliente de OVHcloud](/links/manager){.external}. Una vez conectado a su Managed Bare Metal, abra la pestaña `Seguridad`{.action}. Se mostrará una tabla en la que podrá consultar las direcciones IP autorizadas o denegadas. Para añadir nuevas direcciones IP, haga clic en el botón `Añadir IP`{.action}, situado a la derecha.
 
 ![Añadir IP](images/adding_ip.png){.thumbnail}
 
 ### Crear usuarios específicos
 
-Le recomendamos encarecidamente que cree un acceso personal para cada usuario que necesite acceder a la infraestructura. Puede realizar esta operación desde el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}, en la pestaña `Usuarios`{.action}. Para añadir nuevos usuarios, haga clic en el botón `Crear un usuario`{.action}.
+Le recomendamos encarecidamente que cree un acceso personal para cada usuario que necesite acceder a la infraestructura. Puede realizar esta operación desde el [área de cliente de OVHcloud](/links/manager){.external}, en la pestaña `Usuarios`{.action}. Para añadir nuevos usuarios, haga clic en el botón `Crear un usuario`{.action}.
 
 ![Usuarios](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ A continuación, podrá administrar los permisos de cada usuario haciendo clic e
 
 Le recomendamos que cierre la sesión cuando termine de utilizar el cliente. Es posible añadir un plazo de expiración para limitar la duración de las sesiones.
 
-Puede configurar este parámetro directamente en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}. Una vez conectado a su Managed Bare Metal, abra la pestaña `Seguridad`{.action}. A continuación, haga clic en el botón `Cambiar el plazo de expiración`{.action}, situado a la derecha.
+Puede configurar este parámetro directamente en el [área de cliente de OVHcloud](/links/manager){.external}. Una vez conectado a su Managed Bare Metal, abra la pestaña `Seguridad`{.action}. A continuación, haga clic en el botón `Cambiar el plazo de expiración`{.action}, situado a la derecha.
 
 ![Expiración de la sesión](images/security-expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.es-us.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.es-us.md
@@ -12,7 +12,7 @@ Restringir el acceso a su infraestructura es una medida recomendable para garant
 
 ## Requisitos
 
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 
 ## Procedimiento
 
@@ -20,13 +20,13 @@ Restringir el acceso a su infraestructura es una medida recomendable para garant
 
 En primer lugar, debe restringir los accesos por IP. Le aconsejamos que utilice siempre un sistema de lista blanca. Esta técnica consiste en prohibir el acceso por defecto a todas las direcciones IP e indicar las direcciones que sí pueden acceder a la infraestructura.
 
-Puede realizar esta operación directamente desde el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}. Una vez conectado a su Managed Bare Metal, abra la pestaña `Seguridad`{.action}. Se mostrará una tabla en la que podrá consultar las direcciones IP autorizadas o denegadas. Para añadir nuevas direcciones IP, haga clic en el botón `Añadir IP`{.action}, situado a la derecha.
+Puede realizar esta operación directamente desde el [área de cliente de OVHcloud](/links/manager){.external}. Una vez conectado a su Managed Bare Metal, abra la pestaña `Seguridad`{.action}. Se mostrará una tabla en la que podrá consultar las direcciones IP autorizadas o denegadas. Para añadir nuevas direcciones IP, haga clic en el botón `Añadir IP`{.action}, situado a la derecha.
 
 ![Añadir IP](images/adding_ip.png){.thumbnail}
 
 ### Crear usuarios específicos
 
-Le recomendamos encarecidamente que cree un acceso personal para cada usuario que necesite acceder a la infraestructura. Puede realizar esta operación desde el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}, en la pestaña `Usuarios`{.action}. Para añadir nuevos usuarios, haga clic en el botón `Crear un usuario`{.action}.
+Le recomendamos encarecidamente que cree un acceso personal para cada usuario que necesite acceder a la infraestructura. Puede realizar esta operación desde el [área de cliente de OVHcloud](/links/manager){.external}, en la pestaña `Usuarios`{.action}. Para añadir nuevos usuarios, haga clic en el botón `Crear un usuario`{.action}.
 
 ![Usuarios](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ A continuación, podrá administrar los permisos de cada usuario haciendo clic e
 
 Le recomendamos que cierre la sesión cuando termine de utilizar el cliente. Es posible añadir un plazo de expiración para limitar la duración de las sesiones.
 
-Puede configurar este parámetro directamente en el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}. Una vez conectado a su Managed Bare Metal, abra la pestaña `Seguridad`{.action}. A continuación, haga clic en el botón `Cambiar el plazo de expiración`{.action}, situado a la derecha.
+Puede configurar este parámetro directamente en el [área de cliente de OVHcloud](/links/manager){.external}. Una vez conectado a su Managed Bare Metal, abra la pestaña `Seguridad`{.action}. A continuación, haga clic en el botón `Cambiar el plazo de expiración`{.action}, situado a la derecha.
 
 ![Expiración de la sesión](images/security-expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.fr-ca.md
@@ -12,7 +12,7 @@ Pour assurer l'intégrité de votre infrastructure, il convient d'en restreindre
 
 ## Prérequis
 
-- Être connecté à l'[espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}.
+- Être connecté à l'[espace client OVHcloud](/links/manager){.external}.
 
 ## En pratique
 
@@ -20,13 +20,13 @@ Pour assurer l'intégrité de votre infrastructure, il convient d'en restreindre
 
 Le premier conseil est lié à la restriction de l'accès par IP. Nous vous conseillons de toujours fonctionner avec un système d'inscription sur une liste blanche. Cette technique fonctionne sur l'interdiction de principe de toutes les adresses IP et d'ajout des adresses pouvant avoir accès à votre infrastructure.
 
-Cette action est accessible directement dans votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}. Une fois sur votre espace Managed Bare Metal, allez dans `Sécurité`{.action}. Un tableau s'affichera, sur lequel vous pourrez voir les adresses IP autorisées ou refusées. Pour en ajouter de nouvelles, cliquez à droite sur `Ajout des IP`{.action} :
+Cette action est accessible directement dans votre [espace client OVHcloud](/links/manager){.external}. Une fois sur votre espace Managed Bare Metal, allez dans `Sécurité`{.action}. Un tableau s'affichera, sur lequel vous pourrez voir les adresses IP autorisées ou refusées. Pour en ajouter de nouvelles, cliquez à droite sur `Ajout des IP`{.action} :
 
 ![Ajout d'IP](images/adding_ip.png){.thumbnail}
 
 ### Créer des utilisateurs spécifiques
 
-Nous vous conseillons fortement de créer un accès personnel pour chaque personne devant avoir accès à votre infrastructure. Cette opération s'effectue également dans l'[espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}, mais cette fois dans l'onglet `Utilisateurs`{.action}. Pour en ajouter de nouveaux, cliquez sur le bouton situé à droite : `Créer un utilisateur`{.action}.
+Nous vous conseillons fortement de créer un accès personnel pour chaque personne devant avoir accès à votre infrastructure. Cette opération s'effectue également dans l'[espace client OVHcloud](/links/manager){.external}, mais cette fois dans l'onglet `Utilisateurs`{.action}. Pour en ajouter de nouveaux, cliquez sur le bouton situé à droite : `Créer un utilisateur`{.action}.
 
 ![Utilisateurs](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ Vous pourrez ensuite gérer les droits de chaque utilisateur en cliquant sur le 
 
 En fin d'utilisation, il est conseillé de fermer la session de votre utilisateur. Pour limiter le temps de connexion, il est possible d'ajouter une durée d'expiration de session.
 
-Celle-ci est paramétrable dans l'[espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}. Une fois sur votre espace Managed Bare Metal, choisissez `Sécurité`{.action}. Cliquez ensuite sur le bouton `Changer le délai d'expiration`{.action} situé sur la droite.
+Celle-ci est paramétrable dans l'[espace client OVHcloud](/links/manager){.external}. Une fois sur votre espace Managed Bare Metal, choisissez `Sécurité`{.action}. Cliquez ensuite sur le bouton `Changer le délai d'expiration`{.action} situé sur la droite.
 
 ![Expiration de la session](images/security-expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.fr-fr.md
@@ -12,7 +12,7 @@ Pour assurer l'intégrité de votre infrastructure, il convient d'en restreindre
 
 ## Prérequis
 
-- Être connecté à l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Être connecté à l'[espace client OVHcloud](/links/manager){.external}.
 
 ## En pratique
 
@@ -20,13 +20,13 @@ Pour assurer l'intégrité de votre infrastructure, il convient d'en restreindre
 
 Le premier conseil est lié à la restriction de l'accès par IP. Nous vous conseillons de toujours fonctionner avec un système d'inscription sur une liste blanche. Cette technique fonctionne sur l'interdiction de principe de toutes les adresses IP et d'ajout des adresses pouvant avoir accès à votre infrastructure.
 
-Cette action est accessible directement dans votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}. Une fois sur votre espace Managed Bare Metal, allez dans `Sécurité`{.action}. Un tableau s'affichera, sur lequel vous pourrez voir les adresses IP autorisées ou refusées. Pour en ajouter de nouvelles, cliquez à droite sur `Ajout des IP`{.action} :
+Cette action est accessible directement dans votre [espace client OVHcloud](/links/manager){.external}. Une fois sur votre espace Managed Bare Metal, allez dans `Sécurité`{.action}. Un tableau s'affichera, sur lequel vous pourrez voir les adresses IP autorisées ou refusées. Pour en ajouter de nouvelles, cliquez à droite sur `Ajout des IP`{.action} :
 
 ![Ajout d'IP](images/adding_ip.png){.thumbnail}
 
 ### Créer des utilisateurs spécifiques
 
-Nous vous conseillons fortement de créer un accès personnel pour chaque personne devant avoir accès à votre infrastructure. Cette opération s'effectue également dans l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}, mais cette fois dans l'onglet `Utilisateurs`{.action}. Pour en ajouter de nouveaux, cliquez sur le bouton situé à droite : `Créer un utilisateur`{.action}.
+Nous vous conseillons fortement de créer un accès personnel pour chaque personne devant avoir accès à votre infrastructure. Cette opération s'effectue également dans l'[espace client OVHcloud](/links/manager){.external}, mais cette fois dans l'onglet `Utilisateurs`{.action}. Pour en ajouter de nouveaux, cliquez sur le bouton situé à droite : `Créer un utilisateur`{.action}.
 
 ![Utilisateurs](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ Vous pourrez ensuite gérer les droits de chaque utilisateur en cliquant sur le 
 
 En fin d'utilisation, il est conseillé de fermer la session de votre utilisateur. Pour limiter le temps de connexion, il est possible d'ajouter une durée d'expiration de session.
 
-Celle-ci est paramétrable dans l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}. Une fois sur votre espace Managed Bare Metal, choisissez `Sécurité`{.action}. Cliquez ensuite sur le bouton `Changer le délai d'expiration`{.action} situé sur la droite.
+Celle-ci est paramétrable dans l'[espace client OVHcloud](/links/manager){.external}. Une fois sur votre espace Managed Bare Metal, choisissez `Sécurité`{.action}. Cliquez ensuite sur le bouton `Changer le délai d'expiration`{.action} situé sur la droite.
 
 ![Expiration de la session](images/security-expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.it-it.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.it-it.md
@@ -12,7 +12,7 @@ Per assicurare un livello di sicurezza ottimale di un’infrastruttura, limitare
 
 ## Prerequisiti
 
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}
 
 ## Procedura
 
@@ -20,13 +20,13 @@ Per assicurare un livello di sicurezza ottimale di un’infrastruttura, limitare
 
 Il primo consiglio è relativo alla restrizione dell’accesso tramite IP, per cui suggeriamo di utilizzare un sistema di registrazione basato su <i>whitelist</i>. Questa tecnica consiste nel rifiutare di default l’accesso a tutti gli indirizzi IP e aggiungere gli indirizzi autorizzati a connettersi all’infrastruttura.
 
-Questa operazione è disponibile nello [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}. Accedi alla sezione Managed Bare Metal, seleziona il servizio in questione e clicca sulla scheda `Sicurezza`{.action}: compare una tabella che mostra gli indirizzi IP autorizzati o bloccati. Per aggiungerne di nuovi, clicca sul pulsante `Aggiungi IP`{.action} a destra:
+Questa operazione è disponibile nello [Spazio Cliente OVHcloud](/links/manager){.external}. Accedi alla sezione Managed Bare Metal, seleziona il servizio in questione e clicca sulla scheda `Sicurezza`{.action}: compare una tabella che mostra gli indirizzi IP autorizzati o bloccati. Per aggiungerne di nuovi, clicca sul pulsante `Aggiungi IP`{.action} a destra:
 
 ![Aggiunta di IP](images/adding_ip.png){.thumbnail}
 
 ### Crea utenti specifici
 
-Consigliamo vivamente di creare un accesso personale per ogni utente che ha bisogno di connettersi all’infrastruttura. Anche questa operazione è disponibile nello [Spazio Cliente](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}: accedi alla scheda `Utenti`{.action} e clicca sul pulsante `Crea un utente`{.action}.
+Consigliamo vivamente di creare un accesso personale per ogni utente che ha bisogno di connettersi all’infrastruttura. Anche questa operazione è disponibile nello [Spazio Cliente](/links/manager){.external}: accedi alla scheda `Utenti`{.action} e clicca sul pulsante `Crea un utente`{.action}.
 
 ![Utenti](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ In seguito sarà possibile gestire i diritti di ogni account cliccando sul pulsa
 
 Al termine dell’utilizzo, consigliamo di chiudere la sessione aperta con l’account utilizzato.   Per limitare la durata delle connessioni è possibile impostare la scadenza della sessione.
 
-Questa operazione è disponibile nello [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}. Accedi alla sezione Managed Bare Metal, seleziona la scheda `Sicurezza`{.action} e clicca sul pulsante `Modifica la durata di una sessione `{.action} a destra.
+Questa operazione è disponibile nello [Spazio Cliente OVHcloud](/links/manager){.external}. Accedi alla sezione Managed Bare Metal, seleziona la scheda `Sicurezza`{.action} e clicca sul pulsante `Modifica la durata di una sessione `{.action} a destra.
 
 ![Scadenza della sessione](images/security-expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.pl-pl.md
@@ -12,7 +12,7 @@ Zalecamy ograniczenie dostępu do infrastruktury w celu zapewnienia jej optymaln
 
 ## Wymagania początkowe
 
-- Dostęp do [Panelu klienta OVH](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}
+- Dostęp do [Panelu klienta OVH](/links/manager){.external}
 
 ## W praktyce
 
@@ -20,13 +20,13 @@ Zalecamy ograniczenie dostępu do infrastruktury w celu zapewnienia jej optymaln
 
 Pierwsze zalecenie dotyczy ograniczenia dostępu z adresów IP. Zalecamy korzystanie z systemu dodawania adresów IP do białej listy.  Metoda ta działa w oparciu o zasadę odrzucania wszystkich adresów IP i dodawania do białej listy adresów uprawnionych do dostępu do Twojej infrastruktury.
 
-Funkcja ta dostępna jest w Twoim [Panelu klienta](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}. Przejdź do sekcji Managed Bare Metal, a następnie do zakładki `Bezpieczeństwo`{.action}. Pojawi się tabela, w której wyświetlą się adresy IP uprawnione do dostępu oraz adresy z odmową dostępu. Aby dodać nowe adresy, kliknij przycisk po prawej stronie `Dodanie adresów IP`{.action} :
+Funkcja ta dostępna jest w Twoim [Panelu klienta](/links/manager){.external}. Przejdź do sekcji Managed Bare Metal, a następnie do zakładki `Bezpieczeństwo`{.action}. Pojawi się tabela, w której wyświetlą się adresy IP uprawnione do dostępu oraz adresy z odmową dostępu. Aby dodać nowe adresy, kliknij przycisk po prawej stronie `Dodanie adresów IP`{.action} :
 
 ![Dodanie adresów IP](images/adding_ip.png){.thumbnail}
 
 ### Tworzenie indywidualnych dostępów dla użytkowników 
 
-Zalecamy tworzenie odrębnego dostępu dla każdego użytkownika. Aby wykonać tę operację przejdź do[Panelu klienta](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}, zakładka `Użytkownicy`{.action}. Aby dodać nowych użytkowników, kliknij przycisk po prawej stronie: `Stwórz użytkownika`{.action}.
+Zalecamy tworzenie odrębnego dostępu dla każdego użytkownika. Aby wykonać tę operację przejdź do[Panelu klienta](/links/manager){.external}, zakładka `Użytkownicy`{.action}. Aby dodać nowych użytkowników, kliknij przycisk po prawej stronie: `Stwórz użytkownika`{.action}.
 
 ![Użytkownicy](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ Następnie możesz zarządzać uprawnieniami każdego użytkownika. W tym celu k
 
 Zalecamy każdorazowe zamknięcie sesji użytkownika. Aby ograniczyć czas połączenia, możesz określić liczbę minut, po upływie których wygasa sesja.
 
-Ustawienia te możesz wprowadzić w [Panelu klienta](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}. Przejdź do sekcji Managed Bare Metal, po czym wybierz `Bezpieczeństwo`{.action}. Następnie kliknij przycisk po prawej stronie`Zmień czas wygasania sesji`{.action}. W oknie, które się ukaże, wybierz czas (w minutach) wygaśnięcia sesji.
+Ustawienia te możesz wprowadzić w [Panelu klienta](/links/manager){.external}. Przejdź do sekcji Managed Bare Metal, po czym wybierz `Bezpieczeństwo`{.action}. Następnie kliknij przycisk po prawej stronie`Zmień czas wygasania sesji`{.action}. W oknie, które się ukaże, wybierz czas (w minutach) wygaśnięcia sesji.
 
 ![Wygaśnięcie sesji](images/expiration.png){.thumbnail}
 

--- a/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/managed_bare_metal/vsphere_access_security_advices/guide.pt-pt.md
@@ -12,7 +12,7 @@ Para assegurar a integridade da sua infraestrutura, convém que restrinja o aces
 
 ## Requisitos
 
-- Ter acesso à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}.
+- Ter acesso à [Área de Cliente OVHcloud](/links/manager){.external}.
 
 ## Instruções
 
@@ -20,13 +20,13 @@ Para assegurar a integridade da sua infraestrutura, convém que restrinja o aces
 
 O primeiro conselho está ligado à restrição do acesso por IP. Aconselhamos que trabalhe sempre com um sistema de registo que use whitelisting. Esta técnica assenta sobre a recusa de princípio de todos os endereços IP e sobre o acrescento de endereços que possam dar acesso à sua infraestrutura.
 
-Esta ação pode ser feita diretamente através da [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}. Quando estiver no espaço Managed Bare Metal, clique em `Segurança`{.action}. Aparecerá um quadro, no qual poderá ver os endereços IP autorizados ou recusados. Para acrescentar novos, clique à direita, em `Adicionar IP`{.action}:
+Esta ação pode ser feita diretamente através da [Área de Cliente OVHcloud](/links/manager){.external}. Quando estiver no espaço Managed Bare Metal, clique em `Segurança`{.action}. Aparecerá um quadro, no qual poderá ver os endereços IP autorizados ou recusados. Para acrescentar novos, clique à direita, em `Adicionar IP`{.action}:
 
 ![Adicionar IP](images/adding_ip.png){.thumbnail}
 
 ### Criar utilizadores específicos
 
-Recomendamos fortemente que crie um acesso personalizado para cada pessoa que deva ter acesso à sua infraestrutura. Esta operação também pode ser feita na [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}, mas desta vez no separador `Utilizadores`{.action}. Para adicionar novos, clique no botão situado à direita: `Criar um utilizador`{.action}.
+Recomendamos fortemente que crie um acesso personalizado para cada pessoa que deva ter acesso à sua infraestrutura. Esta operação também pode ser feita na [Área de Cliente OVHcloud](/links/manager){.external}, mas desta vez no separador `Utilizadores`{.action}. Para adicionar novos, clique no botão situado à direita: `Criar um utilizador`{.action}.
 
 ![Utilizadores](images/users.png){.thumbnail}
 
@@ -54,7 +54,7 @@ A seguir, poderá gerir as autorizações de cada utilizador clicando no botão 
 
 No final da sessão, aconselha-se que os utilizadores a concluam em conformidade. Para limitar o tempo de conexão, é possível adicionar uma duração de expiração da sessão.
 
-Esta pode ser configurada na [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}. Quando estiver no espaço Managed Bare Metal, escolha `Segurança`{.action}. A seguir, clique em `Alterar o prazo de expiração`{.action}, à direita.
+Esta pode ser configurada na [Área de Cliente OVHcloud](/links/manager){.external}. Quando estiver no espaço Managed Bare Metal, escolha `Segurança`{.action}. A seguir, clique em `Alterar o prazo de expiração`{.action}, à direita.
 
 ![Expiração da sessão](images/security-expiration.png){.thumbnail}
 


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their /links values.

Example: replace all https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB links with /links/manager.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.