### PR TITLE
Fix global links in Hosted private cloud sap on ovhcloud

### DIFF
--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.de-de.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.de-de.md
@@ -14,7 +14,7 @@ This implementation reduces the Recovery Time Objective (RTO), in case of a virt
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A deployed [SAP HANA on Private Cloud](https://www.ovhcloud.com/de/hosted-private-cloud/sap-hana/) solution.
 - Two deployed SAP HANA virtual machines with the same SAP HANA version installed .
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-asia.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-asia.md
@@ -14,7 +14,7 @@ This implementation reduces the Recovery Time Objective (RTO), in case of a virt
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A deployed [SAP HANA on Private Cloud](https://www.ovhcloud.com/asia/hosted-private-cloud/sap-hana/) solution.
 - Two deployed SAP HANA virtual machines with the same SAP HANA version installed .
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-au.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-au.md
@@ -14,7 +14,7 @@ This implementation reduces the Recovery Time Objective (RTO), in case of a virt
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A deployed [SAP HANA on Private Cloud](https://www.ovhcloud.com/en-au/hosted-private-cloud/sap-hana/) solution.
 - Two deployed SAP HANA virtual machines with the same SAP HANA version installed .
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-ca.md
@@ -14,7 +14,7 @@ This implementation reduces the Recovery Time Objective (RTO), in case of a virt
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A deployed [SAP HANA on Private Cloud](https://www.ovhcloud.com/en-ca/hosted-private-cloud/sap-hana/) solution.
 - Two deployed SAP HANA virtual machines with the same SAP HANA version installed .
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-gb.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-gb.md
@@ -14,7 +14,7 @@ This implementation reduces the Recovery Time Objective (RTO), in case of a virt
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A deployed [SAP HANA on Private Cloud](https://www.ovhcloud.com/en-gb/hosted-private-cloud/sap-hana/) solution.
 - Two deployed SAP HANA virtual machines with the same SAP HANA version installed .
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-ie.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-ie.md
@@ -14,7 +14,7 @@ This implementation reduces the Recovery Time Objective (RTO), in case of a virt
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A deployed [SAP HANA on Private Cloud](https://www.ovhcloud.com/en-ie/hosted-private-cloud/sap-hana/) solution.
 - Two deployed SAP HANA virtual machines with the same SAP HANA version installed .
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-sg.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-sg.md
@@ -14,7 +14,7 @@ This implementation reduces the Recovery Time Objective (RTO), in case of a virt
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A deployed [SAP HANA on Private Cloud](https://www.ovhcloud.com/en-sg/hosted-private-cloud/sap-hana/) solution.
 - Two deployed SAP HANA virtual machines with the same SAP HANA version installed .
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-us.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.en-us.md
@@ -14,7 +14,7 @@ This implementation reduces the Recovery Time Objective (RTO), in case of a virt
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A deployed [SAP HANA on Private Cloud](https://www.ovhcloud.com/en/hosted-private-cloud/sap-hana/) solution.
 - Two deployed SAP HANA virtual machines with the same SAP HANA version installed .
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.es-es.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.es-es.md
@@ -14,7 +14,7 @@ This implementation reduces the Recovery Time Objective (RTO), in case of a virt
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A deployed [SAP HANA on Private Cloud](https://www.ovhcloud.com/es-es/hosted-private-cloud/sap-hana/) solution.
 - Two deployed SAP HANA virtual machines with the same SAP HANA version installed .
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.es-us.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.es-us.md
@@ -14,7 +14,7 @@ This implementation reduces the Recovery Time Objective (RTO), in case of a virt
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A deployed [SAP HANA on Private Cloud](https://www.ovhcloud.com/es/hosted-private-cloud/sap-hana/) solution.
 - Two deployed SAP HANA virtual machines with the same SAP HANA version installed .
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.fr-ca.md
@@ -14,7 +14,7 @@ Cette configuration réduit la durée maximale d'interruption admissible (RTO), 
 
 ## Prérequis
 
-- Un accès à l'[espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Un accès à l'[espace client OVHcloud](/links/manager).
 - Une solution [SAP HANA on Private Cloud](https://www.ovhcloud.com/fr-ca/hosted-private-cloud/sap-hana/) déployée.
 - Deux machines virtuelles SAP HANA déployées ayant la même version SAP HANA installée.
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.fr-fr.md
@@ -14,7 +14,7 @@ Cette configuration réduit la durée maximale d'interruption admissible (RTO), 
 
 ## Prérequis
 
-- Un accès à l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Un accès à l'[espace client OVHcloud](/links/manager).
 - Une solution [SAP HANA on Private Cloud](https://www.ovhcloud.com/fr/hosted-private-cloud/sap-hana/) déployée.
 - Deux machines virtuelles SAP HANA déployées ayant la même version SAP HANA installée.
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.it-it.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.it-it.md
@@ -14,7 +14,7 @@ This implementation reduces the Recovery Time Objective (RTO), in case of a virt
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A deployed [SAP HANA on Private Cloud](https://www.ovhcloud.com/it/hosted-private-cloud/sap-hana/) solution.
 - Two deployed SAP HANA virtual machines with the same SAP HANA version installed .
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.pl-pl.md
@@ -14,7 +14,7 @@ This implementation reduces the Recovery Time Objective (RTO), in case of a virt
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A deployed [SAP HANA on Private Cloud](https://www.ovhcloud.com/pl/hosted-private-cloud/sap-hana/) solution.
 - Two deployed SAP HANA virtual machines with the same SAP HANA version installed .
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/guide.pt-pt.md
@@ -14,7 +14,7 @@ This implementation reduces the Recovery Time Objective (RTO), in case of a virt
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A deployed [SAP HANA on Private Cloud](https://www.ovhcloud.com/pt/hosted-private-cloud/sap-hana/) solution.
 - Two deployed SAP HANA virtual machines with the same SAP HANA version installed .
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.de-de.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.de-de.md
@@ -12,7 +12,7 @@ This guide provides instructions for deploying the SLES 15 for SAP image on an O
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An [HGR-SAP dedicated server](https://www.ovhcloud.com/de/lp/sap/)
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-asia.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-asia.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying the SLES 15 for SAP image on an O
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An [HGR-SAP dedicated server](https://www.ovhcloud.com/asia/lp/sap/)
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-au.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-au.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying the SLES 15 for SAP image on an O
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An [HGR-SAP dedicated server](https://www.ovhcloud.com/en-au/lp/sap/)
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-ca.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying the SLES 15 for SAP image on an O
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An [HGR-SAP dedicated server](https://www.ovhcloud.com/en-ca/lp/sap/)
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-gb.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-gb.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying the SLES 15 for SAP image on an O
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An [HGR-SAP dedicated server](https://www.ovhcloud.com/en-gb/lp/sap/)
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-ie.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-ie.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying the SLES 15 for SAP image on an O
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An [HGR-SAP dedicated server](https://www.ovhcloud.com/en-ie/lp/sap/)
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-sg.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-sg.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying the SLES 15 for SAP image on an O
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An [HGR-SAP dedicated server](https://www.ovhcloud.com/en-sg/lp/sap/)
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-us.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.en-us.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying the SLES 15 for SAP image on an O
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An [HGR-SAP dedicated server](https://www.ovhcloud.com/en/lp/sap/)
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.es-es.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.es-es.md
@@ -12,7 +12,7 @@ This guide provides instructions for deploying the SLES 15 for SAP image on an O
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An [HGR-SAP dedicated server](https://www.ovhcloud.com/es-es/lp/sap/)
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.es-us.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.es-us.md
@@ -12,7 +12,7 @@ This guide provides instructions for deploying the SLES 15 for SAP image on an O
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An [HGR-SAP dedicated server](https://www.ovhcloud.com/es/lp/sap/)
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.fr-ca.md
@@ -10,7 +10,7 @@ Ce guide fournit des instructions pour le déploiement de l'image SUSE Linux Ent
 
 ## Prérequis
 
-- Un accès à l’[espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Un accès à l’[espace client OVHcloud](/links/manager)
 - Un [serveur dédié HGR-SAP Bare Metal](https://www.ovhcloud.com/fr-ca/lp/sap/)
 
 ## En pratique

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.fr-fr.md
@@ -10,7 +10,7 @@ Ce guide fournit des instructions pour le déploiement de l'image SUSE Linux Ent
 
 ## Prérequis
 
-- Un accès à l’[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Un accès à l’[espace client OVHcloud](/links/manager)
 - Un [serveur dédié HGR-SAP Bare Metal](https://www.ovhcloud.com/fr/lp/sap/)
 
 ## En pratique

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.it-it.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.it-it.md
@@ -12,7 +12,7 @@ This guide provides instructions for deploying the SLES 15 for SAP image on an O
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An [HGR-SAP dedicated server](https://www.ovhcloud.com/it/lp/sap/)
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.pl-pl.md
@@ -12,7 +12,7 @@ This guide provides instructions for deploying the SLES 15 for SAP image on an O
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An [HGR-SAP dedicated server](https://www.ovhcloud.com/pl/lp/sap/)
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_sles_sap_hana_dedicated_server/guide.pt-pt.md
@@ -12,7 +12,7 @@ This guide provides instructions for deploying the SLES 15 for SAP image on an O
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An [HGR-SAP dedicated server](https://www.ovhcloud.com/pt/lp/sap/)
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.de-de.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.de-de.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying a SLES for SAP virtual machine wi
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - A [SAP HANA on Private Cloud solution](https://www.ovhcloud.com/de/hosted-private-cloud/sap-hana/) deployed
 - A [Public Cloud project](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) in your OVHcloud account with:
     - [An Object Storage bucket](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) and [an Object Storage user](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) with read right

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-asia.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-asia.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying a SLES for SAP virtual machine wi
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - A [SAP HANA on Private Cloud solution](https://www.ovhcloud.com/asia/hosted-private-cloud/sap-hana/) deployed
 - A [Public Cloud project](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) in your OVHcloud account with:
     - [An Object Storage bucket](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) and [an Object Storage user](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) with read right

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-au.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-au.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying a SLES for SAP virtual machine wi
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - A [SAP HANA on Private Cloud solution](https://www.ovhcloud.com/en-au/hosted-private-cloud/sap-hana/) deployed
 - A [Public Cloud project](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) in your OVHcloud account with:
     - [An Object Storage bucket](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) and [an Object Storage user](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) with read right

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-ca.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying a SLES for SAP virtual machine wi
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - A [SAP HANA on Private Cloud solution](https://www.ovhcloud.com/en-ca/hosted-private-cloud/sap-hana/) deployed
 - A [Public Cloud project](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) in your OVHcloud account with:
     - [An Object Storage bucket](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) and [an Object Storage user](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) with read right

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-gb.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-gb.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying a SLES for SAP virtual machine wi
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - A [SAP HANA on Private Cloud solution](https://www.ovhcloud.com/en-gb/hosted-private-cloud/sap-hana/) deployed
 - A [Public Cloud project](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) in your OVHcloud account with:
     - [An Object Storage bucket](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) and [an Object Storage user](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) with read right

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-ie.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-ie.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying a SLES for SAP virtual machine wi
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - A [SAP HANA on Private Cloud solution](https://www.ovhcloud.com/en-ie/hosted-private-cloud/sap-hana/) deployed
 - A [Public Cloud project](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) in your OVHcloud account with:
     - [An Object Storage bucket](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) and [an Object Storage user](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) with read right

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-sg.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-sg.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying a SLES for SAP virtual machine wi
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - A [SAP HANA on Private Cloud solution](https://www.ovhcloud.com/en-sg/hosted-private-cloud/sap-hana/) deployed
 - A [Public Cloud project](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) in your OVHcloud account with:
     - [An Object Storage bucket](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) and [an Object Storage user](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) with read right

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-us.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.en-us.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying a SLES for SAP virtual machine wi
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - A [SAP HANA on Private Cloud solution](https://www.ovhcloud.com/en/hosted-private-cloud/sap-hana/) deployed
 - A [Public Cloud project](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) in your OVHcloud account with:
     - [An Object Storage bucket](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) and [an Object Storage user](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) with read right

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.es-es.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.es-es.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying a SLES for SAP virtual machine wi
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - A [SAP HANA on Private Cloud solution](https://www.ovhcloud.com/es-es/hosted-private-cloud/sap-hana/) deployed
 - A [Public Cloud project](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) in your OVHcloud account with:
     - [An Object Storage bucket](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) and [an Object Storage user](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) with read right

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.es-us.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.es-us.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying a SLES for SAP virtual machine wi
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - A [SAP HANA on Private Cloud solution](https://www.ovhcloud.com/es/hosted-private-cloud/sap-hana/) deployed
 - A [Public Cloud project](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) in your OVHcloud account with:
     - [An Object Storage bucket](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) and [an Object Storage user](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) with read right

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.fr-ca.md
@@ -10,7 +10,7 @@ Ce guide vous détaille les étapes pour le déploiement d'une machine virtuelle
 
 ## Prérequis
 
-- Un accès à l’[espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Un accès à l’[espace client OVHcloud](/links/manager)
 - Une [solution SAP HANA on Private Cloud](https://www.ovhcloud.com/fr-ca/hosted-private-cloud/sap-hana/) déployée
 - [Un projet Public Cloud](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) dans votre compte OVHcloud avec :
     - [Un bucket Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) et [un utilisateur Object Storage](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) avec le droit de lecture

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.fr-fr.md
@@ -10,7 +10,7 @@ Ce guide vous détaille les étapes pour le déploiement d'une machine virtuelle
 
 ## Prérequis
 
-- Un accès à l’[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Un accès à l’[espace client OVHcloud](/links/manager)
 - Une [solution SAP HANA on Private Cloud](https://www.ovhcloud.com/fr/hosted-private-cloud/sap-hana/) déployée
 - [Un projet Public Cloud](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) dans votre compte OVHcloud avec :
     - [Un bucket Object Storage](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) et [un utilisateur Object Storage](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) avec le droit de lecture

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.it-it.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.it-it.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying a SLES for SAP virtual machine wi
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - A [SAP HANA on Private Cloud solution](https://www.ovhcloud.com/it/hosted-private-cloud/sap-hana/) deployed
 - A [Public Cloud project](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) in your OVHcloud account with:
     - [An Object Storage bucket](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) and [an Object Storage user](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) with read right

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.pl-pl.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying a SLES for SAP virtual machine wi
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - A [SAP HANA on Private Cloud solution](https://www.ovhcloud.com/pl/hosted-private-cloud/sap-hana/) deployed
 - A [Public Cloud project](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) in your OVHcloud account with:
     - [An Object Storage bucket](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) and [an Object Storage user](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) with read right

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_sap_hana_template_vmware/guide.pt-pt.md
@@ -10,7 +10,7 @@ This guide provides instructions for deploying a SLES for SAP virtual machine wi
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - A [SAP HANA on Private Cloud solution](https://www.ovhcloud.com/pt/hosted-private-cloud/sap-hana/) deployed
 - A [Public Cloud project](/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project) in your OVHcloud account with:
     - [An Object Storage bucket](/pages/storage_and_backup/object_storage/s3_getting_started_with_object_storage) and [an Object Storage user](/pages/storage_and_backup/object_storage/s3_identity_and_access_management#creation-dun-utilsateur) with read right

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.de-de.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.de-de.md
@@ -11,7 +11,7 @@ This guide provides instructions for using the SAP Application Servers Terraform
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/en/&ovhSubsidiary=en).
-- [VMware on OVHcloud solution](https://www.ovhcloud.com/de/hosted-private-cloud/vmware/) deployed.
+- [VMware on OVHcloud solution](/links/hosted-private-cloud/vmware) deployed.
 - Terraform binary (version >= 1.4).
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-asia.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-asia.md
@@ -11,7 +11,7 @@ This guide provides instructions for using the SAP Application Servers Terraform
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/en/&ovhSubsidiary=en).
-- [VMware on OVHcloud solution](https://www.ovhcloud.com/asia/hosted-private-cloud/vmware/) deployed.
+- [VMware on OVHcloud solution](/links/hosted-private-cloud/vmware) deployed.
 - Terraform binary (version >= 1.4).
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-au.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-au.md
@@ -11,7 +11,7 @@ This guide provides instructions for using the SAP Application Servers Terraform
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/en/&ovhSubsidiary=en).
-- [VMware on OVHcloud solution](https://www.ovhcloud.com/en-au/hosted-private-cloud/vmware/) deployed.
+- [VMware on OVHcloud solution](/links/hosted-private-cloud/vmware) deployed.
 - Terraform binary (version >= 1.4).
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-ca.md
@@ -11,7 +11,7 @@ This guide provides instructions for using the SAP Application Servers Terraform
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/en/&ovhSubsidiary=en).
-- [VMware on OVHcloud solution](https://www.ovhcloud.com/en-ca/hosted-private-cloud/vmware/) deployed.
+- [VMware on OVHcloud solution](/links/hosted-private-cloud/vmware) deployed.
 - Terraform binary (version >= 1.4).
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-gb.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-gb.md
@@ -11,7 +11,7 @@ This guide provides instructions for using the SAP Application Servers Terraform
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/en/&ovhSubsidiary=en).
-- [VMware on OVHcloud solution](https://www.ovhcloud.com/en-gb/hosted-private-cloud/vmware/) deployed.
+- [VMware on OVHcloud solution](/links/hosted-private-cloud/vmware) deployed.
 - Terraform binary (version >= 1.4).
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-ie.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-ie.md
@@ -11,7 +11,7 @@ This guide provides instructions for using the SAP Application Servers Terraform
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/en/&ovhSubsidiary=en).
-- [VMware on OVHcloud solution](https://www.ovhcloud.com/en-ie/hosted-private-cloud/vmware/) deployed.
+- [VMware on OVHcloud solution](/links/hosted-private-cloud/vmware) deployed.
 - Terraform binary (version >= 1.4).
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-sg.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-sg.md
@@ -11,7 +11,7 @@ This guide provides instructions for using the SAP Application Servers Terraform
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/en/&ovhSubsidiary=en).
-- [VMware on OVHcloud solution](https://www.ovhcloud.com/en-sg/hosted-private-cloud/vmware/) deployed.
+- [VMware on OVHcloud solution](/links/hosted-private-cloud/vmware) deployed.
 - Terraform binary (version >= 1.4).
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-us.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.en-us.md
@@ -11,7 +11,7 @@ This guide provides instructions for using the SAP Application Servers Terraform
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/en/&ovhSubsidiary=en).
-- [VMware on OVHcloud solution](https://www.ovhcloud.com/en/hosted-private-cloud/vmware/) deployed.
+- [VMware on OVHcloud solution](/links/hosted-private-cloud/vmware) deployed.
 - Terraform binary (version >= 1.4).
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.es-es.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.es-es.md
@@ -11,7 +11,7 @@ This guide provides instructions for using the SAP Application Servers Terraform
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/en/&ovhSubsidiary=en).
-- [VMware on OVHcloud solution](https://www.ovhcloud.com/es-es/hosted-private-cloud/vmware/) deployed.
+- [VMware on OVHcloud solution](/links/hosted-private-cloud/vmware) deployed.
 - Terraform binary (version >= 1.4).
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.es-us.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.es-us.md
@@ -11,7 +11,7 @@ This guide provides instructions for using the SAP Application Servers Terraform
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/en/&ovhSubsidiary=en).
-- [VMware on OVHcloud solution](https://www.ovhcloud.com/es/hosted-private-cloud/vmware/) deployed.
+- [VMware on OVHcloud solution](/links/hosted-private-cloud/vmware) deployed.
 - Terraform binary (version >= 1.4).
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.fr-ca.md
@@ -10,8 +10,8 @@ Ce guide fournit des instructions sur l'utilisation du module Terraform SAP Appl
 
 ## Prérequis
 
-- Être connecté à l'[espace client](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
-- Une [solution VMware on OVHcloud](https://www.ovhcloud.com/fr-ca/hosted-private-cloud/vmware/) déployée.
+- Être connecté à l'[espace client](/links/manager).
+- Une [solution VMware on OVHcloud](/links/hosted-private-cloud/vmware) déployée.
 - Binaire Terraform (version >= 1.4).
 
 ## En pratique

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.fr-fr.md
@@ -10,8 +10,8 @@ Ce guide fournit des instructions sur l'utilisation du module Terraform SAP Appl
 
 ## Prérequis
 
-- Être connecté à l'[espace client](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
-- Une [solution VMware on OVHcloud](https://www.ovhcloud.com/fr/hosted-private-cloud/vmware/) déployée.
+- Être connecté à l'[espace client](/links/manager).
+- Une [solution VMware on OVHcloud](/links/hosted-private-cloud/vmware) déployée.
 - Binaire Terraform (version >= 1.4).
 
 ## En pratique

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.it-it.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.it-it.md
@@ -11,7 +11,7 @@ This guide provides instructions for using the SAP Application Servers Terraform
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/en/&ovhSubsidiary=en).
-- [VMware on OVHcloud solution](https://www.ovhcloud.com/it/hosted-private-cloud/vmware/) deployed.
+- [VMware on OVHcloud solution](/links/hosted-private-cloud/vmware) deployed.
 - Terraform binary (version >= 1.4).
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.pl-pl.md
@@ -11,7 +11,7 @@ This guide provides instructions for using the SAP Application Servers Terraform
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/en/&ovhSubsidiary=en).
-- [VMware on OVHcloud solution](https://www.ovhcloud.com/pl/hosted-private-cloud/vmware/) deployed.
+- [VMware on OVHcloud solution](/links/hosted-private-cloud/vmware) deployed.
 - Terraform binary (version >= 1.4).
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/guide.pt-pt.md
@@ -11,7 +11,7 @@ This guide provides instructions for using the SAP Application Servers Terraform
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/en/&ovhSubsidiary=en).
-- [VMware on OVHcloud solution](https://www.ovhcloud.com/pt/hosted-private-cloud/vmware/) deployed.
+- [VMware on OVHcloud solution](/links/hosted-private-cloud/vmware) deployed.
 - Terraform binary (version >= 1.4).
 
 ## Instructions

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_hana_database/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_hana_database/guide.fr-ca.md
@@ -10,8 +10,8 @@ Ce guide fournit des instructions sur l'utilisation du module Terraform SAP HANA
 
 ## Prérequis
 
-- Être connecté à l'[espace client](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
-- Une [solution VMware on OVHcloud](https://www.ovhcloud.com/fr-ca/hosted-private-cloud/vmware/) déployée.
+- Être connecté à l'[espace client](/links/manager).
+- Une [solution VMware on OVHcloud](/links/hosted-private-cloud/vmware) déployée.
 - Binaire Terraform (version >= 1.4).
 
 ## En pratique

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_hana_database/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_hana_database/guide.fr-fr.md
@@ -10,8 +10,8 @@ Ce guide fournit des instructions sur l'utilisation du module Terraform SAP HANA
 
 ## Prérequis
 
-- Être connecté à l'[espace client](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
-- Une [solution VMware on OVHcloud](https://www.ovhcloud.com/fr/hosted-private-cloud/vmware/) déployée.
+- Être connecté à l'[espace client](/links/manager).
+- Une [solution VMware on OVHcloud](/links/hosted-private-cloud/vmware) déployée.
 - Binaire Terraform (version >= 1.4).
 
 ## En pratique

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_system/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_system/guide.fr-ca.md
@@ -10,8 +10,8 @@ Ce guide fournit des instructions sur l'utilisation du module Terraform SAP syst
 
 ## Prérequis
 
-- Être connecté à l'[espace client](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
-- Une [solution VMware on OVHcloud](https://www.ovhcloud.com/fr-ca/hosted-private-cloud/vmware/) déployée.
+- Être connecté à l'[espace client](/links/manager).
+- Une [solution VMware on OVHcloud](/links/hosted-private-cloud/vmware) déployée.
 - Binaire Terraform (version >= 1.4).
 
 ## En pratique

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_system/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_system/guide.fr-fr.md
@@ -10,8 +10,8 @@ Ce guide fournit des instructions sur l'utilisation du module Terraform SAP syst
 
 ## Prérequis
 
-- Être connecté à l'[espace client](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
-- Une [solution VMware on OVHcloud](https://www.ovhcloud.com/fr/hosted-private-cloud/vmware/) déployée.
+- Être connecté à l'[espace client](/links/manager).
+- Une [solution VMware on OVHcloud](/links/hosted-private-cloud/vmware) déployée.
 - Binaire Terraform (version >= 1.4).
 
 ## En pratique

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.de-de.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.de-de.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 This guide provides instructions for backing up SAP HANA databases using Veeam Backup and Replication 12.2 and the Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus with OVHcloud](https://www.ovhcloud.com/de/storage-solutions/veeam-enterprise/) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
+[Veeam Enterprise Plus with OVHcloud](/links/hosted-private-cloud/veeam-enterprise) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
 
 ## Requirements
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-asia.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-asia.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 This guide provides instructions for backing up SAP HANA databases using Veeam Backup and Replication 12.2 and the Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus with OVHcloud](https://www.ovhcloud.com/asia/storage-solutions/veeam-enterprise/) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
+[Veeam Enterprise Plus with OVHcloud](/links/hosted-private-cloud/veeam-enterprise) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
 
 ## Requirements
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-au.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-au.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 This guide provides instructions for backing up SAP HANA databases using Veeam Backup and Replication 12.2 and the Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus with OVHcloud](https://www.ovhcloud.com/en-au/storage-solutions/veeam-enterprise/) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
+[Veeam Enterprise Plus with OVHcloud](/links/hosted-private-cloud/veeam-enterprise) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
 
 ## Requirements
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-ca.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 This guide provides instructions for backing up SAP HANA databases using Veeam Backup and Replication 12.2 and the Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus with OVHcloud](https://www.ovhcloud.com/en-ca/storage-solutions/veeam-enterprise/) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
+[Veeam Enterprise Plus with OVHcloud](/links/hosted-private-cloud/veeam-enterprise) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
 
 ## Requirements
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-gb.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-gb.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 This guide provides instructions for backing up SAP HANA databases using Veeam Backup and Replication 12.2 and the Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus with OVHcloud](https://www.ovhcloud.com/en-gb/storage-solutions/veeam-enterprise/) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
+[Veeam Enterprise Plus with OVHcloud](/links/hosted-private-cloud/veeam-enterprise) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
 
 ## Requirements
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-ie.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-ie.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 This guide provides instructions for backing up SAP HANA databases using Veeam Backup and Replication 12.2 and the Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus with OVHcloud](https://www.ovhcloud.com/en-ie/storage-solutions/veeam-enterprise/) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
+[Veeam Enterprise Plus with OVHcloud](/links/hosted-private-cloud/veeam-enterprise) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
 
 ## Requirements
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-sg.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-sg.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 This guide provides instructions for backing up SAP HANA databases using Veeam Backup and Replication 12.2 and the Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus with OVHcloud](https://www.ovhcloud.com/en-sg/storage-solutions/veeam-enterprise/) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
+[Veeam Enterprise Plus with OVHcloud](/links/hosted-private-cloud/veeam-enterprise) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
 
 ## Requirements
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-us.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.en-us.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 This guide provides instructions for backing up SAP HANA databases using Veeam Backup and Replication 12.2 and the Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus with OVHcloud](https://www.ovhcloud.com/en/storage-solutions/veeam-enterprise/) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
+[Veeam Enterprise Plus with OVHcloud](/links/hosted-private-cloud/veeam-enterprise) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
 
 ## Requirements
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.es-es.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.es-es.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 This guide provides instructions for backing up SAP HANA databases using Veeam Backup and Replication 12.2 and the Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus with OVHcloud](https://www.ovhcloud.com/es-es/storage-solutions/veeam-enterprise/) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
+[Veeam Enterprise Plus with OVHcloud](/links/hosted-private-cloud/veeam-enterprise) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
 
 ## Requirements
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.es-us.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.es-us.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 This guide provides instructions for backing up SAP HANA databases using Veeam Backup and Replication 12.2 and the Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus with OVHcloud](https://www.ovhcloud.com/es/storage-solutions/veeam-enterprise/) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
+[Veeam Enterprise Plus with OVHcloud](/links/hosted-private-cloud/veeam-enterprise) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
 
 ## Requirements
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.fr-ca.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 Ce guide fournit des instructions générales pour sauvegarder des bases de données SAP HANA avec Veeam Backup and Replication 12.2 et Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus avec OVHcloud](https://www.ovhcloud.com/fr-ca/storage-solutions/veeam-enterprise/) vous permet d’utiliser Veeam Backup and Replication 12 au sein de votre infrastructure OVHcloud en bénéficiant d'un niveau de licence Veeam Enterprise Plus.
+[Veeam Enterprise Plus avec OVHcloud](/links/hosted-private-cloud/veeam-enterprise) vous permet d’utiliser Veeam Backup and Replication 12 au sein de votre infrastructure OVHcloud en bénéficiant d'un niveau de licence Veeam Enterprise Plus.
 
 ## Prérequis
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.fr-fr.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 Ce guide fournit des instructions générales pour sauvegarder des bases de données SAP HANA avec Veeam Backup and Replication 12.2 et Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus avec OVHcloud](https://www.ovhcloud.com/fr/storage-solutions/veeam-enterprise/) vous permet d’utiliser Veeam Backup and Replication 12 au sein de votre infrastructure OVHcloud en bénéficiant d'un niveau de licence Veeam Enterprise Plus.
+[Veeam Enterprise Plus avec OVHcloud](/links/hosted-private-cloud/veeam-enterprise) vous permet d’utiliser Veeam Backup and Replication 12 au sein de votre infrastructure OVHcloud en bénéficiant d'un niveau de licence Veeam Enterprise Plus.
 
 ## Prérequis
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.it-it.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.it-it.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 This guide provides instructions for backing up SAP HANA databases using Veeam Backup and Replication 12.2 and the Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus with OVHcloud](https://www.ovhcloud.com/it/storage-solutions/veeam-enterprise/) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
+[Veeam Enterprise Plus with OVHcloud](/links/hosted-private-cloud/veeam-enterprise) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
 
 ## Requirements
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.pl-pl.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 This guide provides instructions for backing up SAP HANA databases using Veeam Backup and Replication 12.2 and the Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus with OVHcloud](https://www.ovhcloud.com/pl/storage-solutions/veeam-enterprise/) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
+[Veeam Enterprise Plus with OVHcloud](/links/hosted-private-cloud/veeam-enterprise) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
 
 ## Requirements
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_veeam_backup_sap_hana/guide.pt-pt.md
@@ -8,7 +8,7 @@ updated: 2024-09-17
 
 This guide provides instructions for backing up SAP HANA databases using Veeam Backup and Replication 12.2 and the Veeam Plug-in for SAP HANA.
 
-[Veeam Enterprise Plus with OVHcloud](https://www.ovhcloud.com/pt/storage-solutions/veeam-enterprise/) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
+[Veeam Enterprise Plus with OVHcloud](/links/hosted-private-cloud/veeam-enterprise) allows you to use Veeam Backup and Replication 12 within your OVHcloud infrastructure and benefiting from a Veeam Enterprise Plus licence.
 
 ## Requirements
 

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.de-de.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.de-de.md
@@ -10,7 +10,7 @@ This guides provides instructions for deploying an SAProuter on VMware on OVHclo
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A [VMware on OVHcloud solution](https://www.ovhcloud.com/de/enterprise/products/hosted-private-cloud/) deployed.
 - Access to NSX with management rights.
 
@@ -25,7 +25,7 @@ If you didn't create a Network Firewall and a firewall rule for the public IP ad
 > [!tabs]
 > **Step 1**
 >>
->> Connect to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
+>> Connect to your [OVHcloud Control Panel](/links/manager), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
 >>
 >> If you have many public IP addresses or services, you can filter them with the `All service types`{.action} value and select `Hosting Private Cloud (VMware)`{.action}, or with the `All services`{.action} value and select your VMware on OVHcloud solution.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-asia.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-asia.md
@@ -10,7 +10,7 @@ This guides provides instructions for deploying an SAProuter on VMware on OVHclo
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A [VMware on OVHcloud solution](https://www.ovhcloud.com/asia/enterprise/products/hosted-private-cloud/) deployed.
 - Access to NSX with management rights.
 
@@ -25,7 +25,7 @@ If you didn't create a Network Firewall and a firewall rule for the public IP ad
 > [!tabs]
 > **Step 1**
 >>
->> Connect to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
+>> Connect to your [OVHcloud Control Panel](/links/manager), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
 >>
 >> If you have many public IP addresses or services, you can filter them with the `All service types`{.action} value and select `Hosting Private Cloud (VMware)`{.action}, or with the `All services`{.action} value and select your VMware on OVHcloud solution.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-au.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-au.md
@@ -10,7 +10,7 @@ This guides provides instructions for deploying an SAProuter on VMware on OVHclo
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A [VMware on OVHcloud solution](https://www.ovhcloud.com/en-au/enterprise/products/hosted-private-cloud/) deployed.
 - Access to NSX with management rights.
 
@@ -25,7 +25,7 @@ If you didn't create a Network Firewall and a firewall rule for the public IP ad
 > [!tabs]
 > **Step 1**
 >>
->> Connect to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
+>> Connect to your [OVHcloud Control Panel](/links/manager), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
 >>
 >> If you have many public IP addresses or services, you can filter them with the `All service types`{.action} value and select `Hosting Private Cloud (VMware)`{.action}, or with the `All services`{.action} value and select your VMware on OVHcloud solution.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-ca.md
@@ -10,7 +10,7 @@ This guides provides instructions for deploying an SAProuter on VMware on OVHclo
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A [VMware on OVHcloud solution](https://www.ovhcloud.com/en-ca/enterprise/products/hosted-private-cloud/) deployed.
 - Access to NSX with management rights.
 
@@ -25,7 +25,7 @@ If you didn't create a Network Firewall and a firewall rule for the public IP ad
 > [!tabs]
 > **Step 1**
 >>
->> Connect to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
+>> Connect to your [OVHcloud Control Panel](/links/manager), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
 >>
 >> If you have many public IP addresses or services, you can filter them with the `All service types`{.action} value and select `Hosting Private Cloud (VMware)`{.action}, or with the `All services`{.action} value and select your VMware on OVHcloud solution.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-gb.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-gb.md
@@ -10,7 +10,7 @@ This guides provides instructions for deploying an SAProuter on VMware on OVHclo
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A [VMware on OVHcloud solution](https://www.ovhcloud.com/en-gb/enterprise/products/hosted-private-cloud/) deployed.
 - Access to NSX with management rights.
 
@@ -25,7 +25,7 @@ If you didn't create a Network Firewall and a firewall rule for the public IP ad
 > [!tabs]
 > **Step 1**
 >>
->> Connect to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
+>> Connect to your [OVHcloud Control Panel](/links/manager), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
 >>
 >> If you have many public IP addresses or services, you can filter them with the `All service types`{.action} value and select `Hosting Private Cloud (VMware)`{.action}, or with the `All services`{.action} value and select your VMware on OVHcloud solution.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-ie.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-ie.md
@@ -10,7 +10,7 @@ This guides provides instructions for deploying an SAProuter on VMware on OVHclo
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A [VMware on OVHcloud solution](https://www.ovhcloud.com/en-ie/enterprise/products/hosted-private-cloud/) deployed.
 - Access to NSX with management rights.
 
@@ -25,7 +25,7 @@ If you didn't create a Network Firewall and a firewall rule for the public IP ad
 > [!tabs]
 > **Step 1**
 >>
->> Connect to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
+>> Connect to your [OVHcloud Control Panel](/links/manager), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
 >>
 >> If you have many public IP addresses or services, you can filter them with the `All service types`{.action} value and select `Hosting Private Cloud (VMware)`{.action}, or with the `All services`{.action} value and select your VMware on OVHcloud solution.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-sg.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-sg.md
@@ -10,7 +10,7 @@ This guides provides instructions for deploying an SAProuter on VMware on OVHclo
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A [VMware on OVHcloud solution](https://www.ovhcloud.com/en-sg/enterprise/products/hosted-private-cloud/) deployed.
 - Access to NSX with management rights.
 
@@ -25,7 +25,7 @@ If you didn't create a Network Firewall and a firewall rule for the public IP ad
 > [!tabs]
 > **Step 1**
 >>
->> Connect to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
+>> Connect to your [OVHcloud Control Panel](/links/manager), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
 >>
 >> If you have many public IP addresses or services, you can filter them with the `All service types`{.action} value and select `Hosting Private Cloud (VMware)`{.action}, or with the `All services`{.action} value and select your VMware on OVHcloud solution.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-us.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.en-us.md
@@ -10,7 +10,7 @@ This guides provides instructions for deploying an SAProuter on VMware on OVHclo
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A [VMware on OVHcloud solution](https://www.ovhcloud.com/en/enterprise/products/hosted-private-cloud/) deployed.
 - Access to NSX with management rights.
 
@@ -25,7 +25,7 @@ If you didn't create a Network Firewall and a firewall rule for the public IP ad
 > [!tabs]
 > **Step 1**
 >>
->> Connect to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
+>> Connect to your [OVHcloud Control Panel](/links/manager), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
 >>
 >> If you have many public IP addresses or services, you can filter them with the `All service types`{.action} value and select `Hosting Private Cloud (VMware)`{.action}, or with the `All services`{.action} value and select your VMware on OVHcloud solution.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.es-es.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.es-es.md
@@ -10,7 +10,7 @@ This guides provides instructions for deploying an SAProuter on VMware on OVHclo
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A [VMware on OVHcloud solution](https://www.ovhcloud.com/es-es/enterprise/products/hosted-private-cloud/) deployed.
 - Access to NSX with management rights.
 
@@ -25,7 +25,7 @@ If you didn't create a Network Firewall and a firewall rule for the public IP ad
 > [!tabs]
 > **Step 1**
 >>
->> Connect to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
+>> Connect to your [OVHcloud Control Panel](/links/manager), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
 >>
 >> If you have many public IP addresses or services, you can filter them with the `All service types`{.action} value and select `Hosting Private Cloud (VMware)`{.action}, or with the `All services`{.action} value and select your VMware on OVHcloud solution.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.es-us.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.es-us.md
@@ -10,7 +10,7 @@ This guides provides instructions for deploying an SAProuter on VMware on OVHclo
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A [VMware on OVHcloud solution](https://www.ovhcloud.com/es/enterprise/products/hosted-private-cloud/) deployed.
 - Access to NSX with management rights.
 
@@ -25,7 +25,7 @@ If you didn't create a Network Firewall and a firewall rule for the public IP ad
 > [!tabs]
 > **Step 1**
 >>
->> Connect to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
+>> Connect to your [OVHcloud Control Panel](/links/manager), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
 >>
 >> If you have many public IP addresses or services, you can filter them with the `All service types`{.action} value and select `Hosting Private Cloud (VMware)`{.action}, or with the `All services`{.action} value and select your VMware on OVHcloud solution.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.fr-ca.md
@@ -10,7 +10,7 @@ Ce guide vous détaille le déploiement d'un SAProuter sur VMware on OVHcloud av
 
 ## Prérequis
 
-- Être connecté à l’[espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à l’[espace client OVHcloud](/links/manager).
 - Une solution [VMware on OVHcloud](https://www.ovhcloud.com/fr-ca/enterprise/products/hosted-private-cloud/) avec NSX déployée dans votre compte OVHcloud.
 - Un accès avec les droits de gestion pour NSX.
 
@@ -25,7 +25,7 @@ Si vous n'avez pas créé de Network Firewall et de règles de filtrage réseau 
 > [!tabs]
 > **Étape 1**
 >>
->> Connectez-vous à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc), ouvrez l'onglet `Bare Metal Cloud`{.action}, menu `Network`{.action} puis cliquez sur `IP`{.action}.
+>> Connectez-vous à votre [espace client OVHcloud](/links/manager), ouvrez l'onglet `Bare Metal Cloud`{.action}, menu `Network`{.action} puis cliquez sur `IP`{.action}.
 >>
 >> Si vous possédez plusieurs adresses IP publiques ou services, vous pouvez soit filtrer avec les valeurs `Tous les types de service`{.action} et sélectionner `Hosting Private Cloud (VMware)`{.action}, soit avec les valeurs `Tous les services`{.action} et sélectionner votre solution VMware on OVHcloud.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.fr-fr.md
@@ -10,7 +10,7 @@ Ce guide vous détaille le déploiement d'un SAProuter sur VMware on OVHcloud av
 
 ## Prérequis
 
-- Être connecté à l’[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à l’[espace client OVHcloud](/links/manager).
 - Une solution [VMware on OVHcloud](https://www.ovhcloud.com/fr/enterprise/products/hosted-private-cloud/) avec NSX déployée dans votre compte OVHcloud.
 - Un accès avec les droits de gestion pour NSX.
 
@@ -25,7 +25,7 @@ Si vous n'avez pas créé de Network Firewall et de règles de filtrage réseau 
 > [!tabs]
 > **Étape 1**
 >>
->> Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr), ouvrez l'onglet `Bare Metal Cloud`{.action}, menu `Network`{.action} puis cliquez sur `IP`{.action}.
+>> Connectez-vous à votre [espace client OVHcloud](/links/manager), ouvrez l'onglet `Bare Metal Cloud`{.action}, menu `Network`{.action} puis cliquez sur `IP`{.action}.
 >>
 >> Si vous possédez plusieurs adresses IP publiques ou services, vous pouvez soit filtrer avec les valeurs `Tous les types de service`{.action} et sélectionner `Hosting Private Cloud (VMware)`{.action}, soit avec les valeurs `Tous les services`{.action} et sélectionner votre solution VMware on OVHcloud.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.it-it.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.it-it.md
@@ -10,7 +10,7 @@ This guides provides instructions for deploying an SAProuter on VMware on OVHclo
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A [VMware on OVHcloud solution](https://www.ovhcloud.com/it/enterprise/products/hosted-private-cloud/) deployed.
 - Access to NSX with management rights.
 
@@ -25,7 +25,7 @@ If you didn't create a Network Firewall and a firewall rule for the public IP ad
 > [!tabs]
 > **Step 1**
 >>
->> Connect to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
+>> Connect to your [OVHcloud Control Panel](/links/manager), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
 >>
 >> If you have many public IP addresses or services, you can filter them with the `All service types`{.action} value and select `Hosting Private Cloud (VMware)`{.action}, or with the `All services`{.action} value and select your VMware on OVHcloud solution.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.pl-pl.md
@@ -10,7 +10,7 @@ This guides provides instructions for deploying an SAProuter on VMware on OVHclo
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A [VMware on OVHcloud solution](https://www.ovhcloud.com/pl/enterprise/products/hosted-private-cloud/) deployed.
 - Access to NSX with management rights.
 
@@ -25,7 +25,7 @@ If you didn't create a Network Firewall and a firewall rule for the public IP ad
 > [!tabs]
 > **Step 1**
 >>
->> Connect to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
+>> Connect to your [OVHcloud Control Panel](/links/manager), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
 >>
 >> If you have many public IP addresses or services, you can filter them with the `All service types`{.action} value and select `Hosting Private Cloud (VMware)`{.action}, or with the `All services`{.action} value and select your VMware on OVHcloud solution.
 >>

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_vmware_saprouter/guide.pt-pt.md
@@ -10,7 +10,7 @@ This guides provides instructions for deploying an SAProuter on VMware on OVHclo
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - A [VMware on OVHcloud solution](https://www.ovhcloud.com/pt/enterprise/products/hosted-private-cloud/) deployed.
 - Access to NSX with management rights.
 
@@ -25,7 +25,7 @@ If you didn't create a Network Firewall and a firewall rule for the public IP ad
 > [!tabs]
 > **Step 1**
 >>
->> Connect to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
+>> Connect to your [OVHcloud Control Panel](/links/manager), open the `Bare Metal Cloud`{.action} tab, expand the `Network`{.action} menu then click on `IP`{.action}.
 >>
 >> If you have many public IP addresses or services, you can filter them with the `All service types`{.action} value and select `Hosting Private Cloud (VMware)`{.action}, or with the `All services`{.action} value and select your VMware on OVHcloud solution.
 >>


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their /links values.

Example: replace all https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB links with /links/manager.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.