### PR TITLE
Fix global links in Bare metal cloud virtual private servers

### DIFF
--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.de-de.md
@@ -17,14 +17,14 @@ Wenn Sie Ihren VPS als DNS-Server konfigurieren, können Sie einen OVHcloud DNS-
 ## Voraussetzungen
 
 - Sie haben adminstrativen Zugriff auf einen Domainnamen.
-- Sie haben einen [VPS](https://www.ovhcloud.com/de/vps/) in Ihrem Kunden-Account.
+- Sie haben einen [VPS](/links/bare-metal/vps) in Ihrem Kunden-Account.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 > [!warning]
 >
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 > 
-> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
+> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
 > 
 
 ## In der praktischen Anwendung

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-asia.md
@@ -13,13 +13,13 @@ If you are configuring your VPS as a DNS server, you can make use of the OVHclou
 ## Requirements
 
 - A domain name to which you have administrative access
-- A [Virtual Private Server](https://www.ovhcloud.com/asia/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/asia/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-au.md
@@ -13,13 +13,13 @@ If you are configuring your VPS as a DNS server, you can make use of the OVHclou
 ## Requirements
 
 - A domain name to which you have administrative access
-- A [Virtual Private Server](https://www.ovhcloud.com/en-au/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-au/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-ca.md
@@ -13,13 +13,13 @@ If you are configuring your VPS as a DNS server, you can make use of the OVHclou
 ## Requirements
 
 - A domain name to which you have administrative access
-- A [Virtual Private Server](https://www.ovhcloud.com/en-ca/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-gb.md
@@ -13,13 +13,13 @@ If you are configuring your VPS as a DNS server, you can make use of the OVHclou
 ## Requirements
 
 - A domain name to which you have administrative access
-- A [Virtual Private Server](https://www.ovhcloud.com/en-gb/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-ie.md
@@ -13,13 +13,13 @@ If you are configuring your VPS as a DNS server, you can make use of the OVHclou
 ## Requirements
 
 - A domain name to which you have administrative access
-- A [Virtual Private Server](https://www.ovhcloud.com/en-ie/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-sg.md
@@ -13,13 +13,13 @@ If you are configuring your VPS as a DNS server, you can make use of the OVHclou
 ## Requirements
 
 - A domain name to which you have administrative access
-- A [Virtual Private Server](https://www.ovhcloud.com/en-sg/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.en-us.md
@@ -13,13 +13,13 @@ If you are configuring your VPS as a DNS server, you can make use of the OVHclou
 ## Requirements
 
 - A domain name to which you have administrative access
-- A [Virtual Private Server](https://www.ovhcloud.com/en/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.es-es.md
@@ -17,7 +17,7 @@ Si configura su VPS como servidor DNS, puede utilizar el servicio DNS secundario
 ## Requisitos
 
 - Un dominio al que puede acceder como administrador
-- Un servidor [VPS](https://www.ovhcloud.com/es-es/vps/) desde el área de cliente de OVHcloud
+- Un servidor [VPS](/links/bare-metal/vps) desde el área de cliente de OVHcloud
 - Haber iniciado sesión en el [Panel de configuración de OVHcloud](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.es-us.md
@@ -17,7 +17,7 @@ Si configura su VPS como servidor DNS, puede utilizar el servicio DNS secundario
 ## Requisitos
 
 - Un dominio al que puede acceder como administrador
-- Un servidor [VPS](https://www.ovhcloud.com/es/vps/) desde el área de cliente de OVHcloud
+- Un servidor [VPS](/links/bare-metal/vps) desde el área de cliente de OVHcloud
 - Haber iniciado sesión en el [Panel de configuración de OVHcloud](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.fr-ca.md
@@ -13,13 +13,13 @@ Si vous configurez votre VPS comme serveur DNS, vous pouvez utiliser le service 
 ## Prérequis
 
 - Un nom de domaine auquel vous avez accès en tant qu’administrateur
-- Un serveur [VPS](https://www.ovhcloud.com/fr-ca/vps/) dans votre espace client OVHcloud
+- Un serveur [VPS](/links/bare-metal/vps) dans votre espace client OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 > [!warning]
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
 >
-> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.fr-fr.md
@@ -13,13 +13,13 @@ Si vous configurez votre VPS comme serveur DNS, vous pouvez utiliser le service 
 ## Prérequis
 
 - Un nom de domaine auquel vous avez accès en tant qu’administrateur
-- Un serveur [VPS](https://www.ovhcloud.com/fr/vps/) dans votre espace client OVHcloud
+- Un serveur [VPS](/links/bare-metal/vps) dans votre espace client OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 > [!warning]
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
 >
-> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.it-it.md
@@ -17,7 +17,7 @@ Se configuri il tuo VPS come server DNS, puoi utilizzare il servizio DNS seconda
 ## Prerequisiti
 
 - Un dominio a cui hai accesso in qualità di amministratore
-- Un server [VPS](https://www.ovhcloud.com/it/vps/) nello Spazio Cliente OVHcloud
+- Un server [VPS](/links/bare-metal/vps) nello Spazio Cliente OVHcloud
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.pl-pl.md
@@ -17,7 +17,7 @@ Jeśli skonfigurujesz serwer VPS jako serwer DNS, możesz użyć Secondary DNS O
 ## Wymagania początkowe
 
 - Domena, do której masz dostęp jako administrator
-- Serwer [VPS](https://www.ovhcloud.com/pl/vps/) w Panelu klienta OVHcloud
+- Serwer [VPS](/links/bare-metal/vps) w Panelu klienta OVHcloud
 - Dostęp do [Panelu client OVHcloud](/links/manager)
 
 > [!warning]

--- a/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/adding-secondary-dns-on-vps/guide.pt-pt.md
@@ -17,13 +17,13 @@ Se configurar o VPS como servidor DNS, pode utilizar o serviço DNS secundário 
 ## Requisitos
 
 - Um domínio ao qual terá acesso enquanto administrador.
-- Um servidor [VPS](https://www.ovhcloud.com/pt/vps/) na sua Área de Cliente OVHcloud.
+- Um servidor [VPS](/links/bare-metal/vps) na sua Área de Cliente OVHcloud.
 - Estar ligado à [Área de Cliente OVHcloud](/links/manager).
 
 > [!warning]
 > A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
 >
-> Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de um serviço num servidor, recomendamos que recorra a um [prestador de serviços especializado](https://partner.ovhcloud.com/pt/directory/).
+> Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de um serviço num servidor, recomendamos que recorra a um [prestador de serviços especializado](/links/partner).
 >
 
 ## Instruções

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.de-de.md
@@ -16,7 +16,7 @@ OVHcloud bietet VPS-Nutzern vorinstallierte Images verschiedener Anwendungen fü
 
 ## Voraussetzungen
 
-- Sie haben einen [VPS](https://www.ovhcloud.com/de/vps/) in Ihrem Kunden-Account.
+- Sie haben einen [VPS](/links/bare-metal/vps) in Ihrem Kunden-Account.
 
 ## In der praktischen Anwendung
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-asia.md
@@ -12,7 +12,7 @@ OVHcloud offers VPS customers pre-installed application images for quick and eas
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/asia/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-au.md
@@ -12,7 +12,7 @@ OVHcloud offers VPS customers pre-installed application images for quick and eas
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-au/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-ca.md
@@ -12,7 +12,7 @@ OVHcloud offers VPS customers pre-installed application images for quick and eas
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ca/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-gb.md
@@ -12,7 +12,7 @@ OVHcloud offers VPS customers pre-installed application images for quick and eas
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-gb/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-ie.md
@@ -12,7 +12,7 @@ OVHcloud offers VPS customers pre-installed application images for quick and eas
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ie/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-sg.md
@@ -12,7 +12,7 @@ OVHcloud offers VPS customers pre-installed application images for quick and eas
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-sg/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.en-us.md
@@ -12,7 +12,7 @@ OVHcloud offers VPS customers pre-installed application images for quick and eas
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.es-es.md
@@ -16,7 +16,7 @@ OVHcloud ofrece a los clientes VPS imágenes de aplicaciones preinstaladas para 
 
 ## Requisitos
 
-- Tener un [VPS](https://www.ovhcloud.com/es/vps/) en su cuenta de OVHcloud.
+- Tener un [VPS](/links/bare-metal/vps) en su cuenta de OVHcloud.
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.es-us.md
@@ -16,7 +16,7 @@ OVHcloud ofrece a los clientes VPS imágenes de aplicaciones preinstaladas para 
 
 ## Requisitos
 
-- Tener un [VPS](https://www.ovhcloud.com/es/vps/) en su cuenta de OVHcloud.
+- Tener un [VPS](/links/bare-metal/vps) en su cuenta de OVHcloud.
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.fr-ca.md
@@ -12,7 +12,7 @@ OVHcloud offre aux clients VPS des images d'applications préinstallées pour un
 
 ## Prérequis
 
-- Disposer d'un [VPS](https://www.ovhcloud.com/fr/vps/) sur votre compte OVHcloud.
+- Disposer d'un [VPS](/links/bare-metal/vps) sur votre compte OVHcloud.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.fr-fr.md
@@ -12,7 +12,7 @@ OVHcloud offre aux clients VPS des images d'applications préinstallées pour un
 
 ## Prérequis
 
-- Disposer d'un [VPS](https://www.ovhcloud.com/fr/vps/) sur votre compte OVHcloud.
+- Disposer d'un [VPS](/links/bare-metal/vps) sur votre compte OVHcloud.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.it-it.md
@@ -16,7 +16,7 @@ OVHcloud offre ai clienti VPS immagini di applicazioni preinstallate per un'impl
 
 ## Prerequisiti
 
-- Disporre di un [VPS](https://www.ovhcloud.com/it/vps/) sul proprio account OVHcloud
+- Disporre di un [VPS](/links/bare-metal/vps) sul proprio account OVHcloud
 
 ## Procedura
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.pl-pl.md
@@ -16,7 +16,7 @@ OVHcloud udostępnia klientom VPS obrazy wstępnie zainstalowanych aplikacji, kt
 
 ## Wymagania początkowe
 
-- Posiadanie serwera [VPS](https://www.ovhcloud.com/pl/vps/) na koncie OVHcloud
+- Posiadanie serwera [VPS](/links/bare-metal/vps) na koncie OVHcloud
 
 ## W praktyce
 

--- a/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/apps_first_steps/guide.pt-pt.md
@@ -16,7 +16,7 @@ A OVHcloud oferece aos clientes VPS imagens de aplicações pré-instaladas para
 
 ## Requisitos
 
-- Ter um [VPS](https://www.ovhcloud.com/pt/vps/) na sua conta OVHcloud.
+- Ter um [VPS](/links/bare-metal/vps) na sua conta OVHcloud.
 
 ## Instruções
 

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.de-de.md
@@ -23,12 +23,12 @@ Wenn Ihr VPS nicht mehr antwortet, können Sie diesen in der Regel immer noch ü
 >
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 > 
-> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die OVHcloud Community unter <https://community.ovh.com/en/> zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
+> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die OVHcloud Community unter <https://community.ovh.com/en/> zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben.
 > 
 
 ## Voraussetzungen
 
-- Sie haben einen OVHcloud [VPS](https://www.ovhcloud.com/de/vps/) in Ihrem Kunden-Account.
+- Sie haben einen OVHcloud [VPS](/links/bare-metal/vps) in Ihrem Kunden-Account.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 ## In der praktischen Anwendung
@@ -78,7 +78,7 @@ sdb       8:16   0   50G  0 disk
 
 Das vorstehende Beispielergebnis zeigt, dass die Systempartition auf **/mnt/sdb1** eingehängt ist. (Die primäre Disk ist **sdb**, während **sda** die Rescue-Platte ist und **sda1** die primäre Rettungspartition, die auf **/** eingehängt ist).
 
-Wenn Ihr VPS zu den [**aktuellen VPS-Reihen**](https://www.ovhcloud.com/de/vps/) gehört, wird kein automatischer Mount durchgeführt und die Spalte "MOUNTPOINT" sollte leer sein. In diesem Fall gehen Sie direkt [zu Schritt 4](#step4).
+Wenn Ihr VPS zu den [**aktuellen VPS-Reihen**](/links/bare-metal/vps) gehört, wird kein automatischer Mount durchgeführt und die Spalte "MOUNTPOINT" sollte leer sein. In diesem Fall gehen Sie direkt [zu Schritt 4](#step4).
 
 ### Schritt 3: Partition aushängen (nur für ältere VPS Reihen)
 
@@ -90,7 +90,7 @@ Auf einem VPS der älteren Reihen ist im Rescue-Modus die primäre Disk bereits 
 
 ### Schritt 4: Partition mit den geeigneten Einstellungen mounten <a name="step4"></a>
 
-Wenn Ihr VPS zu den [**aktuellen VPS-Reihen**](https://www.ovhcloud.com/de/vps/) gehört, überprüfen Sie zunächst, dass der Mount-Ordner erstellt wurde:
+Wenn Ihr VPS zu den [**aktuellen VPS-Reihen**](/links/bare-metal/vps) gehört, überprüfen Sie zunächst, dass der Mount-Ordner erstellt wurde:
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-asia.md
@@ -18,12 +18,12 @@ If your VPS has become unresponsive, you still have the possibility to access it
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/asia/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/asia/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
@@ -73,7 +73,7 @@ sdb       8:16   0   50G  0 disk
 
 The example output above shows that the system partition is mounted on **/mnt/sdb1**. (The primary disk is **sdb**, whereas **sda** is the rescue disk and **sda1** is the primary rescue partition mounted on **/**).
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/asia/vps/), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
 
 ### Step 3: Unmount the partition (older ranges only)
 
@@ -85,7 +85,7 @@ On a legacy VPS in rescue mode, the primary disk is already mounted. Therefore, 
 
 ### Step 4: Mount the partition with the correct settings <a name="step4"></a>
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/asia/vps/), first make sure the mount folder is created:
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), first make sure the mount folder is created:
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-au.md
@@ -18,12 +18,12 @@ If your VPS has become unresponsive, you still have the possibility to access it
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-au/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-au/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
@@ -73,7 +73,7 @@ sdb       8:16   0   50G  0 disk
 
 The example output above shows that the system partition is mounted on **/mnt/sdb1**. (The primary disk is **sdb**, whereas **sda** is the rescue disk and **sda1** is the primary rescue partition mounted on **/**).
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/en-au/vps/), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
 
 ### Step 3: Unmount the partition (older ranges only)
 
@@ -85,7 +85,7 @@ On a legacy VPS in rescue mode, the primary disk is already mounted. Therefore, 
 
 ### Step 4: Mount the partition with the correct settings <a name="step4"></a>
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/en-au/vps/), first make sure the mount folder is created:
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), first make sure the mount folder is created:
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-ca.md
@@ -18,12 +18,12 @@ If your VPS has become unresponsive, you still have the possibility to access it
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ca/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
@@ -73,7 +73,7 @@ sdb       8:16   0   50G  0 disk
 
 The example output above shows that the system partition is mounted on **/mnt/sdb1**. (The primary disk is **sdb**, whereas **sda** is the rescue disk and **sda1** is the primary rescue partition mounted on **/**).
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/en-ca/vps/), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
 
 ### Step 3: Unmount the partition (older ranges only)
 
@@ -85,7 +85,7 @@ On a legacy VPS in rescue mode, the primary disk is already mounted. Therefore, 
 
 ### Step 4: Mount the partition with the correct settings <a name="step4"></a>
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/en-ca/vps/), first make sure the mount folder is created:
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), first make sure the mount folder is created:
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-gb.md
@@ -18,12 +18,12 @@ If your VPS has become unresponsive, you still have the possibility to access it
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-gb/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
@@ -73,7 +73,7 @@ sdb       8:16   0   50G  0 disk
 
 The example output above shows that the system partition is mounted on **/mnt/sdb1**. (The primary disk is **sdb**, whereas **sda** is the rescue disk and **sda1** is the primary rescue partition mounted on **/**).
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/en-gb/vps/), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
 
 ### Step 3: Unmount the partition (older ranges only)
 
@@ -85,7 +85,7 @@ On a legacy VPS in rescue mode, the primary disk is already mounted. Therefore, 
 
 ### Step 4: Mount the partition with the correct settings <a name="step4"></a>
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/en-gb/vps/), first make sure the mount folder is created:
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), first make sure the mount folder is created:
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-ie.md
@@ -18,12 +18,12 @@ If your VPS has become unresponsive, you still have the possibility to access it
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ie/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
@@ -73,7 +73,7 @@ sdb       8:16   0   50G  0 disk
 
 The example output above shows that the system partition is mounted on **/mnt/sdb1**. (The primary disk is **sdb**, whereas **sda** is the rescue disk and **sda1** is the primary rescue partition mounted on **/**).
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/en-ie/vps/), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
 
 ### Step 3: Unmount the partition (older ranges only)
 
@@ -85,7 +85,7 @@ On a legacy VPS in rescue mode, the primary disk is already mounted. Therefore, 
 
 ### Step 4: Mount the partition with the correct settings <a name="step4"></a>
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/en-ie/vps/), first make sure the mount folder is created:
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), first make sure the mount folder is created:
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-sg.md
@@ -18,12 +18,12 @@ If your VPS has become unresponsive, you still have the possibility to access it
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-sg/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
@@ -73,7 +73,7 @@ sdb       8:16   0   50G  0 disk
 
 The example output above shows that the system partition is mounted on **/mnt/sdb1**. (The primary disk is **sdb**, whereas **sda** is the rescue disk and **sda1** is the primary rescue partition mounted on **/**).
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/en-sg/vps/), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
 
 ### Step 3: Unmount the partition (older ranges only)
 
@@ -85,7 +85,7 @@ On a legacy VPS in rescue mode, the primary disk is already mounted. Therefore, 
 
 ### Step 4: Mount the partition with the correct settings <a name="step4"></a>
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/en-sg/vps/), first make sure the mount folder is created:
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), first make sure the mount folder is created:
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.en-us.md
@@ -18,12 +18,12 @@ If your VPS has become unresponsive, you still have the possibility to access it
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
@@ -73,7 +73,7 @@ sdb       8:16   0   50G  0 disk
 
 The example output above shows that the system partition is mounted on **/mnt/sdb1**. (The primary disk is **sdb**, whereas **sda** is the rescue disk and **sda1** is the primary rescue partition mounted on **/**).
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/en/vps/), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), no automatic mounting will occur and the `MOUNTPOINT` column should be empty. In that case, proceed with [step 4](#step4).
 
 ### Step 3: Unmount the partition (older ranges only)
 
@@ -85,7 +85,7 @@ On a legacy VPS in rescue mode, the primary disk is already mounted. Therefore, 
 
 ### Step 4: Mount the partition with the correct settings <a name="step4"></a>
 
-If your VPS is of the [**current ranges**](https://www.ovhcloud.com/en/vps/), first make sure the mount folder is created:
+If your VPS is of the [**current ranges**](/links/bare-metal/vps), first make sure the mount folder is created:
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.es-es.md
@@ -27,7 +27,7 @@ Si su VPS no responde, siempre debería poder acceder a él desde el área de cl
 
 ## Requisitos
 
-- Disponer de un [VPS](https://www.ovhcloud.com/es-es/vps/) en su cuenta de OVHcloud
+- Disponer de un [VPS](/links/bare-metal/vps) en su cuenta de OVHcloud
 - Tener acceso al [Panel de configuración de OVHcloud](/links/manager)
 
 ## Procedimiento
@@ -77,7 +77,7 @@ sdb       8:16   0   50G  0 disk
 
 El ejemplo anterior muestra que la partición del sistema está montada en **/mnt/sdb1**. (El disco principal es **sdb**. El disco rescue es **sda** y **sda1** es la partición principal en rescue montada en **/**).
 
-Si su VPS pertenece a las [**gamas VPS actuales**](https://www.ovhcloud.com/es-es/vps/), no se realizará ningún montaje automático y la columna "MOUNTPOINT" debería estar vacía. En ese caso, vaya al [paso 4](#step4).
+Si su VPS pertenece a las [**gamas VPS actuales**](/links/bare-metal/vps), no se realizará ningún montaje automático y la columna "MOUNTPOINT" debería estar vacía. En ese caso, vaya al [paso 4](#step4).
 
 ### Paso 3: desmontar la partición (solo para las antiguas gamas VPS)
 
@@ -89,7 +89,7 @@ En un VPS perteneciente a las antiguas gamas en modo de rescate, el disco princi
 
 ### Paso 4: montar la partición con los parámetros adecuados <a name="step4"></a>
 
-Si su VPS pertenece a las [**gamas VPS actuales**](https://www.ovhcloud.com/es-es/vps/), compruebe que la carpeta de montaje esté creada:
+Si su VPS pertenece a las [**gamas VPS actuales**](/links/bare-metal/vps), compruebe que la carpeta de montaje esté creada:
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.es-us.md
@@ -27,7 +27,7 @@ Si su VPS no responde, siempre debería poder acceder a él desde el área de cl
 
 ## Requisitos
 
-- Disponer de un [VPS](https://www.ovhcloud.com/es/vps/) en su cuenta de OVHcloud
+- Disponer de un [VPS](/links/bare-metal/vps) en su cuenta de OVHcloud
 - Tener acceso al [Panel de configuración de OVHcloud](/links/manager)
 
 ## Procedimiento
@@ -77,7 +77,7 @@ sdb       8:16   0   50G  0 disk
 
 El ejemplo anterior muestra que la partición del sistema está montada en **/mnt/sdb1**. (El disco principal es **sdb**. El disco rescue es **sda** y **sda1** es la partición principal en rescue montada en **/**).
 
-Si su VPS pertenece a las [**gamas VPS actuales**](https://www.ovhcloud.com/es/vps/), no se realizará ningún montaje automático y la columna "MOUNTPOINT" debería estar vacía. En ese caso, vaya al [paso 4](#step4).
+Si su VPS pertenece a las [**gamas VPS actuales**](/links/bare-metal/vps), no se realizará ningún montaje automático y la columna "MOUNTPOINT" debería estar vacía. En ese caso, vaya al [paso 4](#step4).
 
 ### Paso 3: desmontar la partición (solo para las antiguas gamas VPS)
 
@@ -89,7 +89,7 @@ En un VPS perteneciente a las antiguas gamas en modo de rescate, el disco princi
 
 ### Paso 4: montar la partición con los parámetros adecuados <a name="step4"></a>
 
-Si su VPS pertenece a las [**gamas VPS actuales**](https://www.ovhcloud.com/es/vps/), compruebe que la carpeta de montaje esté creada:
+Si su VPS pertenece a las [**gamas VPS actuales**](/links/bare-metal/vps), compruebe que la carpeta de montaje esté creada:
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.fr-ca.md
@@ -23,7 +23,7 @@ Si votre VPS ne répond plus, vous devriez toujours pouvoir y accéder depuis vo
 
 ## Prérequis
 
-- disposer d'un [VPS](https://www.ovhcloud.com/fr-ca/vps/) dans votre compte OVHcloud
+- disposer d'un [VPS](/links/bare-metal/vps) dans votre compte OVHcloud
 - disposer d'un accès à l'[espace client OVHcloud](/links/manager)
 
 ## En pratique
@@ -73,7 +73,7 @@ sdb       8:16   0   50G  0 disk
 
 L'exemple obtenu ci-dessus montre que la partition système est montée sur **/mnt/sdb1**. (Le disque principal est **sdb**. Le disque rescue est **sda** et **sda1** est la partition principale en rescue montée sur **/**).
 
-Si votre VPS appartient aux [**gammes VPS actuelles**](https://www.ovhcloud.com/fr-ca/vps/), aucun montage automatique ne sera effectué et la colonne "MOUNTPOINT" devrait être vide. Dans ce cas, passez à [l'étape 4](#step4).
+Si votre VPS appartient aux [**gammes VPS actuelles**](/links/bare-metal/vps), aucun montage automatique ne sera effectué et la colonne "MOUNTPOINT" devrait être vide. Dans ce cas, passez à [l'étape 4](#step4).
 
 ### Étape 3 : démonter la partition (uniquement pour les anciennes gammes VPS)
 
@@ -85,7 +85,7 @@ Sur un VPS appartenant aux anciennes gammes placé en mode rescue, le disque pri
 
 ### Étape 4 : monter la partition avec les paramètres appropriés <a name="step4"></a>
 
-Si votre VPS appartient aux [**gammes VPS actuelles**](https://www.ovhcloud.com/fr-ca/vps/), vérifiez d'abord que le dossier de montage est créé :
+Si votre VPS appartient aux [**gammes VPS actuelles**](/links/bare-metal/vps), vérifiez d'abord que le dossier de montage est créé :
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.fr-fr.md
@@ -23,7 +23,7 @@ Si votre VPS ne répond plus, vous devriez toujours pouvoir y accéder depuis vo
 
 ## Prérequis
 
-- disposer d'un [VPS](https://www.ovhcloud.com/fr/vps/) dans votre compte OVHcloud
+- disposer d'un [VPS](/links/bare-metal/vps) dans votre compte OVHcloud
 - disposer d'un accès à l'[espace client OVHcloud](/links/manager)
 
 ## En pratique
@@ -73,7 +73,7 @@ sdb       8:16   0   50G  0 disk
 
 L'exemple obtenu ci-dessus montre que la partition système est montée sur **/mnt/sdb1**. (Le disque principal est **sdb**. Le disque rescue est **sda** et **sda1** est la partition principale en rescue montée sur **/**).
 
-Si votre VPS appartient aux [**gammes VPS actuelles**](https://www.ovhcloud.com/fr/vps/), aucun montage automatique ne sera effectué et la colonne "MOUNTPOINT" devrait être vide. Dans ce cas, passez à [l'étape 4](#step4).
+Si votre VPS appartient aux [**gammes VPS actuelles**](/links/bare-metal/vps), aucun montage automatique ne sera effectué et la colonne "MOUNTPOINT" devrait être vide. Dans ce cas, passez à [l'étape 4](#step4).
 
 ### Étape 3 : démonter la partition (uniquement pour les anciennes gammes VPS)
 
@@ -85,7 +85,7 @@ Sur un VPS appartenant aux anciennes gammes placé en mode rescue, le disque pri
 
 ### Étape 4 : monter la partition avec les paramètres appropriés <a name="step4"></a>
 
-Si votre VPS appartient aux [**gammes VPS actuelles**](https://www.ovhcloud.com/fr/vps/), vérifiez d'abord que le dossier de montage est créé :
+Si votre VPS appartient aux [**gammes VPS actuelles**](/links/bare-metal/vps), vérifiez d'abord que le dossier de montage est créé :
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.it-it.md
@@ -27,7 +27,7 @@ Se il tuo VPS non risponde, accedi al tuo Spazio Cliente OVHcloud tramite il [KV
 
 ## Prerequisiti
 
-- disporre di un [VPS](https://www.ovhcloud.com/it/vps/) nel tuo account OVHcloud
+- disporre di un [VPS](/links/bare-metal/vps) nel tuo account OVHcloud
 - avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 ## Procedura
@@ -77,7 +77,7 @@ sdb 8:16 0 50G 0 disk
 
 L'esempio che hai mostrato qui sopra mostra che la partizione di sistema è montata su **/mnt/sdb1**. (Il disco principale è **sdb**. Il disco rescue è **sda** e **sda1** è la partizione principale in rescue montata su **/**).
 
-Se il tuo VPS appartiene alle [**gamme VPS esistenti**](https://www.ovhcloud.com/it/vps/), non verrà effettuato alcun mount automatico e la colonna "MOUNTPOINT" sarà vuota. In questo caso passa allo [Step 4](#step4).
+Se il tuo VPS appartiene alle [**gamme VPS esistenti**](/links/bare-metal/vps), non verrà effettuato alcun mount automatico e la colonna "MOUNTPOINT" sarà vuota. In questo caso passa allo [Step 4](#step4).
 
 ### Step 3: smontare la partizione (solo per le gamme VPS precedenti)
 
@@ -89,7 +89,7 @@ Sui VPS appartenenti alle gamme precedenti in modalità Rescue, il disco princip
 
 ### Step 4: monta la partizione con i parametri appropriati <a name="step4"></a>
 
-Se il tuo VPS appartiene alle [**gamme VPS esistenti**](https://www.ovhcloud.com/it/vps/), verifica prima che la cartella di mount sia creata:
+Se il tuo VPS appartiene alle [**gamme VPS esistenti**](/links/bare-metal/vps), verifica prima che la cartella di mount sia creata:
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.pl-pl.md
@@ -27,7 +27,7 @@ Jeśli Twój serwer VPS nie odpowiada, powinieneś mieć dostęp do niego za po�
 
 ## Wymagania początkowe
 
-- posiadanie serwera [VPS](https://www.ovhcloud.com/pl/vps/) na koncie OVHcloud
+- posiadanie serwera [VPS](/links/bare-metal/vps) na koncie OVHcloud
 - dostęp do [Panelu client OVHcloud](/links/manager)
 
 ## W praktyce
@@ -77,7 +77,7 @@ sdb       8:16   0   50G  0 disk
 
 Powyższy przykład pokazuje, że partycja systemowa jest zamontowana na **/mnt/sdb**. (Dysk główny to **sdb**. Dysk rescue to **sda**, a **sda1** to główna partycja w trybie rescue zamontowana na **/**).
 
-Jeśli Twój VPS należy do [**bieżącej gamy VPS**](https://www.ovhcloud.com/pl/vps/), nie zostanie wykonany automatyczny montaż, a kolumna "MOUNTPOINT" powinna być pusta. W tym przypadku przejdź do [etapu czwartego](#step4).
+Jeśli Twój VPS należy do [**bieżącej gamy VPS**](/links/bare-metal/vps), nie zostanie wykonany automatyczny montaż, a kolumna "MOUNTPOINT" powinna być pusta. W tym przypadku przejdź do [etapu czwartego](#step4).
 
 ### Etap 3: odmontuj partycję (tylko dla starszych gam VPS)
 
@@ -89,7 +89,7 @@ Na serwerze VPS należącym do poprzednich gam znajdujących się w trybie Rescu
 
 ### Etap 4: zamontować partycję z odpowiednimi parametrami <a name="step4"></a>
 
-Jeśli Twój VPS należy do [**bieżącej gamy VPS**](https://www.ovhcloud.com/pl/vps/), sprawdź najpierw, czy folder montowania jest utworzony:
+Jeśli Twój VPS należy do [**bieżącej gamy VPS**](/links/bare-metal/vps), sprawdź najpierw, czy folder montowania jest utworzony:
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/bootlog_display_kvm/guide.pt-pt.md
@@ -27,7 +27,7 @@ Se o seu VPS não responder, deverá sempre poder aceder ao VPS a partir da Áre
 
 ## Requisitos
 
-- dispor de um [VPS](https://www.ovhcloud.com/pt/vps/) na sua conta OVHcloud
+- dispor de um [VPS](/links/bare-metal/vps) na sua conta OVHcloud
 - ter acesso à [Área de Cliente OVHcloud](/links/manager)
 
 ## Instruções
@@ -77,7 +77,7 @@ sdb       8:16   0   50G  0 disk
 
 O exemplo acima mostra que a partição do sistema está montada em **/mnt/sdb1**. (O disco principal é **sdb**. O disco rescue é **sda** e **sda1** é a partição principal em rescue montada sobre **/**).
 
-Se o seu VPS pertencer às [**gamas VPS atuais**](https://www.ovhcloud.com/pt/vps/), não será efetuada nenhuma montagem automática e a coluna "MOUNTPOINT" deverá estar vazia. Nesse caso, passe [ao passo 4](#step4).
+Se o seu VPS pertencer às [**gamas VPS atuais**](/links/bare-metal/vps), não será efetuada nenhuma montagem automática e a coluna "MOUNTPOINT" deverá estar vazia. Nesse caso, passe [ao passo 4](#step4).
 
 ### Etapa 3: desmontar a partição (apenas para as antigas gamas VPS)
 
@@ -89,7 +89,7 @@ Num VPS pertencente às antigas gamas colocado em modo rescue, o disco principal
 
 ### Etapa 4: montar a partição com os parâmetros apropriados <a name="step4"></a>
 
-Se o seu VPS pertence às [**gamas VPS atuais**](https://www.ovhcloud.com/pt/vps/), verifique primeiro se a pasta de montagem foi criada:
+Se o seu VPS pertence às [**gamas VPS atuais**](/links/bare-metal/vps), verifique primeiro se a pasta de montagem foi criada:
 
 ```sh
 ~$ mkdir -p /mnt/sdb1

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.de-de.md
@@ -16,12 +16,12 @@ updated: 2023-09-20
 >
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 > 
-> Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) und/oder stellen Ihre Fragen in der OVHcloud Community unter https://community.ovh.com/en/ (Englisch). Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. 
+> Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](/links/partner) und/oder stellen Ihre Fragen in der OVHcloud Community unter https://community.ovh.com/en/ (Englisch). Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. 
 >
 
 ## Voraussetzungen
 
-- Sie haben einen [VPS](https://www.ovhcloud.com/de/vps/) in Ihrem Kunden-Account.
+- Sie haben einen [VPS](/links/bare-metal/vps) in Ihrem Kunden-Account.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 ## In der praktischen Anwendung

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-asia.md
@@ -11,12 +11,12 @@ updated: 2023-09-20
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/asia/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/asia/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-au.md
@@ -11,12 +11,12 @@ updated: 2023-09-20
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-au/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-au/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-ca.md
@@ -11,12 +11,12 @@ updated: 2023-09-20
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ca/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-gb.md
@@ -11,12 +11,12 @@ updated: 2023-09-20
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-gb/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-ie.md
@@ -11,12 +11,12 @@ updated: 2023-09-20
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ie/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-sg.md
@@ -11,12 +11,12 @@ updated: 2023-09-20
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-sg/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.en-us.md
@@ -11,12 +11,12 @@ updated: 2023-09-20
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.es-es.md
@@ -20,7 +20,7 @@ updated: 2023-09-20
 
 ## Requisitos
 
-- Un [VPS](https://www.ovhcloud.com/es-es/vps/) en su cuenta OVHcloud
+- Un [VPS](/links/bare-metal/vps) en su cuenta OVHcloud
 - Tener acceso al [área de cliente de OVHcloud](/links/manager)
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.es-us.md
@@ -20,7 +20,7 @@ updated: 2023-09-20
 
 ## Requisitos
 
-- Un [VPS](https://www.ovhcloud.com/es/vps/) en su cuenta OVHcloud
+- Un [VPS](/links/bare-metal/vps) en su cuenta OVHcloud
 - Tener acceso al [área de cliente de OVHcloud](/links/manager)
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.fr-ca.md
@@ -16,7 +16,7 @@ updated: 2023-09-20
 
 ## Prérequis
 
-- un [VPS](https://www.ovhcloud.com/fr-ca/vps/) dans votre compte OVHcloud
+- un [VPS](/links/bare-metal/vps) dans votre compte OVHcloud
 - disposer d'un accès à l'[espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.fr-fr.md
@@ -16,7 +16,7 @@ updated: 2023-09-20
 
 ## Prérequis
 
-- un [VPS](https://www.ovhcloud.com/fr/vps/) dans votre compte OVHcloud
+- un [VPS](/links/bare-metal/vps) dans votre compte OVHcloud
 - disposer d'un accès à l'[espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.it-it.md
@@ -20,7 +20,7 @@ updated: 2023-09-20
 
 ## Prerequisiti
 
-- un [VPS](https://www.ovhcloud.com/it/vps/) nel tuo account OVHcloud
+- un [VPS](/links/bare-metal/vps) nel tuo account OVHcloud
 - avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 ## Procedura

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.pl-pl.md
@@ -20,7 +20,7 @@ updated: 2023-09-20
 
 ## Wymagania początkowe
 
-- jednego [VPS](https://www.ovhcloud.com/pl/vps/) na koncie OVHcloud
+- jednego [VPS](/links/bare-metal/vps) na koncie OVHcloud
 - dostęp do [Panelu klienta OVHcloud](/links/manager)
 
 ## W praktyce

--- a/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/check-filesystem/guide.pt-pt.md
@@ -20,7 +20,7 @@ updated: 2023-09-20
 
 ## Requisitos
 
-- um [VPS](https://www.ovhcloud.com/pt/vps/) na sua conta OVHcloud
+- um [VPS](/links/bare-metal/vps) na sua conta OVHcloud
 - ter acesso à [Área de Cliente OVHcloud](/links/manager)
 
 ## Instruções

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.de-de.md
@@ -16,7 +16,7 @@ Bei den VPS von OVHcloud können Sie einen sicheren Speicherplatz als Dienstopti
 
 ## Voraussetzungen
 
-- Sie haben einen [VPS](https://www.ovhcloud.com/de/vps/) in Ihrem OVHcloud Kunden-Account.
+- Sie haben einen [VPS](/links/bare-metal/vps) in Ihrem OVHcloud Kunden-Account.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 - Administrativer Zugriff via SSH oder RDP auf Ihren VPS.
 
@@ -37,7 +37,7 @@ Beachten Sie die Preisinformationen und klicken Sie dann auf `Bestellen`{.action
 > [!warning]
 > OVHcloud stellt Ihnen Dienste zur Verfügung, für deren Konfiguration und Verwaltung Sie verantwortlich sind. Sie sind also verantwortlich für das ordnungsgemäße Funktionieren dieser Systeme.
 >
->Sollten Sie Schwierigkeiten haben, diese Aktionen durchzuführen, kontaktieren Sie einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) oder besprechen Sie das Problem mit unserer User Community unter https://community.ovh.com/en/. OVHcloud kann Ihnen hierzu keinen technischen Support bieten.
+>Sollten Sie Schwierigkeiten haben, diese Aktionen durchzuführen, kontaktieren Sie einen [spezialisierten Dienstleister](/links/partner) oder besprechen Sie das Problem mit unserer User Community unter https://community.ovh.com/en/. OVHcloud kann Ihnen hierzu keinen technischen Support bieten.
 >
 
 #### Auf einem Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-asia.md
@@ -12,7 +12,7 @@ With OVHcloud Virtual Private Servers you have the possibility to add a secure s
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/asia/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
 
@@ -33,7 +33,7 @@ Take note of the pricing information, then click on `Order`{.action}. You will b
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/asia/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-au.md
@@ -12,7 +12,7 @@ With OVHcloud Virtual Private Servers you have the possibility to add a secure s
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-au/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
 
@@ -33,7 +33,7 @@ Take note of the pricing information, then click on `Order`{.action}. You will b
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-au/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-ca.md
@@ -12,7 +12,7 @@ With OVHcloud Virtual Private Servers you have the possibility to add a secure s
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ca/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
 
@@ -33,7 +33,7 @@ Take note of the pricing information, then click on `Order`{.action}. You will b
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-gb.md
@@ -12,7 +12,7 @@ With OVHcloud Virtual Private Servers you have the possibility to add a secure s
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-gb/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
 
@@ -33,7 +33,7 @@ Take note of the pricing information, then click on `Order`{.action}. You will b
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-ie.md
@@ -12,7 +12,7 @@ With OVHcloud Virtual Private Servers you have the possibility to add a secure s
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ie/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
 
@@ -33,7 +33,7 @@ Take note of the pricing information, then click on `Order`{.action}. You will b
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-sg.md
@@ -12,7 +12,7 @@ With OVHcloud Virtual Private Servers you have the possibility to add a secure s
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-sg/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
 
@@ -33,7 +33,7 @@ Take note of the pricing information, then click on `Order`{.action}. You will b
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.en-us.md
@@ -12,7 +12,7 @@ With OVHcloud Virtual Private Servers you have the possibility to add a secure s
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
 
@@ -33,7 +33,7 @@ Take note of the pricing information, then click on `Order`{.action}. You will b
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/. OVHcloud cannot provide you with technical support in this regard.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.es-es.md
@@ -16,7 +16,7 @@ Con los VPS de OVHcloud, puede añadir un espacio de almacenamiento seguro como 
 
 ## Requisitos
 
-- Tener un [VPS](https://www.ovhcloud.com/es-es/vps/) en su cuenta de OVHcloud.
+- Tener un [VPS](/links/bare-metal/vps) en su cuenta de OVHcloud.
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 - Tener acceso administrativo a su VPS por SSH o RDP.
 

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.es-us.md
@@ -16,7 +16,7 @@ Con los VPS de OVHcloud, puede añadir un espacio de almacenamiento seguro como 
 
 ## Requisitos
 
-- Tener un [VPS](https://www.ovhcloud.com/es/vps/) en su cuenta de OVHcloud.
+- Tener un [VPS](/links/bare-metal/vps) en su cuenta de OVHcloud.
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 - Tener acceso administrativo a su VPS por SSH o RDP.
 

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.fr-ca.md
@@ -12,7 +12,7 @@ Avec les VPS OVHcloud, vous avez la possibilité d'ajouter un espace de stockage
 
 ## Prérequis
 
-- Disposer d'un [VPS](https://www.ovhcloud.com/fr-ca/vps/) dans votre compte OVHcloud
+- Disposer d'un [VPS](/links/bare-metal/vps) dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 - Disposer d'un accès administratif via SSH ou RDP à votre VPS
 

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.fr-fr.md
@@ -12,7 +12,7 @@ Avec les VPS OVHcloud, vous avez la possibilité d'ajouter un espace de stockage
 
 ## Prérequis
 
-- Disposer d'un [VPS](https://www.ovhcloud.com/fr/vps/) dans votre compte OVHcloud
+- Disposer d'un [VPS](/links/bare-metal/vps) dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 - Disposer d'un accès administratif via SSH ou RDP à votre VPS
 

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.it-it.md
@@ -16,7 +16,7 @@ Con i VPS OVHcloud è possibile aggiungere spazio di storage sicuro come opzione
 
 ## Prerequisiti
 
-- Disporre di un [VPS](https://www.ovhcloud.com/it/vps/) nel proprio account OVHcloud
+- Disporre di un [VPS](/links/bare-metal/vps) nel proprio account OVHcloud
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 - Avere accesso amministrativo via SSH o RDP al VPS
 

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.pl-pl.md
@@ -16,7 +16,7 @@ Wraz z ofertą VPS OVHcloud możesz dodać bezpieczną przestrzeń dyskową jako
 
 ## Wymagania początkowe
 
-- Posiadanie [serwera VPS](https://www.ovhcloud.com/pl/vps/) na koncie OVHcloud
+- Posiadanie [serwera VPS](/links/bare-metal/vps) na koncie OVHcloud
 - Zalogowanie do [Panelu klienta OVHcloud](/links/manager)
 - Dostęp administracyjny przez SSH lub RDP do serwera VPS
 

--- a/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk/guide.pt-pt.md
@@ -16,7 +16,7 @@ Com os VPS OVHcloud, tem a possibilidade de adicionar um espaço de armazenament
 
 ## Requisitos
 
-- Ter um [VPS](https://www.ovhcloud.com/pt/vps/) na sua conta OVHcloud
+- Ter um [VPS](/links/bare-metal/vps) na sua conta OVHcloud
 - Estar ligado à [Área de Cliente OVHcloud](/links/manager)
 - Ter acesso administrativo via SSH ou RDP ao VPS
 

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.de-de.md
@@ -17,12 +17,12 @@ IPv6 ist die neueste Version des *Internet Protocol* (IP). Jeder OVHcloud VPS wi
 > [!warning]
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für die Sie die alleinige Verantwortung tragen. Da wir keinen Zugriff auf diese Maschinen haben, können wir hierfür keinerlei Administrator-Aufgaben übernehmen oder sonstige Hilfeleistung anbieten. Es liegt daher in Ihrer Verantwortung, das Softwaremanagement und die tägliche Sicherheit zu gewährleisten.
 >
-> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovh.com/en/) wenden, um sich mit anderen Benutzern auszutauschen.
+> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](/links/partner) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovh.com/en/) wenden, um sich mit anderen Benutzern auszutauschen.
 >
 
 ## Voraussetzungen
 
-- Sie verfügen über einen [OVHcloud VPS](https://www.ovhcloud.com/de/vps/).
+- Sie verfügen über einen [OVHcloud VPS](/links/bare-metal/vps).
 - Sie haben administrativen Zugriff (sudo) auf Ihren VPS über SSH oder RDP (Windows).
 - Sie verfügen über grundlegende Netzwerkkenntnisse.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager) / die [OVHcloud API](https://api.ovh.com/).

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-asia.md
@@ -19,10 +19,10 @@ IPv6 is the latest version of the *Internet Protocol*. Each OVHcloud VPS server 
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/asia/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (sudo) via SSH or remote desktop (Windows) to your server
 - A basic understanding of networking
-- Access to the [OVHcloud Control Panel](/links/manager) / to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud Control Panel](/links/manager) / to the [OVHcloud API](/links/api)
 
 ## Instructions
 
@@ -58,7 +58,7 @@ The IPv6 address and the IPv6 gateway assigned to your server will appear in the
 
 #### Via the OVHcloud API <a name="viaapi"></a>
 
-On the [OVHcloud API page](https://ca.api.ovh.com/) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
+On the [OVHcloud API page](/links/api) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
 
 Use this call to retrieve the IPv6 address assigned to your server:
 

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-au.md
@@ -19,10 +19,10 @@ IPv6 is the latest version of the *Internet Protocol*. Each OVHcloud VPS server 
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-au/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (sudo) via SSH or remote desktop (Windows) to your server
 - A basic understanding of networking
-- Access to the [OVHcloud Control Panel](/links/manager) / to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud Control Panel](/links/manager) / to the [OVHcloud API](/links/api)
 
 ## Instructions
 
@@ -58,7 +58,7 @@ The IPv6 address and the IPv6 gateway assigned to your server will appear in the
 
 #### Via the OVHcloud API <a name="viaapi"></a>
 
-On the [OVHcloud API page](https://ca.api.ovh.com/) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
+On the [OVHcloud API page](/links/api) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
 
 Use this call to retrieve the IPv6 address assigned to your server:
 

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-ca.md
@@ -19,10 +19,10 @@ IPv6 is the latest version of the *Internet Protocol*. Each OVHcloud VPS server 
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-ca/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (sudo) via SSH or remote desktop (Windows) to your server
 - A basic understanding of networking
-- Access to the [OVHcloud Control Panel](/links/manager) / to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud Control Panel](/links/manager) / to the [OVHcloud API](/links/api)
 
 ## Instructions
 
@@ -58,7 +58,7 @@ The IPv6 address and the IPv6 gateway assigned to your server will appear in the
 
 #### Via the OVHcloud API <a name="viaapi"></a>
 
-On the [OVHcloud API page](https://ca.api.ovh.com/) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
+On the [OVHcloud API page](/links/api) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
 
 Use this call to retrieve the IPv6 address assigned to your server:
 

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-gb.md
@@ -19,7 +19,7 @@ IPv6 is the latest version of the *Internet Protocol*. Each OVHcloud VPS server 
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-gb/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (sudo) via SSH or remote desktop (Windows) to your server
 - A basic understanding of networking
 - Access to the [OVHcloud Control Panel](/links/manager) / to the [OVHcloud API](https://api.ovh.com/)

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-ie.md
@@ -19,7 +19,7 @@ IPv6 is the latest version of the *Internet Protocol*. Each OVHcloud VPS server 
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-ie/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (sudo) via SSH or remote desktop (Windows) to your server
 - A basic understanding of networking
 - Access to the [OVHcloud Control Panel](/links/manager) / to the [OVHcloud API](https://api.ovh.com/)

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-sg.md
@@ -19,10 +19,10 @@ IPv6 is the latest version of the *Internet Protocol*. Each OVHcloud VPS server 
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-sg/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (sudo) via SSH or remote desktop (Windows) to your server
 - A basic understanding of networking
-- Access to the [OVHcloud Control Panel](/links/manager) / to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud Control Panel](/links/manager) / to the [OVHcloud API](/links/api)
 
 ## Instructions
 
@@ -58,7 +58,7 @@ The IPv6 address and the IPv6 gateway assigned to your server will appear in the
 
 #### Via the OVHcloud API <a name="viaapi"></a>
 
-On the [OVHcloud API page](https://ca.api.ovh.com/) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
+On the [OVHcloud API page](/links/api) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
 
 Use this call to retrieve the IPv6 address assigned to your server:
 

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.en-us.md
@@ -19,10 +19,10 @@ IPv6 is the latest version of the *Internet Protocol*. Each OVHcloud VPS server 
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (sudo) via SSH or remote desktop (Windows) to your server
 - A basic understanding of networking
-- Access to the [OVHcloud Control Panel](/links/manager) / to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud Control Panel](/links/manager) / to the [OVHcloud API](/links/api)
 
 ## Instructions
 
@@ -58,7 +58,7 @@ The IPv6 address and the IPv6 gateway assigned to your server will appear in the
 
 #### Via the OVHcloud API <a name="viaapi"></a>
 
-On the [OVHcloud API page](https://ca.api.ovh.com/) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
+On the [OVHcloud API page](/links/api) click on `Login`{.action} in the top-right corner. On the following page, enter the credentials of your OVHcloud account.
 
 Use this call to retrieve the IPv6 address assigned to your server:
 

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.es-es.md
@@ -21,7 +21,7 @@ El protocolo de internet versión 6 (IPv6) es la última versión del protocolo 
 
 ## Requisitos
 
-- Tener un [VPS de OVHcloud](https://www.ovhcloud.com/es-es/vps/){.external}.
+- Tener un [VPS de OVHcloud](/links/bare-metal/vps){.external}.
 - Estar conectado al VPS por SSH (acceso root) o a través de un escritorio remoto (Windows).
 - Tener conocimientos básicos de redes.
 - Estar conectado al [área de cliente de OVHcloud](/links/manager){.external} o a la [API de OVHcloud](https://api.ovh.com/).

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.es-us.md
@@ -21,7 +21,7 @@ El protocolo de internet versión 6 (IPv6) es la última versión del protocolo 
 
 ## Requisitos
 
-- Tener un [VPS de OVHcloud](https://www.ovhcloud.com/es/vps/){.external}.
+- Tener un [VPS de OVHcloud](/links/bare-metal/vps){.external}.
 - Estar conectado al VPS por SSH (acceso root) o a través de un escritorio remoto (Windows).
 - Tener conocimientos básicos de redes.
 - Estar conectado al [área de cliente de OVHcloud](/links/manager){.external} o a la [API de OVHcloud](https://api.ovh.com/).

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.fr-ca.md
@@ -12,15 +12,15 @@ L'IPv6 est la dernière version de l'*Internet Protocol* (IP). Chaque serveur VP
 
 > [!warning]
 >
-> OVHcloud met à votre disposition des machines dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien. Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
+> OVHcloud met à votre disposition des machines dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien. Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
 > 
 
 ## Prérequis
 
-- Disposer d'un [serveur VPS OVHcloud](https://www.ovhcloud.com/fr-ca/vps/){.external}.
+- Disposer d'un [serveur VPS OVHcloud](/links/bare-metal/vps){.external}.
 - Être connecté à votre VPS en SSH (accès root) ou via un bureau à distance (Windows).
 - Disposer de connaissances basiques en réseau.
-- Être connecté à l'[espace client OVHcloud](/links/manager){.external} ou à l'[API OVHcloud](https://ca.api.ovh.com/).
+- Être connecté à l'[espace client OVHcloud](/links/manager){.external} ou à l'[API OVHcloud](/links/api).
 
 ## En pratique
 
@@ -58,7 +58,7 @@ L'adresse IPv6 et la gateway IPv6 assignées à votre serveur apparaissent dans 
 
 #### Via les API OVHcloud <a name="viaapi"></a>
 
-Rendez-vous sur le site <https://ca.api.ovh.com/> et connectez-vous à ce dernier avec votre identifiant OVHcloud. Utilisez ensuite les deux API ci-dessous.
+Rendez-vous sur le site </links/api> et connectez-vous à ce dernier avec votre identifiant OVHcloud. Utilisez ensuite les deux API ci-dessous.
 
 La première vous permet de récupérer l'adresse IPv6 assignée à votre serveur.
 

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.fr-fr.md
@@ -12,12 +12,12 @@ L'IPv6 est la dernière version de l'*Internet Protocol* (IP). Chaque serveur VP
 
 > [!warning]
 >
-> OVHcloud met à votre disposition des machines dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien. Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
+> OVHcloud met à votre disposition des machines dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien. Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
 > 
 
 ## Prérequis
 
-- Disposer d'un [serveur VPS OVHcloud](https://www.ovhcloud.com/fr/vps/){.external}.
+- Disposer d'un [serveur VPS OVHcloud](/links/bare-metal/vps){.external}.
 - Être connecté à votre VPS en SSH (accès root) ou via un bureau à distance (Windows).
 - Disposer de connaissances basiques en réseau.
 - Être connecté à l'[espace client OVHcloud](/links/manager){.external} ou à l'[API OVHcloud](https://api.ovh.com/).

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.it-it.md
@@ -21,7 +21,7 @@ L’IPv6 è la versione più recente dell’*Internet Protocol*(IP). Ogni server
 
 ## Prerequisiti
 
-- Disporre di un [server VPS OVHcloud](https://www.ovhcloud.com/it/vps/){.external}
+- Disporre di un [server VPS OVHcloud](/links/bare-metal/vps){.external}
 - Essere connesso al tuo VPS in SSH (accesso root) o tramite desktop remoto (Windows)
 - Possedere conoscenze base di rete
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external} o all'[API OVHcloud](https://api.ovh.com/)

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.pl-pl.md
@@ -21,7 +21,7 @@ IPv6 to najnowsza wersja *Internet Protocol* (IP). Każdy serwer VPS OVHcloud je
 
 ## Wymagania początkowe
 
-- Posiadanie [serwera VPS OVHcloud](https://www.ovhcloud.com/pl/vps/){.external}.
+- Posiadanie [serwera VPS OVHcloud](/links/bare-metal/vps){.external}.
 - Połączenie z serwerem VPS przez SSH (dostęp root) lub przez zdalny pulpit (Windows).
 - Posiadanie podstawowej wiedzy w zakresie sieci.
 - Dostęp do [Panelu klienta OVHcloud](/links/manager){.external} lub [API OVHcloud](https://api.ovh.com/).

--- a/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configure-ipv6/guide.pt-pt.md
@@ -21,7 +21,7 @@ O IPv6 é a versão mais recente do *Internet Protocol* (IP). Cada servidor VPS 
 
 ## Requisitos
 
-- Dispor de um [servidor VPS da OVHcloud](https://www.ovhcloud.com/pt/vps/){.external}.
+- Dispor de um [servidor VPS da OVHcloud](/links/bare-metal/vps){.external}.
 - Ter acesso ao VPS através de SSH (acesso root) ou de um ambiente de trabalho remoto (Windows).
 - Ter conhecimentos básciso de rede.
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager){.external} ou à [API OVHcloud](https://api.ovh.com/).

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.de-de.md
@@ -18,13 +18,13 @@ Bei *IP Aliasing* handelt es sich um eine spezielle Netzwerkkonfiguration für b
 > [!warning]
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für die Sie die alleinige Verantwortung tragen. Da wir keinen Zugriff auf diese Dienste haben, können wir hierfür keinerlei Administrator-Aufgaben übernehmen oder sonstige Hilfeleistung anbieten. Es liegt daher in Ihrer Verantwortung, das Softwaremanagement und die tägliche Sicherheit zu gewährleisten.
 >
-> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovh.com/en/) wenden, um sich mit anderen Benutzern auszutauschen.
+> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](/links/partner) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovh.com/en/) wenden, um sich mit anderen Benutzern auszutauschen.
 >
 
 ## Voraussetzungen
 
-- Sie haben einen [VPS](https://www.ovhcloud.com/de/vps/) in Ihrem OVHcloud Account.
-- Sie verfügen über eine [Additional IP](https://www.ovhcloud.com/de/bare-metal/ip/)-Adresse.
+- Sie haben einen [VPS](/links/bare-metal/vps) in Ihrem OVHcloud Account.
+- Sie verfügen über eine [Additional IP](/links/bare-metal/ip)-Adresse.
 - Sie haben administrativen Zugriff (sudo) auf Ihren VPS über SSH oder GUI. 
 - Sie haben Grundkenntnisse in Administration und Netzwerkkonfiguration.
 
@@ -479,6 +479,6 @@ Um die Verbindung zu testen senden Sie einfach von außerhalb einen Ping an Ihre
 
 [VPS Rescue-Modus aktivieren](/pages/bare_metal_cloud/virtual_private_servers/rescue).
 
-Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](https://www.ovhcloud.com/de/support-levels/).
+Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](/links/support).
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-asia.md
@@ -18,13 +18,13 @@ IP aliasing refers to a special network configuration for certain OVHcloud servi
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/asia/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/asia/vps/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/asia/bare-metal/ip/)
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip)
 - Administrative access (sudo) via SSH or GUI to your server
 - Basic networking and administration knowledge
 
@@ -489,6 +489,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Activating Rescue Mode on VPS](/pages/bare_metal_cloud/virtual_private_servers/rescue)
 
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/asia/support-levels/).
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-au.md
@@ -18,13 +18,13 @@ IP aliasing refers to a special network configuration for certain OVHcloud servi
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-au/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-au/vps/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/en-au/bare-metal/ip/)
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip)
 - Administrative access (sudo) via SSH or GUI to your server
 - Basic networking and administration knowledge
 
@@ -488,6 +488,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Activating Rescue Mode on VPS](/pages/bare_metal_cloud/virtual_private_servers/rescue)
 
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-au/support-levels/).
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-ca.md
@@ -18,13 +18,13 @@ IP aliasing refers to a special network configuration for certain OVHcloud servi
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-ca/vps/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/en-ca/bare-metal/ip/)
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip)
 - Administrative access (sudo) via SSH or GUI to your server
 - Basic networking and administration knowledge
 
@@ -488,6 +488,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Activating Rescue Mode on VPS](/pages/bare_metal_cloud/virtual_private_servers/rescue)
 
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-ca/support-levels/).
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-gb.md
@@ -18,13 +18,13 @@ IP aliasing refers to a special network configuration for certain OVHcloud servi
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-gb/vps/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/en-gb/bare-metal/ip/)
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip)
 - Administrative access (sudo) via SSH or GUI to your server
 - Basic networking and administration knowledge
 
@@ -488,6 +488,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Activating Rescue Mode on VPS](/pages/bare_metal_cloud/virtual_private_servers/rescue)
 
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-gb/support-levels/).
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-ie.md
@@ -18,13 +18,13 @@ IP aliasing refers to a special network configuration for certain OVHcloud servi
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-ie/vps/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/en-ie/bare-metal/ip/)
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip)
 - Administrative access (sudo) via SSH or GUI to your server
 - Basic networking and administration knowledge
 
@@ -488,6 +488,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Activating Rescue Mode on VPS](/pages/bare_metal_cloud/virtual_private_servers/rescue)
 
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en-ie/support-levels/).
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-sg.md
@@ -18,13 +18,13 @@ IP aliasing refers to a special network configuration for certain OVHcloud servi
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-sg/vps/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/en-sg/bare-metal/ip/)
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip)
 - Administrative access (sudo) via SSH or GUI to your server
 - Basic networking and administration knowledge
 
@@ -488,6 +488,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Activating Rescue Mode on VPS](/pages/bare_metal_cloud/virtual_private_servers/rescue)
 
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en/support-levels/).
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.en-us.md
@@ -18,13 +18,13 @@ IP aliasing refers to a special network configuration for certain OVHcloud servi
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on https://community.ovh.com/en/ if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en/vps/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/en/bare-metal/ip/)
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip)
 - Administrative access (sudo) via SSH or GUI to your server
 - Basic networking and administration knowledge
 
@@ -488,6 +488,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Activating Rescue Mode on VPS](/pages/bare_metal_cloud/virtual_private_servers/rescue)
 
-If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](https://www.ovhcloud.com/en/support-levels/).
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.es-es.md
@@ -19,13 +19,13 @@ El alias de IP (*IP aliasing* en inglés) es una configuración especial de red 
 >
 > OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. No tenemos acceso a estas máquinas, por lo que no somos los administradores de las mismas y no podremos asistirle. Por lo tanto, usted es responsable de la gestión del software y de la seguridad diaria.
 >
-> Esta guía le ayudará a realizar las tareas más habituales. No obstante, le recomendamos que, si tiene problemas o dudas sobre la administración, la utilización o la seguridad de un servidor, contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/). Para más información, consulte el apartado "Más información" de esta guía.
+> Esta guía le ayudará a realizar las tareas más habituales. No obstante, le recomendamos que, si tiene problemas o dudas sobre la administración, la utilización o la seguridad de un servidor, contacte con un [proveedor especializado](/links/partner). Para más información, consulte el apartado "Más información" de esta guía.
 >
 
 ## Requisitos
 
-- Tener un [VPS](https://www.ovhcloud.com/es-es/vps/) en su cuenta OVHcloud
-- Tener una [dirección Additional IP](https://www.ovhcloud.com/es-es/bare-metal/ip/)
+- Tener un [VPS](/links/bare-metal/vps) en su cuenta OVHcloud
+- Tener una [dirección Additional IP](/links/bare-metal/ip)
 - Tener acceso de administrador (sudo) a través de SSH o GUI en su servidor
 - Tener conocimientos básicos de redes y administración
 
@@ -486,6 +486,6 @@ Para probar la conexión, solo tiene que enviar un ping a su dirección Addition
 
 [Activar el modo de rescate en un VPS](/pages/bare_metal_cloud/virtual_private_servers/rescue)
 
-Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es-es/support-levels/).
+Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](/links/support).
  
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.es-us.md
@@ -19,13 +19,13 @@ El alias de IP (*IP aliasing* en inglés) es una configuración especial de red 
 >
 > OVHcloud pone a su disposición servicios cuya configuración, gestión y responsabilidad recaen sobre usted. No tenemos acceso a estas máquinas, por lo que no somos los administradores de las mismas y no podremos asistirle. Por lo tanto, usted es responsable de la gestión del software y de la seguridad diaria.
 >
-> Esta guía le ayudará a realizar las tareas más habituales. No obstante, le recomendamos que, si tiene problemas o dudas sobre la administración, la utilización o la seguridad de un servidor, contacte con un [proveedor especializado](https://partner.ovhcloud.com/es/directory/). Para más información, consulte el apartado "Más información" de esta guía.
+> Esta guía le ayudará a realizar las tareas más habituales. No obstante, le recomendamos que, si tiene problemas o dudas sobre la administración, la utilización o la seguridad de un servidor, contacte con un [proveedor especializado](/links/partner). Para más información, consulte el apartado "Más información" de esta guía.
 >
 
 ## Requisitos
 
-- Tener un [VPS](https://www.ovhcloud.com/es/vps/) en su cuenta OVHcloud
-- Tener una [dirección Additional IP](https://www.ovhcloud.com/es/bare-metal/ip/)
+- Tener un [VPS](/links/bare-metal/vps) en su cuenta OVHcloud
+- Tener una [dirección Additional IP](/links/bare-metal/ip)
 - Tener acceso de administrador (sudo) a través de SSH o GUI en su servidor
 - Tener conocimientos básicos de redes y administración
 
@@ -486,6 +486,6 @@ Para probar la conexión, solo tiene que enviar un ping a su dirección Addition
 
 [Activar el modo de rescate en un VPS](/pages/bare_metal_cloud/virtual_private_servers/rescue)
 
-Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](https://www.ovhcloud.com/es/support-levels/).
+Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](/links/support).
  
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.fr-ca.md
@@ -24,8 +24,8 @@ L'alias d'IP (*IP aliasing* en anglais) est une configuration spéciale du rése
 
 ## Prérequis
 
-- Disposer d'une offre [VPS](https://www.ovhcloud.com/fr-ca/vps/) dans votre compte OVHcloud
-- Disposer d'une [adresse Additional IP](https://www.ovhcloud.com/fr-ca/bare-metal/ip/)
+- Disposer d'une offre [VPS](/links/bare-metal/vps) dans votre compte OVHcloud
+- Disposer d'une [adresse Additional IP](/links/bare-metal/ip)
 - Avoir un accès administrateur (sudo) via SSH ou GUI sur votre serveur
 - Avoir les connaissances de base sur les réseaux et leur administration
 
@@ -483,6 +483,6 @@ Pour tester la connexion, envoyez un ping à votre adresse Additional IP depuis 
 
 [Activer le mode rescue sur un VPS](/pages/bare_metal_cloud/virtual_private_servers/rescue)
 
-Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr-ca/support-levels/).
+Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).
  
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.fr-fr.md
@@ -24,8 +24,8 @@ L'alias d'IP (*IP aliasing* en anglais) est une configuration spéciale du rése
 
 ## Prérequis
 
-- Disposer d'une offre [VPS](https://www.ovhcloud.com/fr/vps/) dans votre compte OVHcloud
-- Disposer d'une [adresse Additional IP](https://www.ovhcloud.com/fr/bare-metal/ip/)
+- Disposer d'une offre [VPS](/links/bare-metal/vps) dans votre compte OVHcloud
+- Disposer d'une [adresse Additional IP](/links/bare-metal/ip)
 - Avoir un accès administrateur (sudo) via SSH ou GUI sur votre serveur
 - Avoir les connaissances de base sur les réseaux et leur administration
 
@@ -485,6 +485,6 @@ Pour tester la connexion, envoyez un ping à votre adresse Additional IP depuis 
 
 [OVHcloud Marketplace](https://marketplace.ovhcloud.com/)
 
-Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](https://www.ovhcloud.com/fr/support-levels/).
+Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.it-it.md
@@ -19,13 +19,13 @@ L'alias IP (*IP aliasing* in inglese) è una configurazione di rete speciale per
 >
 > OVHcloud mette a tua disposizione servizi di cui sei responsabile. ma non è autorizzata ad accedervi e non si occupa quindi della loro amministrazione. Garantire quotidianamente la gestione software e la sicurezza di queste macchine è quindi responsabilità dell’utente.
 >
-> Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi relativamente ad amministrazione e sicurezza, ti consigliamo di contattare un [provider specializzato](https://partner.ovhcloud.com/it/directory/). Per maggiori informazioni consulta la sezione "Per saperne di più".
+> Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi relativamente ad amministrazione e sicurezza, ti consigliamo di contattare un [provider specializzato](/links/partner). Per maggiori informazioni consulta la sezione "Per saperne di più".
 >
 
 ## Prerequisiti
 
-- Disporre di una soluzione [VPS](https://www.ovhcloud.com/it/vps/) nel tuo account OVHcloud
-- Disporre di un [indirizzo Additional IP](https://www.ovhcloud.com/it/bare-metal/ip/)
+- Disporre di una soluzione [VPS](/links/bare-metal/vps) nel tuo account OVHcloud
+- Disporre di un [indirizzo Additional IP](/links/bare-metal/ip)
 - Avere un accesso amministrator (sudo) via SSH o GUI sul tuo server
 - Possedere conoscenze di base sulle reti e la loro amministrazione
 
@@ -483,6 +483,6 @@ Per testare la connessione, ti basta inviare un ping al tuo indirizzo Additional
 
 [Attiva la modalità Rescue su un VPS](/pages/bare_metal_cloud/virtual_private_servers/rescue)
 
-Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre soluzioni [offerte di supporto](https://www.ovhcloud.com/it/support-levels/).
+Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre soluzioni [offerte di supporto](/links/support).
  
 Contatta la nostra Community di utenti all'indirizzo <https://community.ovh.com/en/>.

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.pl-pl.md
@@ -19,13 +19,13 @@ Alias IP (*IP aliasing* w języku angielskim) to specjalna konfiguracja sieci dl
 >
 > OVHcloud oddaje do Twojej dyspozycji usługi, za które przejmujesz odpowiedzialność. Firma OVHcloud nie ma dostępu do Twoich serwerów, nie pełni funkcji administratora i w związku z tym nie będzie mogła udzielić Ci wsparcia. Zarządzanie oprogramowaniem i wdrażanie środków bezpieczeństwa należy do klienta.
 >
-> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Jeśli jednak napotkasz jakiekolwiek trudności lub wątpliwości związane z administrowaniem, użytkowaniem lub dbaniem o bezpieczeństwo serwera, zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/). Więcej informacji znajduje się w sekcji "Sprawdź również".
+> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Jeśli jednak napotkasz jakiekolwiek trudności lub wątpliwości związane z administrowaniem, użytkowaniem lub dbaniem o bezpieczeństwo serwera, zalecamy skontaktowanie się z [wyspecjalizowanym dostawcą](/links/partner). Więcej informacji znajduje się w sekcji "Sprawdź również".
 >
 
 ## Wymagania początkowe
 
-- Posiadanie usługi [VPS](https://www.ovhcloud.com/pl/vps/) na koncie OVHcloud
-- Posiadanie adresu [Additional IP](https://www.ovhcloud.com/pl/bare-metal/ip/)
+- Posiadanie usługi [VPS](/links/bare-metal/vps) na koncie OVHcloud
+- Posiadanie adresu [Additional IP](/links/bare-metal/ip)
 - Dostęp administratora (sudo) przez SSH lub GUI do serwera
 - Posiadanie podstawowej wiedzy na temat sieci i zarządzania nimi
 
@@ -485,6 +485,6 @@ Aby przetestować połączenie, wystarczy wysłać ping na adres Additional IP z
 
 [Włącz tryb Rescue na serwerze VPS](/pages/bare_metal_cloud/virtual_private_servers/rescue)
 
-Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](https://www.ovhcloud.com/pl/support-levels/).
+Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](/links/support).
 
 Przyłącz się do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/configuring-ip-aliasing/guide.pt-pt.md
@@ -19,13 +19,13 @@ O alias de IP (*IP aliasing* em inglês) é uma configuração especial da rede 
 >
 > A OVHcloud oferece-lhe serviços que são da sua responsabilidade. Uma vez que não temos acesso a estas máquinas, não podemos administrá-las nem fornecer-lhe assistência. O cliente é o único responsável pela gestão e pela segurança do serviço.
 >
-> Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou tiver dúvidas relativamente à administração, à utilização ou à segurança de um servidor, deverá contactar um [fornecedor especializado](https://partner.ovhcloud.com/pt/directory/). Para mais informações, aceda à secção deste manual intitulada: “Quer saber mais?”.
+> Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou tiver dúvidas relativamente à administração, à utilização ou à segurança de um servidor, deverá contactar um [fornecedor especializado](/links/partner). Para mais informações, aceda à secção deste manual intitulada: “Quer saber mais?”.
 >
 
 ## Requisitos
 
-- Ter uma oferta [VPS](https://www.ovhcloud.com/pt/vps/) na sua conta OVHcloud
-- Dispor de um [endereço Additional IP](https://www.ovhcloud.com/pt/bare-metal/ip/)
+- Ter uma oferta [VPS](/links/bare-metal/vps) na sua conta OVHcloud
+- Dispor de um [endereço Additional IP](/links/bare-metal/ip)
 - Ter um acesso administrador (sudo) via SSH ou GUI no seu servidor
 - Ter conhecimentos básicos sobre as redes e a sua administração
 
@@ -471,6 +471,6 @@ Para testar a ligação, basta enviar um ping ao seu endereço Additional IP a p
 
 [Ativar o modo rescue num VPS](/pages/bare_metal_cloud/virtual_private_servers/rescue).
 
-Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](https://www.ovhcloud.com/pt/support-levels/).
+Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
 
 Junte-se à nossa comunidade de utilizadores em <https://community.ovh.com/en/>.

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.de-de.md
@@ -24,7 +24,7 @@ Dank einer grafischen Oberfläche, die die Automatisierung von Einstellungen erl
 
 ## Voraussetzungen
 
-- Sie haben einen [VPS](https://www.ovhcloud.com/de/vps/) mit einer [kompatiblen Distribution](https://www.ovhcloud.com/de/vps/os/).
+- Sie haben einen [VPS](/links/bare-metal/vps) mit einer [kompatiblen Distribution](https://www.ovhcloud.com/de/vps/os/).
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 ## In der praktischen Anwendung

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.es-es.md
@@ -26,7 +26,7 @@ Gracias a una interfaz gráfica que permite automatizar los parámetros, el aloj
 
 ## Requisitos
 
-- Tener contratado un servicio [VPS reciente](https://www.ovhcloud.com/es-es/vps/){.external} con un [OS compatible con cPanel](https://www.ovhcloud.com/es-es/vps/os/).
+- Tener contratado un servicio [VPS reciente](/links/bare-metal/vps){.external} con un [OS compatible con cPanel](https://www.ovhcloud.com/es-es/vps/os/).
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.es-us.md
@@ -26,7 +26,7 @@ Gracias a una interfaz gráfica que permite automatizar los parámetros, el aloj
 
 ## Requisitos
 
-- Tener contratado un servicio [VPS reciente](https://www.ovhcloud.com/es/vps/){.external} con un [OS compatible con cPanel](https://www.ovhcloud.com/es/vps/os/).
+- Tener contratado un servicio [VPS reciente](/links/bare-metal/vps){.external} con un [OS compatible con cPanel](https://www.ovhcloud.com/es/vps/os/).
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.fr-ca.md
@@ -20,7 +20,7 @@ Grâce à une interface graphique permettant l'automatisation des paramètres, l
 
 ## Prérequis
 
-- Disposer d'une offre [VPS](https://www.ovhcloud.com/fr-ca/vps/){.external} avec une distribution [compatible](https://www.ovhcloud.com/fr-ca/vps/os/).
+- Disposer d'une offre [VPS](/links/bare-metal/vps){.external} avec une distribution [compatible](https://www.ovhcloud.com/fr-ca/vps/os/).
 - Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.fr-fr.md
@@ -20,7 +20,7 @@ Grâce à une interface graphique permettant l'automatisation des paramètres, l
 
 ## Prérequis
 
-- Disposer d'une offre [VPS](https://www.ovhcloud.com/fr/vps/){.external} avec une distribution [compatible](https://www.ovhcloud.com/fr/vps/os/).
+- Disposer d'une offre [VPS](/links/bare-metal/vps){.external} avec une distribution [compatible](https://www.ovhcloud.com/fr/vps/os/).
 - Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.it-it.md
@@ -26,7 +26,7 @@ Grazie a unâ€™interfaccia grafica che permette di automatizzare i parametri, lâ€
 
 ## Prerequisiti
 
-- Disporre di una soluzione [VPS recente](https://www.ovhcloud.com/it/vps/){.external} con un [OS compatibile con cPanel](https://www.ovhcloud.com/it/vps/os/).
+- Disporre di una soluzione [VPS recente](/links/bare-metal/vps){.external} con un [OS compatibile con cPanel](https://www.ovhcloud.com/it/vps/os/).
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager).
 
 ## Procedura

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.pl-pl.md
@@ -24,7 +24,7 @@ Dzięki interfejsowi graficznemu umożliwiającemu automatyzację parametrów, h
 
 ## Wymagania początkowe
 
-- Wykupienie usługi [VPS](https://www.ovhcloud.com/pl/vps/){.external} z dystrybucją [kompatybilną](https://www.ovhcloud.com/pl/vps/os/).
+- Wykupienie usługi [VPS](/links/bare-metal/vps){.external} z dystrybucją [kompatybilną](https://www.ovhcloud.com/pl/vps/os/).
 - zalogowanie do [Panelu client OVHcloud](/links/manager).
 
 ## W praktyce

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel/guide.pt-pt.md
@@ -24,7 +24,7 @@ Graças a uma interface gráfica que permite a automatização dos parâmetros, 
 
 ## Requisitos
 
-- Ter uma oferta [VPS recente](https://www.ovhcloud.com/pt/vps/){.external} com uma distribuição [compatível com cPanel](https://www.ovhcloud.com/pt/vps/os/).
+- Ter uma oferta [VPS recente](/links/bare-metal/vps){.external} com uma distribuição [compatível com cPanel](https://www.ovhcloud.com/pt/vps/os/).
 - Estar ligado à [Área de Cliente OVHcloud](/links/manager).
 
 ## Instruções

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.de-de.md
@@ -22,7 +22,7 @@ Wenn Sie jedoch den Jailed Shell Zugang aktiviert haben, erstellt cPanel ein *vi
 
 ## Voraussetzungen
 
-- Sie haben einen [VPS](https://www.ovhcloud.com/de/vps/) mit einer [kompatiblen Distribution](https://www.ovhcloud.com/de/vps/os/).
+- Sie haben einen [VPS](/links/bare-metal/vps) mit einer [kompatiblen Distribution](https://www.ovhcloud.com/de/vps/os/).
 - cPanel ist auf dem Server installiert.
 
 ## In der praktischen Anwendung

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.es-es.md
@@ -22,7 +22,7 @@ Al crear una copia de seguridad de su VPS (en caso de suscribirse a las copias d
 
 ## Requisitos
 
-- Tener contratado un servicio [VPS reciente](https://www.ovhcloud.com/es-es/vps/){.external} con un [OS compatible con cPanel](https://www.ovhcloud.com/es-es/vps/os/).
+- Tener contratado un servicio [VPS reciente](/links/bare-metal/vps){.external} con un [OS compatible con cPanel](https://www.ovhcloud.com/es-es/vps/os/).
 - cPanel debe estar instalado en su servidor
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.es-us.md
@@ -22,7 +22,7 @@ Al crear una copia de seguridad de su VPS (en caso de suscribirse a las copias d
 
 ## Requisitos
 
-- Tener contratado un servicio [VPS reciente](https://www.ovhcloud.com/es/vps/){.external} con un [OS compatible con cPanel](https://www.ovhcloud.com/es/vps/os/).
+- Tener contratado un servicio [VPS reciente](/links/bare-metal/vps){.external} con un [OS compatible con cPanel](https://www.ovhcloud.com/es/vps/os/).
 - cPanel debe estar instalado en su servidor
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.fr-ca.md
@@ -18,7 +18,7 @@ Lors de la création d'une sauvegarde de votre VPS (dans le cas d'une souscripti
 
 ## Prérequis
 
-- Disposer d'un [VPS](https://www.ovhcloud.com/fr-ca/vps/) avec une distribution [compatible](https://www.ovhcloud.com/fr-ca/vps/os/)
+- Disposer d'un [VPS](/links/bare-metal/vps) avec une distribution [compatible](https://www.ovhcloud.com/fr-ca/vps/os/)
 - cPanel doit être installé sur votre serveur
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.fr-fr.md
@@ -18,7 +18,7 @@ Lors de la création d'une sauvegarde de votre VPS (dans le cas d'une souscripti
 
 ## Prérequis
 
-- Disposer d'un [VPS](https://www.ovhcloud.com/fr/vps/) avec une distribution [compatible](https://www.ovhcloud.com/fr/vps/os/)
+- Disposer d'un [VPS](/links/bare-metal/vps) avec une distribution [compatible](https://www.ovhcloud.com/fr/vps/os/)
 - cPanel doit être installé sur votre serveur
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.it-it.md
@@ -22,7 +22,7 @@ Quando crei un backup del tuo VPS (nel caso di una sottoscrizione di backup auto
 
 ## Prerequisiti
 
-- Disporre di una soluzione [VPS recente](https://www.ovhcloud.com/it/vps/){.external} con un [OS compatibile con cPanel](https://www.ovhcloud.com/it/vps/os/).
+- Disporre di una soluzione [VPS recente](/links/bare-metal/vps){.external} con un [OS compatibile con cPanel](https://www.ovhcloud.com/it/vps/os/).
 - cPanel deve essere installato sul tuo server
 
 ## Procedura

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.pl-pl.md
@@ -22,7 +22,7 @@ Podczas tworzenia kopii zapasowej Twojego serwera VPS (w przypadku zamówienia a
 
 ## Wymagania początkowe
 
-- Wykupienie usługi [VPS](https://www.ovhcloud.com/pl/vps/){.external} z dystrybucją [kompatybilną](https://www.ovhcloud.com/pl/vps/os/).
+- Wykupienie usługi [VPS](/links/bare-metal/vps){.external} z dystrybucją [kompatybilną](https://www.ovhcloud.com/pl/vps/os/).
 - cPanel musi być zainstalowany na serwerze
 
 ## W praktyce

--- a/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/cpanel_snapshot/guide.pt-pt.md
@@ -22,7 +22,7 @@ Ao criar um backup do seu VPS (no caso de subscrição dos backups automáticos 
 
 ## Requisitos
 
-- Ter uma oferta [VPS recente](https://www.ovhcloud.com/pt/vps/){.external} com uma distribuição [compatível com cPanel](https://www.ovhcloud.com/pt/vps/os/).
+- Ter uma oferta [VPS recente](/links/bare-metal/vps){.external} com uma distribuição [compatível com cPanel](https://www.ovhcloud.com/pt/vps/os/).
 - cPanel deve ser instalado no seu servidor
 
 ## Instruções

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.de-de.md
@@ -14,12 +14,12 @@ Firewalls implementieren Regeln, die erlaubten und gesperrten Traffic verwalten.
 > [!warning]
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für die Sie die alleinige Verantwortung tragen. Da wir keinen Zugriff auf diese Dienste haben, können wir hierfür keinerlei Administrator-Aufgaben übernehmen oder sonstige Hilfeleistung anbieten. Es liegt daher in Ihrer Verantwortung, das Softwaremanagement und die tägliche Sicherheit zu gewährleisten.
 >
-> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovh.com/en/) wenden, um sich mit anderen Benutzern auszutauschen.
+> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](/links/partner) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Servers haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovh.com/en/) wenden, um sich mit anderen Benutzern auszutauschen.
 >
 
 ## Voraussetzungen
 
-- Sie haben einen [VPS](https://www.ovhcloud.com/de/vps/) in Ihrem OVHcloud Kunden-Account.
+- Sie haben einen [VPS](/links/bare-metal/vps) in Ihrem OVHcloud Kunden-Account.
 - Sie haben administrativen Zugriff (root/sudo) über SSH auf Ihren Server. 
 
 ## In der praktischen Anwendung

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-asia.md
@@ -14,12 +14,12 @@ Firewalls work by defining rules that govern both authorised and blocked traffic
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/asia/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/asia/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (root/sudo) to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-au.md
@@ -14,12 +14,12 @@ Firewalls work by defining rules that govern both authorised and blocked traffic
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-au/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-au/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (root/sudo) to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-ca.md
@@ -14,12 +14,12 @@ Firewalls work by defining rules that govern both authorised and blocked traffic
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-ca/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (root/sudo) to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-gb.md
@@ -14,12 +14,12 @@ Firewalls work by defining rules that govern both authorised and blocked traffic
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-gb/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (root/sudo) to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-ie.md
@@ -14,12 +14,12 @@ Firewalls work by defining rules that govern both authorised and blocked traffic
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-ie/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (root/sudo) to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-sg.md
@@ -14,12 +14,12 @@ Firewalls work by defining rules that govern both authorised and blocked traffic
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en-sg/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (root/sudo) to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.en-us.md
@@ -14,12 +14,12 @@ Firewalls work by defining rules that govern both authorised and blocked traffic
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Virtual Private Server](https://www.ovhcloud.com/en/vps/) in your OVHcloud account
+- A [Virtual Private Server](/links/bare-metal/vps) in your OVHcloud account
 - Administrative access (root/sudo) to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.es-es.md
@@ -20,7 +20,7 @@ Los cortafuegos funcionan estableciendo reglas que regulan el tráfico autorizad
 
 ## Requisitos
 
-- Tener un [VPS](https://www.ovhcloud.com/es-es/vps/) en su cuenta de OVHcloud.
+- Tener un [VPS](/links/bare-metal/vps) en su cuenta de OVHcloud.
 - Tener acceso de administrador (root/sudo) a su servidor por SSH.
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.es-us.md
@@ -20,7 +20,7 @@ Los cortafuegos funcionan estableciendo reglas que regulan el tráfico autorizad
 
 ## Requisitos
 
-- Tener un [VPS](https://www.ovhcloud.com/es/vps/) en su cuenta de OVHcloud.
+- Tener un [VPS](/links/bare-metal/vps) en su cuenta de OVHcloud.
 - Tener acceso de administrador (root/sudo) a su servidor por SSH.
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.fr-ca.md
@@ -15,12 +15,12 @@ Les pare-feux fonctionnent en définissant des règles qui régissent le trafic 
 >
 > OVHcloud met à votre disposition des services dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d'assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
 >
 
 ## Prérequis
 
-- Disposer d'un [VPS](https://www.ovhcloud.com/fr-ca/vps/) dans votre compte OVHcloud
+- Disposer d'un [VPS](/links/bare-metal/vps) dans votre compte OVHcloud
 - Disposer d'un accès administrateur (root/sudo) à votre serveur via SSH
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.fr-fr.md
@@ -15,12 +15,12 @@ Les pare-feux fonctionnent en définissant des règles qui régissent le trafic 
 >
 > OVHcloud met à votre disposition des services dont la responsabilité vous revient. En effet, n’ayant aucun accès à ces machines, nous n’en sommes pas les administrateurs et ne pourrons vous fournir d'assistance. Il vous appartient de ce fait d’en assurer la gestion logicielle et la sécurisation au quotidien.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou avez des doutes concernant l’administration, l’utilisation ou la sécurisation d’un serveur. Plus d’informations dans la section « Aller plus loin » de ce guide.
 >
 
 ## Prérequis
 
-- Disposer d'un [VPS](https://www.ovhcloud.com/fr/vps/) dans votre compte OVHcloud
+- Disposer d'un [VPS](/links/bare-metal/vps) dans votre compte OVHcloud
 - Disposer d'un accès administrateur (root/sudo) à votre serveur via SSH
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.it-it.md
@@ -20,7 +20,7 @@ I firewall funzionano definendo regole che disciplinano il traffico autorizzato 
 
 ## Prerequisiti
 
-- Disporre di un [VPS](https://www.ovhcloud.com/it/vps/) nel proprio account OVHcloud
+- Disporre di un [VPS](/links/bare-metal/vps) nel proprio account OVHcloud
 - Avere accesso amministratore (root/sudo) al server via SSH
 
 ## Procedura

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.pl-pl.md
@@ -15,12 +15,12 @@ Firewall działa poprzez określenie zasad regulujących dozwolony ruch i zablok
 >
 > OVHcloud oddaje do Twojej dyspozycji usługi, za które przejmujesz odpowiedzialność. Firma OVHcloud nie ma dostępu do Twoich serwerów, nie pełni funkcji administratora i w związku z tym nie będzie mogła udzielić Ci wsparcia. Zarządzanie oprogramowaniem i wdrażanie środków bezpieczeństwa należy do klienta.
 >
-> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności lub wątpliwości związanych z administrowaniem, użytkowaniem lub zabezpieczeniem serwera rekomendujemy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](https://partner.ovhcloud.com/pl/directory/). Więcej informacji znajduje się w sekcji “Sprawdź również”.
+> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności lub wątpliwości związanych z administrowaniem, użytkowaniem lub zabezpieczeniem serwera rekomendujemy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Więcej informacji znajduje się w sekcji “Sprawdź również”.
 >
 
 ## Wymagania początkowe
 
-- Posiadanie serwera [VPS](https://www.ovhcloud.com/pl/vps/) na koncie OVHcloud
+- Posiadanie serwera [VPS](/links/bare-metal/vps) na koncie OVHcloud
 - Dostęp administratora (root/sudo) do serwera przez SSH
 
 ## W praktyce

--- a/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/firewall-Linux-iptable/guide.pt-pt.md
@@ -15,12 +15,12 @@ As firewalls funcionam definindo regras que regulem o tráfego autorizado e o qu
 >
 > A OVHcloud oferece-lhe serviços que são da sua responsabilidade. Uma vez que não temos acesso a estas máquinas, não podemos administrá-las nem fornecer-lhe assistência. O cliente é o único responsável pela gestão e pela segurança do serviço.
 >
-> Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou tiver dúvidas quanto à administração, utilização ou segurança de um servidor, recomendamos que recorra a um [prestador de serviços especializado](https://partner.ovhcloud.com/pt/directory/). Para mais informações, aceda à secção “Quer saber mais?” deste manual.
+> Este guia fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou tiver dúvidas quanto à administração, utilização ou segurança de um servidor, recomendamos que recorra a um [prestador de serviços especializado](/links/partner). Para mais informações, aceda à secção “Quer saber mais?” deste manual.
 >
 
 ## Requisitos
 
-- Dispor de um [VPS](https://www.ovhcloud.com/pt/vps/) na sua conta OVHcloud
+- Dispor de um [VPS](/links/bare-metal/vps) na sua conta OVHcloud
 - Dispor de um acesso administrador (root/sudo) ao seu servidor através de SSH
 
 ## Instruções

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.de-de.md
@@ -16,7 +16,7 @@ Wenn Sie die maximale Kapazität Ihrer zusätzlichen Disk erreicht haben, könne
 
 ## Voraussetzungen
 
-- Sie haben einen [VPS](https://www.ovhcloud.com/de/vps/) in Ihrem OVHcloud Kunden-Account.
+- Sie haben einen [VPS](/links/bare-metal/vps) in Ihrem OVHcloud Kunden-Account.
 - Sie haben eine [zusätzliche Disk konfiguriert](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk).
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 - Sie haben administrativen Zugriff auf Ihren VPS über SSH (Linux) oder RDP (Windows).
@@ -55,7 +55,7 @@ Die Erhöhung der Disk-Kapazität wird nach der Bestätigung der Zahlung einige 
 > [!warning]
 >Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Denken Sie daran, diese Aktionen nötigenfalls an Ihre Situation anzupassen.
 >
-> Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) oder stellen Sie Ihre Fragen in der [OVHcloud Community](https://community.ovh.com/en/). Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. 
+> Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](/links/partner) oder stellen Sie Ihre Fragen in der [OVHcloud Community](https://community.ovh.com/en/). Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. 
 >
 
 #### Auf einem Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-asia.md
@@ -12,7 +12,7 @@ This guide explains how to increase the size of an additional disk and extend th
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/asia/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - An [additional disk](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) configured on the VPS
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
@@ -51,7 +51,7 @@ After the payment is confirmed, the disk upgrade will take a few minutes. You ca
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/asia/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-au.md
@@ -12,7 +12,7 @@ This guide explains how to increase the size of an additional disk and extend th
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-au/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - An [additional disk](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) configured on the VPS
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
@@ -51,7 +51,7 @@ After the payment is confirmed, the disk upgrade will take a few minutes. You ca
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-au/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-ca.md
@@ -12,7 +12,7 @@ This guide explains how to increase the size of an additional disk and extend th
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ca/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - An [additional disk](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) configured on the VPS
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
@@ -51,7 +51,7 @@ After the payment is confirmed, the disk upgrade will take a few minutes. You ca
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-gb.md
@@ -12,7 +12,7 @@ This guide explains how to increase the size of an additional disk and extend th
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-gb/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - An [additional disk](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) configured on the VPS
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
@@ -51,7 +51,7 @@ After the payment is confirmed, the disk upgrade will take a few minutes. You ca
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-ie.md
@@ -12,7 +12,7 @@ This guide explains how to increase the size of an additional disk and extend th
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ie/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - An [additional disk](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) configured on the VPS
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
@@ -51,7 +51,7 @@ After the payment is confirmed, the disk upgrade will take a few minutes. You ca
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-sg.md
@@ -12,7 +12,7 @@ This guide explains how to increase the size of an additional disk and extend th
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-sg/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - An [additional disk](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) configured on the VPS
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
@@ -51,7 +51,7 @@ After the payment is confirmed, the disk upgrade will take a few minutes. You ca
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.en-us.md
@@ -12,7 +12,7 @@ This guide explains how to increase the size of an additional disk and extend th
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en/vps/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) in your OVHcloud account
 - An [additional disk](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) configured on the VPS
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access via SSH or RDP to your VPS
@@ -51,7 +51,7 @@ After the payment is confirmed, the disk upgrade will take a few minutes. You ca
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 #### On a Linux VPS

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.es-es.md
@@ -16,7 +16,7 @@ Si ha alcanzado la capacidad máxima de su disco adicional, puede añadir almace
 
 ## Requisitos
 
-- Un [VPS](https://www.ovhcloud.com/es-es/vps/) en su cuenta de OVHcloud.
+- Un [VPS](/links/bare-metal/vps) en su cuenta de OVHcloud.
 - Un [disco adicional](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) configurado en el VPS.
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager).
 - Tener acceso al VPS por SSH o RDP para la administración.
@@ -55,7 +55,7 @@ El aumento de la capacidad del disco tardará unos minutos después de la valida
 > [!warning]
 > La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
 >
-> Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](https://community.ovh.com/en/).
+> Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [nuestra comunidad](https://community.ovh.com/en/).
 >
 
 #### En un VPS Linux

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.es-us.md
@@ -16,7 +16,7 @@ Si ha alcanzado la capacidad máxima de su disco adicional, puede añadir almace
 
 ## Requisitos
 
-- Un [VPS](https://www.ovhcloud.com/es/vps/) en su cuenta de OVHcloud.
+- Un [VPS](/links/bare-metal/vps) en su cuenta de OVHcloud.
 - Un [disco adicional](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) configurado en el VPS.
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager).
 - Tener acceso al VPS por SSH o RDP para la administración.
@@ -55,7 +55,7 @@ El aumento de la capacidad del disco tardará unos minutos después de la valida
 > [!warning]
 > La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
 >
-> Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) o con [nuestra comunidad](https://community.ovh.com/en/).
+> Esta guía le ayudará a realizar las tareas más habituales. No obstante, si necesita ayuda, le recomendamos que contacte con un [proveedor especializado](/links/partner) o con [nuestra comunidad](https://community.ovh.com/en/).
 >
 
 #### En un VPS Linux

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.fr-ca.md
@@ -12,7 +12,7 @@ Si vous avez atteint la capacité maximale de votre disque additionnel, vous pou
 
 ## Prérequis
 
-- Un [VPS](https://www.ovhcloud.com/fr-ca/vps/) dans votre compte OVHcloud.
+- Un [VPS](/links/bare-metal/vps) dans votre compte OVHcloud.
 - Un [disque additionnel](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) configuré sur le VPS.
 - Être connecté à votre [espace client OVHcloud](/links/manager).
 - Avoir accès à votre VPS en SSH ou en RDP pour l'administration.
@@ -51,7 +51,7 @@ L'augmentation de capacité du disque prendra quelques minutes après la validat
 > [!warning]
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) ou de faire appel à [notre communauté](/links/community) si vous éprouvez des difficultés.
+> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou de faire appel à [notre communauté](/links/community) si vous éprouvez des difficultés.
 >
 
 #### Sur un VPS Linux

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.fr-fr.md
@@ -12,7 +12,7 @@ Si vous avez atteint la capacité maximale de votre disque additionnel, vous pou
 
 ## Prérequis
 
-- Un [VPS](https://www.ovhcloud.com/fr/vps/) dans votre compte OVHcloud.
+- Un [VPS](/links/bare-metal/vps) dans votre compte OVHcloud.
 - Un [disque additionnel](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) configuré sur le VPS.
 - Être connecté à votre [espace client OVHcloud](/links/manager).
 - Avoir accès à votre VPS en SSH ou en RDP pour l'administration.
@@ -51,7 +51,7 @@ L'augmentation de capacité du disque prendra quelques minutes après la validat
 > [!warning]
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de faire appel à [notre communauté](/links/community) si vous éprouvez des difficultés.
+> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou de faire appel à [notre communauté](/links/community) si vous éprouvez des difficultés.
 >
 
 #### Sur un VPS Linux

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.it-it.md
@@ -16,7 +16,7 @@ Se hai raggiunto la capacità massima del tuo disco aggiuntivo, puoi aggiungere 
 
 ## Prerequisiti
 
-- Un [VPS](https://www.ovhcloud.com/it/vps/) nel tuo account OVHcloud.
+- Un [VPS](/links/bare-metal/vps) nel tuo account OVHcloud.
 - Un [disco aggiuntivo](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) configurato sul VPS.
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager).
 - Avere accesso al VPS in SSH o in RDP per l'amministrazione.
@@ -55,7 +55,7 @@ L'aumento di capacità del disco richiederà alcuni minuti dopo la conferma del 
 > [!warning]
 > OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Assicurarne il corretto funzionamento è quindi responsabilità dell'utente.
 >
-> Questa guida ti aiuta a eseguire le operazioni necessarie sul tuo VPS. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a un [provider specializzato](https://partner.ovhcloud.com/it/directory/) o di contattare la [nostra Community](https://community.ovh.com/en/).
+> Questa guida ti aiuta a eseguire le operazioni necessarie sul tuo VPS. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di rivolgerti a un [provider specializzato](/links/partner) o di contattare la [nostra Community](https://community.ovh.com/en/).
 >
 
 #### Su un VPS Linux

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.pl-pl.md
@@ -16,7 +16,7 @@ Jeśli osiągnąłeś maksymalną pojemność dodatkowego dysku, możesz zwięks
 
 ## Wymagania początkowe
 
-- Jeden [VPS](https://www.ovhcloud.com/pl/vps/) na koncie OVHcloud.
+- Jeden [VPS](/links/bare-metal/vps) na koncie OVHcloud.
 - Dodatkowy [dysk](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) skonfigurowany na serwerze VPS.
 - Dostęp do [Panelu client OVHcloud](/links/manager).
 - Dostęp do serwera VPS przez SSH lub RDP.
@@ -55,7 +55,7 @@ Zwiększenie pojemności dysku zajmie kilka minut po zatwierdzeniu płatności. 
 > [!warning]
 > OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. W związku z tym to do Ciebie należy zapewnienie prawidłowego funkcjonowania systemu.
 >
-> Niniejszy przewodnik ułatwi Ci realizację bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego [usługodawcy](https://partner.ovhcloud.com/pl/directory/) lub skorzystanie z pomocy [naszej społeczności](https://community.ovh.com/en/).
+> Niniejszy przewodnik ułatwi Ci realizację bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego [usługodawcy](/links/partner) lub skorzystanie z pomocy [naszej społeczności](https://community.ovh.com/en/).
 >
 
 #### Na serwerze VPS Linux

--- a/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/increase_additional_disk/guide.pt-pt.md
@@ -16,7 +16,7 @@ Se atingiu a capacidade máxima do seu disco adicional, pode adicionar armazenam
 
 ## Requisitos
 
-- Um [VPS](https://www.ovhcloud.com/pt/vps/) na sua conta OVHcloud.
+- Um [VPS](/links/bare-metal/vps) na sua conta OVHcloud.
 - Um [disco adicional](/pages/bare_metal_cloud/virtual_private_servers/config_additional_disk) configurado no VPS.
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager).
 - Ter acesso ao VPS por SSH ou RDP para a administração.
@@ -55,7 +55,7 @@ O aumento da capacidade do disco demorará alguns minutos após a validação do
 > [!warning]
 > A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, é da sua responsabilidade assegurar o seu bom funcionamento.
 >
-> Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](https://partner.ovhcloud.com/pt/directory/) ou que recorra à [nossa comunidade](https://community.ovh.com/en/).
+> Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se precisar de ajuda, recomendamos que recorra a um [fornecedor especializado](/links/partner) ou que recorra à [nossa comunidade](https://community.ovh.com/en/).
 >
 
 #### Num VPS Linux

--- a/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-asia.md
@@ -22,7 +22,7 @@ If you would like to install a CMS (**C**ontent **M**anagement **S**ystem) on yo
 
 ## Requirements
 
-- A [VPS] solution (https://www.ovhcloud.com/asia/vps) or a [dedicated server](https://www.ovhcloud.com/asia/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS] solution (https://www.ovhcloud.com/asia/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-au.md
@@ -22,7 +22,7 @@ If you would like to install a CMS (**C**ontent **M**anagement **S**ystem) on yo
 
 ## Requirements
 
-- A [VPS] solution (https://www.ovhcloud.com/en-au/vps/) or a [dedicated server](https://www.ovhcloud.com/en-au/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS] solution (/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-ca.md
@@ -22,7 +22,7 @@ If you would like to install a CMS (**C**ontent **M**anagement **S**ystem) on yo
 
 ## Requirements
 
-- A [VPS] solution (https://www.ovhcloud.com/en-ca/vps/) or a [dedicated server](https://www.ovhcloud.com/en-ca/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS] solution (/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-gb.md
@@ -22,7 +22,7 @@ If you would like to install a CMS (**C**ontent **M**anagement **S**ystem) on yo
 
 ## Requirements
 
-- A [VPS] solution (https://www.ovhcloud.com/en-gb/vps/) or a [dedicated server](https://www.ovhcloud.com/en-gb/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS] solution (/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-ie.md
@@ -22,7 +22,7 @@ If you would like to install a CMS (**C**ontent **M**anagement **S**ystem) on yo
 
 ## Requirements
 
-- A [VPS] solution (https://www.ovhcloud.com/en-ie/vps/) or a [dedicated server](https://www.ovhcloud.com/en-ie/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS] solution (/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-sg.md
@@ -22,7 +22,7 @@ If you would like to install a CMS (**C**ontent **M**anagement **S**ystem) on yo
 
 ## Requirements
 
-- A [VPS] solution (https://www.ovhcloud.com/en-sg/vps/) or a [dedicated server](https://www.ovhcloud.com/en-sg/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS] solution (/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.en-us.md
@@ -22,7 +22,7 @@ If you would like to install a CMS (**C**ontent **M**anagement **S**ystem) on yo
 
 ## Requirements
 
-- A [VPS] solution (https://www.ovhcloud.com/en/vps/) or a [dedicated server](https://www.ovhcloud.com/en/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS] solution (/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.fr-ca.md
@@ -23,7 +23,7 @@ Si vous souhaitez installer un CMS (**C**ontent **M**anagement **S**ystem) sur v
 
 ## Prérequis
 
-- Disposer d'une offre [VPS](https://www.ovhcloud.com/fr-ca/vps/) ou d'un [serveur dédié](https://www.ovhcloud.com/fr-ca/bare-metal/) dans votre [espace client OVHcloud](/links/manager)
+- Disposer d'une offre [VPS](/links/bare-metal/vps) ou d'un [serveur dédié](/links/bare-metal/bare-metal) dans votre [espace client OVHcloud](/links/manager)
 - Disposer d'un accès administrateur (sudo) via SSH à votre serveur
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps/guide.fr-fr.md
@@ -23,7 +23,7 @@ Si vous souhaitez installer un CMS (**C**ontent **M**anagement **S**ystem) sur v
 
 ## Prérequis
 
-- Disposer d'une offre [VPS](https://www.ovhcloud.com/fr/vps/) ou d'un [serveur dédié](https://www.ovhcloud.com/fr/bare-metal/) dans votre [espace client OVHcloud](/links/manager)
+- Disposer d'une offre [VPS](/links/bare-metal/vps) ou d'un [serveur dédié](/links/bare-metal/bare-metal) dans votre [espace client OVHcloud](/links/manager)
 - Disposer d'un accès administrateur (sudo) via SSH à votre serveur
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-asia.md
@@ -13,12 +13,12 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/asia/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/asia/vps/) solution  or a [dedicated server](https://www.ovhcloud.com/asia/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution  or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A domain name (registered with OVHcloud or another registrar)
 
@@ -269,6 +269,6 @@ For some general tips on securing a GNU/Linux-based server, see our guides:
 
 [Securing a dedicated server](/pages/bare_metal_cloud/dedicated_servers/securing-a-dedicated-server)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/asia/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-au.md
@@ -13,12 +13,12 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-au/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-au/vps/) solution  or a [dedicated server](https://www.ovhcloud.com/en-au/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution  or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A domain name (registered with OVHcloud or another registrar)
 
@@ -269,6 +269,6 @@ For some general tips on securing a GNU/Linux-based server, see our guides:
 
 [Securing a dedicated server](/pages/bare_metal_cloud/dedicated_servers/securing-a-dedicated-server)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-au/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-ca.md
@@ -13,12 +13,12 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ca/vps/) solution  or a [dedicated server](https://www.ovhcloud.com/en-ca/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution  or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A domain name (registered with OVHcloud or another registrar)
 
@@ -269,6 +269,6 @@ For some general tips on securing a GNU/Linux-based server, see our guides:
 
 [Securing a dedicated server](/pages/bare_metal_cloud/dedicated_servers/securing-a-dedicated-server)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-ca/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-gb.md
@@ -13,12 +13,12 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-gb/vps/) solution  or a [dedicated server](https://www.ovhcloud.com/en-gb/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution  or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A domain name (registered with OVHcloud or another registrar)
 
@@ -269,6 +269,6 @@ For some general tips on securing a GNU/Linux-based server, see our guides:
 
 [Securing a dedicated server](/pages/bare_metal_cloud/dedicated_servers/securing-a-dedicated-server)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-ie.md
@@ -13,12 +13,12 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ie/vps/) solution  or a [dedicated server](https://www.ovhcloud.com/en-ie/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution  or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A domain name (registered with OVHcloud or another registrar)
 
@@ -269,6 +269,6 @@ For some general tips on securing a GNU/Linux-based server, see our guides:
 
 [Securing a dedicated server](/pages/bare_metal_cloud/dedicated_servers/securing-a-dedicated-server)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-ie/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-sg.md
@@ -13,12 +13,12 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-sg/vps/) solution  or a [dedicated server](https://www.ovhcloud.com/en-sg/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution  or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A domain name (registered with OVHcloud or another registrar)
 
@@ -269,6 +269,6 @@ For some general tips on securing a GNU/Linux-based server, see our guides:
 
 [Securing a dedicated server](/pages/bare_metal_cloud/dedicated_servers/securing-a-dedicated-server)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-sg/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.en-us.md
@@ -13,12 +13,12 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en/vps/) solution  or a [dedicated server](https://www.ovhcloud.com/en/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution  or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A domain name (registered with OVHcloud or another registrar)
 
@@ -269,6 +269,6 @@ For some general tips on securing a GNU/Linux-based server, see our guides:
 
 [Securing a dedicated server](/pages/bare_metal_cloud/dedicated_servers/securing-a-dedicated-server)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.fr-ca.md
@@ -14,12 +14,12 @@ Installer WordPress sur un VPS ou un serveur dédié présente plusieurs avantag
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce tutoriel.
+> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce tutoriel.
 >
 
 ## Prérequis
 
-- Disposer d'une offre [VPS](https://www.ovhcloud.com/fr-ca/vps/) ou d'un [serveur dédié](https://www.ovhcloud.com/fr-ca/bare-metal/) dans votre [espace client OVHcloud](/links/manager)
+- Disposer d'une offre [VPS](/links/bare-metal/vps) ou d'un [serveur dédié](/links/bare-metal/bare-metal) dans votre [espace client OVHcloud](/links/manager)
 - Disposer d'un accès administrateur (sudo) via SSH à votre serveur
 - Disposer d'un nom de domaine (enregistré chez OVHcloud ou auprès d'un autre bureau d'enregistrements)
 
@@ -270,6 +270,6 @@ Pour obtenir quelques conseils généraux pour sécuriser un serveur basé sur G
 
 [Sécuriser un serveur dédié](/pages/bare_metal_cloud/dedicated_servers/securing-a-dedicated-server)
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr-ca/directory/)
+Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner)
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps/guide.fr-fr.md
@@ -14,12 +14,12 @@ Installer WordPress sur un VPS ou un serveur dédié présente plusieurs avantag
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce tutoriel.
+> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce tutoriel.
 >
 
 ## Prérequis
 
-- Disposer d'une offre [VPS](https://www.ovhcloud.com/fr/vps/) ou d'un [serveur dédié](https://www.ovhcloud.com/fr/bare-metal/) dans votre [espace client OVHcloud](/links/manager)
+- Disposer d'une offre [VPS](/links/bare-metal/vps) ou d'un [serveur dédié](/links/bare-metal/bare-metal) dans votre [espace client OVHcloud](/links/manager)
 - Disposer d'un accès administrateur (sudo) via SSH à votre serveur
 - Disposer d'un nom de domaine (enregistré chez OVHcloud ou auprès d'un autre bureau d'enregistrements)
 
@@ -270,6 +270,6 @@ Pour obtenir quelques conseils généraux pour sécuriser un serveur basé sur G
 
 [Sécuriser un serveur dédié](/pages/bare_metal_cloud/dedicated_servers/securing-a-dedicated-server)
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/)
+Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner)
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-asia.md
@@ -13,14 +13,14 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/asia/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 <a name="requirements"></a>
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/asia/vps/) solution or a [dedicated server](https://www.ovhcloud.com/asia/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A [web development environment configured on your VPS or your dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps)
 - A domain name (registered with OVHcloud or another registrar)
@@ -262,6 +262,6 @@ You have just installed WordPress on your OVHcloud VPS or dedicated server with 
 
 [How to install WordPress with Docker on VPS or a dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/asia/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-au.md
@@ -13,14 +13,14 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-au/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 <a name="requirements"></a>
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-au/vps/) solution or a [dedicated server](https://www.ovhcloud.com/en-au/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A [web development environment configured on your VPS or your dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps)
 - A domain name (registered with OVHcloud or another registrar)
@@ -262,6 +262,6 @@ You have just installed WordPress on your OVHcloud VPS or dedicated server with 
 
 [How to install WordPress with Docker on VPS or a dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-au/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-ca.md
@@ -13,14 +13,14 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 <a name="requirements"></a>
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ca/vps/) solution or a [dedicated server](https://www.ovhcloud.com/en-ca/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A [web development environment configured on your VPS or your dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps)
 - A domain name (registered with OVHcloud or another registrar)
@@ -262,6 +262,6 @@ You have just installed WordPress on your OVHcloud VPS or dedicated server with 
 
 [How to install WordPress with Docker on VPS or a dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-ca/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-gb.md
@@ -13,14 +13,14 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 <a name="requirements"></a>
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-gb/vps/) solution or a [dedicated server](https://www.ovhcloud.com/en-gb/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A [web development environment configured on your VPS or your dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps)
 - A domain name (registered with OVHcloud or another registrar)
@@ -262,6 +262,6 @@ You have just installed WordPress on your OVHcloud VPS or dedicated server with 
 
 [How to install WordPress with Docker on VPS or a dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-gb/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-ie.md
@@ -13,14 +13,14 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 <a name="requirements"></a>
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ie/vps/) solution or a [dedicated server](https://www.ovhcloud.com/en-ie/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A [web development environment configured on your VPS or your dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps)
 - A domain name (registered with OVHcloud or another registrar)
@@ -262,6 +262,6 @@ You have just installed WordPress on your OVHcloud VPS or dedicated server with 
 
 [How to install WordPress with Docker on VPS or a dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-ie/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-sg.md
@@ -13,14 +13,14 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 <a name="requirements"></a>
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-sg/vps/) solution or a [dedicated server](https://www.ovhcloud.com/en-sg/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A [web development environment configured on your VPS or your dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps)
 - A domain name (registered with OVHcloud or another registrar)
@@ -262,6 +262,6 @@ You have just installed WordPress on your OVHcloud VPS or dedicated server with 
 
 [How to install WordPress with Docker on VPS or a dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en-sg/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.en-us.md
@@ -13,14 +13,14 @@ Installing WordPress on a VPS or dedicated server has several advantages, such a
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and the changes you need to make in specific contexts. You may need to adapt the instructions according to your situation.
 >
-> We recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> We recommend that you contact a [specialist service provider](/links/partner) or reach out to [our community](https://community.ovh.com/en/) if you face difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 <a name="requirements"></a>
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en/vps/) solution or a [dedicated server](https://www.ovhcloud.com/en/bare-metal/) in your [OVHcloud Control Panel](/links/manager)
+- A [VPS](/links/bare-metal/vps) solution or a [dedicated server](/links/bare-metal/bare-metal) in your [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your server via SSH
 - A [web development environment configured on your VPS or your dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps)
 - A domain name (registered with OVHcloud or another registrar)
@@ -262,6 +262,6 @@ You have just installed WordPress on your OVHcloud VPS or dedicated server with 
 
 [How to install WordPress with Docker on VPS or a dedicated server](/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps)
 
-For specialised services (SEO, development, etc.), contact [OVHcloud partners](https://partner.ovhcloud.com/en/directory/).
+For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 Join our [community of users](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.fr-ca.md
@@ -14,12 +14,12 @@ Installer WordPress sur un VPS ou un serveur dédié présente plusieurs avantag
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce tutoriel.
+> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce tutoriel.
 >
 
 ## Prérequis
 
-- Disposer d'une offre [VPS](https://www.ovhcloud.com/fr-ca/vps/) ou d'un [serveur dédié](https://www.ovhcloud.com/fr-ca/bare-metal/) dans votre [espace client OVHcloud](/links/manager)
+- Disposer d'une offre [VPS](/links/bare-metal/vps) ou d'un [serveur dédié](/links/bare-metal/bare-metal) dans votre [espace client OVHcloud](/links/manager)
 - Disposer d'un accès administrateur (sudo) via SSH à votre serveur
 - Avoir [configuré un environnement de développement web sur votre VPS ou votre serveur dédié](/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps)
 - Disposer d'un nom de domaine (enregistré chez OVHcloud ou auprès d'un autre bureau d'enregistrements)
@@ -260,6 +260,6 @@ Vous venez d'installer WordPress sur votre VPS OVHcloud ou votre Serveur Dédié
 
 [Installer WordPress avec Docker sur un VPS OVHcloud](/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps)
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr-ca/directory/).
+Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner).
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_site_on_vps/guide.fr-fr.md
@@ -14,12 +14,12 @@ Installer WordPress sur un VPS ou un serveur dédié présente plusieurs avantag
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce tutoriel.
+> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce tutoriel.
 >
 
 ## Prérequis
 
-- Disposer d'une offre [VPS](https://www.ovhcloud.com/fr/vps/) ou d'un [serveur dédié](https://www.ovhcloud.com/fr/bare-metal/) dans votre [espace client OVHcloud](/links/manager)
+- Disposer d'une offre [VPS](/links/bare-metal/vps) ou d'un [serveur dédié](/links/bare-metal/bare-metal) dans votre [espace client OVHcloud](/links/manager)
 - Disposer d'un accès administrateur (sudo) via SSH à votre serveur
 - Avoir [configuré un environnement de développement web sur votre VPS ou votre serveur dédié](/pages/bare_metal_cloud/virtual_private_servers/install_env_web_dev_on_vps)
 - Disposer d'un nom de domaine (enregistré chez OVHcloud ou auprès d'un autre bureau d'enregistrements)
@@ -260,6 +260,6 @@ Vous venez d'installer WordPress sur votre VPS OVHcloud ou votre Serveur Dédié
 
 [Installer WordPress avec Docker sur un VPS OVHcloud](/pages/bare_metal_cloud/virtual_private_servers/install_wordpress_docker_on_vps)
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](https://partner.ovhcloud.com/fr/directory/).
+Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner).
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/bare_metal_cloud/virtual_private_servers/minecraft_server_on_vps/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/minecraft_server_on_vps/guide.it-it.md
@@ -12,7 +12,7 @@ updated: 2025-06-06
 
 Minecraft è un videogioco da costruzione di successo globale. Per giocare in modalità multiplayer, il server deve essere ospitato su un server.
 
-È possibile noleggiare un server Minecraft precostruito o configurarlo su un [VPS](https://www.ovhcloud.com/it/vps/) o su un [server dedicato](https://www.ovhcloud.com/it/bare-metal/) per permetterti di risparmiare e avere il controllo completo sull'istanza di gioco.
+È possibile noleggiare un server Minecraft precostruito o configurarlo su un [VPS](/links/bare-metal/vps) o su un [server dedicato](/links/bare-metal/bare-metal) per permetterti di risparmiare e avere il controllo completo sull'istanza di gioco.
 
 **Questa guida ti mostra come avviare un server Minecraft Java Edition su un VPS OVHcloud e testarne la connettività.**
 
@@ -24,7 +24,7 @@ Minecraft è un videogioco da costruzione di successo globale. Per giocare in mo
 
 ## Prerequisiti
 
-- Disporre di un [VPS](https://www.ovhcloud.com/it/vps/) sul proprio account OVHcloud
+- Disporre di un [VPS](/links/bare-metal/vps) sul proprio account OVHcloud
 - Aver installato una distribuzione GNU/Linux sul server
 - Avere accesso amministratore (sudo) via SSH al server
 - Comprendere principalmente l'amministrazione GNU/Linux
@@ -189,7 +189,7 @@ Nessuna porta da inserire di default
 
 Il tuo server Vanilla Minecraft è installato sul tuo VPS.
 
-Questa guida è valida anche per un [server dedicato OVHcloud](https://www.ovhcloud.com/it/bare-metal/) o un'istanza [Public Cloud](https://www.ovhcloud.com/it/public-cloud/). Con queste soluzioni, potrai usufruire anche di risorse fisiche garantite e stabili in qualsiasi momento della giornata, dato che l'hardware è dedicato.
+Questa guida è valida anche per un [server dedicato OVHcloud](/links/bare-metal/bare-metal) o un'istanza [Public Cloud](/links/public-cloud/public-cloud). Con queste soluzioni, potrai usufruire anche di risorse fisiche garantite e stabili in qualsiasi momento della giornata, dato che l'hardware è dedicato.
 
 ## Per saperne di più <a name="gofurther"></a>
 

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.de-de.md
@@ -13,7 +13,7 @@ Having your own server to play a game such as Palworld offers several advantages
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/de/vps/) or a [dedicated server](https://www.ovhcloud.com/de/bare-metal/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - A GNU/Linux operating system installed on the server
 - Administrative (sudo) SSH access to your server
 - Basic understanding of GNU/Linux administration

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-asia.md
@@ -13,7 +13,7 @@ Having your own server to play a game such as Palworld offers several advantages
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/asia/vps/) or a [dedicated server](https://www.ovhcloud.com/asia/bare-metal/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - A GNU/Linux operating system installed on the server
 - Administrative (sudo) SSH access to your server
 - Basic understanding of GNU/Linux administration

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-au.md
@@ -13,7 +13,7 @@ Having your own server to play a game such as Palworld offers several advantages
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-au/vps/) or a [dedicated server](https://www.ovhcloud.com/en-au/bare-metal/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - A GNU/Linux operating system installed on the server
 - Administrative (sudo) SSH access to your server
 - Basic understanding of GNU/Linux administration

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-ca.md
@@ -13,7 +13,7 @@ Having your own server to play a game such as Palworld offers several advantages
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ca/vps/) or a [dedicated server](https://www.ovhcloud.com/en-ca/bare-metal/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - A GNU/Linux operating system installed on the server
 - Administrative (sudo) SSH access to your server
 - Basic understanding of GNU/Linux administration

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-gb.md
@@ -13,7 +13,7 @@ Having your own server to play a game such as Palworld offers several advantages
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-gb/vps/) or a [dedicated server](https://www.ovhcloud.com/en-gb/bare-metal/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - A GNU/Linux operating system installed on the server
 - Administrative (sudo) SSH access to your server
 - Basic understanding of GNU/Linux administration

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-ie.md
@@ -13,7 +13,7 @@ Having your own server to play a game such as Palworld offers several advantages
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ie/vps/) or a [dedicated server](https://www.ovhcloud.com/en-ie/bare-metal/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - A GNU/Linux operating system installed on the server
 - Administrative (sudo) SSH access to your server
 - Basic understanding of GNU/Linux administration

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-sg.md
@@ -13,7 +13,7 @@ Having your own server to play a game such as Palworld offers several advantages
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-sg/vps/) or a [dedicated server](https://www.ovhcloud.com/en-sg/bare-metal/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - A GNU/Linux operating system installed on the server
 - Administrative (sudo) SSH access to your server
 - Basic understanding of GNU/Linux administration

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.en-us.md
@@ -13,7 +13,7 @@ Having your own server to play a game such as Palworld offers several advantages
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en/vps/) or a [dedicated server](https://www.ovhcloud.com/en/bare-metal/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - A GNU/Linux operating system installed on the server
 - Administrative (sudo) SSH access to your server
 - Basic understanding of GNU/Linux administration

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.es-es.md
@@ -13,7 +13,7 @@ Having your own server to play a game such as Palworld offers several advantages
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/es-es/vps/) or a [dedicated server](https://www.ovhcloud.com/es-es/bare-metal/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - A GNU/Linux operating system installed on the server
 - Administrative (sudo) SSH access to your server
 - Basic understanding of GNU/Linux administration

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.es-us.md
@@ -13,7 +13,7 @@ Having your own server to play a game such as Palworld offers several advantages
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/es/vps/) or a [dedicated server](https://www.ovhcloud.com/es/bare-metal/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - A GNU/Linux operating system installed on the server
 - Administrative (sudo) SSH access to your server
 - Basic understanding of GNU/Linux administration

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.fr-ca.md
@@ -12,7 +12,7 @@ Développé par Pocket Pair, Palworld est un jeu vidéo qui mélange des éléme
 
 ## Prérequis
 
-- Disposer d'un [VPS](https://www.ovhcloud.com/fr-ca/vps/) ou d'un [serveur dédié](https://www.ovhcloud.com/fr-ca/bare-metal/) dans votre compte OVHcloud
+- Disposer d'un [VPS](/links/bare-metal/vps) ou d'un [serveur dédié](/links/bare-metal/bare-metal) dans votre compte OVHcloud
 - Avoir installé une distribution GNU/Linux sur le serveur
 - Disposer d'un accès administrateur (sudo) via SSH à votre serveur
 - Avoir une compréhension basique de l'administration GNU/Linux

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.fr-fr.md
@@ -12,7 +12,7 @@ Développé par Pocket Pair, Palworld est un jeu vidéo qui mélange des éléme
 
 ## Prérequis
 
-- Disposer d'un [VPS](https://www.ovhcloud.com/fr/vps/) ou d'un [serveur dédié](https://www.ovhcloud.com/fr/bare-metal/) dans votre compte OVHcloud
+- Disposer d'un [VPS](/links/bare-metal/vps) ou d'un [serveur dédié](/links/bare-metal/bare-metal) dans votre compte OVHcloud
 - Avoir installé une distribution GNU/Linux sur le serveur
 - Disposer d'un accès administrateur (sudo) via SSH à votre serveur
 - Avoir une compréhension basique de l'administration GNU/Linux

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.it-it.md
@@ -13,7 +13,7 @@ Having your own server to play a game such as Palworld offers several advantages
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/it/vps/) or a [dedicated server](https://www.ovhcloud.com/it/bare-metal/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - A GNU/Linux operating system installed on the server
 - Administrative (sudo) SSH access to your server
 - Basic understanding of GNU/Linux administration

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.pl-pl.md
@@ -13,7 +13,7 @@ Having your own server to play a game such as Palworld offers several advantages
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/pl/vps/) or a [dedicated server](https://www.ovhcloud.com/pl/bare-metal/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - A GNU/Linux operating system installed on the server
 - Administrative (sudo) SSH access to your server
 - Basic understanding of GNU/Linux administration

--- a/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/palworld-server-on-vps/guide.pt-pt.md
@@ -13,7 +13,7 @@ Having your own server to play a game such as Palworld offers several advantages
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/pt/vps/) or a [dedicated server](https://www.ovhcloud.com/pt/bare-metal/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - A GNU/Linux operating system installed on the server
 - Administrative (sudo) SSH access to your server
 - Basic understanding of GNU/Linux administration

--- a/pages/bare_metal_cloud/virtual_private_servers/rescue/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/rescue/guide.de-de.md
@@ -32,7 +32,7 @@ Wenn Sie ein Problem mit Ihrem System feststellen, können Sie mithilfe des Resc
 >
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 > 
-> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovh.com/en/) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben. 
+> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovh.com/en/) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben. 
 >
 
 ## In der praktischen Anwendung

--- a/pages/bare_metal_cloud/virtual_private_servers/rescue/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/rescue/guide.fr-ca.md
@@ -31,7 +31,7 @@ Si vous rencontrez un problème avec votre système, effectuer des vérification
 > [!warning]
 > OVHcloud fournit des services dont la configuration et la gestion relèvent de votre responsabilité. Il est donc de votre responsabilité de vous assurer de leur bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](/links/partner) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
 >
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/rescue/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/rescue/guide.fr-fr.md
@@ -31,7 +31,7 @@ Si vous rencontrez un problème avec votre système, effectuer des vérification
 > [!warning]
 > OVHcloud fournit des services dont la configuration et la gestion relèvent de votre responsabilité. Il est donc de votre responsabilité de vous assurer de leur bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](https://partner.ovhcloud.com/fr/directory/) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de contacter un [prestataire de services spécialisé](/links/partner) ou de contacter [notre communauté](/links/community) si vous rencontrez des difficultés ou des doutes concernant l'administration, l'utilisation ou la mise en œuvre de services sur un serveur.
 >
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/rescue/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/rescue/guide.it-it.md
@@ -26,12 +26,12 @@ In caso di problemi al sistema, eseguire controlli in Rescue mode permette di de
 ## Prerequisiti
 
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
-- Disporre di un [VPS OVHcloud](https://www.ovhcloud.com/it/vps/) già configurato
+- Disporre di un [VPS OVHcloud](/links/bare-metal/vps) già configurato
 
 > [!warning]
 > OVHcloud fornisce servizi la cui configurazione e gestione sono di vostra responsabilità. È quindi vostra responsabilità assicurarvi che funzionino correttamente.
 >
-> Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi relativamente all’amministrazione, all’utilizzo o all’implementazione dei servizi di un server, ti consigliamo di contattare un [provider di servizi specializzato](https://partner.ovhcloud.com/it/directory/) o [la nostra Community](https://community.ovh.com/en/).
+> Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi relativamente all’amministrazione, all’utilizzo o all’implementazione dei servizi di un server, ti consigliamo di contattare un [provider di servizi specializzato](/links/partner) o [la nostra Community](https://community.ovh.com/en/).
 >
 
 ## Procedura

--- a/pages/bare_metal_cloud/virtual_private_servers/rescue/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/rescue/guide.pl-pl.md
@@ -26,12 +26,12 @@ W przypadku problemów z systemem można przeprowadzić weryfikację w trybie Re
 ## Wymagania początkowe
 
 - Dostęp do [Panelu klienta OVHcloud](/links/manager)
-- Posiadanie już skonfigurowanego [VPS OVHcloud](https://www.ovhcloud.com/pl/vps/)
+- Posiadanie już skonfigurowanego [VPS OVHcloud](/links/bare-metal/vps)
 
 > [!warning]
 > OVHcloud zapewnia usługi, ale to użytkownik ponosi odpowiedzialność za zarządzanie nimi oraz ich konfigurację. Do Twoich obowiązków należy zatem upewnienie się, że działają one prawidłowo.
 >
-> Ten przewodnik ułatwi Ci realizację bieżących zadań. Niemniej jednak, w przypadku trudności lub wątpliwości związanych z administrowaniem usługami, korzystaniem z nich lub ich wdrażaniem na serwerze, zalecamy kontakt z [wyspecjalizowanym dostawcą](https://partner.ovhcloud.com/pl/directory/) lub [naszą społecznością](https://community.ovh.com/en/).
+> Ten przewodnik ułatwi Ci realizację bieżących zadań. Niemniej jednak, w przypadku trudności lub wątpliwości związanych z administrowaniem usługami, korzystaniem z nich lub ich wdrażaniem na serwerze, zalecamy kontakt z [wyspecjalizowanym dostawcą](/links/partner) lub [naszą społecznością](https://community.ovh.com/en/).
 >
 
 ## W praktyce

--- a/pages/bare_metal_cloud/virtual_private_servers/rescue/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/rescue/guide.pt-pt.md
@@ -26,12 +26,12 @@ Se encontrar um problema com o seu sistema, efetuar verificações em modo rescu
 ## Requisitos
 
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager)
-- Ter o seu [VPS OVHcloud](https://www.ovhcloud.com/pt/vps/){.external} já configurado.
+- Ter o seu [VPS OVHcloud](/links/bare-metal/vps){.external} já configurado.
 
 > [!warning]
 > A OVHcloud fornece serviços cuja configuração e gestão são da sua responsabilidade. É da sua responsabilidade assegurar o seu bom funcionamento.
 >
-> Este guia fornece as instruções necessárias para realizar as operações mais habituais. Contudo, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de serviços num servidor, recomendamos que contacte um [fornecedor de serviços especializado](https://partner.ovhcloud.com/pt/directory/) ou que contacte a [nossa comunidade](https://community.ovh.com/en/).
+> Este guia fornece as instruções necessárias para realizar as operações mais habituais. Contudo, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de serviços num servidor, recomendamos que contacte um [fornecedor de serviços especializado](/links/partner) ou que contacte a [nossa comunidade](https://community.ovh.com/en/).
 >
 
 ## Instruções

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.de-de.md
@@ -18,7 +18,7 @@ Wenn Sie Ihr Administrator-Passwort nicht mehr haben, können Sie es über den O
 
 ## Voraussetzungen
 
-- Sie haben einen [VPS](https://www.ovhcloud.com/de/vps/) oder eine Public Cloud Instanz(https://www.ovhcloud.com/de/public-cloud/) in Ihrem OVHcloud Account
+- Sie haben einen [VPS](/links/bare-metal/vps) oder eine Public Cloud Instanz(/links/public-cloud/public-cloud) in Ihrem OVHcloud Account
 - Sie sind in Ihrem [OVHcloud Kundencenter](/links/manager) angemeldet.
 
 ## In der praktischen Anwendung

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-asia.md
@@ -14,7 +14,7 @@ If you have lost your Administrator password, you can reset it via the OVHcloud 
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/asia/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-au.md
@@ -14,7 +14,7 @@ If you have lost your Administrator password, you can reset it via the OVHcloud 
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-au/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-ca.md
@@ -14,7 +14,7 @@ If you have lost your Administrator password, you can reset it via the OVHcloud 
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ca/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-gb.md
@@ -14,7 +14,7 @@ If you have lost your Administrator password, you can reset it via the OVHcloud 
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-gb/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-ie.md
@@ -14,7 +14,7 @@ If you have lost your Administrator password, you can reset it via the OVHcloud 
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en-ie/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-sg.md
@@ -14,7 +14,7 @@ If you have lost your Administrator password, you can reset it via the OVHcloud 
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.en-us.md
@@ -14,7 +14,7 @@ If you have lost your Administrator password, you can reset it via the OVHcloud 
 
 ## Requirements
 
-- A [VPS](https://www.ovhcloud.com/en/vps/) or a [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [VPS](/links/bare-metal/vps) or a [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.es-es.md
@@ -18,7 +18,7 @@ Si ha perdido su contraseña de administrador, puede restablecerla utilizando el
 
 ## Requisitos
 
-- Tener un [VPS](https://www.ovhcloud.com/es-es/vps/) o una [instancia de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud
+- Tener un [VPS](/links/bare-metal/vps) o una [instancia de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.es-us.md
@@ -18,7 +18,7 @@ Si ha perdido su contraseña de administrador, puede restablecerla utilizando el
 
 ## Requisitos
 
-- Tener un [VPS](https://www.ovhcloud.com/es/vps/) o una [instancia de Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud
+- Tener un [VPS](/links/bare-metal/vps) o una [instancia de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.fr-ca.md
@@ -14,7 +14,7 @@ Si vous avez perdu votre mot de passe administrateur, vous pouvez le réinitiali
 
 ## Prérequis
 
-- Disposer d'un [VPS](https://www.ovhcloud.com/fr-ca/vps/) ou d'une [instance Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud
+- Disposer d'un [VPS](/links/bare-metal/vps) ou d'une [instance Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.fr-fr.md
@@ -14,7 +14,7 @@ Si vous avez perdu votre mot de passe administrateur, vous pouvez le réinitiali
 
 ## Prérequis
 
-- Disposer d'un [VPS](https://www.ovhcloud.com/fr/vps/) ou d'une [instance Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
+- Disposer d'un [VPS](/links/bare-metal/vps) ou d'une [instance Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.it-it.md
@@ -18,7 +18,7 @@ In caso di perdita della password amministratore, è possibile ripristinarla tra
 
 ## Prerequisiti
 
-- Disporre di un [VPS](https://www.ovhcloud.com/it/vps/) o di un’[istanza Public Cloud](https://www.ovhcloud.com/it/public-cloud/) OVHcloud
+- Disporre di un [VPS](/links/bare-metal/vps) o di un’[istanza Public Cloud](/links/public-cloud/public-cloud) OVHcloud
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 ## Procedura

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.pl-pl.md
@@ -18,7 +18,7 @@ Jeśli utracisz hasło administratora, możesz je zresetować przy użyciu trybu
 
 ## Wymagania początkowe
 
-- Posiadanie na koncie OVHcloud serwera [VPS](https://www.ovhcloud.com/pl/vps/) lub [instancji Public Cloud](https://www.ovhcloud.com/pl/public-cloud/)
+- Posiadanie na koncie OVHcloud serwera [VPS](/links/bare-metal/vps) lub [instancji Public Cloud](/links/public-cloud/public-cloud)
 - Zalogowanie do [Panelu klienta OVHcloud](/links/manager)
 
 ## W praktyce

--- a/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/resetting_a_windows_password/guide.pt-pt.md
@@ -18,7 +18,7 @@ Se perder a sua palavra-passe de administrador, pode repô-la através do modo r
 
 ## Requisitos
 
-- Dispor de uma [VPS](https://www.ovhcloud.com/pt/vps/) ou de uma [instância Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud
+- Dispor de uma [VPS](/links/bare-metal/vps) ou de uma [instância Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud
 - Estar ligado à [Área de Cliente OVHcloud](/links/manager).
 
 ## Instruções

--- a/pages/bare_metal_cloud/virtual_private_servers/secure_your_vps/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/secure_your_vps/guide.de-de.md
@@ -18,12 +18,12 @@ Wenn Sie Ihren VPS bestellen, können Sie eine Distribution oder ein Betriebssys
 >
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 > 
-> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovh.com/en/) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben. 
+> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovh.com/en/) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben. 
 >
 
 ## Voraussetzungen
 
-- Sie haben einen [VPS](https://www.ovhcloud.com/de/vps/) in Ihrem Kunden-Account.
+- Sie haben einen [VPS](/links/bare-metal/vps) in Ihrem Kunden-Account.
 - Sie haben administrativen Zugriff (sudo) auf Ihren VPS über SSH.
 
 ## In der praktischen Anwendung
@@ -278,7 +278,7 @@ Die Sicherung Ihrer Daten ist ebenso essenziell, deshalb bietet Ihnen OVHcloud m
 - Mit der `Snapshot` Option können Sie manuelle Snapshots erstellen.
 - `Automatische Backups` ermöglichen es, regelmäßige Backups Ihres VPS zu speichern (mit Ausnahme zusätzlicher Disks).
 
-Alle Informationen zu den für Ihren Dienst verfügbaren Backup-Lösungen finden Sie auf der [Produktseite](https://www.ovhcloud.com/de/vps/options/) und in den [zugehörigen Anleitungen](/products/bare-metal-cloud-virtual-private-servers).
+Alle Informationen zu den für Ihren Dienst verfügbaren Backup-Lösungen finden Sie auf der [Produktseite](/links/bare-metal/vps-options) und in den [zugehörigen Anleitungen](/products/bare-metal-cloud-virtual-private-servers).
 
 ## Weiterführende Informationen
 

--- a/pages/bare_metal_cloud/virtual_private_servers/secure_your_vps/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/secure_your_vps/guide.it-it.md
@@ -21,7 +21,7 @@ Al momento dell'ordine del tuo VPS, puoi scegliere una distribuzione o un sistem
 
 ## Prerequisiti
 
-- Un [VPS](https://www.ovhcloud.com/it/vps/) nel tuo account OVHcloud
+- Un [VPS](/links/bare-metal/vps) nel tuo account OVHcloud
 - Avere un accesso amministratore (sudo) al server via SSH
 
 ## Procedura
@@ -279,7 +279,7 @@ La protezione dei dati è un elemento chiave e per questo OVHcloud offre diverse
 - L'opzione `Snapshot` che ti permette di creare un'istantanea manuale.
 - L'opzione di `backup automatico` permette di conservare i backup regolari del VPS (ad eccezione dei dischi supplementari).
 
-Tutte le informazioni sulle soluzioni di backup disponibili per il tuo servizio sono disponibili sulla [pagina del prodotto](https://www.ovhcloud.com/it/vps/options/) e nelle [rispettive](/products/bare-metal-cloud-virtual-private-servers) guide.
+Tutte le informazioni sulle soluzioni di backup disponibili per il tuo servizio sono disponibili sulla [pagina del prodotto](/links/bare-metal/vps-options) e nelle [rispettive](/products/bare-metal-cloud-virtual-private-servers) guide.
 
 ## Per saperne di più
 

--- a/pages/bare_metal_cloud/virtual_private_servers/secure_your_vps/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/secure_your_vps/guide.pl-pl.md
@@ -22,7 +22,7 @@ Kiedy zamawiasz serwer VPS, możesz wybrać dystrybucję lub system operacyjny d
 
 ## Wymagania początkowe
 
-- Jeden [VPS](https://www.ovhcloud.com/pl/vps/) na Twoim koncie OVHcloud.
+- Jeden [VPS](/links/bare-metal/vps) na Twoim koncie OVHcloud.
 - Dostęp administratora (sudo) do serwera przez SSH.
 
 ## W praktyce
@@ -279,7 +279,7 @@ Zabezpieczenie danych jest jednym z kluczowych czynników, dlatego OVHcloud ofer
 - Opcja `Snapshot` umożliwia tworzenie zrzutu ręcznego.
 - Opcja automatycznej `kopii zapasowej` pozwala na zachowanie regularnych kopii zapasowych serwera VPS (z wyjątkiem dodatkowych dysków).
 
-Wszystkie informacje na temat rozwiązań kopii zapasowych dostępnych dla Twojej usługi znajdują się na [stronie produktu](https://www.ovhcloud.com/pl/vps/options/) i w odpowiednich [przewodnikach](/products/bare-metal-cloud-virtual-private-servers).
+Wszystkie informacje na temat rozwiązań kopii zapasowych dostępnych dla Twojej usługi znajdują się na [stronie produktu](/links/bare-metal/vps-options) i w odpowiednich [przewodnikach](/products/bare-metal-cloud-virtual-private-servers).
 
 ## Sprawdź również
 

--- a/pages/bare_metal_cloud/virtual_private_servers/secure_your_vps/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/secure_your_vps/guide.pt-pt.md
@@ -22,7 +22,7 @@ Quando encomendar o seu VPS, pode escolher uma distribuição ou um sistema oper
 
 ## Requisitos
 
-- Um [VPS](https://www.ovhcloud.com/pt/vps/) na sua conta OVHcloud
+- Um [VPS](/links/bare-metal/vps) na sua conta OVHcloud
 - Ter acesso de administrador (sudo) ao seu servidor através de SSH
 
 ## Instruções
@@ -281,7 +281,7 @@ A segurança dos seus dados é um elemento chave. É por isso que a OVHcloud ofe
 - A opção `Snapshot` que lhe permite criar uma imagem manual.
 - A opção de `Backup automático` permite-lhe conservar os backups regulares do seu VPS (à exceção dos discos suplementares).
 
-Na [página do produto](https://www.ovhcloud.com/pt/vps/options/) e nos respetivos [guias](/products/bare-metal-cloud-virtual-private-servers), poderá encontrar todas as informações sobre as soluções de backup disponíveis para o seu serviço.
+Na [página do produto](/links/bare-metal/vps-options) e nos respetivos [guias](/products/bare-metal-cloud-virtual-private-servers), poderá encontrar todas as informações sobre as soluções de backup disponíveis para o seu serviço.
 
 ## Quer saber mais?
 

--- a/pages/bare_metal_cloud/virtual_private_servers/starting_with_a_vps/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/starting_with_a_vps/guide.de-de.md
@@ -137,7 +137,7 @@ In diesen Abschnitten finden Sie die wichtigsten Daten zur Abrechnung Ihres Dien
 >
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 > 
-> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovh.com/en/) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben. 
+> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](https://community.ovh.com/en/) zu richten, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben. 
 >
 
 <a name="reinstallvps"></a>

--- a/pages/bare_metal_cloud/virtual_private_servers/starting_with_a_vps/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/starting_with_a_vps/guide.pl-pl.md
@@ -135,7 +135,7 @@ W tych sekcjach znajdują się najważniejsze informacje dotyczące fakturowania
 >
 > OVHcloud udostępnia Ci usługi, ale to użytkownik ponosi odpowiedzialność za zarządzanie nimi oraz ich konfigurację. Do Twoich obowiązków należy zatem upewnienie się, że działają one prawidłowo.
 >
-> Celem niniejszego przewodnika jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności lub wątpliwości związanych z administrowaniem, użytkowaniem lub wdrażaniem usług na serwerze, zalecamy skontaktowanie się z [wyspecjalizowanym](https://partner.ovhcloud.com/pl/directory/) dostawcą usług lub [naszą społecznością](https://community.ovh.com/en/).
+> Celem niniejszego przewodnika jest pomoc w jak najbardziej optymalnym wykonywaniu bieżących zadań. Niemniej jednak, w przypadku trudności lub wątpliwości związanych z administrowaniem, użytkowaniem lub wdrażaniem usług na serwerze, zalecamy skontaktowanie się z [wyspecjalizowanym](/links/partner) dostawcą usług lub [naszą społecznością](https://community.ovh.com/en/).
 >
 
 ### Reinstalacja serwera VPS <a name="reinstallvps"></a>

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.de-de.md
@@ -12,13 +12,13 @@ Diese Option bietet eine komfortable Möglichkeit, vollständige VPS Backups reg
 
 > [!primary]
 >
-Bevor Sie Backup-Optionen anwenden, empfehlen wir, die [Produktseiten und FAQ](https://www.ovhcloud.com/de/vps/options/) zu Preisvergleichen und weiteren Details zu konsultieren.
+Bevor Sie Backup-Optionen anwenden, empfehlen wir, die [Produktseiten und FAQ](/links/bare-metal/vps-options) zu Preisvergleichen und weiteren Details zu konsultieren.
 >
 
 ## Voraussetzungen
 
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
-- Sie haben einen [VPS](https://www.ovhcloud.com/de/vps/) in Ihrem Kunden-Account.
+- Sie haben einen [VPS](/links/bare-metal/vps) in Ihrem Kunden-Account.
 - Administratorzugang (sudo) über SSH auf Ihren VPS (optional)
 
 ## In der praktischen Anwendung
@@ -69,7 +69,7 @@ Es ist nicht erforderlich, Ihren laufenden Dienst mit einer Wiederherstellung vo
 >
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 > 
-> Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) oder stellen Ihre Fragen in der [OVHcloud Community](https://community.ovh.com/en/). Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
+> Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister](/links/partner) oder stellen Ihre Fragen in der [OVHcloud Community](https://community.ovh.com/en/). Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten.
 >
 
 Klicken Sie auf `...`{.action} neben dem Backup, auf das Sie zugreifen möchten, und wählen Sie `Mounten`{.action}.

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-asia.md
@@ -12,13 +12,13 @@ This option offers a convenient way to frequently have complete VPS backups avai
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/asia/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/asia/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 - Administrative access (sudo) via SSH to your VPS (optional)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-au.md
@@ -12,13 +12,13 @@ This option offers a convenient way to frequently have complete VPS backups avai
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/en-au/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/en-au/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 - Administrative access (sudo) via SSH to your VPS (optional)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-ca.md
@@ -12,13 +12,13 @@ This option offers a convenient way to frequently have complete VPS backups avai
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/en-ca/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/en-ca/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 - Administrative access (sudo) via SSH to your VPS (optional)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-gb.md
@@ -12,13 +12,13 @@ This option offers a convenient way to frequently have complete VPS backups avai
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/en-gb/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/en-gb/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 - Administrative access (sudo) via SSH to your VPS (optional)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-ie.md
@@ -12,13 +12,13 @@ This option offers a convenient way to frequently have complete VPS backups avai
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/en-ie/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/en-ie/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 - Administrative access (sudo) via SSH to your VPS (optional)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-sg.md
@@ -12,13 +12,13 @@ This option offers a convenient way to frequently have complete VPS backups avai
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/en-sg/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/en-sg/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 - Administrative access (sudo) via SSH to your VPS (optional)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.en-us.md
@@ -12,13 +12,13 @@ This option offers a convenient way to frequently have complete VPS backups avai
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/en/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/en/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 - Administrative access (sudo) via SSH to your VPS (optional)
 
 ## Instructions

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.es-es.md
@@ -16,13 +16,13 @@ Esta opción disponible desde el área de cliente de OVHcloud le ofrece una form
 
 > [!primary]
 >
-Antes de aplicar las opciones de copia de seguridad, le recomendamos que consulte las [preguntas frecuentes y demás páginas del producto](https://www.ovhcloud.com/es-es/vps/options/) para acceder a una comparativa de los precios y otras informaciones.
+Antes de aplicar las opciones de copia de seguridad, le recomendamos que consulte las [preguntas frecuentes y demás páginas del producto](/links/bare-metal/vps-options) para acceder a una comparativa de los precios y otras informaciones.
 >
 
 ## Requisitos
 
 - Tener acceso al [área de cliente de OVHcloud](/links/manager).
-- Tener un [servidor privado virtual (VPS)](https://www.ovhcloud.com/es-es/vps/) de OVHcloud ya configurado.
+- Tener un [servidor privado virtual (VPS)](/links/bare-metal/vps) de OVHcloud ya configurado.
 - Tener acceso de administrador (sudo) a su servidor virtual privado (VPS) a través del protocolo/programa SSH (opcional).
 
 ## Procedimiento
@@ -72,7 +72,7 @@ No es necesario sobrescribir íntegramente el servicio existente con una restaur
 > [!warning]
 >La configuración y la gestión de la serie de servicios que OVHcloud le ofrece recae sobre usted. Por lo tanto, es su responsabilidad asegurarse de que estos servicios funcionen correctamente.
 >
->El propósito de esta guía es ayudarle, en la medida de lo posible, con las tareas generales. No obstante, póngase en contacto con un [proveedor especializado](https://partner.ovhcloud.com/es-es/directory/) y/o el editor del <i>software</i> del servicio si tiene alguna dificultad. Nosotros no podremos ayudarle al respecto. Puede encontrar información adicional en la sección «Más información» de esta guía.
+>El propósito de esta guía es ayudarle, en la medida de lo posible, con las tareas generales. No obstante, póngase en contacto con un [proveedor especializado](/links/partner) y/o el editor del <i>software</i> del servicio si tiene alguna dificultad. Nosotros no podremos ayudarle al respecto. Puede encontrar información adicional en la sección «Más información» de esta guía.
 >
 
 Haga clic en `...`{.action} junto a la copia de seguridad a la que necesite acceder y seleccione `Montaje`{.action}.

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.es-us.md
@@ -16,7 +16,7 @@ Esta opción disponible desde el área de cliente de OVHcloud le ofrece una form
 
 > [!primary]
 >
-Antes de aplicar las opciones de copia de seguridad, le recomendamos que consulte las [preguntas frecuentes y demás páginas del producto](https://www.ovhcloud.com/es-es/vps/options/) para acceder a una comparativa de los precios y otras informaciones.
+Antes de aplicar las opciones de copia de seguridad, le recomendamos que consulte las [preguntas frecuentes y demás páginas del producto](/links/bare-metal/vps-options) para acceder a una comparativa de los precios y otras informaciones.
 >
 
 ## Requisitos
@@ -72,7 +72,7 @@ No es necesario sobrescribir íntegramente el servicio existente con una restaur
 > [!warning]
 >La configuración y la gestión de la serie de servicios que OVHcloud le ofrece recae sobre usted. Por lo tanto, es su responsabilidad asegurarse de que estos servicios funcionen correctamente.
 >
->El propósito de esta guía es ayudarle, en la medida de lo posible, con las tareas generales. No obstante, póngase en contacto con un [proveedor especializado](https://partner.ovhcloud.com/es/directory/) y/o el editor del <i>software</i> del servicio si tiene alguna dificultad. Nosotros no podremos ayudarle al respecto. Puede encontrar información adicional en la sección «Más información» de esta guía.
+>El propósito de esta guía es ayudarle, en la medida de lo posible, con las tareas generales. No obstante, póngase en contacto con un [proveedor especializado](/links/partner) y/o el editor del <i>software</i> del servicio si tiene alguna dificultad. Nosotros no podremos ayudarle al respecto. Puede encontrar información adicional en la sección «Más información» de esta guía.
 >
 
 Haga clic en `...`{.action} junto a la copia de seguridad a la que necesite acceder y seleccione `Montaje`{.action}.

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.fr-ca.md
@@ -13,13 +13,13 @@ Cette option vous offre un moyen pratique de disposer fréquemment de sauvegarde
 <iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Pazh9ozbkEk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 > [!primary]
->Avant d'appliquer une option de sauvegarde, nous vous recommandons de consulter les [options VPS](https://www.ovhcloud.com/fr-ca/vps/options/) afin de comparer les détails et tarifs de chaque option.
+>Avant d'appliquer une option de sauvegarde, nous vous recommandons de consulter les [options VPS](/links/bare-metal/vps-options) afin de comparer les détails et tarifs de chaque option.
 >
 
 ## Prérequis
 
 - Être connecté à [l'espace client OVHcloud](/links/manager)
-- Un [VPS OVHcloud](https://www.ovhcloud.com/fr-ca/vps/options/) déjà configuré
+- Un [VPS OVHcloud](/links/bare-metal/vps-options) déjà configuré
 - Un accès administrateur (sudo) en SSH à votre VPS (facultatif)
 
 ## En pratique
@@ -71,7 +71,7 @@ Cette option permet d'accéder aux données de sauvegarde au cas où vous ne sou
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « Aller plus loin » de ce guide.
 >
 
 Cliquez sur `...`{.action} à droite de la sauvegarde souhaitée et sélectionnez `Montage`{.action}.

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.fr-fr.md
@@ -13,7 +13,7 @@ Cette option vous offre un moyen pratique de disposer fréquemment de sauvegarde
 <iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Pazh9ozbkEk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 > [!primary]
->Avant d'appliquer une option de sauvegarde, nous vous recommandons de consulter les [options VPS](https://www.ovhcloud.com/fr/vps/options/) afin de comparer les détails et tarifs de chaque option.
+>Avant d'appliquer une option de sauvegarde, nous vous recommandons de consulter les [options VPS](/links/bare-metal/vps-options) afin de comparer les détails et tarifs de chaque option.
 >
 
 ## Prérequis
@@ -70,7 +70,7 @@ Cette option permet d'accéder aux données de sauvegarde au cas où vous ne sou
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « Aller plus loin » de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « Aller plus loin » de ce guide.
 >
 
 Cliquez sur `...`{.action} à droite de la sauvegarde souhaitée et sélectionnez `Montage`{.action}.

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.it-it.md
@@ -16,13 +16,13 @@ Questa opzione offre una comoda modalità per avere frequenti backup sul VPS, di
 
 > [!primary]
 >
-Prima di applicare le opzioni di backup, consigliamo di fare riferimento alle pagine prodotto [e alle domande frequenti](https://www.ovhcloud.com/it/vps/options/) per confrontare i prezzi e per visualizzare ulteriori dettagli.
+Prima di applicare le opzioni di backup, consigliamo di fare riferimento alle pagine prodotto [e alle domande frequenti](/links/bare-metal/vps-options) per confrontare i prezzi e per visualizzare ulteriori dettagli.
 >
 
 ## Prerequisiti
 
 - avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
-- un servizio [VPS OVHcloud](https://www.ovhcloud.com/it/vps/) già impostato
+- un servizio [VPS OVHcloud](/links/bare-metal/vps) già impostato
 - accesso come amministratore (sudo) mediante SSH al tuo VPS (opzionale)
 
 ## Procedura

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.pl-pl.md
@@ -16,13 +16,13 @@ Dzięki tej opcji będziesz mieć w Panelu klienta OVHcloud gotowe kopie zapasow
 
 > [!primary]
 >
-Przed zastosowaniem opcji tworzenia kopii zapasowych zalecamy przejrzenie [stron produktów oraz często zadawanych pytań (FAQ)](https://www.ovhcloud.com/pl/vps/options/) w celu porównania cen i uzyskania szczegółowych informacji.
+Przed zastosowaniem opcji tworzenia kopii zapasowych zalecamy przejrzenie [stron produktów oraz często zadawanych pytań (FAQ)](/links/bare-metal/vps-options) w celu porównania cen i uzyskania szczegółowych informacji.
 >
 
 ## Wymagania początkowe
 
 - dostęp do [Panelu klienta OVHcloud](/links/manager)
-- skonfigurowana [usługa VPS](https://www.ovhcloud.com/pl/vps/) OVHcloud
+- skonfigurowana [usługa VPS](/links/bare-metal/vps) OVHcloud
 - dostęp administracyjny (uprawnienia użytkownika root) do prywatnego serwera wirtualnego za pośrednictwem protokołu SSH
 
 ## W praktyce

--- a/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-automated-backups-on-a-vps/guide.pt-pt.md
@@ -16,13 +16,13 @@ Esta opção oferece-lhe uma forma prática de ter backups VPS completos e dispo
 
 > [!primary]
 >
-Antes de aplicar as opções de backup, recomendamos que consulte as [páginas e perguntas frequentes do produto](https://www.ovhcloud.com/pt/vps/options/) para obter uma comparação de preços e outras informações.
+Antes de aplicar as opções de backup, recomendamos que consulte as [páginas e perguntas frequentes do produto](/links/bare-metal/vps-options) para obter uma comparação de preços e outras informações.
 >
 
 ## Requisitos
 
 - acesso à [Área de Cliente OVHcloud](/links/manager)
-- um [serviço VPS](https://www.ovhcloud.com/pt/vps/) OVHcloud já instalado
+- um [serviço VPS](/links/bare-metal/vps) OVHcloud já instalado
 - acesso administrativo (sudo) via SSH ao seu alojamento VPS (opcional)
 
 ## Instruções

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.de-de.md
@@ -16,13 +16,13 @@ Mithilfe eines Snapshots haben Sie die Möglichkeit, schnell und einfach ein lau
 
 > [!primary]
 >
-Bevor Sie Backup-Optionen anwenden, empfehlen wir, die [Produktseiten und FAQ](https://www.ovhcloud.com/de/vps/options/) zu Preisvergleichen und weiteren Details zu konsultieren.
+Bevor Sie Backup-Optionen anwenden, empfehlen wir, die [Produktseiten und FAQ](/links/bare-metal/vps-options) zu Preisvergleichen und weiteren Details zu konsultieren.
 >
 
 ## Voraussetzungen
 
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
-- Sie haben einen [VPS](https://www.ovhcloud.com/de/vps/) in Ihrem Kunden-Account.
+- Sie haben einen [VPS](/links/bare-metal/vps) in Ihrem Kunden-Account.
 
 ## In der praktischen Anwendung
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-asia.md
@@ -12,13 +12,13 @@ Creating a snapshot is a fast and simple way to secure a functioning system befo
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/asia/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/asia/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-au.md
@@ -12,13 +12,13 @@ Creating a snapshot is a fast and simple way to secure a functioning system befo
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/en-au/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/en-au/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-ca.md
@@ -12,13 +12,13 @@ Creating a snapshot is a fast and simple way to secure a functioning system befo
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/en-ca/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/en-ca/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-gb.md
@@ -12,13 +12,13 @@ Creating a snapshot is a fast and simple way to secure a functioning system befo
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/en-gb/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/en-gb/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-ie.md
@@ -12,13 +12,13 @@ Creating a snapshot is a fast and simple way to secure a functioning system befo
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/en-ie/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/en-ie/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-sg.md
@@ -12,14 +12,14 @@ Creating a snapshot is a fast and simple way to secure a functioning system befo
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/en-sg/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/en-sg/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.en-us.md
@@ -12,13 +12,13 @@ Creating a snapshot is a fast and simple way to secure a functioning system befo
 
 > [!primary]
 >
-Before applying backup options, we recommend to consult the [product pages and FAQ](https://www.ovhcloud.com/en/vps/options/) for pricing comparisons and further details.
+Before applying backup options, we recommend to consult the [product pages and FAQ](/links/bare-metal/vps-options) for pricing comparisons and further details.
 >
 
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An OVHcloud [VPS service](https://www.ovhcloud.com/en-ca/vps/) already set up
+- An OVHcloud [VPS service](/links/bare-metal/vps) already set up
 
 ## Instructions
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.es-es.md
@@ -16,13 +16,13 @@ Crear una instantánea (<i>snapshot</i>) es una forma simple y rápida de proteg
 
 > [!primary]
 >
-Antes de aplicar las opciones de copia de seguridad, le recomendamos que consulte las [preguntas frecuentes y demás páginas del producto](https://www.ovhcloud.com/es-es/vps/options/) para acceder a una comparativa de los precios y otras informaciones.
+Antes de aplicar las opciones de copia de seguridad, le recomendamos que consulte las [preguntas frecuentes y demás páginas del producto](/links/bare-metal/vps-options) para acceder a una comparativa de los precios y otras informaciones.
 >
 
 ## Requisitos
 
 - Tener acceso al [panel de control de OVHcloud](/links/manager).
-- Tener un [servicio de servidor virtual privado (VPS)](https://www.ovhcloud.com/es-es/vps/) de OVHcloud configurado.
+- Tener un [servicio de servidor virtual privado (VPS)](/links/bare-metal/vps) de OVHcloud configurado.
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.es-us.md
@@ -16,13 +16,13 @@ Crear una instantánea (<i>snapshot</i>) es una forma simple y rápida de proteg
 
 > [!primary]
 >
-Antes de aplicar las opciones de copia de seguridad, le recomendamos que consulte las [preguntas frecuentes y demás páginas del producto](https://www.ovhcloud.com/es/vps/options/) para acceder a una comparativa de los precios y otras informaciones.
+Antes de aplicar las opciones de copia de seguridad, le recomendamos que consulte las [preguntas frecuentes y demás páginas del producto](/links/bare-metal/vps-options) para acceder a una comparativa de los precios y otras informaciones.
 >
 
 ## Requisitos
 
 - Tener acceso al [panel de control de OVHcloud](/links/manager).
-- Tener un [servicio de servidor virtual privado (VPS)](https://www.ovhcloud.com/es/vps/) de OVHcloud configurado.
+- Tener un [servicio de servidor virtual privado (VPS)](/links/bare-metal/vps) de OVHcloud configurado.
 
 ## Procedimiento
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.fr-ca.md
@@ -14,13 +14,13 @@ Un snapshot ne constitue pas pour autant une sauvegarde complète du système.
 <iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Pazh9ozbkEk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 > [!primary]
-> Avant d'appliquer une option de sauvegarde, nous vous recommandons de consulter les [options VPS](https://www.ovhcloud.com/fr-ca/vps/options/) afin de comparer les détails et tarifs de chaque option.
+> Avant d'appliquer une option de sauvegarde, nous vous recommandons de consulter les [options VPS](/links/bare-metal/vps-options) afin de comparer les détails et tarifs de chaque option.
 >
 
 ## Prérequis
 
 - Avoir accès à votre [espace client OVHcloud](/links/manager).
-- Un [VPS OVHcloud](https://www.ovhcloud.com/fr-ca/vps/) déjà configuré.
+- Un [VPS OVHcloud](/links/bare-metal/vps) déjà configuré.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.fr-fr.md
@@ -14,13 +14,13 @@ Un snapshot ne constitue pas pour autant une sauvegarde complète du système.
 <iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Pazh9ozbkEk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 > [!primary]
-> Avant d'appliquer une option de sauvegarde, nous vous recommandons de consulter les [options VPS](https://www.ovhcloud.com/fr/vps/options/) afin de comparer les détails et tarifs de chaque option.
+> Avant d'appliquer une option de sauvegarde, nous vous recommandons de consulter les [options VPS](/links/bare-metal/vps-options) afin de comparer les détails et tarifs de chaque option.
 >
 
 ## Prérequis
 
 - Avoir accès à votre [espace client OVHcloud](/links/manager).
-- Un [VPS OVHcloud](https://www.ovhcloud.com/fr/vps/) déjà configuré.
+- Un [VPS OVHcloud](/links/bare-metal/vps) déjà configuré.
 
 ## En pratique
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.it-it.md
@@ -16,13 +16,13 @@ Creare uno snapshot è un modo semplice e rapido per mettere al sicuro un sistem
 
 > [!primary]
 >
-Prima di applicare opzioni di backup, consigliamo di fare riferimento alle pagine prodotto [e alle domande frequenti](https://www.ovhcloud.com/it/vps/options/) per confrontare i prezzi e per visualizzare ulteriori dettagli.
+Prima di applicare opzioni di backup, consigliamo di fare riferimento alle pagine prodotto [e alle domande frequenti](/links/bare-metal/vps-options) per confrontare i prezzi e per visualizzare ulteriori dettagli.
 >
 
 ## Prerequisiti
 
 - avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
-- un servizio [VPS OVHcloud](https://www.ovhcloud.com/it/vps/) già impostato
+- un servizio [VPS OVHcloud](/links/bare-metal/vps) già impostato
 
 ## Procedura
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.pl-pl.md
@@ -16,13 +16,13 @@ Utworzenie migawki jest szybkim i prostym sposobem na zabezpieczenie działania 
 
 > [!primary]
 >
-Przed zastosowaniem opcji tworzenia kopii zapasowych zalecamy przejrzenie [stron produktów oraz często zadawanych pytań (FAQ)](https://www.ovhcloud.com/pl/vps/options/) w celu porównania cen i uzyskania szczegółowych informacji.
+Przed zastosowaniem opcji tworzenia kopii zapasowych zalecamy przejrzenie [stron produktów oraz często zadawanych pytań (FAQ)](/links/bare-metal/vps-options) w celu porównania cen i uzyskania szczegółowych informacji.
 >
 
 ## Wymagania początkowe
 
 - dostęp do [Panelu klienta OVHcloud](/links/manager)
-- skonfigurowana [usługa VPS](https://www.ovhcloud.com/pl/vps/) OVHcloud
+- skonfigurowana [usługa VPS](/links/bare-metal/vps) OVHcloud
 
 ## W praktyce
 

--- a/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/using-snapshots-on-a-vps/guide.pt-pt.md
@@ -16,13 +16,13 @@ Criar um snapshot é uma forma simples e rápida de garantir o funcionamento de 
 
 > [!primary]
 >
-Antes de aplicar as opções de backup, recomendamos que consulte as [páginas e perguntas frequentes do produto](https://www.ovhcloud.com/pt/vps/options/) para obter uma comparação de preços e outras informações.
+Antes de aplicar as opções de backup, recomendamos que consulte as [páginas e perguntas frequentes do produto](/links/bare-metal/vps-options) para obter uma comparação de preços e outras informações.
 >
 
 ## Requisitos
 
 - acesso à [Área de Cliente OVHcloud](/links/manager)
-- um [serviço VPS](https://www.ovhcloud.com/pt/vps/) OVHcloud já instalado
+- um [serviço VPS](/links/bare-metal/vps) OVHcloud já instalado
 
 ## Instruções
 

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.de-de.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.de-de.md
@@ -10,7 +10,7 @@ updated: 2024-01-22
 
 ## Ziel
 
-Sie können anhand des in Ihrem [OVHcloud Kundencenter](/links/manager) angezeigten Referenznamens feststellen, ob ein VPS aus einer alten Reihe stammt: Wenn diese interne Referenz im Format *vpsXXXX.ovh.net* vorliegt (wobei *X* für eine Zahl steht) und Sie den entsprechenden VPS nicht auf [unsere aktuelle Produktreihe](https://www.ovhcloud.com/de/vps/) migriert haben, handelt es sich um einen *Legacy* VPS. 
+Sie können anhand des in Ihrem [OVHcloud Kundencenter](/links/manager) angezeigten Referenznamens feststellen, ob ein VPS aus einer alten Reihe stammt: Wenn diese interne Referenz im Format *vpsXXXX.ovh.net* vorliegt (wobei *X* für eine Zahl steht) und Sie den entsprechenden VPS nicht auf [unsere aktuelle Produktreihe](/links/bare-metal/vps) migriert haben, handelt es sich um einen *Legacy* VPS. 
 
 Die Referenz für einen VPS der aktuellen Reihe has das Format: *vps-XXXXXXX.vps.ovh.net* (wobei *X* eine Ziffer oder ein Buchstabe sein kann).
 
@@ -20,7 +20,7 @@ Für einen *Legacy* VPS bestehen einige Unterschiede bezüglich dessen Verwaltun
 
 ## Voraussetzungen
 
-- Sie haben einen [*Legacy* VPS](https://www.ovhcloud.com/de/vps/) in Ihrem Kunden-Account.
+- Sie haben einen [*Legacy* VPS](/links/bare-metal/vps) in Ihrem Kunden-Account.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 ## In der praktischen Anwendung

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-asia.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-asia.md
@@ -6,7 +6,7 @@ updated: 2024-01-22
 
 ## Objective
 
-You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](https://www.ovhcloud.com/asia/vps/), this is a legacy VPS. There are a few differences to consider when managing such a service.
+You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](/links/bare-metal/vps), this is a legacy VPS. There are a few differences to consider when managing such a service.
 
 The reference name of a current VPS looks like this: *vps-XXXXXXX.vps.ovh.net* (where *X* can be a number or a letter).
 

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-au.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-au.md
@@ -6,7 +6,7 @@ updated: 2024-01-22
 
 ## Objective
 
-You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](https://www.ovhcloud.com/en-au/vps/), this is a legacy VPS. There are a few differences to consider when managing such a service.
+You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](/links/bare-metal/vps), this is a legacy VPS. There are a few differences to consider when managing such a service.
 
 The reference name of a current VPS looks like this: *vps-XXXXXXX.vps.ovh.net* (where *X* can be a number or a letter).
 

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-ca.md
@@ -6,7 +6,7 @@ updated: 2024-01-22
 
 ## Objective
 
-You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](https://www.ovhcloud.com/en-ca/vps/), this is a legacy VPS. There are a few differences to consider when managing such a service.
+You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](/links/bare-metal/vps), this is a legacy VPS. There are a few differences to consider when managing such a service.
 
 The reference name of a current VPS looks like this: *vps-XXXXXXX.vps.ovh.net* (where *X* can be a number or a letter).
 

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-gb.md
@@ -6,7 +6,7 @@ updated: 2024-01-22
 
 ## Objective
 
-You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](https://www.ovhcloud.com/en-gb/vps/), this is a legacy VPS. There are a few differences to consider when managing such a service.
+You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](/links/bare-metal/vps), this is a legacy VPS. There are a few differences to consider when managing such a service.
 
 The reference name of a current VPS looks like this: *vps-XXXXXXX.vps.ovh.net* (where *X* can be a number or a letter).
 

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-ie.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-ie.md
@@ -6,7 +6,7 @@ updated: 2024-01-22
 
 ## Objective
 
-You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](https://www.ovhcloud.com/en-ie/vps/), this is a legacy VPS. There are a few differences to consider when managing such a service.
+You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](/links/bare-metal/vps), this is a legacy VPS. There are a few differences to consider when managing such a service.
 
 The reference name of a current VPS looks like this: *vps-XXXXXXX.vps.ovh.net* (where *X* can be a number or a letter).
 

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-sg.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-sg.md
@@ -6,7 +6,7 @@ updated: 2024-01-22
 
 ## Objective
 
-You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](https://www.ovhcloud.com/en-sg/vps/), this is a legacy VPS. There are a few differences to consider when managing such a service.
+You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](/links/bare-metal/vps), this is a legacy VPS. There are a few differences to consider when managing such a service.
 
 The reference name of a current VPS looks like this: *vps-XXXXXXX.vps.ovh.net* (where *X* can be a number or a letter).
 

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.en-us.md
@@ -6,7 +6,7 @@ updated: 2024-01-22
 
 ## Objective
 
-You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](https://www.ovhcloud.com/en/vps/), this is a legacy VPS. There are a few differences to consider when managing such a service.
+You can identify an old-range VPS by the reference name displayed in your [OVHcloud Control Panel](/links/manager): If this internal identifier has the format *vpsXXXX.ovh.net* (in which *X* stands for a number) and you have not migrated the corresponding VPS to our [current product line](/links/bare-metal/vps), this is a legacy VPS. There are a few differences to consider when managing such a service.
 
 The reference name of a current VPS looks like this: *vps-XXXXXXX.vps.ovh.net* (where *X* can be a number or a letter).
 

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.es-es.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.es-es.md
@@ -9,7 +9,7 @@ updated: 2024-01-22
 > 
 ## Objetivo
 
-Puede identificar si un VPS procede de una antigua gama gracias al nombre de referencia que aparece en el [área de cliente de OVHcloud](/links/manager): si dicha referencia interna está en formato *vpsXXXX.ovh.net* (donde *X* representa un número) y no ha migrado el VPS correspondiente a [nuestra gama actual de productos](https://www.ovhcloud.com/es-es/vps/), se trata de un VPS *legacy*. 
+Puede identificar si un VPS procede de una antigua gama gracias al nombre de referencia que aparece en el [área de cliente de OVHcloud](/links/manager): si dicha referencia interna está en formato *vpsXXXX.ovh.net* (donde *X* representa un número) y no ha migrado el VPS correspondiente a [nuestra gama actual de productos](/links/bare-metal/vps), se trata de un VPS *legacy*. 
 
 La referencia de un VPS de gama actual se presenta de esta manera: *vps-XXXXXXX.vps.ovh.net* (donde *X* puede ser una cifra o una letra).
 
@@ -19,7 +19,7 @@ Un VPS *legacy* implica algunas diferencias en términos de gestión.
 
 ## Requisitos
 
-- Un [VPS *legacy*](https://www.ovhcloud.com/es-es/vps/) en su cuenta de OVHcloud
+- Un [VPS *legacy*](/links/bare-metal/vps) en su cuenta de OVHcloud
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.es-us.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.es-us.md
@@ -10,7 +10,7 @@ updated: 2024-01-22
 
 ## Objetivo
 
-Puede identificar si un VPS procede de una antigua gama gracias al nombre de referencia que aparece en el [área de cliente de OVHcloud](/links/manager): si dicha referencia interna está en formato *vpsXXXX.ovh.net* (donde *X* representa un número) y no ha migrado el VPS correspondiente a [nuestra gama actual de productos](https://www.ovhcloud.com/es/vps/), se trata de un VPS *legacy*. 
+Puede identificar si un VPS procede de una antigua gama gracias al nombre de referencia que aparece en el [área de cliente de OVHcloud](/links/manager): si dicha referencia interna está en formato *vpsXXXX.ovh.net* (donde *X* representa un número) y no ha migrado el VPS correspondiente a [nuestra gama actual de productos](/links/bare-metal/vps), se trata de un VPS *legacy*. 
 
 La referencia de un VPS de gama actual se presenta de esta manera: *vps-XXXXXXX.vps.ovh.net* (donde *X* puede ser una cifra o una letra).
 
@@ -20,7 +20,7 @@ Un VPS *legacy* implica algunas diferencias en términos de gestión.
 
 ## Requisitos
 
-- Un [VPS *legacy*](https://www.ovhcloud.com/es/vps/) en su cuenta de OVHcloud
+- Un [VPS *legacy*](/links/bare-metal/vps) en su cuenta de OVHcloud
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
 
 ## Procedimiento

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.fr-ca.md
@@ -6,7 +6,7 @@ updated: 2024-01-22
 
 ## Objectif
 
-Vous pouvez identifier si un VPS est issu d'une ancienne gamme grâce au nom de référence affiché dans votre [espace client OVHcloud](/links/manager) : si cette référence interne est au format *vpsXXXX.ovh.net* (où *X* représente un chiffre) et que vous n’avez pas migré le VPS correspondant vers [notre gamme actuelle de produits](https://www.ovhcloud.com/fr-ca/vps/), il s’agit d’un VPS *legacy*. 
+Vous pouvez identifier si un VPS est issu d'une ancienne gamme grâce au nom de référence affiché dans votre [espace client OVHcloud](/links/manager) : si cette référence interne est au format *vpsXXXX.ovh.net* (où *X* représente un chiffre) et que vous n’avez pas migré le VPS correspondant vers [notre gamme actuelle de produits](/links/bare-metal/vps), il s’agit d’un VPS *legacy*. 
 
 La référence d'un VPS de gamme actuelle se présente de cette façon : *vps-XXXXXXX.vps.ovh.net* (où *X* peut être un chiffre ou une lettre).
 
@@ -16,7 +16,7 @@ Un VPS *legacy* implique quelques différences en termes de gestion.
 
 ## Prérequis
 
-- Un [VPS](https://www.ovhcloud.com/fr-ca/vps/) *legacy* dans votre compte OVHcloud
+- Un [VPS](/links/bare-metal/vps) *legacy* dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.fr-fr.md
@@ -6,7 +6,7 @@ updated: 2024-01-22
 
 ## Objectif
 
-Vous pouvez identifier si un VPS est issu d'une ancienne gamme grâce au nom de référence affiché dans votre [espace client OVHcloud](/links/manager) : si cette référence interne est au format *vpsXXXX.ovh.net* (où *X* représente un chiffre) et que vous n’avez pas migré le VPS correspondant vers [notre gamme actuelle de produits](https://www.ovhcloud.com/fr/vps/), il s’agit d’un VPS *legacy*. 
+Vous pouvez identifier si un VPS est issu d'une ancienne gamme grâce au nom de référence affiché dans votre [espace client OVHcloud](/links/manager) : si cette référence interne est au format *vpsXXXX.ovh.net* (où *X* représente un chiffre) et que vous n’avez pas migré le VPS correspondant vers [notre gamme actuelle de produits](/links/bare-metal/vps), il s’agit d’un VPS *legacy*. 
 
 La référence d'un VPS de gamme actuelle se présente de cette façon : *vps-XXXXXXX.vps.ovh.net* (où *X* peut être un chiffre ou une lettre).
 
@@ -16,7 +16,7 @@ Un VPS *legacy* implique quelques différences en termes de gestion.
 
 ## Prérequis
 
-- Un [VPS](https://www.ovhcloud.com/fr/vps/) *legacy* dans votre compte OVHcloud
+- Un [VPS](/links/bare-metal/vps) *legacy* dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.it-it.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.it-it.md
@@ -10,7 +10,7 @@ updated: 2024-01-22
 
 ## Obiettivo
 
-Il nome visualizzato nello [Spazio Cliente OVHcloud](/links/manager) permette di stabilire se un VPS appartiene a una gamma meno recente. Se invece la referenza interna è in formato *vpsXXXX.ovh.net* (dove *X* rappresenta una cifra) e non è stato effettuato il trasferimento del VPS corrispondente alla [nostra gamma attuale di prodotti](https://www.ovhcloud.com/it/vps/), si tratta di un VPS *legacy*. 
+Il nome visualizzato nello [Spazio Cliente OVHcloud](/links/manager) permette di stabilire se un VPS appartiene a una gamma meno recente. Se invece la referenza interna è in formato *vpsXXXX.ovh.net* (dove *X* rappresenta una cifra) e non è stato effettuato il trasferimento del VPS corrispondente alla [nostra gamma attuale di prodotti](/links/bare-metal/vps), si tratta di un VPS *legacy*. 
 
 Il riferimento di un VPS della gamma attuale si presenta in questo modo: *vps-XXXXXXX.vps.ovh.net* (dove *X* può essere una cifra o una lettera).
 
@@ -20,7 +20,7 @@ Un VPS *legacy* implica alcune differenze in termini di gestione.
 
 ## Prerequisiti
 
-- Un [VPS *legacy*](https://www.ovhcloud.com/it/vps/) nel tuo account OVHcloud
+- Un [VPS *legacy*](/links/bare-metal/vps) nel tuo account OVHcloud
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 ## Procedura

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.pl-pl.md
@@ -10,7 +10,7 @@ updated: 2024-01-22
 
 ## Wprowadzenie
 
-Możesz sprawdzić, czy VPS pochodzi z poprzedniej gamy serwerów, używając nazwy wyświetlanej w [Panelu klienta](/links/manager): jeśli ten wewnętrzny numer referencyjny ma format *vpsXXXX.ovh.net* (gdzie *X* odpowiada liczbie) i nie przeniosłeś odpowiedniego serwera VPS do [naszej aktualnej gamy produktów](https://www.ovhcloud.com/pl/vps/), jest to VPS *legacy*. 
+Możesz sprawdzić, czy VPS pochodzi z poprzedniej gamy serwerów, używając nazwy wyświetlanej w [Panelu klienta](/links/manager): jeśli ten wewnętrzny numer referencyjny ma format *vpsXXXX.ovh.net* (gdzie *X* odpowiada liczbie) i nie przeniosłeś odpowiedniego serwera VPS do [naszej aktualnej gamy produktów](/links/bare-metal/vps), jest to VPS *legacy*. 
 
 Model VPS gamy dostępny obecnie: *vps-XXXXX.vps.ovh.net* (gdzie *X* może być cyfrą lub literą).
 
@@ -20,7 +20,7 @@ Serwer VPS *legacy* wymaga kilku różnic w zarządzaniu.
 
 ## Wymagania początkowe
 
-- [VPS *legacy*](https://www.ovhcloud.com/pl/vps/) na koncie OVHcloud
+- [VPS *legacy*](/links/bare-metal/vps) na koncie OVHcloud
 - Zalogowanie do [Panelu klienta OVHcloud](/links/manager)
 
 ## W praktyce

--- a/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/vps_legacy_control_panel/guide.pt-pt.md
@@ -10,7 +10,7 @@ updated: 2024-01-22
 
 ## Objetivo
 
-Pode identificar se um VPS pertence a uma gama mais antiga graças ao nome de referência apresentado na sua [Área de Cliente OVHcloud](/links/manager): se esta referência interna estiver no formato *vpsXXXX.ovh.net* (em que *X* representa um algarismo) e não tiver migrado o VPS correspondente para a [nossa gama atual de produtos](https://www.ovhcloud.com/pt/vps/), trata-se de um VPS *legacy*. 
+Pode identificar se um VPS pertence a uma gama mais antiga graças ao nome de referência apresentado na sua [Área de Cliente OVHcloud](/links/manager): se esta referência interna estiver no formato *vpsXXXX.ovh.net* (em que *X* representa um algarismo) e não tiver migrado o VPS correspondente para a [nossa gama atual de produtos](/links/bare-metal/vps), trata-se de um VPS *legacy*. 
 
 A referência de um VPS da gama atual apresenta-se desta forma: *vps-XXXXXXX.vps.ovh.net* (em que *X* pode ser um algarismo ou uma letra).
 
@@ -20,7 +20,7 @@ Um VPS *legacy* implica algumas diferenças em termos de gestão.
 
 ## Requisitos
 
-- Um [VPS *legacy*](https://www.ovhcloud.com/pt/vps/) na sua conta OVHcloud
+- Um [VPS *legacy*](/links/bare-metal/vps) na sua conta OVHcloud
 - Estar ligado à [Área de Cliente OVHcloud](/links/manager).
 
 ## Instruções


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their /links values.

Example: replace all https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB links with /links/manager.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.