### PR TITLE
Fix global links in Hosted private cloud nutanix on ovhcloud

### DIFF
--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.de-de.md
@@ -17,7 +17,7 @@ updated: 2022-12-13
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 > [!warning]
@@ -200,6 +200,6 @@ Click `Execute`{.action} to start the cluster redeployment.
 
 [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.en-ca.md
@@ -17,8 +17,8 @@ updated: 2022-12-13
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
-- access to the [OVHcloud API page](https://ca.api.ovh.com/)
+- access to the [OVHcloud Control Panel](/links/manager)
+- access to the [OVHcloud API page](/links/api)
 
 > [!warning]
 > If you have signed up to the **Nutanix on OVHcloud BYOL offer** and have activated licences on your cluster, you will need to uninstall your licences before you launch the redeployment. You can use this guide to manage your licences: [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol).
@@ -200,6 +200,6 @@ Click `Execute`{.action} to start the cluster redeployment.
 
 [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.en-gb.md
@@ -17,7 +17,7 @@ updated: 2022-12-13
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 > [!warning]
@@ -200,6 +200,6 @@ Click `Execute`{.action} to start the cluster redeployment.
 
 [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.en-ie.md
@@ -17,7 +17,7 @@ updated: 2022-12-13
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 > [!warning]
@@ -200,6 +200,6 @@ Click `Execute`{.action} to start the cluster redeployment.
 
 [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.en-us.md
@@ -17,8 +17,8 @@ updated: 2022-12-13
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
-- access to the [OVHcloud API page](https://ca.api.ovh.com/)
+- access to the [OVHcloud Control Panel](/links/manager)
+- access to the [OVHcloud API page](/links/api)
 
 > [!warning]
 > If you have signed up to the **Nutanix on OVHcloud BYOL offer** and have activated licences on your cluster, you will need to uninstall your licences before you launch the redeployment. You can use this guide to manage your licences: [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol).
@@ -200,6 +200,6 @@ Click `Execute`{.action} to start the cluster redeployment.
 
 [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.es-es.md
@@ -17,7 +17,7 @@ updated: 2022-12-13
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 > [!warning]
@@ -200,6 +200,6 @@ Click `Execute`{.action} to start the cluster redeployment.
 
 [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.es-us.md
@@ -17,8 +17,8 @@ updated: 2022-12-13
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
-- access to the [OVHcloud API page](https://ca.api.ovh.com/)
+- access to the [OVHcloud Control Panel](/links/manager)
+- access to the [OVHcloud API page](/links/api)
 
 > [!warning]
 > If you have signed up to the **Nutanix on OVHcloud BYOL offer** and have activated licences on your cluster, you will need to uninstall your licences before you launch the redeployment. You can use this guide to manage your licences: [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol).
@@ -200,6 +200,6 @@ Click `Execute`{.action} to start the cluster redeployment.
 
 [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.fr-ca.md
@@ -11,14 +11,14 @@ updated: 2022-12-13
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un Cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
-- Être connecté sur la page des [API OVHcloud](https://ca.api.ovh.com/)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
+- Être connecté sur la page des [API OVHcloud](/links/api)
 
 > [!warning]
 > Si vous avez souscrit à **l'offre Nutanix on OVHcloud BYOL** et que vous avez activé des licences sur votre cluster, vous devez désinstaller vos licences avant de lancer le redéploiement. Vous pouvez vous aider de ce guide pour gérer vos licences: [Gestion des licences dans votre cluster Nutanix on OVHcloud BYOL](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol).
@@ -202,6 +202,6 @@ Cliquez sur `Execute`{.action} pour lancer le redéploiement du cluster.
 
 [Gestion des licences dans votre cluster Nutanix on OVHcloud BYOL](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol).
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.fr-fr.md
@@ -11,13 +11,13 @@ updated: 2022-12-13
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un Cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté sur la page des [API OVHcloud](https://api.ovh.com/)
 
 > [!warning]
@@ -202,6 +202,6 @@ Cliquez sur `Execute`{.action} pour lancer le redéploiement du cluster.
 
 [Gestion des licences dans votre cluster Nutanix on OVHcloud BYOL](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol).
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.it-it.md
@@ -17,7 +17,7 @@ updated: 2022-12-13
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 > [!warning]
@@ -200,6 +200,6 @@ Click `Execute`{.action} to start the cluster redeployment.
 
 [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.pl-pl.md
@@ -17,7 +17,7 @@ updated: 2022-12-13
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 > [!warning]
@@ -200,6 +200,6 @@ Click `Execute`{.action} to start the cluster redeployment.
 
 [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/00-cluster-custom-redeployment/guide.pt-pt.md
@@ -17,7 +17,7 @@ updated: 2022-12-13
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 > [!warning]
@@ -200,6 +200,6 @@ Click `Execute`{.action} to start the cluster redeployment.
 
 [Manage licences in your Nutanix on OVHcloud BYOL Offer cluster](/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.de-de.md
@@ -12,10 +12,10 @@ This page provides an explanation of the elements that constitute a Nutanix clus
 
 A Nutanix cluster consists of a stack of OVHcloud services:
 
-- [Dedicated server](https://www.ovhcloud.com/de/bare-metal/)
-- [vRack](https://www.ovhcloud.com/de/network/vrack/)
-- [Load Balancer](https://www.ovhcloud.com/de/network/load-balancer/)
-- [Additional IP](https://www.ovhcloud.com/de/bare-metal/ip/)
+- [Dedicated server](/links/bare-metal/bare-metal)
+- [vRack](/links/network/vrack)
+- [Load Balancer](/links/network/load-balancer)
+- [Additional IP](/links/bare-metal/ip)
 
 Dedicated servers (3 minimum) are connected within the vRack which is an L2 network, the hosts (node) private network.
 
@@ -71,6 +71,6 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.en-ca.md
@@ -12,10 +12,10 @@ This page provides an explanation of the elements that constitute a Nutanix clus
 
 A Nutanix cluster consists of a stack of OVHcloud services:
 
-- [Dedicated server](https://www.ovhcloud.com/en-ca/bare-metal/)
-- [vRack](https://www.ovhcloud.com/en-ca/network/vrack/)
-- [Load Balancer](https://www.ovhcloud.com/en-ca/network/load-balancer/)
-- [Additional IP](https://www.ovhcloud.com/en-ca/bare-metal/ip/)
+- [Dedicated server](/links/bare-metal/bare-metal)
+- [vRack](/links/network/vrack)
+- [Load Balancer](/links/network/load-balancer)
+- [Additional IP](/links/bare-metal/ip)
 
 Dedicated servers (3 minimum) are connected within the vRack which is an L2 network, the hosts (node) private network.
 
@@ -71,6 +71,6 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.en-gb.md
@@ -12,10 +12,10 @@ This page provides an explanation of the elements that constitute a Nutanix clus
 
 A Nutanix cluster consists of a stack of OVHcloud services:
 
-- [Dedicated server](https://www.ovhcloud.com/en-gb/bare-metal/)
-- [vRack](https://www.ovhcloud.com/en-gb/network/vrack/)
-- [Load Balancer](https://www.ovhcloud.com/en-gb/network/load-balancer/)
-- [Additional IP](https://www.ovhcloud.com/en-gb/bare-metal/ip/)
+- [Dedicated server](/links/bare-metal/bare-metal)
+- [vRack](/links/network/vrack)
+- [Load Balancer](/links/network/load-balancer)
+- [Additional IP](/links/bare-metal/ip)
 
 Dedicated servers (3 minimum) are connected within the vRack which is an L2 network, the hosts (node) private network.
 
@@ -71,6 +71,6 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.en-ie.md
@@ -12,10 +12,10 @@ This page provides an explanation of the elements that constitute a Nutanix clus
 
 A Nutanix cluster consists of a stack of OVHcloud services:
 
-- [Dedicated server](https://www.ovhcloud.com/en-ie/bare-metal/)
-- [vRack](https://www.ovhcloud.com/en-ie/network/vrack/)
-- [Load Balancer](https://www.ovhcloud.com/en-ie/network/load-balancer/)
-- [Additional IP](https://www.ovhcloud.com/en-ie/bare-metal/ip/)
+- [Dedicated server](/links/bare-metal/bare-metal)
+- [vRack](/links/network/vrack)
+- [Load Balancer](/links/network/load-balancer)
+- [Additional IP](/links/bare-metal/ip)
 
 Dedicated servers (3 minimum) are connected within the vRack which is an L2 network, the hosts (node) private network.
 
@@ -71,6 +71,6 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.en-us.md
@@ -12,10 +12,10 @@ This page provides an explanation of the elements that constitute a Nutanix clus
 
 A Nutanix cluster consists of a stack of OVHcloud services:
 
-- [Dedicated server](https://www.ovhcloud.com/en/bare-metal/)
-- [vRack](https://www.ovhcloud.com/en/network/vrack/)
-- [Load Balancer](https://www.ovhcloud.com/en/network/load-balancer/)
-- [Additional IP](https://www.ovhcloud.com/en/bare-metal/ip/)
+- [Dedicated server](/links/bare-metal/bare-metal)
+- [vRack](/links/network/vrack)
+- [Load Balancer](/links/network/load-balancer)
+- [Additional IP](/links/bare-metal/ip)
 
 Dedicated servers (3 minimum) are connected within the vRack which is an L2 network, the hosts (node) private network.
 
@@ -71,6 +71,6 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.es-es.md
@@ -12,10 +12,10 @@ This page provides an explanation of the elements that constitute a Nutanix clus
 
 A Nutanix cluster consists of a stack of OVHcloud services:
 
-- [Dedicated server](https://www.ovhcloud.com/es-es/bare-metal/)
-- [vRack](https://www.ovhcloud.com/es-es/network/vrack/)
-- [Load Balancer](https://www.ovhcloud.com/es-es/network/load-balancer/)
-- [Additional IP](https://www.ovhcloud.com/es-es/bare-metal/ip/)
+- [Dedicated server](/links/bare-metal/bare-metal)
+- [vRack](/links/network/vrack)
+- [Load Balancer](/links/network/load-balancer)
+- [Additional IP](/links/bare-metal/ip)
 
 Dedicated servers (3 minimum) are connected within the vRack which is an L2 network, the hosts (node) private network.
 
@@ -71,6 +71,6 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.es-us.md
@@ -12,10 +12,10 @@ This page provides an explanation of the elements that constitute a Nutanix clus
 
 A Nutanix cluster consists of a stack of OVHcloud services:
 
-- [Dedicated server](https://www.ovhcloud.com/es/bare-metal/)
-- [vRack](https://www.ovhcloud.com/es/network/vrack/)
-- [Load Balancer](https://www.ovhcloud.com/es/network/load-balancer/)
-- [Additional IP](https://www.ovhcloud.com/es/bare-metal/ip/)
+- [Dedicated server](/links/bare-metal/bare-metal)
+- [vRack](/links/network/vrack)
+- [Load Balancer](/links/network/load-balancer)
+- [Additional IP](/links/bare-metal/ip)
 
 Dedicated servers (3 minimum) are connected within the vRack which is an L2 network, the hosts (node) private network.
 
@@ -71,6 +71,6 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.fr-ca.md
@@ -14,10 +14,10 @@ Cette page fournit une explication sur les éléments qui constituent un cluster
 
 Un cluster Nutanix est constitué d’un ensemble de services OVHcloud :
 
-- [Serveur dédié](https://www.ovhcloud.com/fr-ca/bare-metal/)
-- [vRack](https://www.ovhcloud.com/fr-ca/network/vrack/)
-- [Load Balancer](https://www.ovhcloud.com/fr-ca/network/load-balancer/)
-- [Additional IP](https://www.ovhcloud.com/fr-ca/bare-metal/ip/)
+- [Serveur dédié](/links/bare-metal/bare-metal)
+- [vRack](/links/network/vrack)
+- [Load Balancer](/links/network/load-balancer)
+- [Additional IP](/links/bare-metal/ip)
 
 Les serveurs dédiés (3 minimum) sont connectés au sein du vRack qui est un réseau L2, le réseau privé des hosts (noeud ou *node*).
 
@@ -73,6 +73,6 @@ L'accès à Prism Central est disponible à l'adresse suivante : `https://<fqdn>
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.fr-fr.md
@@ -14,10 +14,10 @@ Cette page fournit une explication sur les éléments qui constituent un cluster
 
 Un cluster Nutanix est constitué d’un ensemble de services OVHcloud :
 
-- [Serveur dédié](https://www.ovhcloud.com/fr/bare-metal/)
-- [vRack](https://www.ovhcloud.com/fr/network/vrack/)
-- [Load Balancer](https://www.ovhcloud.com/fr/network/load-balancer/)
-- [Additional IP](https://www.ovhcloud.com/fr/bare-metal/ip/)
+- [Serveur dédié](/links/bare-metal/bare-metal)
+- [vRack](/links/network/vrack)
+- [Load Balancer](/links/network/load-balancer)
+- [Additional IP](/links/bare-metal/ip)
 
 Les serveurs dédiés (3 minimum) sont connectés au sein du vRack qui est un réseau L2, le réseau privé des hosts (noeud ou *node*).
 
@@ -73,6 +73,6 @@ L'accès à Prism Central est disponible à l'adresse suivante : `https://<fqdn>
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.it-it.md
@@ -12,10 +12,10 @@ This page provides an explanation of the elements that constitute a Nutanix clus
 
 A Nutanix cluster consists of a stack of OVHcloud services:
 
-- [Dedicated server](https://www.ovhcloud.com/it/bare-metal/)
-- [vRack](https://www.ovhcloud.com/it/network/vrack/)
-- [Load Balancer](https://www.ovhcloud.com/it/network/load-balancer/)
-- [Additional IP](https://www.ovhcloud.com/it/bare-metal/ip/)
+- [Dedicated server](/links/bare-metal/bare-metal)
+- [vRack](/links/network/vrack)
+- [Load Balancer](/links/network/load-balancer)
+- [Additional IP](/links/bare-metal/ip)
 
 Dedicated servers (3 minimum) are connected within the vRack which is an L2 network, the hosts (node) private network.
 
@@ -71,6 +71,6 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.pl-pl.md
@@ -12,10 +12,10 @@ This page provides an explanation of the elements that constitute a Nutanix clus
 
 A Nutanix cluster consists of a stack of OVHcloud services:
 
-- [Dedicated server](https://www.ovhcloud.com/pl/bare-metal/)
-- [vRack](https://www.ovhcloud.com/pl/network/vrack/)
-- [Load Balancer](https://www.ovhcloud.com/pl/network/load-balancer/)
-- [Additional IP](https://www.ovhcloud.com/pl/bare-metal/ip/)
+- [Dedicated server](/links/bare-metal/bare-metal)
+- [vRack](/links/network/vrack)
+- [Load Balancer](/links/network/load-balancer)
+- [Additional IP](/links/bare-metal/ip)
 
 Dedicated servers (3 minimum) are connected within the vRack which is an L2 network, the hosts (node) private network.
 
@@ -71,6 +71,6 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/01-global-high-level-doc/guide.pt-pt.md
@@ -12,10 +12,10 @@ This page provides an explanation of the elements that constitute a Nutanix clus
 
 A Nutanix cluster consists of a stack of OVHcloud services:
 
-- [Dedicated server](https://www.ovhcloud.com/pt/bare-metal/)
-- [vRack](https://www.ovhcloud.com/pt/network/vrack/)
-- [Load Balancer](https://www.ovhcloud.com/pt/network/load-balancer/)
-- [Additional IP](https://www.ovhcloud.com/pt/bare-metal/ip/)
+- [Dedicated server](/links/bare-metal/bare-metal)
+- [vRack](/links/network/vrack)
+- [Load Balancer](/links/network/load-balancer)
+- [Additional IP](/links/bare-metal/ip)
 
 Dedicated servers (3 minimum) are connected within the vRack which is an L2 network, the hosts (node) private network.
 
@@ -71,6 +71,6 @@ Acces to Prism Central is available under `https://<fqdn>:9440`. This access is 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.de-de.md
@@ -17,7 +17,7 @@ This document details the operation of a Nutanix hyperconvergence solution and d
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Technical solution overview
 
@@ -116,6 +116,6 @@ Click `Diagrams`{.action} for a graphical summary as shown below.
 
 Visit the website <https://www.nutanixbible.com/> for more information on how Nutanix works.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.en-ca.md
@@ -17,7 +17,7 @@ This document details the operation of a Nutanix hyperconvergence solution and d
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Technical solution overview
 
@@ -116,6 +116,6 @@ Click `Diagrams`{.action} for a graphical summary as shown below.
 
 Visit the website <https://www.nutanixbible.com/> for more information on how Nutanix works.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.en-gb.md
@@ -17,7 +17,7 @@ This document details the operation of a Nutanix hyperconvergence solution and d
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Technical solution overview
 
@@ -116,6 +116,6 @@ Click `Diagrams`{.action} for a graphical summary as shown below.
 
 Visit the website <https://www.nutanixbible.com/> for more information on how Nutanix works.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.en-ie.md
@@ -17,7 +17,7 @@ This document details the operation of a Nutanix hyperconvergence solution and d
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Technical solution overview
 
@@ -116,6 +116,6 @@ Click `Diagrams`{.action} for a graphical summary as shown below.
 
 Visit the website <https://www.nutanixbible.com/> for more information on how Nutanix works.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.en-us.md
@@ -17,7 +17,7 @@ This document details the operation of a Nutanix hyperconvergence solution and d
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Technical solution overview
 
@@ -116,6 +116,6 @@ Click `Diagrams`{.action} for a graphical summary as shown below.
 
 Visit the website <https://www.nutanixbible.com/> for more information on how Nutanix works.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.es-es.md
@@ -17,7 +17,7 @@ This document details the operation of a Nutanix hyperconvergence solution and d
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Technical solution overview
 
@@ -116,6 +116,6 @@ Click `Diagrams`{.action} for a graphical summary as shown below.
 
 Visit the website <https://www.nutanixbible.com/> for more information on how Nutanix works.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.es-us.md
@@ -17,7 +17,7 @@ This document details the operation of a Nutanix hyperconvergence solution and d
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Technical solution overview
 
@@ -116,6 +116,6 @@ Click `Diagrams`{.action} for a graphical summary as shown below.
 
 Visit the website <https://www.nutanixbible.com/> for more information on how Nutanix works.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.fr-ca.md
@@ -11,13 +11,13 @@ Ce document rappelle le fonctionnement d'une solution d'hyperconvergence Nutanix
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## Présentation de la solution technique
 
@@ -116,6 +116,6 @@ Cliquez sur `Diagrams`{.action} pour obtenir un résumé graphique tel que prés
 
 Visitez le site <https://www.nutanixbible.com/> pour plus d'informations sur le fonctionnement de Nutanix.
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.fr-fr.md
@@ -11,13 +11,13 @@ Ce document rappelle le fonctionnement d'une solution d'hyperconvergence Nutanix
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## Présentation de la solution technique
 
@@ -116,6 +116,6 @@ Cliquez sur `Diagrams`{.action} pour obtenir un résumé graphique tel que prés
 
 Visitez le site <https://www.nutanixbible.com/> pour plus d'informations sur le fonctionnement de Nutanix.
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.it-it.md
@@ -17,7 +17,7 @@ This document details the operation of a Nutanix hyperconvergence solution and d
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Technical solution overview
 
@@ -116,6 +116,6 @@ Click `Diagrams`{.action} for a graphical summary as shown below.
 
 Visit the website <https://www.nutanixbible.com/> for more information on how Nutanix works.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.pl-pl.md
@@ -17,7 +17,7 @@ This document details the operation of a Nutanix hyperconvergence solution and d
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Technical solution overview
 
@@ -116,6 +116,6 @@ Click `Diagrams`{.action} for a graphical summary as shown below.
 
 Visit the website <https://www.nutanixbible.com/> for more information on how Nutanix works.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/03-nutanix-hci/guide.pt-pt.md
@@ -17,7 +17,7 @@ This document details the operation of a Nutanix hyperconvergence solution and d
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Technical solution overview
 
@@ -116,6 +116,6 @@ Click `Diagrams`{.action} for a graphical summary as shown below.
 
 Visit the website <https://www.nutanixbible.com/> for more information on how Nutanix works.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.de-de.md
@@ -18,7 +18,7 @@ This guide will show you how to create a **storage container** and a **volume gr
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Being connected to the cluster via the Prism Element web interface
 
 ## Overview of storage operations in a Nutanix cluster
@@ -115,6 +115,6 @@ The **Volume Group** will then appear in the list.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.en-ca.md
@@ -18,7 +18,7 @@ This guide will show you how to create a **storage container** and a **volume gr
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Being connected to the cluster via the Prism Element web interface
 
 ## Overview of storage operations in a Nutanix cluster
@@ -115,6 +115,6 @@ The **Volume Group** will then appear in the list.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.en-gb.md
@@ -18,7 +18,7 @@ This guide will show you how to create a **storage container** and a **volume gr
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Being connected to the cluster via the Prism Element web interface
 
 ## Overview of storage operations in a Nutanix cluster
@@ -115,6 +115,6 @@ The **Volume Group** will then appear in the list.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.en-ie.md
@@ -18,7 +18,7 @@ This guide will show you how to create a **storage container** and a **volume gr
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Being connected to the cluster via the Prism Element web interface
 
 ## Overview of storage operations in a Nutanix cluster
@@ -115,6 +115,6 @@ The **Volume Group** will then appear in the list.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.en-us.md
@@ -18,7 +18,7 @@ This guide will show you how to create a **storage container** and a **volume gr
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Being connected to the cluster via the Prism Element web interface
 
 ## Overview of storage operations in a Nutanix cluster
@@ -115,6 +115,6 @@ The **Volume Group** will then appear in the list.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.es-es.md
@@ -18,7 +18,7 @@ This guide will show you how to create a **storage container** and a **volume gr
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Being connected to the cluster via the Prism Element web interface
 
 ## Overview of storage operations in a Nutanix cluster
@@ -115,6 +115,6 @@ The **Volume Group** will then appear in the list.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.es-us.md
@@ -18,7 +18,7 @@ This guide will show you how to create a **storage container** and a **volume gr
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Being connected to the cluster via the Prism Element web interface
 
 ## Overview of storage operations in a Nutanix cluster
@@ -115,6 +115,6 @@ The **Volume Group** will then appear in the list.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.fr-ca.md
@@ -11,14 +11,14 @@ Ce guide vous présente le stockage ainsi que la création d'un **storage contai
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 > Certaines options comme l'utilisation de la compression ou de la déduplication nécessitent des licences particulières fournies par Nutanix au travers d'OVHcloud, nous vous invitons à vous renseigner auprès du service commercial OVHcloud pour plus d'informations.
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté sur le cluster via Prism Element
 
 ## Présentation du fonctionnement du stockage dans un cluster Nutanix
@@ -115,6 +115,6 @@ Le **Volume Group** apparait alors dans la liste.
 
 [Les licences Nutanix](https://www.nutanix.com/products/software-options)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.fr-fr.md
@@ -11,14 +11,14 @@ Ce guide vous présente le stockage ainsi que la création d'un **storage contai
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 > Certaines options comme l'utilisation de la compression ou de la déduplication nécessitent des licences particulières fournies par Nutanix au travers d'OVHcloud, nous vous invitons à vous renseigner auprès du service commercial OVHcloud pour plus d'informations.
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté sur le cluster via Prism Element
 
 ## Présentation du fonctionnement du stockage dans un cluster Nutanix
@@ -115,6 +115,6 @@ Le **Volume Group** apparait alors dans la liste.
 
 [Les licences Nutanix](https://www.nutanix.com/products/software-options)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.it-it.md
@@ -18,7 +18,7 @@ This guide will show you how to create a **storage container** and a **volume gr
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Being connected to the cluster via the Prism Element web interface
 
 ## Overview of storage operations in a Nutanix cluster
@@ -115,6 +115,6 @@ The **Volume Group** will then appear in the list.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.pl-pl.md
@@ -18,7 +18,7 @@ This guide will show you how to create a **storage container** and a **volume gr
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Being connected to the cluster via the Prism Element web interface
 
 ## Overview of storage operations in a Nutanix cluster
@@ -115,6 +115,6 @@ The **Volume Group** will then appear in the list.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/04-storage/guide.pt-pt.md
@@ -18,7 +18,7 @@ This guide will show you how to create a **storage container** and a **volume gr
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Being connected to the cluster via the Prism Element web interface
 
 ## Overview of storage operations in a Nutanix cluster
@@ -115,6 +115,6 @@ The **Volume Group** will then appear in the list.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.de-de.md
@@ -20,7 +20,7 @@ You can add ISO images to the Nutanix system for later use when installing an op
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of the image system in Nutanix
@@ -77,6 +77,6 @@ The imported image appears in the images dashboard in Prism Central.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.en-ca.md
@@ -20,7 +20,7 @@ You can add ISO images to the Nutanix system for later use when installing an op
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of the image system in Nutanix
@@ -77,6 +77,6 @@ The imported image appears in the images dashboard in Prism Central.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.en-gb.md
@@ -20,7 +20,7 @@ You can add ISO images to the Nutanix system for later use when installing an op
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of the image system in Nutanix
@@ -77,6 +77,6 @@ The imported image appears in the images dashboard in Prism Central.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.en-ie.md
@@ -20,7 +20,7 @@ You can add ISO images to the Nutanix system for later use when installing an op
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of the image system in Nutanix
@@ -77,6 +77,6 @@ The imported image appears in the images dashboard in Prism Central.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.en-us.md
@@ -20,7 +20,7 @@ You can add ISO images to the Nutanix system for later use when installing an op
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of the image system in Nutanix
@@ -77,6 +77,6 @@ The imported image appears in the images dashboard in Prism Central.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.es-es.md
@@ -20,7 +20,7 @@ You can add ISO images to the Nutanix system for later use when installing an op
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of the image system in Nutanix
@@ -77,6 +77,6 @@ The imported image appears in the images dashboard in Prism Central.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.es-us.md
@@ -20,7 +20,7 @@ You can add ISO images to the Nutanix system for later use when installing an op
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of the image system in Nutanix
@@ -77,6 +77,6 @@ The imported image appears in the images dashboard in Prism Central.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.fr-ca.md
@@ -13,14 +13,14 @@ Vous pouvez ajouter des images ISO dans le système Nutanix pour les utiliser ul
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 > Certains logiciels nécessitent une licence comme les produits Microsoft il faudra alors s'assurer que tous les systèmes et logiciels installés possèdent ces licences.
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté à Prism Central sur le cluster
 
 ## Présentation du système d'images dans Nutanix
@@ -77,6 +77,6 @@ L'image importée apparaît dans le tableau de bord des images dans Prism Centra
 
 [Les licences Nutanix](https://www.nutanix.com/products/software-options)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.fr-fr.md
@@ -13,14 +13,14 @@ Vous pouvez ajouter des images ISO dans le système Nutanix pour les utiliser ul
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 > Certains logiciels nécessitent une licence comme les produits Microsoft il faudra alors s'assurer que tous les systèmes et logiciels installés possèdent ces licences.
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté à Prism Central sur le cluster
 
 ## Présentation du système d'images dans Nutanix
@@ -77,6 +77,6 @@ L'image importée apparaît dans le tableau de bord des images dans Prism Centra
 
 [Les licences Nutanix](https://www.nutanix.com/products/software-options)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.it-it.md
@@ -20,7 +20,7 @@ You can add ISO images to the Nutanix system for later use when installing an op
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of the image system in Nutanix
@@ -77,6 +77,6 @@ The imported image appears in the images dashboard in Prism Central.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.pl-pl.md
@@ -20,7 +20,7 @@ You can add ISO images to the Nutanix system for later use when installing an op
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of the image system in Nutanix
@@ -77,6 +77,6 @@ The imported image appears in the images dashboard in Prism Central.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/05-image-import/guide.pt-pt.md
@@ -20,7 +20,7 @@ You can add ISO images to the Nutanix system for later use when installing an op
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of the image system in Nutanix
@@ -77,6 +77,6 @@ The imported image appears in the images dashboard in Prism Central.
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.de-de.md
@@ -18,7 +18,7 @@ Find out how to manage virtual machines in a Nutanix cluster, and how to create 
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of Virtual Machine Management in Prism Central
@@ -282,6 +282,6 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.en-ca.md
@@ -18,7 +18,7 @@ Find out how to manage virtual machines in a Nutanix cluster, and how to create 
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of Virtual Machine Management in Prism Central
@@ -282,6 +282,6 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.en-gb.md
@@ -18,7 +18,7 @@ Find out how to manage virtual machines in a Nutanix cluster, and how to create 
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of Virtual Machine Management in Prism Central
@@ -282,6 +282,6 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.en-ie.md
@@ -18,7 +18,7 @@ Find out how to manage virtual machines in a Nutanix cluster, and how to create 
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of Virtual Machine Management in Prism Central
@@ -282,6 +282,6 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.en-us.md
@@ -18,7 +18,7 @@ Find out how to manage virtual machines in a Nutanix cluster, and how to create 
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of Virtual Machine Management in Prism Central
@@ -282,6 +282,6 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.es-es.md
@@ -18,7 +18,7 @@ Find out how to manage virtual machines in a Nutanix cluster, and how to create 
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of Virtual Machine Management in Prism Central
@@ -282,6 +282,6 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.es-us.md
@@ -18,7 +18,7 @@ Find out how to manage virtual machines in a Nutanix cluster, and how to create 
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of Virtual Machine Management in Prism Central
@@ -282,6 +282,6 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.fr-ca.md
@@ -11,14 +11,14 @@ Découvrez comment gérer des machines virtuelles dans un cluster Nutanix et com
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 > Certains logiciels nécessitent une licence comme les produits Microsoft il faudra alors s'assurer que tous les systèmes et logiciels installés possèdent ces licences.
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté à Prism Central sur le cluster
 
 ## Présentation de la gestion des machines virtuelles dans Prism Central
@@ -282,6 +282,6 @@ Le nom du nouveau nœud apparaîtra en face de **Host** si la  migration s'est b
 
 [Les licences Nutanix](https://www.nutanix.com/products/software-options)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.fr-fr.md
@@ -11,14 +11,14 @@ Découvrez comment gérer des machines virtuelles dans un cluster Nutanix et com
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 > Certains logiciels nécessitent une licence comme les produits Microsoft il faudra alors s'assurer que tous les systèmes et logiciels installés possèdent ces licences.
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté à Prism Central sur le cluster
 
 ## Présentation de la gestion des machines virtuelles dans Prism Central
@@ -282,6 +282,6 @@ Le nom du nouveau nœud apparaîtra en face de **Host** si la  migration s'est b
 
 [Les licences Nutanix](https://www.nutanix.com/products/software-options)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.it-it.md
@@ -18,7 +18,7 @@ Find out how to manage virtual machines in a Nutanix cluster, and how to create 
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of Virtual Machine Management in Prism Central
@@ -282,6 +282,6 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.pl-pl.md
@@ -18,7 +18,7 @@ Find out how to manage virtual machines in a Nutanix cluster, and how to create 
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of Virtual Machine Management in Prism Central
@@ -282,6 +282,6 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management/guide.pt-pt.md
@@ -18,7 +18,7 @@ Find out how to manage virtual machines in a Nutanix cluster, and how to create 
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to Prism Central on the cluster
 
 ## Overview of Virtual Machine Management in Prism Central
@@ -282,6 +282,6 @@ The name of the new node will appear in front of **Host** if the migration is co
 
 [Nutanix licences](https://www.nutanix.com/products/software-options)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.de-de.md
@@ -17,7 +17,7 @@ This guide details how to view alerts and events, and create custom alerts.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 
 ## Defining alerts, events, and tasks in Prism Central
@@ -136,6 +136,6 @@ The task list appears.
 
 [Alert and event management in Prism Central](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-v5_20:mul-alerts-management-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.en-ca.md
@@ -17,7 +17,7 @@ This guide details how to view alerts and events, and create custom alerts.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 
 ## Defining alerts, events, and tasks in Prism Central
@@ -136,6 +136,6 @@ The task list appears.
 
 [Alert and event management in Prism Central](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-v5_20:mul-alerts-management-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.en-gb.md
@@ -17,7 +17,7 @@ This guide details how to view alerts and events, and create custom alerts.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 
 ## Defining alerts, events, and tasks in Prism Central
@@ -136,6 +136,6 @@ The task list appears.
 
 [Alert and event management in Prism Central](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-v5_20:mul-alerts-management-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.en-ie.md
@@ -17,7 +17,7 @@ This guide details how to view alerts and events, and create custom alerts.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 
 ## Defining alerts, events, and tasks in Prism Central
@@ -136,6 +136,6 @@ The task list appears.
 
 [Alert and event management in Prism Central](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-v5_20:mul-alerts-management-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.en-us.md
@@ -17,7 +17,7 @@ This guide details how to view alerts and events, and create custom alerts.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 
 ## Defining alerts, events, and tasks in Prism Central
@@ -136,6 +136,6 @@ The task list appears.
 
 [Alert and event management in Prism Central](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-v5_20:mul-alerts-management-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.es-es.md
@@ -17,7 +17,7 @@ This guide details how to view alerts and events, and create custom alerts.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 
 ## Defining alerts, events, and tasks in Prism Central
@@ -136,6 +136,6 @@ The task list appears.
 
 [Alert and event management in Prism Central](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-v5_20:mul-alerts-management-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.es-us.md
@@ -17,7 +17,7 @@ This guide details how to view alerts and events, and create custom alerts.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 
 ## Defining alerts, events, and tasks in Prism Central
@@ -136,6 +136,6 @@ The task list appears.
 
 [Alert and event management in Prism Central](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-v5_20:mul-alerts-management-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.fr-ca.md
@@ -11,13 +11,13 @@ Ce guide vous détaille comment consulter les alertes et les évènements ainsi 
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté sur le cluster via Prism Central
 
 ## Définitions des alertes, événements et tâches dans Prism Central
@@ -136,6 +136,6 @@ La liste des tâches apparaît.
 
 [Gestion des alertes et des évènement dans Prism Central](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-v5_20:mul-alerts-management-pc-c.html)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.fr-fr.md
@@ -11,13 +11,13 @@ Ce guide vous détaille comment consulter les alertes et les évènements ainsi 
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté sur le cluster via Prism Central
 
 ## Définitions des alertes, événements et tâches dans Prism Central
@@ -136,6 +136,6 @@ La liste des tâches apparaît.
 
 [Gestion des alertes et des évènement dans Prism Central](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-v5_20:mul-alerts-management-pc-c.html)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.it-it.md
@@ -17,7 +17,7 @@ This guide details how to view alerts and events, and create custom alerts.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 
 ## Defining alerts, events, and tasks in Prism Central
@@ -136,6 +136,6 @@ The task list appears.
 
 [Alert and event management in Prism Central](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-v5_20:mul-alerts-management-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.pl-pl.md
@@ -17,7 +17,7 @@ This guide details how to view alerts and events, and create custom alerts.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 
 ## Defining alerts, events, and tasks in Prism Central
@@ -136,6 +136,6 @@ The task list appears.
 
 [Alert and event management in Prism Central](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-v5_20:mul-alerts-management-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/07-alert-management/guide.pt-pt.md
@@ -17,7 +17,7 @@ This guide details how to view alerts and events, and create custom alerts.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 
 ## Defining alerts, events, and tasks in Prism Central
@@ -136,6 +136,6 @@ The task list appears.
 
 [Alert and event management in Prism Central](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-v5_20:mul-alerts-management-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.de-de.md
@@ -13,12 +13,12 @@ Once an upgrade of one Nutanix software component is needed, let's review all th
 ## Requirements
 
 - A Nutanix Cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/de/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/de/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions
@@ -194,6 +194,6 @@ Click `Apply N Updates`{.action}.
 
 [Nutanix official documentation](https://www.nutanix.com/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.en-ca.md
@@ -13,12 +13,12 @@ Once an upgrade of one Nutanix software component is needed, let's review all th
 ## Requirements
 
 - A Nutanix Cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ca/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions
@@ -194,6 +194,6 @@ Click `Apply N Updates`{.action}.
 
 [Nutanix official documentation](https://www.nutanix.com/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.en-gb.md
@@ -13,12 +13,12 @@ Once an upgrade of one Nutanix software component is needed, let's review all th
 ## Requirements
 
 - A Nutanix Cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions
@@ -194,6 +194,6 @@ Click `Apply N Updates`{.action}.
 
 [Nutanix official documentation](https://www.nutanix.com/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.en-ie.md
@@ -13,12 +13,12 @@ Once an upgrade of one Nutanix software component is needed, let's review all th
 ## Requirements
 
 - A Nutanix Cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ie/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions
@@ -194,6 +194,6 @@ Click `Apply N Updates`{.action}.
 
 [Nutanix official documentation](https://www.nutanix.com/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.en-us.md
@@ -13,12 +13,12 @@ Once an upgrade of one Nutanix software component is needed, let's review all th
 ## Requirements
 
 - A Nutanix Cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-us/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-us/professional-services/) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions
@@ -194,6 +194,6 @@ Click `Apply N Updates`{.action}.
 
 [Nutanix official documentation](https://www.nutanix.com/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.es-es.md
@@ -13,12 +13,12 @@ Once an upgrade of one Nutanix software component is needed, let's review all th
 ## Requirements
 
 - A Nutanix Cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/es-es/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions
@@ -194,6 +194,6 @@ Click `Apply N Updates`{.action}.
 
 [Nutanix official documentation](https://www.nutanix.com/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.es-us.md
@@ -13,12 +13,12 @@ Once an upgrade of one Nutanix software component is needed, let's review all th
 ## Requirements
 
 - A Nutanix Cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/es/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/es/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions
@@ -194,6 +194,6 @@ Click `Apply N Updates`{.action}.
 
 [Nutanix official documentation](https://www.nutanix.com/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.fr-ca.md
@@ -13,12 +13,12 @@ Une fois qu'une mise à niveau d'un composant logiciel Nutanix est nécessaire, 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## En pratique
@@ -194,6 +194,6 @@ Cliquez sur `Apply N Updates`{.action}.
 
 [Documentation officielle de Nutanix](https://www.nutanix.com/){.external}
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.fr-fr.md
@@ -13,12 +13,12 @@ Une fois qu'une mise à niveau d'un composant logiciel Nutanix est nécessaire, 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## En pratique
@@ -194,6 +194,6 @@ Cliquez sur `Apply N Updates`{.action}.
 
 [Documentation officielle de Nutanix](https://www.nutanix.com/){.external}
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.it-it.md
@@ -13,12 +13,12 @@ Once an upgrade of one Nutanix software component is needed, let's review all th
 ## Requirements
 
 - A Nutanix Cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/it/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/it/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions
@@ -194,6 +194,6 @@ Click `Apply N Updates`{.action}.
 
 [Nutanix official documentation](https://www.nutanix.com/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.pl-pl.md
@@ -13,12 +13,12 @@ Once an upgrade of one Nutanix software component is needed, let's review all th
 ## Requirements
 
 - A Nutanix Cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/pl/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions
@@ -194,6 +194,6 @@ Click `Apply N Updates`{.action}.
 
 [Nutanix official documentation](https://www.nutanix.com/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/08-upgrade-prismcentral/guide.pt-pt.md
@@ -13,12 +13,12 @@ Once an upgrade of one Nutanix software component is needed, let's review all th
 ## Requirements
 
 - A Nutanix Cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/pt/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Instructions
@@ -194,6 +194,6 @@ Click `Apply N Updates`{.action}.
 
 [Nutanix official documentation](https://www.nutanix.com/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.de-de.md
@@ -22,7 +22,7 @@ This guide will show you all the administration tools, other than the **Prism Ce
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- access to the [OVHcloud Control Panel](/links/manager)
 - For the **REST API**, you must have a virtual machine running Linux with a text editor to run the **curl** and **jq** commands.
 
 > [!primary]
@@ -769,6 +769,6 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 [References to Nutanix development tools](https://www.nutanix.dev)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.en-ca.md
@@ -22,7 +22,7 @@ This guide will show you all the administration tools, other than the **Prism Ce
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- access to the [OVHcloud Control Panel](/links/manager)
 - For the **REST API**, you must have a virtual machine running Linux with a text editor to run the **curl** and **jq** commands.
 
 > [!primary]
@@ -769,6 +769,6 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 [References to Nutanix development tools](https://www.nutanix.dev)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.en-gb.md
@@ -22,7 +22,7 @@ This guide will show you all the administration tools, other than the **Prism Ce
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 - For the **REST API**, you must have a virtual machine running Linux with a text editor to run the **curl** and **jq** commands.
 
 > [!primary]
@@ -769,6 +769,6 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 [References to Nutanix development tools](https://www.nutanix.dev)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.en-ie.md
@@ -22,7 +22,7 @@ This guide will show you all the administration tools, other than the **Prism Ce
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 - For the **REST API**, you must have a virtual machine running Linux with a text editor to run the **curl** and **jq** commands.
 
 > [!primary]
@@ -769,6 +769,6 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 [References to Nutanix development tools](https://www.nutanix.dev)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.en-us.md
@@ -22,7 +22,7 @@ This guide will show you all the administration tools, other than the **Prism Ce
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- access to the [OVHcloud Control Panel](/links/manager)
 - For the **REST API**, you must have a virtual machine running Linux with a text editor to run the **curl** and **jq** commands.
 
 > [!primary]
@@ -769,6 +769,6 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 [References to Nutanix development tools](https://www.nutanix.dev)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.es-es.md
@@ -22,7 +22,7 @@ This guide will show you all the administration tools, other than the **Prism Ce
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- access to the [OVHcloud Control Panel](/links/manager)
 - For the **REST API**, you must have a virtual machine running Linux with a text editor to run the **curl** and **jq** commands.
 
 > [!primary]
@@ -769,6 +769,6 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 [References to Nutanix development tools](https://www.nutanix.dev)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.es-us.md
@@ -22,7 +22,7 @@ This guide will show you all the administration tools, other than the **Prism Ce
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- access to the [OVHcloud Control Panel](/links/manager)
 - For the **REST API**, you must have a virtual machine running Linux with a text editor to run the **curl** and **jq** commands.
 
 > [!primary]
@@ -769,6 +769,6 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 [References to Nutanix development tools](https://www.nutanix.dev)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.fr-ca.md
@@ -16,13 +16,13 @@ Ce guide vous présente l'ensemble des outils d'administration, autres que les i
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Pour l'interface **REST API**, vous devez disposer d'une machine virtuelle sous Linux avec un éditeur de texte, afin d'exécuter les commandes **curl** et **jq**.
 
 > [!primary]
@@ -767,6 +767,6 @@ La nouvelle machine virtuelle doit apparaitre dans **Prism Central**, elle est a
 
 [Réferences sur les outils de développements de Nutanix](https://www.nutanix.dev)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.fr-fr.md
@@ -16,13 +16,13 @@ Ce guide vous présente l'ensemble des outils d'administration, autres que les i
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Pour l'interface **REST API**, vous devez disposer d'une machine virtuelle sous Linux avec un éditeur de texte, afin d'exécuter les commandes **curl** et **jq**.
 
 > [!primary]
@@ -767,6 +767,6 @@ La nouvelle machine virtuelle doit apparaitre dans **Prism Central**, elle est a
 
 [Réferences sur les outils de développements de Nutanix](https://www.nutanix.dev)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.it-it.md
@@ -22,7 +22,7 @@ This guide will show you all the administration tools, other than the **Prism Ce
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- access to the [OVHcloud Control Panel](/links/manager)
 - For the **REST API**, you must have a virtual machine running Linux with a text editor to run the **curl** and **jq** commands.
 
 > [!primary]
@@ -769,6 +769,6 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 [References to Nutanix development tools](https://www.nutanix.dev)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.pl-pl.md
@@ -22,7 +22,7 @@ This guide will show you all the administration tools, other than the **Prism Ce
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- access to the [OVHcloud Control Panel](/links/manager)
 - For the **REST API**, you must have a virtual machine running Linux with a text editor to run the **curl** and **jq** commands.
 
 > [!primary]
@@ -769,6 +769,6 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 [References to Nutanix development tools](https://www.nutanix.dev)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/09-advanced-tools/guide.pt-pt.md
@@ -22,7 +22,7 @@ This guide will show you all the administration tools, other than the **Prism Ce
 ## Requirements
 
 - a Nutanix cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- access to the [OVHcloud Control Panel](/links/manager)
 - For the **REST API**, you must have a virtual machine running Linux with a text editor to run the **curl** and **jq** commands.
 
 > [!primary]
@@ -769,6 +769,6 @@ The new virtual machine will appear in **Prism Central**, it is then started wit
 
 [References to Nutanix development tools](https://www.nutanix.dev)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.de-de.md
@@ -11,13 +11,13 @@ updated: 2022-11-25
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they work properly.
 >
-> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/de/directory/) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
+> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
 >
 
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 ## Overview of versions supported on an OVHcloud Nutanix cluster
@@ -71,6 +71,6 @@ The query result appears below `availableVersions` with both versions supported 
 
 [Using the OVHcloud API](/products/manage-operate-api-apiv6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.en-ca.md
@@ -17,8 +17,8 @@ updated: 2022-11-25
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
-- access to the [OVHcloud API page](https://ca.api.ovh.com/)
+- access to the [OVHcloud Control Panel](/links/manager)
+- access to the [OVHcloud API page](/links/api)
 
 ## Overview of versions supported on an OVHcloud Nutanix cluster
 
@@ -71,6 +71,6 @@ The query result appears below `availableVersions` with both versions supported 
 
 [Using the OVHcloud API](/products/manage-operate-api-apiv6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.en-gb.md
@@ -11,13 +11,13 @@ updated: 2022-11-25
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they work properly.
 >
-> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/en-gb/directory/) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
+> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
 >
 
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 ## Overview of versions supported on an OVHcloud Nutanix cluster
@@ -71,6 +71,6 @@ The query result appears below `availableVersions` with both versions supported 
 
 [Using the OVHcloud API](/products/manage-operate-api-apiv6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.en-ie.md
@@ -11,13 +11,13 @@ updated: 2022-11-25
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they work properly.
 >
-> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/en-ie/directory/) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
+> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
 >
 
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 ## Overview of versions supported on an OVHcloud Nutanix cluster
@@ -71,6 +71,6 @@ The query result appears below `availableVersions` with both versions supported 
 
 [Using the OVHcloud API](/products/manage-operate-api-apiv6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.en-us.md
@@ -11,14 +11,14 @@ updated: 2022-11-25
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they work properly.
 >
-> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/en/directory/) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
+> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
 >
 
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
-- access to the [OVHcloud API page](https://ca.api.ovh.com/)
+- access to the [OVHcloud Control Panel](/links/manager)
+- access to the [OVHcloud API page](/links/api)
 
 ## Overview of versions supported on an OVHcloud Nutanix cluster
 
@@ -71,6 +71,6 @@ The query result appears below `availableVersions` with both versions supported 
 
 [Using the OVHcloud API](/products/manage-operate-api-apiv6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.es-es.md
@@ -11,13 +11,13 @@ updated: 2022-11-25
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they work properly.
 >
-> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/es-es/directory/) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
+> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
 >
 
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 ## Overview of versions supported on an OVHcloud Nutanix cluster
@@ -71,6 +71,6 @@ The query result appears below `availableVersions` with both versions supported 
 
 [Using the OVHcloud API](/products/manage-operate-api-apiv6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.es-us.md
@@ -11,14 +11,14 @@ updated: 2022-11-25
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they work properly.
 >
-> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/es/directory/) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
+> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
 >
 
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
-- access to the [OVHcloud API page](https://ca.api.ovh.com/)
+- access to the [OVHcloud Control Panel](/links/manager)
+- access to the [OVHcloud API page](/links/api)
 
 ## Overview of versions supported on an OVHcloud Nutanix cluster
 
@@ -71,6 +71,6 @@ The query result appears below `availableVersions` with both versions supported 
 
 [Using the OVHcloud API](/products/manage-operate-api-apiv6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.fr-ca.md
@@ -11,14 +11,14 @@ updated: 2022-11-25
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un Cluster Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
-- Être connecté sur la page des [API OVHcloud](https://ca.api.ovh.com/).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
+- Être connecté sur la page des [API OVHcloud](/links/api).
 
 ## Présentation des versions supportées sur un cluster Nutanix OVHcloud
 
@@ -71,6 +71,6 @@ Le résultat de la requête apparaît en dessous de `availableVersions` avec les
 
 [Utilisation de l'API OVHcloud](/products/manage-operate-api-apiv6)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.fr-fr.md
@@ -11,13 +11,13 @@ updated: 2022-11-25
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un Cluster Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur la page des [API OVHcloud](https://api.ovh.com/).
 
 ## Présentation des versions supportées sur un cluster Nutanix OVHcloud
@@ -71,6 +71,6 @@ Le résultat de la requête apparaît en dessous de `availableVersions` avec les
 
 [Utilisation de l'API OVHcloud](/products/manage-operate-api-apiv6)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.it-it.md
@@ -11,13 +11,13 @@ updated: 2022-11-25
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they work properly.
 >
-> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/it/directory/) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
+> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
 >
 
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 ## Overview of versions supported on an OVHcloud Nutanix cluster
@@ -71,6 +71,6 @@ The query result appears below `availableVersions` with both versions supported 
 
 [Using the OVHcloud API](/products/manage-operate-api-apiv6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.pl-pl.md
@@ -11,13 +11,13 @@ updated: 2022-11-25
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they work properly.
 >
-> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/pl/directory/) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
+> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
 >
 
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 ## Overview of versions supported on an OVHcloud Nutanix cluster
@@ -71,6 +71,6 @@ The query result appears below `availableVersions` with both versions supported 
 
 [Using the OVHcloud API](/products/manage-operate-api-apiv6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/11-nutanix-aos-supported-versions/guide.pt-pt.md
@@ -11,13 +11,13 @@ updated: 2022-11-25
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure that they work properly.
 >
-> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](https://partner.ovhcloud.com/pt/directory/) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
+> This guide is designed to assist you as much as possible with common tasks. However, we recommend contacting a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to managing, using or setting up a service on a server.
 >
 
 ## Requirements
 
 - a Nutanix Cluster in your OVHcloud account
-- access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- access to the [OVHcloud Control Panel](/links/manager)
 - access to the [OVHcloud API page](https://api.ovh.com/)
 
 ## Overview of versions supported on an OVHcloud Nutanix cluster
@@ -71,6 +71,6 @@ The query result appears below `availableVersions` with both versions supported 
 
 [Using the OVHcloud API](/products/manage-operate-api-apiv6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.de-de.md
@@ -11,12 +11,12 @@ updated: 2022-11-16
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/de/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/de/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - Access to your clusters via **Prism Central**.
 - You must have your Nutanix login details on [Nutanix Official Site](https://www.nutanix.com).
 - You must have valid licences with your Nutanix NIC handle.
@@ -214,6 +214,6 @@ The licence has been deleted.
 
 [Nutanix Licence Management Guide](https://portal.nutanix.com/page/documents/details?targetId=Licensing-Guide:lic-lic-manage-manual-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.en-ca.md
@@ -11,12 +11,12 @@ updated: 2022-11-16
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ca/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - You must have Nutanix licences and have them available on the Nutanix portal.
 - You must have your Nutanix login details on [Nutanix Official Site](https://www.nutanix.com).
@@ -215,6 +215,6 @@ The licence has been deleted.
 
 [Nutanix Licence Management Guide](https://portal.nutanix.com/page/documents/details?targetId=Licensing-Guide:lic-lic-manage-manual-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.en-gb.md
@@ -11,12 +11,12 @@ updated: 2022-11-16
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - Access to your clusters via **Prism Central**.
 - You must have your Nutanix login details on [Nutanix Official Site](https://www.nutanix.com).
 - You must have valid licences with your Nutanix NIC handle.
@@ -214,6 +214,6 @@ The licence has been deleted.
 
 [Nutanix Licence Management Guide](https://portal.nutanix.com/page/documents/details?targetId=Licensing-Guide:lic-lic-manage-manual-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.en-ie.md
@@ -11,12 +11,12 @@ updated: 2022-11-16
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ie/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - You must have your Nutanix login details on [Nutanix Official Site](https://www.nutanix.com).
 - You must have valid licences with your Nutanix NIC handle.
@@ -214,6 +214,6 @@ The licence has been deleted.
 
 [Nutanix Licence Management Guide](https://portal.nutanix.com/page/documents/details?targetId=Licensing-Guide:lic-lic-manage-manual-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.en-us.md
@@ -11,12 +11,12 @@ updated: 2022-11-16
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-us/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-us/professional-services/) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must have your Nutanix login details on [Nutanix Official Site](https://www.nutanix.com).
 - You must have valid licences with your Nutanix NIC handle.
 
@@ -213,6 +213,6 @@ The licence has been deleted.
 
 [Nutanix Licence Management Guide](https://portal.nutanix.com/page/documents/details?targetId=Licensing-Guide:lic-lic-manage-manual-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.es-es.md
@@ -11,12 +11,12 @@ updated: 2022-11-16
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/es-es/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - You must have your Nutanix login details on [Nutanix Official Site](https://www.nutanix.com).
 - You must have valid licences with your Nutanix NIC handle.
@@ -214,6 +214,6 @@ The licence has been deleted.
 
 [Nutanix Licence Management Guide](https://portal.nutanix.com/page/documents/details?targetId=Licensing-Guide:lic-lic-manage-manual-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.es-us.md
@@ -11,12 +11,12 @@ updated: 2022-11-16
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/es/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/es/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - You must have your Nutanix login details on [Nutanix Official Site](https://www.nutanix.com).
 - You must have valid licences with your Nutanix NIC handle.
@@ -214,6 +214,6 @@ The licence has been deleted.
 
 [Nutanix Licence Management Guide](https://portal.nutanix.com/page/documents/details?targetId=Licensing-Guide:lic-lic-manage-manual-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.fr-ca.md
@@ -11,12 +11,12 @@ updated: 2022-11-16
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur vos clusters via **Prism Central**.
 - Disposer de vos identifiants Nutanix sur le [Site officiel Nutanix](https://www.nutanix.com).
 - Avoir des licences valides avec votre identifiant Nutanix.
@@ -214,6 +214,6 @@ La suppression de la licence est effective.
 
 [Guide de gestion des licences Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Licensing-Guide:lic-lic-manage-manual-c.html)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.fr-fr.md
@@ -11,12 +11,12 @@ updated: 2022-11-16
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur vos clusters via **Prism Central**.
 - Disposer de vos identifiants Nutanix sur le [Site officiel Nutanix](https://www.nutanix.com).
 - Avoir des licences valides avec votre identifiant Nutanix.
@@ -214,6 +214,6 @@ La suppression de la licence est effective.
 
 [Guide de gestion des licences Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Licensing-Guide:lic-lic-manage-manual-c.html)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.it-it.md
@@ -11,12 +11,12 @@ updated: 2022-11-16
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/it/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/it/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - You must have your Nutanix login details on [Nutanix Official Site](https://www.nutanix.com).
 - You must have valid licences with your Nutanix NIC handle.
@@ -214,6 +214,6 @@ The licence has been deleted.
 
 [Nutanix Licence Management Guide](https://portal.nutanix.com/page/documents/details?targetId=Licensing-Guide:lic-lic-manage-manual-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.pl-pl.md
@@ -11,12 +11,12 @@ updated: 2022-11-16
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/pl/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - You must have your Nutanix login details on [Nutanix Official Site](https://www.nutanix.com).
 - You must have valid licences with your Nutanix NIC handle.
@@ -214,6 +214,6 @@ The licence has been deleted.
 
 [Nutanix Licence Management Guide](https://portal.nutanix.com/page/documents/details?targetId=Licensing-Guide:lic-lic-manage-manual-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/12-activate-licenses-on-byol/guide.pt-pt.md
@@ -11,12 +11,12 @@ updated: 2022-11-16
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/pt/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - You must have your Nutanix login details on [Nutanix Official Site](https://www.nutanix.com).
 - You must have valid licences with your Nutanix NIC handle.
@@ -214,6 +214,6 @@ The licence has been deleted.
 
 [Nutanix Licence Management Guide](https://portal.nutanix.com/page/documents/details?targetId=Licensing-Guide:lic-lic-manage-manual-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.de-de.md
@@ -121,7 +121,7 @@ To redeploy the gateway VM you will need:
 
 ##### **Check the Additional IP address**
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) and open the management section of your [vRack](https://www.ovhcloud.com/de/network/vrack/){.external}. Verify the Additional IP address used by the Nutanix Cluster.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the management section of your [vRack](/links/network/vrack){.external}. Verify the Additional IP address used by the Nutanix Cluster.
 
 ![Additional IP](images/check_subnet0.png){.thumbnail}
 
@@ -129,7 +129,7 @@ Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomana
 > The following instructions will use the IP block 198.51.100.0/30 for example purposes.
 >
 
-For [vRack](https://www.ovhcloud.com/de/network/vrack/){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
+For [vRack](/links/network/vrack){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
 
 ```console
 198.51.100.0   Reserved: Network address
@@ -271,6 +271,6 @@ Click `Next`{.action}, then `Create VM`{.action}.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.en-ca.md
@@ -121,7 +121,7 @@ To redeploy the gateway VM you will need:
 
 ##### **Check the Additional IP address**
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) and open the management section of your [vRack](https://www.ovhcloud.com/en-ca/network/vrack/){.external}. Verify the Additional IP address used by the Nutanix Cluster.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the management section of your [vRack](/links/network/vrack){.external}. Verify the Additional IP address used by the Nutanix Cluster.
 
 ![Additional IP](images/check_subnet0.png){.thumbnail}
 
@@ -129,7 +129,7 @@ Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanag
 > The following instructions will use the IP block 198.51.100.0/30 for example purposes.
 >
 
-For [vRack](https://www.ovhcloud.com/en-ca/network/vrack/){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
+For [vRack](/links/network/vrack){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
 
 ```console
 198.51.100.0   Reserved: Network address
@@ -271,6 +271,6 @@ Click `Next`{.action}, then `Create VM`{.action}.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.en-gb.md
@@ -121,7 +121,7 @@ To redeploy the gateway VM you will need:
 
 ##### **Check the Additional IP address**
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) and open the management section of your [vRack](https://www.ovhcloud.com/en-gb/network/vrack/){.external}. Verify the Additional IP address used by the Nutanix Cluster.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the management section of your [vRack](/links/network/vrack){.external}. Verify the Additional IP address used by the Nutanix Cluster.
 
 ![Additional IP](images/check_subnet0.png){.thumbnail}
 
@@ -129,7 +129,7 @@ Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomana
 > The following instructions will use the IP block 198.51.100.0/30 for example purposes.
 >
 
-For [vRack](https://www.ovhcloud.com/en-gb/network/vrack/){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
+For [vRack](/links/network/vrack){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
 
 ```console
 198.51.100.0   Reserved: Network address
@@ -271,6 +271,6 @@ Click `Next`{.action}, then `Create VM`{.action}.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.en-ie.md
@@ -121,7 +121,7 @@ To redeploy the gateway VM you will need:
 
 ##### **Check the Additional IP address**
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) and open the management section of your [vRack](https://www.ovhcloud.com/en-ie/network/vrack/){.external}. Verify the Additional IP address used by the Nutanix Cluster.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the management section of your [vRack](/links/network/vrack){.external}. Verify the Additional IP address used by the Nutanix Cluster.
 
 ![Additional IP](images/check_subnet0.png){.thumbnail}
 
@@ -129,7 +129,7 @@ Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomana
 > The following instructions will use the IP block 198.51.100.0/30 for example purposes.
 >
 
-For [vRack](https://www.ovhcloud.com/en-ie/network/vrack/){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
+For [vRack](/links/network/vrack){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
 
 ```console
 198.51.100.0   Reserved: Network address
@@ -271,6 +271,6 @@ Click `Next`{.action}, then `Create VM`{.action}.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.en-us.md
@@ -121,7 +121,7 @@ To redeploy the gateway VM you will need:
 
 ##### **Check the Additional IP address**
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) and open the management section of your [vRack](https://www.ovhcloud.com/en/network/vrack/){.external}. Verify the Additional IP address used by the Nutanix Cluster.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the management section of your [vRack](/links/network/vrack){.external}. Verify the Additional IP address used by the Nutanix Cluster.
 
 ![Additional IP](images/check_subnet0.png){.thumbnail}
 
@@ -129,7 +129,7 @@ Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanag
 > The following instructions will use the IP block 198.51.100.0/30 for example purposes.
 >
 
-For [vRack](https://www.ovhcloud.com/en/network/vrack/){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
+For [vRack](/links/network/vrack){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
 
 ```console
 198.51.100.0   Reserved: Network address
@@ -271,6 +271,6 @@ Click `Next`{.action}, then `Create VM`{.action}.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.es-es.md
@@ -121,7 +121,7 @@ To redeploy the gateway VM you will need:
 
 ##### **Check the Additional IP address**
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) and open the management section of your [vRack](https://www.ovhcloud.com/es-es/network/vrack/){.external}. Verify the Additional IP address used by the Nutanix Cluster.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the management section of your [vRack](/links/network/vrack){.external}. Verify the Additional IP address used by the Nutanix Cluster.
 
 ![Additional IP](images/check_subnet0.png){.thumbnail}
 
@@ -129,7 +129,7 @@ Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomana
 > The following instructions will use the IP block 198.51.100.0/30 for example purposes.
 >
 
-For [vRack](https://www.ovhcloud.com/es-es/network/vrack/){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
+For [vRack](/links/network/vrack){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
 
 ```console
 198.51.100.0   Reserved: Network address
@@ -271,6 +271,6 @@ Click `Next`{.action}, then `Create VM`{.action}.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.es-us.md
@@ -121,7 +121,7 @@ To redeploy the gateway VM you will need:
 
 ##### **Check the Additional IP address**
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) and open the management section of your [vRack](https://www.ovhcloud.com/es/network/vrack/){.external}. Verify the Additional IP address used by the Nutanix Cluster.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the management section of your [vRack](/links/network/vrack){.external}. Verify the Additional IP address used by the Nutanix Cluster.
 
 ![Additional IP](images/check_subnet0.png){.thumbnail}
 
@@ -129,7 +129,7 @@ Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanag
 > The following instructions will use the IP block 198.51.100.0/30 for example purposes.
 >
 
-For [vRack](https://www.ovhcloud.com/es/network/vrack/){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
+For [vRack](/links/network/vrack){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
 
 ```console
 198.51.100.0   Reserved: Network address
@@ -271,6 +271,6 @@ Click `Next`{.action}, then `Create VM`{.action}.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.fr-ca.md
@@ -113,7 +113,7 @@ Pour redéployer la VM de la passerelle, vous aurez besoin des éléments suivan
 
 ##### **Vérifier l'adresse Additional IP**
 
-Connectez-vous à l'[espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc) et accédez à la gestion de votre [vRack](https://www.ovhcloud.com/fr-ca/network/vrack/){.external}. Vérifiez l'adresse Additional IP utilisée par le cluster Nutanix.
+Connectez-vous à l'[espace client OVHcloud](/links/manager) et accédez à la gestion de votre [vRack](/links/network/vrack){.external}. Vérifiez l'adresse Additional IP utilisée par le cluster Nutanix.
 
 ![Additional IP](images/check_subnet0.png){.thumbnail}
 
@@ -121,7 +121,7 @@ Connectez-vous à l'[espace client OVHcloud](https://ca.ovh.com/auth/?action=got
 > Les instructions suivantes vont utiliser le bloc IP 198.51.100.0/30 à titre d'exemple.
 >
 
-Dans le cadre d'une utilisation du [vRack](https://www.ovhcloud.com/fr-ca/network/vrack/){.external}, la première adresse, l'avant-dernière et la dernière adresse d'un bloc IP donné sont toujours réservées respectivement à l'adresse réseau, à la passerelle réseau et au broadcast du réseau. Cela signifie que la première adresse utilisable est la seconde adresse du bloc, comme indiqué ci-dessous :
+Dans le cadre d'une utilisation du [vRack](/links/network/vrack){.external}, la première adresse, l'avant-dernière et la dernière adresse d'un bloc IP donné sont toujours réservées respectivement à l'adresse réseau, à la passerelle réseau et au broadcast du réseau. Cela signifie que la première adresse utilisable est la seconde adresse du bloc, comme indiqué ci-dessous :
 
 ```console
 198.51.100.0  Reserved: Network address
@@ -263,6 +263,6 @@ Cliquez sur `Next`{.action}, puis sur `Create VM`{.action}.
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.fr-fr.md
@@ -113,7 +113,7 @@ Pour redéployer la VM de la passerelle, vous aurez besoin des éléments suivan
 
 ##### **Vérifier l'adresse Additional IP**
 
-Connectez-vous à l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) et accédez à la gestion de votre [vRack](https://www.ovhcloud.com/fr/network/vrack/){.external}. Vérifiez l'adresse Additional IP utilisée par le cluster Nutanix.
+Connectez-vous à l'[espace client OVHcloud](/links/manager) et accédez à la gestion de votre [vRack](/links/network/vrack){.external}. Vérifiez l'adresse Additional IP utilisée par le cluster Nutanix.
 
 ![Additional IP](images/check_subnet0.png){.thumbnail}
 
@@ -121,7 +121,7 @@ Connectez-vous à l'[espace client OVHcloud](https://www.ovh.com/auth/?action=go
 > Les instructions suivantes vont utiliser le bloc IP 198.51.100.0/30 à titre d'exemple.
 >
 
-Dans le cadre d'une utilisation du [vRack](https://www.ovhcloud.com/fr/network/vrack/){.external}, la première adresse, l'avant-dernière et la dernière adresse d'un bloc IP donné sont toujours réservées respectivement à l'adresse réseau, à la passerelle réseau et au broadcast du réseau. Cela signifie que la première adresse utilisable est la seconde adresse du bloc, comme indiqué ci-dessous :
+Dans le cadre d'une utilisation du [vRack](/links/network/vrack){.external}, la première adresse, l'avant-dernière et la dernière adresse d'un bloc IP donné sont toujours réservées respectivement à l'adresse réseau, à la passerelle réseau et au broadcast du réseau. Cela signifie que la première adresse utilisable est la seconde adresse du bloc, comme indiqué ci-dessous :
 
 ```console
 198.51.100.0  Reserved: Network address
@@ -263,6 +263,6 @@ Cliquez sur `Next`{.action}, puis sur `Create VM`{.action}.
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.it-it.md
@@ -121,7 +121,7 @@ To redeploy the gateway VM you will need:
 
 ##### **Check the Additional IP address**
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) and open the management section of your [vRack](https://www.ovhcloud.com/it/network/vrack/){.external}. Verify the Additional IP address used by the Nutanix Cluster.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the management section of your [vRack](/links/network/vrack){.external}. Verify the Additional IP address used by the Nutanix Cluster.
 
 ![Additional IP](images/check_subnet0.png){.thumbnail}
 
@@ -129,7 +129,7 @@ Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomana
 > The following instructions will use the IP block 198.51.100.0/30 for example purposes.
 >
 
-For [vRack](https://www.ovhcloud.com/it/network/vrack/){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
+For [vRack](/links/network/vrack){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
 
 ```console
 198.51.100.0   Reserved: Network address
@@ -271,6 +271,6 @@ Click `Next`{.action}, then `Create VM`{.action}.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.pl-pl.md
@@ -121,7 +121,7 @@ To redeploy the gateway VM you will need:
 
 ##### **Check the Additional IP address**
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) and open the management section of your [vRack](https://www.ovhcloud.com/pl/network/vrack/){.external}. Verify the Additional IP address used by the Nutanix Cluster.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the management section of your [vRack](/links/network/vrack){.external}. Verify the Additional IP address used by the Nutanix Cluster.
 
 ![Additional IP](images/check_subnet0.png){.thumbnail}
 
@@ -129,7 +129,7 @@ Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomana
 > The following instructions will use the IP block 198.51.100.0/30 for example purposes.
 >
 
-For [vRack](https://www.ovhcloud.com/pl/network/vrack/){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
+For [vRack](/links/network/vrack){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
 
 ```console
 198.51.100.0   Reserved: Network address
@@ -271,6 +271,6 @@ Click `Next`{.action}, then `Create VM`{.action}.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/23-ovh-gateway-doc/guide.pt-pt.md
@@ -121,7 +121,7 @@ To redeploy the gateway VM you will need:
 
 ##### **Check the Additional IP address**
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt) and open the management section of your [vRack](https://www.ovhcloud.com/pt/network/vrack/){.external}. Verify the Additional IP address used by the Nutanix Cluster.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the management section of your [vRack](/links/network/vrack){.external}. Verify the Additional IP address used by the Nutanix Cluster.
 
 ![Additional IP](images/check_subnet0.png){.thumbnail}
 
@@ -129,7 +129,7 @@ Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomana
 > The following instructions will use the IP block 198.51.100.0/30 for example purposes.
 >
 
-For [vRack](https://www.ovhcloud.com/pt/network/vrack/){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
+For [vRack](/links/network/vrack){.external} purposes, the first, penultimate, and last addresses in any given IP block are always reserved for the network address, network gateway, and network broadcast respectively. This means that the first usable address is the second address in the block, as shown below:
 
 ```console
 198.51.100.0   Reserved: Network address
@@ -271,6 +271,6 @@ Click `Next`{.action}, then `Create VM`{.action}.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.de-de.md
@@ -13,21 +13,21 @@ If you want to create a web front-end or a reverse proxy to create a stack of VM
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/de/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - Login credentials and URL for Prism Central, received via email after the installation
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An available Additional IP address
 
 ## Instructions
 
 ### Adding a new Additional IP to your vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) and add an Additional IP address to your [vRack](https://www.ovh.de/loesungen/vrack/){.external}.
+Log in to the [OVHcloud Control Panel](/links/manager) and add an Additional IP address to your [vRack](https://www.ovh.de/loesungen/vrack/){.external}.
 
 > [!primary]
 > The following instructions will use the IP block 123.45.6.78/30 for example purposes.
@@ -407,6 +407,6 @@ curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:PR
 
 [Nutanix API: How to create a Linux VM](https://www.nutanix.dev/2020/06/16/nutanix-api-v3-creating-a-linux-vm-with-cloud-init/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.en-ca.md
@@ -13,21 +13,21 @@ If you want to create a web front-end or a reverse proxy to create a stack of VM
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ca/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - Login credentials and URL for Prism Central, received via email after the installation
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An available Additional IP address
 
 ## Instructions
 
 ### Adding a new Additional IP to your vRack
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) and add an Additional IP address to your [vRack](https://www.ovh.com/ca/en/solutions/vrack/){.external}.
+Log in to the [OVHcloud Control Panel](/links/manager) and add an Additional IP address to your [vRack](https://www.ovh.com/ca/en/solutions/vrack/){.external}.
 
 > [!primary]
 > The following instructions will use the IP block 123.45.6.78/30 for example purposes.
@@ -407,6 +407,6 @@ curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:PR
 
 [Nutanix API: How to create a Linux VM](https://www.nutanix.dev/2020/06/16/nutanix-api-v3-creating-a-linux-vm-with-cloud-init/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.en-gb.md
@@ -13,21 +13,21 @@ If you want to create a web front-end or a reverse proxy to create a stack of VM
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - Login credentials and URL for Prism Central, received via email after the installation
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An available Additional IP address
 
 ## Instructions
 
 ### Adding a new Additional IP to your vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) and add an Additional IP address to your [vRack](https://www.ovh.co.uk/solutions/vrack/){.external}.
+Log in to the [OVHcloud Control Panel](/links/manager) and add an Additional IP address to your [vRack](https://www.ovh.co.uk/solutions/vrack/){.external}.
 
 > [!primary]
 > The following instructions will use the IP block 123.45.6.78/30 for example purposes.
@@ -407,6 +407,6 @@ curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:PR
 
 [Nutanix API: How to create a Linux VM](https://www.nutanix.dev/2020/06/16/nutanix-api-v3-creating-a-linux-vm-with-cloud-init/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.en-ie.md
@@ -13,21 +13,21 @@ If you want to create a web front-end or a reverse proxy to create a stack of VM
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ie/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - Login credentials and URL for Prism Central, received via email after the installation
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An available Additional IP address
 
 ## Instructions
 
 ### Adding a new Additional IP to your vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) and add an Additional IP address to your [vRack](https://www.ovh.ie/solutions/vrack/){.external}.
+Log in to the [OVHcloud Control Panel](/links/manager) and add an Additional IP address to your [vRack](https://www.ovh.ie/solutions/vrack/){.external}.
 
 > [!primary]
 > The following instructions will use the IP block 123.45.6.78/30 for example purposes.
@@ -407,6 +407,6 @@ curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:PR
 
 [Nutanix API: How to create a Linux VM](https://www.nutanix.dev/2020/06/16/nutanix-api-v3-creating-a-linux-vm-with-cloud-init/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.en-us.md
@@ -13,21 +13,21 @@ If you want to create a web front-end or a reverse proxy to create a stack of VM
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-us/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-us/professional-services/) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - Login credentials and URL for Prism Central, received via email after the installation
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An available Additional IP address
 
 ## Instructions
 
 ### Adding a new Additional IP to your vRack
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) and add an Additional IP address to your [vRack](https://www.ovh.com/world/solutions/vrack/){.external}.
+Log in to the [OVHcloud Control Panel](/links/manager) and add an Additional IP address to your [vRack](https://www.ovh.com/world/solutions/vrack/){.external}.
 
 > [!primary]
 > The following instructions will use the IP block 123.45.6.78/30 for example purposes.
@@ -407,6 +407,6 @@ curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:PR
 
 [Nutanix API: How to create a Linux VM](https://www.nutanix.dev/2020/06/16/nutanix-api-v3-creating-a-linux-vm-with-cloud-init/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.es-es.md
@@ -13,21 +13,21 @@ If you want to create a web front-end or a reverse proxy to create a stack of VM
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/es-es/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - Login credentials and URL for Prism Central, received via email after the installation
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An available Additional IP address
 
 ## Instructions
 
 ### Adding a new Additional IP to your vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) and add a Additional IP address to your [vRack](https://www.ovh.es/soluciones/vrack/){.external}.
+Log in to the [OVHcloud Control Panel](/links/manager) and add a Additional IP address to your [vRack](https://www.ovh.es/soluciones/vrack/){.external}.
 
 > [!primary]
 > The following instructions will use the IP block 123.45.6.78/30 for example purposes.
@@ -407,6 +407,6 @@ curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:PR
 
 [Nutanix API: How to create a Linux VM](https://www.nutanix.dev/2020/06/16/nutanix-api-v3-creating-a-linux-vm-with-cloud-init/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.es-us.md
@@ -13,21 +13,21 @@ If you want to create a web front-end or a reverse proxy to create a stack of VM
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/es/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - Login credentials and URL for Prism Central, received via email after the installation
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An available Additional IP address
 
 ## Instructions
 
 ### Adding a new Additional IP to your vRack
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) and add a Additional IP address to your [vRack](https://www.ovh.com/world/es/soluciones/vrack/){.external}.
+Log in to the [OVHcloud Control Panel](/links/manager) and add a Additional IP address to your [vRack](https://www.ovh.com/world/es/soluciones/vrack/){.external}.
 
 > [!primary]
 > The following instructions will use the IP block 123.45.6.78/30 for example purposes.
@@ -407,6 +407,6 @@ curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:PR
 
 [Nutanix API: How to create a Linux VM](https://www.nutanix.dev/2020/06/16/nutanix-api-v3-creating-a-linux-vm-with-cloud-init/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.fr-ca.md
@@ -13,21 +13,21 @@ Si vous souhaitez créer un frontend web ou un reverse proxy pour créer une pil
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
 - Disposer des identifiants de connexion et l'URL de Prism Central, reçus par mail après l'installation
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Disposer d'une adresse Additional IP disponible
 
 ## En pratique
 
 ### Ajouter une nouvelle Additional IP à votre vRack
 
-Connectez-vous à l'[espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc) et ajoutez une adresse Additional IP à votre [vRack](https://www.ovh.com/ca/fr/solutions/vrack/){.external}.
+Connectez-vous à l'[espace client OVHcloud](/links/manager) et ajoutez une adresse Additional IP à votre [vRack](https://www.ovh.com/ca/fr/solutions/vrack/){.external}.
 
 > [!primary]
 > Les instructions suivantes vont utiliser le bloc IP 123.45.6.78/30 à titre d'exemple.
@@ -407,6 +407,6 @@ curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:PR
 
 [API Nutanix : Création d'une VM Linux](https://www.nutanix.dev/2020/06/16/nutanix-api-v3-creating-a-linux-vm-with-cloud-init/){.external}
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.fr-fr.md
@@ -13,21 +13,21 @@ Si vous souhaitez créer un frontend web ou un reverse proxy pour créer une pil
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
 - Disposer des identifiants de connexion et l'URL de Prism Central, reçus par mail après l'installation
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Disposer d'une adresse Additional IP disponible
 
 ## En pratique
 
 ### Ajouter une nouvelle Additional IP à votre vRack
 
-Connectez-vous à l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) et ajoutez une adresse Additional IP à votre [vRack](https://www.ovh.com/fr/solutions/vrack/){.external}.
+Connectez-vous à l'[espace client OVHcloud](/links/manager) et ajoutez une adresse Additional IP à votre [vRack](https://www.ovh.com/fr/solutions/vrack/){.external}.
 
 > [!primary]
 > Les instructions suivantes vont utiliser le bloc IP 123.45.6.78/30 à titre d'exemple.
@@ -407,6 +407,6 @@ curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:PR
 
 [API Nutanix : Création d'une VM Linux](https://www.nutanix.dev/2020/06/16/nutanix-api-v3-creating-a-linux-vm-with-cloud-init/){.external}
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.it-it.md
@@ -13,21 +13,21 @@ If you want to create a web front-end or a reverse proxy to create a stack of VM
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/it/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - Login credentials and URL for Prism Central, received via email after the installation
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An available Additional IP address
 
 ## Instructions
 
 ### Adding a new Additional IP to your vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) and add an Additional IP address to your [vRack](https://www.ovh.it/soluzioni/vrack/){.external}.
+Log in to the [OVHcloud Control Panel](/links/manager) and add an Additional IP address to your [vRack](https://www.ovh.it/soluzioni/vrack/){.external}.
 
 > [!primary]
 > The following instructions will use the IP block 123.45.6.78/30 for example purposes.
@@ -407,6 +407,6 @@ curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:PR
 
 [Nutanix API: How to create a Linux VM](https://www.nutanix.dev/2020/06/16/nutanix-api-v3-creating-a-linux-vm-with-cloud-init/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.pl-pl.md
@@ -13,21 +13,21 @@ If you want to create a web front-end or a reverse proxy to create a stack of VM
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/pl/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - Login credentials and URL for Prism Central, received via email after the installation
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An available Additional IP address
 
 ## Instructions
 
 ### Adding a new Additional IP to your vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) and add a Additional IP address to your [vRack](https://www.ovh.pl/rozwiazania/vrack/){.external}.
+Log in to the [OVHcloud Control Panel](/links/manager) and add a Additional IP address to your [vRack](https://www.ovh.pl/rozwiazania/vrack/){.external}.
 
 > [!primary]
 > The following instructions will use the IP block 123.45.6.78/30 for example purposes.
@@ -407,6 +407,6 @@ curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:PR
 
 [Nutanix API: How to create a Linux VM](https://www.nutanix.dev/2020/06/16/nutanix-api-v3-creating-a-linux-vm-with-cloud-init/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/24-add-public-ip-on-vm/guide.pt-pt.md
@@ -13,21 +13,21 @@ If you want to create a web front-end or a reverse proxy to create a stack of VM
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/pt/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - Login credentials and URL for Prism Central, received via email after the installation
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - An available Additional IP address
 
 ## Instructions
 
 ### Adding a new Additional IP to your vRack
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt) and add an Additional IP address to your [vRack](https://www.ovh.pt/solucoes/vrack/){.external}.
+Log in to the [OVHcloud Control Panel](/links/manager) and add an Additional IP address to your [vRack](https://www.ovh.pt/solucoes/vrack/){.external}.
 
 > [!primary]
 > The following instructions will use the IP block 123.45.6.78/30 for example purposes.
@@ -407,6 +407,6 @@ curl -k -H Accept:application/json -H Content-Type:application/json -u "admin:PR
 
 [Nutanix API: How to create a Linux VM](https://www.nutanix.dev/2020/06/16/nutanix-api-v3-creating-a-linux-vm-with-cloud-init/){.external}
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.de-de.md
@@ -13,19 +13,19 @@ After delivery, Prism Central is accessible on the public Internet. Access restr
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/de/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Find the relevant Load Balancer
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) and open the Nutanix cluster vRack configuration page.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the Nutanix cluster vRack configuration page.
 
 Identify the name of your Load Balancer.
 
@@ -55,6 +55,6 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.en-ca.md
@@ -13,19 +13,19 @@ After delivery, Prism Central is accessible on the public Internet. Access restr
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ca/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Find the relevant Load Balancer
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) and open the Nutanix cluster vRack configuration page.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the Nutanix cluster vRack configuration page.
 
 Identify the name of your Load Balancer.
 
@@ -55,6 +55,6 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.en-gb.md
@@ -13,19 +13,19 @@ After delivery, Prism Central is accessible on the public Internet. Access restr
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Find the relevant Load Balancer
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) and open the Nutanix cluster vRack configuration page.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the Nutanix cluster vRack configuration page.
 
 Identify the name of your Load Balancer.
 
@@ -55,6 +55,6 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.en-ie.md
@@ -13,19 +13,19 @@ After delivery, Prism Central is accessible on the public Internet. Access restr
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ie/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Find the relevant Load Balancer
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) and open the Nutanix cluster vRack configuration page.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the Nutanix cluster vRack configuration page.
 
 Identify the name of your Load Balancer.
 
@@ -55,6 +55,6 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.en-us.md
@@ -13,19 +13,19 @@ After delivery, Prism Central is accessible on the public Internet. Access restr
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-us/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-us/professional-services/) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Find the relevant Load Balancer
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) and open the Nutanix cluster vRack configuration page.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the Nutanix cluster vRack configuration page.
 
 Identify the name of your Load Balancer.
 
@@ -55,6 +55,6 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.es-es.md
@@ -13,19 +13,19 @@ After delivery, Prism Central is accessible on the public Internet. Access restr
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/es-es/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Find the relevant Load Balancer
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) and open the Nutanix cluster vRack configuration page.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the Nutanix cluster vRack configuration page.
 
 Identify the name of your Load Balancer.
 
@@ -55,6 +55,6 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.es-us.md
@@ -13,19 +13,19 @@ After delivery, Prism Central is accessible on the public Internet. Access restr
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/es/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Find the relevant Load Balancer
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) and open the Nutanix cluster vRack configuration page.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the Nutanix cluster vRack configuration page.
 
 Identify the name of your Load Balancer.
 
@@ -55,6 +55,6 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.fr-ca.md
@@ -13,19 +13,19 @@ Une fois votre service livré, Prism Central est accessible sur l'Internet publi
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique
 
 ### Étape 1 : trouver le Load Balancer concerné
 
-Connectez-vous à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc) et ouvrez la page de configuration du Nutanix Cluster vRack.
+Connectez-vous à votre [espace client OVHcloud](/links/manager) et ouvrez la page de configuration du Nutanix Cluster vRack.
 
 Identifiez le nom de votre Load Balancer.
 
@@ -55,6 +55,6 @@ Dans les paramètres avancés, vous pouvez désormais ajouter l'adresse IP de vo
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.fr-fr.md
@@ -13,19 +13,19 @@ Une fois votre service livré, Prism Central est accessible sur l'Internet publi
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique
 
 ### Étape 1 : trouver le Load Balancer concerné
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) et ouvrez la page de configuration du Nutanix Cluster vRack.
+Connectez-vous à votre [espace client OVHcloud](/links/manager) et ouvrez la page de configuration du Nutanix Cluster vRack.
 
 Identifiez le nom de votre Load Balancer.
 
@@ -55,6 +55,6 @@ Dans les paramètres avancés, vous pouvez désormais ajouter l'adresse IP de vo
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.it-it.md
@@ -13,19 +13,19 @@ After delivery, Prism Central is accessible on the public Internet. Access restr
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/it/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Find the relevant Load Balancer
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) and open the Nutanix cluster vRack configuration page.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the Nutanix cluster vRack configuration page.
 
 Identify the name of your Load Balancer.
 
@@ -55,6 +55,6 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.pl-pl.md
@@ -13,19 +13,19 @@ After delivery, Prism Central is accessible on the public Internet. Access restr
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/pl/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Find the relevant Load Balancer
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) and open the Nutanix cluster vRack configuration page.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the Nutanix cluster vRack configuration page.
 
 Identify the name of your Load Balancer.
 
@@ -55,6 +55,6 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/25-secure-prism-web-access/guide.pt-pt.md
@@ -13,19 +13,19 @@ After delivery, Prism Central is accessible on the public Internet. Access restr
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/pt/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Find the relevant Load Balancer
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt) and open the Nutanix cluster vRack configuration page.
+Log in to the [OVHcloud Control Panel](/links/manager) and open the Nutanix cluster vRack configuration page.
 
 Identify the name of your Load Balancer.
 
@@ -55,6 +55,6 @@ In the advanced settings, you can now add your public ISP IP address or any IP a
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.de-de.md
@@ -13,20 +13,20 @@ A Nutanix cluster is delivered with its own vRack. In order to interconnect with
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/de/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - An additional [vRack](https://www.ovh.de/loesungen/vrack/) service activated in your account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Removing services
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
+Log in to the [OVHcloud Control Panel](/links/manager).
 
 Open the Nutanix cluster vRack configuration page, select all the services (e.g. dedicated server, IP, load balancer) and click on `Remove`{.action}.
 
@@ -84,6 +84,6 @@ acli vm.reset
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.en-ca.md
@@ -13,20 +13,20 @@ A Nutanix cluster is delivered with its own vRack. In order to interconnect with
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ca/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - An additional [vRack](https://www.ovh.com/ca/en/solutions/vrack/) service activated in your account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Removing services
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca).
+Log in to the [OVHcloud Control Panel](/links/manager).
 
 Open the Nutanix cluster vRack configuration page, select all the services (e.g. dedicated server, IP, load balancer) and click on `Remove`{.action}.
 
@@ -84,6 +84,6 @@ acli vm.reset
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.en-gb.md
@@ -13,20 +13,20 @@ A Nutanix cluster is delivered with its own vRack. In order to interconnect with
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - An additional [vRack](https://www.ovh.co.uk/solutions/vrack/) service activated in your account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Removing services
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB).
+Log in to the [OVHcloud Control Panel](/links/manager).
 
 Open the Nutanix cluster vRack configuration page, select all the services (e.g. dedicated server, IP, load balancer) and click on `Remove`{.action}.
 
@@ -84,6 +84,6 @@ acli vm.reset
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.en-ie.md
@@ -13,20 +13,20 @@ A Nutanix cluster is delivered with its own vRack. In order to interconnect with
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ie/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - An additional [vRack](https://www.ovh.ie/solutions/vrack/) service activated in your account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Removing services
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie).
+Log in to the [OVHcloud Control Panel](/links/manager).
 
 Open the Nutanix cluster vRack configuration page, select all the services (e.g. dedicated server, IP, load balancer) and click on `Remove`{.action}.
 
@@ -84,6 +84,6 @@ acli vm.reset
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.en-us.md
@@ -13,20 +13,20 @@ A Nutanix cluster is delivered with its own vRack. In order to interconnect with
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-us/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-us/professional-services/) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - An additional [vRack](https://www.ovh.com/world/solutions/vrack/) service activated in your account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Removing services
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we).
+Log in to the [OVHcloud Control Panel](/links/manager).
 
 Open the Nutanix cluster vRack configuration page, select all the services (e.g. dedicated server, IP, load balancer) and click on `Remove`{.action}.
 
@@ -84,6 +84,6 @@ acli vm.reset
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.es-es.md
@@ -13,20 +13,20 @@ A Nutanix cluster is delivered with its own vRack. In order to interconnect with
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/es-es/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - An additional [vRack](https://www.ovh.es/soluciones/vrack/) service activated in your account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Removing services
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es).
+Log in to the [OVHcloud Control Panel](/links/manager).
 
 Open the Nutanix cluster vRack configuration page, select all the services (e.g. dedicated server, IP, load balancer) and click on `Remove`{.action}.
 
@@ -84,6 +84,6 @@ acli vm.reset
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.es-us.md
@@ -13,20 +13,20 @@ A Nutanix cluster is delivered with its own vRack. In order to interconnect with
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/es/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - An additional [vRack](https://www.ovh.com/world/es/soluciones/vrack/) service activated in your account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Removing services
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+Log in to the [OVHcloud Control Panel](/links/manager).
 
 Open the Nutanix cluster vRack configuration page, select all the services (e.g. dedicated server, IP, load balancer) and click on `Remove`{.action}.
 
@@ -84,6 +84,6 @@ acli vm.reset
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.fr-ca.md
@@ -13,20 +13,20 @@ Un cluster Nutanix est livré avec son propre vRack. Afin de vous interconnecter
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
 - Disposer d'un service [vRack](https://www.ovh.com/ca/fr/solutions/vrack/) supplémentaire activé dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique
 
 ### Étape 1 : suppression des services
 
-Connectez-vous à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc). Ouvrez la page de configuration du Nutanix Cluster vRack, sélectionnez tous les services (par exemple, serveur dédié, IP, load balancer) et cliquez sur `Supprimer`{.action}.
+Connectez-vous à votre [espace client OVHcloud](/links/manager). Ouvrez la page de configuration du Nutanix Cluster vRack, sélectionnez tous les services (par exemple, serveur dédié, IP, load balancer) et cliquez sur `Supprimer`{.action}.
 
 ![Remove Features](images/vrack-1.png){.thumbnail}
 
@@ -82,6 +82,6 @@ acli vm.reset
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.fr-fr.md
@@ -13,20 +13,20 @@ Un cluster Nutanix est livré avec son propre vRack. Afin de vous interconnecter
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
 - Disposer d'un service [vRack](https://www.ovh.com/fr/solutions/vrack/) supplémentaire activé dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique
 
 ### Étape 1 : suppression des services
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr). Ouvrez la page de configuration du Nutanix Cluster vRack, sélectionnez tous les services (par exemple, serveur dédié, IP, load balancer) et cliquez sur `Supprimer`{.action}.
+Connectez-vous à votre [espace client OVHcloud](/links/manager). Ouvrez la page de configuration du Nutanix Cluster vRack, sélectionnez tous les services (par exemple, serveur dédié, IP, load balancer) et cliquez sur `Supprimer`{.action}.
 
 ![Remove Features](images/vrack-1.png){.thumbnail}
 
@@ -82,6 +82,6 @@ acli vm.reset
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.it-it.md
@@ -13,20 +13,20 @@ A Nutanix cluster is delivered with its own vRack. In order to interconnect with
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/it/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - An additional [vRack](https://www.ovh.it/soluzioni/vrack/) service activated in your account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Removing services
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it).
+Log in to the [OVHcloud Control Panel](/links/manager).
 
 Open the Nutanix cluster vRack configuration page, select all the services (e.g. dedicated server, IP, load balancer) and click on `Remove`{.action}.
 
@@ -84,6 +84,6 @@ acli vm.reset
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.pl-pl.md
@@ -13,20 +13,20 @@ A Nutanix cluster is delivered with its own vRack. In order to interconnect with
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/pl/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - An additional [vRack](https://www.ovh.pl/rozwiazania/vrack/) service activated in your account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Removing services
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl).
+Log in to the [OVHcloud Control Panel](/links/manager).
 
 Open the Nutanix cluster vRack configuration page, select all the services (e.g. dedicated server, IP, load balancer) and click on `Remove`{.action}.
 
@@ -84,6 +84,6 @@ acli vm.reset
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/26-change-vrack-postinstall/guide.pt-pt.md
@@ -13,20 +13,20 @@ A Nutanix cluster is delivered with its own vRack. In order to interconnect with
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/pt/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
 - An additional [vRack](https://www.ovh.pt/solucoes/vrack/) service activated in your account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions
 
 ### Step 1: Removing services
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt).
+Log in to the [OVHcloud Control Panel](/links/manager).
 
 Open the Nutanix cluster vRack configuration page, select all the services (e.g. dedicated server, IP, load balancer) and click on `Remove`{.action}.
 
@@ -84,6 +84,6 @@ acli vm.reset
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.de-de.md
@@ -18,7 +18,7 @@ In order to increase the security of management machines, it is recommended to i
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/de/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
@@ -51,6 +51,6 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.en-ca.md
@@ -18,7 +18,7 @@ In order to increase the security of management machines, it is recommended to i
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ca/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
@@ -51,6 +51,6 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.en-gb.md
@@ -18,7 +18,7 @@ In order to increase the security of management machines, it is recommended to i
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
@@ -51,6 +51,6 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.en-ie.md
@@ -18,7 +18,7 @@ In order to increase the security of management machines, it is recommended to i
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ie/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
@@ -51,6 +51,6 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.en-us.md
@@ -18,7 +18,7 @@ In order to increase the security of management machines, it is recommended to i
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-us/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-us/professional-services/) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
@@ -51,6 +51,6 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.es-es.md
@@ -18,7 +18,7 @@ In order to increase the security of management machines, it is recommended to i
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/es-es/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
@@ -51,6 +51,6 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.es-us.md
@@ -18,7 +18,7 @@ In order to increase the security of management machines, it is recommended to i
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/es/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
@@ -51,6 +51,6 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.fr-ca.md
@@ -18,7 +18,7 @@ Afin d’augmenter la sécurité des machines de gestion, il est recommandé de 
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
@@ -51,6 +51,6 @@ Donnez un nom à votre réseau, puis choisissez un VLAN ID, un cluster et le swi
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.fr-fr.md
@@ -18,7 +18,7 @@ Afin d’augmenter la sécurité des machines de gestion, il est recommandé de 
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## Prérequis
@@ -51,6 +51,6 @@ Donnez un nom à votre réseau, puis choisissez un VLAN ID, un cluster et le swi
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.it-it.md
@@ -18,7 +18,7 @@ In order to increase the security of management machines, it is recommended to i
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/it/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
@@ -51,6 +51,6 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.pl-pl.md
@@ -18,7 +18,7 @@ In order to increase the security of management machines, it is recommended to i
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/pl/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
@@ -51,6 +51,6 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/27-isolate-management-vm/guide.pt-pt.md
@@ -18,7 +18,7 @@ In order to increase the security of management machines, it is recommended to i
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](https://www.ovhcloud.com/pt/professional-services/) or a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact the [OVHcloud Professional Services team](/links/professional-services) or a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
@@ -51,6 +51,6 @@ Enter a name for your network, then select a VLAN ID, cluster and the "vs0" virt
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.de-de.md
@@ -411,6 +411,6 @@ The rule you created is in the list of rules.
 
 [Categories in Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-vpc_2022_1:ssp-ssp-categories-manage-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.en-ca.md
@@ -411,6 +411,6 @@ The rule you created is in the list of rules.
 
 [Categories in Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-vpc_2022_1:ssp-ssp-categories-manage-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.en-gb.md
@@ -411,6 +411,6 @@ The rule you created is in the list of rules.
 
 [Categories in Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-vpc_2022_1:ssp-ssp-categories-manage-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.en-ie.md
@@ -411,6 +411,6 @@ The rule you created is in the list of rules.
 
 [Categories in Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-vpc_2022_1:ssp-ssp-categories-manage-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.en-us.md
@@ -411,6 +411,6 @@ The rule you created is in the list of rules.
 
 [Categories in Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-vpc_2022_1:ssp-ssp-categories-manage-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.es-es.md
@@ -411,6 +411,6 @@ The rule you created is in the list of rules.
 
 [Categories in Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-vpc_2022_1:ssp-ssp-categories-manage-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.es-us.md
@@ -411,6 +411,6 @@ The rule you created is in the list of rules.
 
 [Categories in Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-vpc_2022_1:ssp-ssp-categories-manage-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.fr-ca.md
@@ -16,7 +16,7 @@ Nutanix Flow est disponible sur toutes les offres **Nutanix on OVHcloud**. Cette
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## En pratique
@@ -411,6 +411,6 @@ La règle créée se trouve dans la liste des règles.
 
 [Catégories dans Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-vpc_2022_1:ssp-ssp-categories-manage-pc-c.html)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.fr-fr.md
@@ -16,7 +16,7 @@ Nutanix Flow est disponible sur toutes les offres **Nutanix on OVHcloud**. Cette
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 ## En pratique
@@ -411,6 +411,6 @@ La règle créée se trouve dans la liste des règles.
 
 [Catégories dans Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-vpc_2022_1:ssp-ssp-categories-manage-pc-c.html)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.it-it.md
@@ -411,6 +411,6 @@ The rule you created is in the list of rules.
 
 [Categories in Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-vpc_2022_1:ssp-ssp-categories-manage-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.pl-pl.md
@@ -411,6 +411,6 @@ The rule you created is in the list of rules.
 
 [Categories in Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-vpc_2022_1:ssp-ssp-categories-manage-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/28-flow/guide.pt-pt.md
@@ -411,6 +411,6 @@ The rule you created is in the list of rules.
 
 [Categories in Nutanix](https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-Prism-vpc_2022_1:ssp-ssp-categories-manage-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.de-de.md
@@ -9,7 +9,7 @@ updated: 2025-04-29
 
 An **OVHgateway** virtual machine is installed when deploying a **Nutanix on OVHcloud** cluster. This virtual machine serves as the outgoing Internet gateway for the cluster. The maximum throughput is 1 GB/s.
 
-If you need more bandwidth, you can replace this gateway with a [dedicated server](https://www.ovhcloud.com/de/bare-metal/) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
+If you need more bandwidth, you can replace this gateway with a [dedicated server](/links/bare-metal/bare-metal) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
 Contact OVHcloud Sales to help you choose the right server. 
 
 **This guide explains how to replace the default gateway with an OVHcloud dedicated server to increase bandwidth.**
@@ -23,9 +23,9 @@ Contact OVHcloud Sales to help you choose the right server.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via **Prism Central**. 
-- You have a [dedicated server](https://www.ovhcloud.com/de/bare-metal/) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
+- You have a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
 
 ## Instructions
 
@@ -41,7 +41,7 @@ To replace the OVHgateway VM, we will use these settings:
 
 ### Retrieving information needed to deploy your server
 
-In your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
+In your [OVHcloud Control Panel](/links/manager), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
 
 ![01 get nutanix vrack 01](images/01-get-nutanix-vrack01.png){.thumbnail}
 
@@ -375,6 +375,6 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
 
 ## Go further <a name="gofurther"></a>
   
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.en-ca.md
@@ -9,7 +9,7 @@ updated: 2025-04-29
 
 An **OVHgateway** virtual machine is installed when deploying a **Nutanix on OVHcloud** cluster. This virtual machine serves as the outgoing Internet gateway for the cluster. The maximum throughput is 1 GB/s.
 
-If you need more bandwidth, you can replace this gateway with a [dedicated server](https://www.ovhcloud.com/en-ca/bare-metal/) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
+If you need more bandwidth, you can replace this gateway with a [dedicated server](/links/bare-metal/bare-metal) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
 Contact OVHcloud Sales to help you choose the right server. 
 
 **This guide explains how to replace the default gateway with an OVHcloud dedicated server to increase bandwidth.**
@@ -23,9 +23,9 @@ Contact OVHcloud Sales to help you choose the right server.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via **Prism Central**. 
-- You have a [dedicated server](https://www.ovhcloud.com/en-ca/bare-metal/) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
+- You have a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
 
 ## Instructions
 
@@ -41,7 +41,7 @@ To replace the OVHgateway VM, we will use these settings:
 
 ### Retrieving information needed to deploy your server
 
-In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
+In your [OVHcloud Control Panel](/links/manager), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
 
 ![01 get nutanix vrack 01](images/01-get-nutanix-vrack01.png){.thumbnail}
 
@@ -375,6 +375,6 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
 
 ## Go further <a name="gofurther"></a>
   
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.en-gb.md
@@ -9,7 +9,7 @@ updated: 2025-04-29
 
 An **OVHgateway** virtual machine is installed when deploying a **Nutanix on OVHcloud** cluster. This virtual machine serves as the outgoing Internet gateway for the cluster. The maximum throughput is 1 GB/s.
 
-If you need more bandwidth, you can replace this gateway with a [dedicated server](https://www.ovhcloud.com/en-gb/bare-metal/) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
+If you need more bandwidth, you can replace this gateway with a [dedicated server](/links/bare-metal/bare-metal) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
 Contact OVHcloud Sales to help you choose the right server. 
 
 **This guide explains how to replace the default gateway with an OVHcloud dedicated server to increase bandwidth.**
@@ -23,9 +23,9 @@ Contact OVHcloud Sales to help you choose the right server.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via **Prism Central**. 
-- You have a [dedicated server](https://www.ovhcloud.com/en-gb/bare-metal/) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
+- You have a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
 
 ## Instructions
 
@@ -41,7 +41,7 @@ To replace the OVHgateway VM, we will use these settings:
 
 ### Retrieving information needed to deploy your server
 
-In your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
+In your [OVHcloud Control Panel](/links/manager), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
 
 ![01 get nutanix vrack 01](images/01-get-nutanix-vrack01.png){.thumbnail}
 
@@ -375,6 +375,6 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
 
 ## Go further <a name="gofurther"></a>
   
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.en-ie.md
@@ -9,7 +9,7 @@ updated: 2025-04-29
 
 An **OVHgateway** virtual machine is installed when deploying a **Nutanix on OVHcloud** cluster. This virtual machine serves as the outgoing Internet gateway for the cluster. The maximum throughput is 1 GB/s.
 
-If you need more bandwidth, you can replace this gateway with a [dedicated server](https://www.ovhcloud.com/en-ie/bare-metal/) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
+If you need more bandwidth, you can replace this gateway with a [dedicated server](/links/bare-metal/bare-metal) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
 Contact OVHcloud Sales to help you choose the right server. 
 
 **This guide explains how to replace the default gateway with an OVHcloud dedicated server to increase bandwidth.**
@@ -23,9 +23,9 @@ Contact OVHcloud Sales to help you choose the right server.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via **Prism Central**. 
-- You have a [dedicated server](https://www.ovhcloud.com/en-ie/bare-metal/) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
+- You have a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
 
 ## Instructions
 
@@ -41,7 +41,7 @@ To replace the OVHgateway VM, we will use these settings:
 
 ### Retrieving information needed to deploy your server
 
-In your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
+In your [OVHcloud Control Panel](/links/manager), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
 
 ![01 get nutanix vrack 01](images/01-get-nutanix-vrack01.png){.thumbnail}
 
@@ -375,6 +375,6 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
 
 ## Go further <a name="gofurther"></a>
   
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.en-us.md
@@ -9,7 +9,7 @@ updated: 2025-04-29
 
 An **OVHgateway** virtual machine is installed when deploying a **Nutanix on OVHcloud** cluster. This virtual machine serves as the outgoing Internet gateway for the cluster. The maximum throughput is 1 GB/s.
 
-If you need more bandwidth, you can replace this gateway with a [dedicated server](https://www.ovhcloud.com/en/bare-metal/) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
+If you need more bandwidth, you can replace this gateway with a [dedicated server](/links/bare-metal/bare-metal) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
 Contact OVHcloud Sales to help you choose the right server. 
 
 **This guide explains how to replace the default gateway with an OVHcloud dedicated server to increase bandwidth.**
@@ -23,9 +23,9 @@ Contact OVHcloud Sales to help you choose the right server.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via **Prism Central**. 
-- You have a [dedicated server](https://www.ovhcloud.com/en/bare-metal/) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
+- You have a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
 
 ## Instructions
 
@@ -41,7 +41,7 @@ To replace the OVHgateway VM, we will use these settings:
 
 ### Retrieving information needed to deploy your server
 
-In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
+In your [OVHcloud Control Panel](/links/manager), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
 
 ![01 get nutanix vrack 01](images/01-get-nutanix-vrack01.png){.thumbnail}
 
@@ -375,6 +375,6 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
 
 ## Go further <a name="gofurther"></a>
   
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.es-es.md
@@ -9,7 +9,7 @@ updated: 2025-04-29
 
 An **OVHgateway** virtual machine is installed when deploying a **Nutanix on OVHcloud** cluster. This virtual machine serves as the outgoing Internet gateway for the cluster. The maximum throughput is 1 GB/s.
 
-If you need more bandwidth, you can replace this gateway with a [dedicated server](https://www.ovhcloud.com/es-es/bare-metal/) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
+If you need more bandwidth, you can replace this gateway with a [dedicated server](/links/bare-metal/bare-metal) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
 Contact OVHcloud Sales to help you choose the right server. 
 
 **This guide explains how to replace the default gateway with an OVHcloud dedicated server to increase bandwidth.**
@@ -23,9 +23,9 @@ Contact OVHcloud Sales to help you choose the right server.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via **Prism Central**. 
-- You have a [dedicated server](https://www.ovhcloud.com/es-es/bare-metal/) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
+- You have a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
 
 ## Instructions
 
@@ -41,7 +41,7 @@ To replace the OVHgateway VM, we will use these settings:
 
 ### Retrieving information needed to deploy your server
 
-In your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
+In your [OVHcloud Control Panel](/links/manager), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
 
 ![01 get nutanix vrack 01](images/01-get-nutanix-vrack01.png){.thumbnail}
 
@@ -375,6 +375,6 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
 
 ## Go further <a name="gofurther"></a>
   
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.es-us.md
@@ -9,7 +9,7 @@ updated: 2025-04-29
 
 An **OVHgateway** virtual machine is installed when deploying a **Nutanix on OVHcloud** cluster. This virtual machine serves as the outgoing Internet gateway for the cluster. The maximum throughput is 1 GB/s.
 
-If you need more bandwidth, you can replace this gateway with a [dedicated server](https://www.ovhcloud.com/es/bare-metal/) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
+If you need more bandwidth, you can replace this gateway with a [dedicated server](/links/bare-metal/bare-metal) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
 Contact OVHcloud Sales to help you choose the right server. 
 
 **This guide explains how to replace the default gateway with an OVHcloud dedicated server to increase bandwidth.**
@@ -23,9 +23,9 @@ Contact OVHcloud Sales to help you choose the right server.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via **Prism Central**. 
-- You have a [dedicated server](https://www.ovhcloud.com/es/bare-metal/) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
+- You have a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
 
 ## Instructions
 
@@ -41,7 +41,7 @@ To replace the OVHgateway VM, we will use these settings:
 
 ### Retrieving information needed to deploy your server
 
-In your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
+In your [OVHcloud Control Panel](/links/manager), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
 
 ![01 get nutanix vrack 01](images/01-get-nutanix-vrack01.png){.thumbnail}
 
@@ -375,6 +375,6 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
 
 ## Go further <a name="gofurther"></a>
   
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.fr-ca.md
@@ -8,7 +8,7 @@ updated: 2025-04-29
 
 Une machine virtuelle **OVHgateway** est installée lors d'un déploiement d'un cluster **Nutanix on OVHcloud**. Cette machine virtuelle sert de passerelle Internet sortante pour le cluster. Le débit maximal est de 1 GB/s.
 
-Si vous avez besoin d'une bande passante plus importante, vous pouvez remplacer cette passerelle par un [serveur dédié](https://www.ovhcloud.com/fr-ca/bare-metal/) et choisir une offre vous permettant entre 1 GB/s et 10 GB/s sur le réseau public.<br>
+Si vous avez besoin d'une bande passante plus importante, vous pouvez remplacer cette passerelle par un [serveur dédié](/links/bare-metal/bare-metal) et choisir une offre vous permettant entre 1 GB/s et 10 GB/s sur le réseau public.<br>
 Contactez le service commercial OVHcloud pour vous aider à choisir le bon serveur. 
 
 **Découvrez comment remplacer la passerelle par défaut par un serveur dédié OVHcloud afin d'augmenter la bande passante.**
@@ -22,9 +22,9 @@ Contactez le service commercial OVHcloud pour vous aider à choisir le bon serve
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur le cluster via Prism Central. 
-- Disposer d'un [serveur dédié](https://www.ovhcloud.com/fr-ca/bare-metal/) dans votre compte OVHcloud avec plusieurs cartes réseaux, certaines sur le réseau public, d'autres sur le réseau privé. Ce serveur doit être sur le même Data Center que le cluster Nutanix.
+- Disposer d'un [serveur dédié](/links/bare-metal/bare-metal) dans votre compte OVHcloud avec plusieurs cartes réseaux, certaines sur le réseau public, d'autres sur le réseau privé. Ce serveur doit être sur le même Data Center que le cluster Nutanix.
 
 ## En pratique
 
@@ -40,7 +40,7 @@ Pour remplacer la VM OVHgateway, nous allons utiliser ces paramètres :
 
 ### Récupération des informations nécessaires au déploiement de votre serveur
 
-Dans votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc), cliquez sur `Hosted Private Cloud`{.action} dans la barre d'onglets. Sélectionnez votre cluster Nutanix à gauche et notez le nom du vRack associé à votre cluster Nutanix dans `Réseau privé (vRack)`.
+Dans votre [espace client OVHcloud](/links/manager), cliquez sur `Hosted Private Cloud`{.action} dans la barre d'onglets. Sélectionnez votre cluster Nutanix à gauche et notez le nom du vRack associé à votre cluster Nutanix dans `Réseau privé (vRack)`.
 
 ![01 get nutanix vrack 01](images/01-get-nutanix-vrack01.png){.thumbnail}
 
@@ -374,6 +374,6 @@ Le test dure 10 secondes et vous obtiendrez la bande passante de votre cluster a
 
 ## Aller plus loin <a name="gofurther"></a>
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.fr-fr.md
@@ -8,7 +8,7 @@ updated: 2025-04-29
 
 Une machine virtuelle **OVHgateway** est installée lors d'un déploiement d'un cluster **Nutanix on OVHcloud**. Cette machine virtuelle sert de passerelle Internet sortante pour le cluster. Le débit maximal est de 1 GB/s.
 
-Si vous avez besoin d'une bande passante plus importante, vous pouvez remplacer cette passerelle par un [serveur dédié](https://www.ovhcloud.com/fr/bare-metal/) et choisir une offre vous permettant entre 1 GB/s et 10 GB/s sur le réseau public.<br>
+Si vous avez besoin d'une bande passante plus importante, vous pouvez remplacer cette passerelle par un [serveur dédié](/links/bare-metal/bare-metal) et choisir une offre vous permettant entre 1 GB/s et 10 GB/s sur le réseau public.<br>
 Contactez le service commercial OVHcloud pour vous aider à choisir le bon serveur. 
 
 **Découvrez comment remplacer la passerelle par défaut par un serveur dédié OVHcloud afin d'augmenter la bande passante.**
@@ -22,9 +22,9 @@ Contactez le service commercial OVHcloud pour vous aider à choisir le bon serve
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur le cluster via Prism Central. 
-- Disposer d'un [serveur dédié](https://www.ovhcloud.com/fr/bare-metal/) dans votre compte OVHcloud avec plusieurs cartes réseaux, certaines sur le réseau public, d'autres sur le réseau privé. Ce serveur doit être sur le même Data Center que le cluster Nutanix.
+- Disposer d'un [serveur dédié](/links/bare-metal/bare-metal) dans votre compte OVHcloud avec plusieurs cartes réseaux, certaines sur le réseau public, d'autres sur le réseau privé. Ce serveur doit être sur le même Data Center que le cluster Nutanix.
 
 ## En pratique
 
@@ -40,7 +40,7 @@ Pour remplacer la VM OVHgateway, nous allons utiliser ces paramètres :
 
 ### Récupération des informations nécessaires au déploiement de votre serveur
 
-Dans votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr), cliquez sur `Hosted Private Cloud`{.action} dans la barre d'onglets. Sélectionnez votre cluster Nutanix à gauche et notez le nom du vRack associé à votre cluster Nutanix dans `Réseau privé (vRack)`.
+Dans votre [espace client OVHcloud](/links/manager), cliquez sur `Hosted Private Cloud`{.action} dans la barre d'onglets. Sélectionnez votre cluster Nutanix à gauche et notez le nom du vRack associé à votre cluster Nutanix dans `Réseau privé (vRack)`.
 
 ![01 get nutanix vrack 01](images/01-get-nutanix-vrack01.png){.thumbnail}
 
@@ -374,6 +374,6 @@ Le test dure 10 secondes et vous obtiendrez la bande passante de votre cluster a
 
 ## Aller plus loin <a name="gofurther"></a>
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.it-it.md
@@ -9,7 +9,7 @@ updated: 2025-04-29
 
 An **OVHgateway** virtual machine is installed when deploying a **Nutanix on OVHcloud** cluster. This virtual machine serves as the outgoing Internet gateway for the cluster. The maximum throughput is 1 GB/s.
 
-If you need more bandwidth, you can replace this gateway with a [dedicated server](https://www.ovhcloud.com/it/bare-metal/) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
+If you need more bandwidth, you can replace this gateway with a [dedicated server](/links/bare-metal/bare-metal) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
 Contact OVHcloud Sales to help you choose the right server. 
 
 **This guide explains how to replace the default gateway with an OVHcloud dedicated server to increase bandwidth.**
@@ -23,9 +23,9 @@ Contact OVHcloud Sales to help you choose the right server.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via **Prism Central**. 
-- You have a [dedicated server](https://www.ovhcloud.com/it/bare-metal/) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
+- You have a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
 
 ## Instructions
 
@@ -41,7 +41,7 @@ To replace the OVHgateway VM, we will use these settings:
 
 ### Retrieving information needed to deploy your server
 
-In your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
+In your [OVHcloud Control Panel](/links/manager), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
 
 ![01 get nutanix vrack 01](images/01-get-nutanix-vrack01.png){.thumbnail}
 
@@ -375,6 +375,6 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
 
 ## Go further <a name="gofurther"></a>
   
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.pl-pl.md
@@ -9,7 +9,7 @@ updated: 2025-04-29
 
 An **OVHgateway** virtual machine is installed when deploying a **Nutanix on OVHcloud** cluster. This virtual machine serves as the outgoing Internet gateway for the cluster. The maximum throughput is 1 GB/s.
 
-If you need more bandwidth, you can replace this gateway with a [dedicated server](https://www.ovhcloud.com/pl/bare-metal/) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
+If you need more bandwidth, you can replace this gateway with a [dedicated server](/links/bare-metal/bare-metal) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
 Contact OVHcloud Sales to help you choose the right server. 
 
 **This guide explains how to replace the default gateway with an OVHcloud dedicated server to increase bandwidth.**
@@ -23,9 +23,9 @@ Contact OVHcloud Sales to help you choose the right server.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via **Prism Central**. 
-- You have a [dedicated server](https://www.ovhcloud.com/pl/bare-metal/) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
+- You have a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
 
 ## Instructions
 
@@ -41,7 +41,7 @@ To replace the OVHgateway VM, we will use these settings:
 
 ### Retrieving information needed to deploy your server
 
-In your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
+In your [OVHcloud Control Panel](/links/manager), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
 
 ![01 get nutanix vrack 01](images/01-get-nutanix-vrack01.png){.thumbnail}
 
@@ -375,6 +375,6 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
 
 ## Go further <a name="gofurther"></a>
   
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/29-hardware-gateway-replacement/guide.pt-pt.md
@@ -9,7 +9,7 @@ updated: 2025-04-29
 
 An **OVHgateway** virtual machine is installed when deploying a **Nutanix on OVHcloud** cluster. This virtual machine serves as the outgoing Internet gateway for the cluster. The maximum throughput is 1 GB/s.
 
-If you need more bandwidth, you can replace this gateway with a [dedicated server](https://www.ovhcloud.com/pt/bare-metal/) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
+If you need more bandwidth, you can replace this gateway with a [dedicated server](/links/bare-metal/bare-metal) and choose a solution that allows you to connect between 1 GB/s and 10 GB/s on the public network.<br>
 Contact OVHcloud Sales to help you choose the right server. 
 
 **This guide explains how to replace the default gateway with an OVHcloud dedicated server to increase bandwidth.**
@@ -23,9 +23,9 @@ Contact OVHcloud Sales to help you choose the right server.
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via **Prism Central**. 
-- You have a [dedicated server](https://www.ovhcloud.com/pt/bare-metal/) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
+- You have a [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account with several network cards, some on the public network, others on the private network. This server must be in the same data centre as the Nutanix cluster.
 
 ## Instructions
 
@@ -41,7 +41,7 @@ To replace the OVHgateway VM, we will use these settings:
 
 ### Retrieving information needed to deploy your server
 
-In your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
+In your [OVHcloud Control Panel](/links/manager), click `Hosted Private Cloud`{.action} in the tab bar. Select your Nutanix cluster on the left-hand side, and note the name of the vRack associated with your Nutanix cluster in `Private network (vRack)`.
 
 ![01 get nutanix vrack 01](images/01-get-nutanix-vrack01.png){.thumbnail}
 
@@ -375,6 +375,6 @@ The test takes 10 seconds, and you will get your cluster’s bandwidth via your 
 
 ## Go further <a name="gofurther"></a>
   
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.de-de.md
@@ -11,13 +11,13 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - One Nutanix cluster provided by OVHcloud
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 
 ## Instructions
@@ -85,7 +85,7 @@ From the `More`{.action} menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -482,6 +482,6 @@ Your VLAN 2 is now connected to the Internet.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.en-ca.md
@@ -11,13 +11,13 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - One Nutanix cluster provided by OVHcloud
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 
 ## Instructions
@@ -85,7 +85,7 @@ From the `More`{.action} menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -482,6 +482,6 @@ Your VLAN 2 is now connected to the Internet.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.en-gb.md
@@ -11,13 +11,13 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - One Nutanix cluster provided by OVHcloud
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 
 ## Instructions
@@ -85,7 +85,7 @@ From the `More`{.action} menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -482,6 +482,6 @@ Your VLAN 2 is now connected to the Internet.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.en-ie.md
@@ -11,13 +11,13 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - One Nutanix cluster provided by OVHcloud
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 
 ## Instructions
@@ -85,7 +85,7 @@ From the `More`{.action} menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -482,6 +482,6 @@ Your VLAN 2 is now connected to the Internet.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.en-us.md
@@ -11,13 +11,13 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - One Nutanix cluster provided by OVHcloud
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 
 ## Instructions
@@ -85,7 +85,7 @@ From the `More`{.action} menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -482,6 +482,6 @@ Your VLAN 2 is now connected to the Internet.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.es-es.md
@@ -11,13 +11,13 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - One Nutanix cluster provided by OVHcloud
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 
 ## Instructions
@@ -85,7 +85,7 @@ From the `More`{.action} menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -482,6 +482,6 @@ Your VLAN 2 is now connected to the Internet.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.es-us.md
@@ -11,13 +11,13 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - One Nutanix cluster provided by OVHcloud
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 
 ## Instructions
@@ -85,7 +85,7 @@ From the `More`{.action} menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -482,6 +482,6 @@ Your VLAN 2 is now connected to the Internet.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.fr-ca.md
@@ -17,7 +17,7 @@ Ce guide vous explique comment remplacer la passerelle Internet sortante (OVHgat
 ## Prérequis
 
 - Disposer d'un cluster Nutanix fourni par OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur votre cluster via Prism Central.
 
 ## En pratique
@@ -85,7 +85,7 @@ Depuis le menu `More`{.action} en haut, cliquez sur `Soft Shutdown`{.action}.
 
 Récupérez les informations concernant les paramètres réseau de la passerelle OVHcloud.
 
-Connectez-vous à [l'espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc), sélectionnez votre cluster Nutanix et relevez l'information se trouvant dans le champ `IPFO`.
+Connectez-vous à [l'espace client OVHcloud](/links/manager), sélectionnez votre cluster Nutanix et relevez l'information se trouvant dans le champ `IPFO`.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -481,6 +481,6 @@ Votre VLAN2 est maintenant connecté à Internet.
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.fr-fr.md
@@ -17,7 +17,7 @@ Ce guide vous explique comment remplacer la passerelle Internet sortante (OVHgat
 ## Prérequis
 
 - Disposer d'un cluster Nutanix fourni par OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur votre cluster via Prism Central.
 
 ## En pratique
@@ -85,7 +85,7 @@ Depuis le menu `More`{.action} en haut, cliquez sur `Soft Shutdown`{.action}.
 
 Récupérez les informations concernant les paramètres réseau de la passerelle OVHcloud.
 
-Connectez-vous à [l'espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr), sélectionnez votre cluster Nutanix et relevez l'information se trouvant dans le champ `IPFO`.
+Connectez-vous à [l'espace client OVHcloud](/links/manager), sélectionnez votre cluster Nutanix et relevez l'information se trouvant dans le champ `IPFO`.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -481,6 +481,6 @@ Votre VLAN2 est maintenant connecté à Internet.
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.it-it.md
@@ -11,13 +11,13 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - One Nutanix cluster provided by OVHcloud
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 
 ## Instructions
@@ -85,7 +85,7 @@ From the `More`{.action} menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -482,6 +482,6 @@ Your VLAN 2 is now connected to the Internet.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.pl-pl.md
@@ -11,13 +11,13 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - One Nutanix cluster provided by OVHcloud
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 
 ## Instructions
@@ -85,7 +85,7 @@ From the `More`{.action} menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -482,6 +482,6 @@ Your VLAN 2 is now connected to the Internet.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/30-software-gateway-replacement/guide.pt-pt.md
@@ -11,13 +11,13 @@ This guide will explain how to replace the outgoing internet gateway (OVHgateway
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - One Nutanix cluster provided by OVHcloud
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 
 ## Instructions
@@ -85,7 +85,7 @@ From the `More`{.action} menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -482,6 +482,6 @@ Your VLAN 2 is now connected to the Internet.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.de-de.md
@@ -11,13 +11,13 @@ updated: 2022-12-21
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - A Windows licence provided by OVHcloud
 - A virtual machine running Windows Server. You can use this guide to install a virtual machine on Windows: [Virtual Machine Management](/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management)
@@ -72,6 +72,6 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.en-ca.md
@@ -11,13 +11,13 @@ updated: 2022-12-21
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - A Windows licence provided by OVHcloud
 - A virtual machine running Windows Server. You can use this guide to install a virtual machine on Windows: [Virtual Machine Management](/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management)
@@ -72,6 +72,6 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.en-gb.md
@@ -11,13 +11,13 @@ updated: 2022-12-21
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - A Windows licence provided by OVHcloud
 - A virtual machine running Windows Server. You can use this guide to install a virtual machine on Windows: [Virtual Machine Management](/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management)
@@ -72,6 +72,6 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.en-ie.md
@@ -11,13 +11,13 @@ updated: 2022-12-21
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - A Windows licence provided by OVHcloud
 - A virtual machine running Windows Server. You can use this guide to install a virtual machine on Windows: [Virtual Machine Management](/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management)
@@ -72,6 +72,6 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.en-us.md
@@ -11,13 +11,13 @@ updated: 2022-12-21
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - A Windows licence provided by OVHcloud
 - A virtual machine running Windows Server. You can use this guide to install a virtual machine on Windows: [Virtual Machine Management](/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management)
@@ -72,6 +72,6 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.es-es.md
@@ -11,13 +11,13 @@ updated: 2022-12-21
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - A Windows licence provided by OVHcloud
 - A virtual machine running Windows Server. You can use this guide to install a virtual machine on Windows: [Virtual Machine Management](/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management)
@@ -72,6 +72,6 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.es-us.md
@@ -11,13 +11,13 @@ updated: 2022-12-21
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - A Windows licence provided by OVHcloud
 - A virtual machine running Windows Server. You can use this guide to install a virtual machine on Windows: [Virtual Machine Management](/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management)
@@ -72,6 +72,6 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.fr-ca.md
@@ -11,13 +11,13 @@ updated: 2022-12-21
 > [!warning]
 > Ce tutoriel vous explique comment utiliser une ou plusieurs solutions OVHcloud avec des outils externes et décrit les actions à effectuer dans un contexte spécifique. Vous devrez peut-être adapter les instructions en fonction de votre situation.
 >
-> Si vous éprouvez des difficultés à appliquer ces instructions, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/). Pour plus d'informations, consultez la section [Aller plus loin](#go-further) de ce tutoriel.
+> Si vous éprouvez des difficultés à appliquer ces instructions, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner). Pour plus d'informations, consultez la section [Aller plus loin](#go-further) de ce tutoriel.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Une licence Windows fournie par OVHcloud.
 - Une machine virtuelle sous Windows Server. Vous pouvez vous aider de ce guide pour installer une machine virtuelle sous Windows : [Gestion des machines virtuelles](/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management).
 - La machine virtuelle se connecte à Internet au travers du rtvRack (par exemple via la passerelle par défaut).
@@ -71,6 +71,6 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.fr-fr.md
@@ -11,13 +11,13 @@ updated: 2022-12-21
 > [!warning]
 > Ce tutoriel vous explique comment utiliser une ou plusieurs solutions OVHcloud avec des outils externes et décrit les actions à effectuer dans un contexte spécifique. Vous devrez peut-être adapter les instructions en fonction de votre situation.
 >
-> Si vous éprouvez des difficultés à appliquer ces instructions, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/). Pour plus d'informations, consultez la section [Aller plus loin](#go-further) de ce tutoriel.
+> Si vous éprouvez des difficultés à appliquer ces instructions, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner). Pour plus d'informations, consultez la section [Aller plus loin](#go-further) de ce tutoriel.
 >
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Une licence Windows fournie par OVHcloud.
 - Une machine virtuelle sous Windows Server. Vous pouvez vous aider de ce guide pour installer une machine virtuelle sous Windows : [Gestion des machines virtuelles](/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management).
 - La machine virtuelle se connecte à Internet au travers du rtvRack (par exemple via la passerelle par défaut).
@@ -71,6 +71,6 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.it-it.md
@@ -11,13 +11,13 @@ updated: 2022-12-21
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - A Windows licence provided by OVHcloud
 - A virtual machine running Windows Server. You can use this guide to install a virtual machine on Windows: [Virtual Machine Management](/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management)
@@ -72,6 +72,6 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.pl-pl.md
@@ -11,13 +11,13 @@ updated: 2022-12-21
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - A Windows licence provided by OVHcloud
 - A virtual machine running Windows Server. You can use this guide to install a virtual machine on Windows: [Virtual Machine Management](/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management)
@@ -72,6 +72,6 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/34-activate_windows_vm/guide.pt-pt.md
@@ -11,13 +11,13 @@ updated: 2022-12-21
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - A Windows licence provided by OVHcloud
 - A virtual machine running Windows Server. You can use this guide to install a virtual machine on Windows: [Virtual Machine Management](/pages/hosted_private_cloud/nutanix_on_ovhcloud/06-virtual-machine-management)
@@ -72,6 +72,6 @@ cscript.exe c:\windows\system32\slmgr.vbs -ato
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.de-de.md
@@ -18,13 +18,13 @@ updated: 2023-12-18
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -355,6 +355,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.en-ca.md
@@ -18,13 +18,13 @@ updated: 2023-12-18
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -355,6 +355,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.en-gb.md
@@ -18,13 +18,13 @@ updated: 2023-12-18
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -355,6 +355,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.en-ie.md
@@ -18,13 +18,13 @@ updated: 2023-12-18
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -355,6 +355,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.en-us.md
@@ -18,13 +18,13 @@ updated: 2023-12-18
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -355,6 +355,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.es-es.md
@@ -18,13 +18,13 @@ updated: 2023-12-18
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -355,6 +355,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.es-us.md
@@ -18,13 +18,13 @@ updated: 2023-12-18
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -355,6 +355,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.fr-ca.md
@@ -23,7 +23,7 @@ updated: 2023-12-18
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté sur le cluster via Prism Central
 - Connaître le mot de passe admin de Prism Element (lors du déploiement d'un cluster Nutanix by OVHcloud; ce mot de passe est créé à l'identique de celui de Prism Central mais il peut être changé par la suite).
 
@@ -354,6 +354,6 @@ Vous disposez maintenant de Prism Central en mode X-LARGE avec trois machines vi
 
 ## Aller plus loin <a name="gofurther"></a>
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.fr-fr.md
@@ -23,7 +23,7 @@ updated: 2023-12-18
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté sur le cluster via Prism Central
 - Connaître le mot de passe admin de Prism Element (lors du déploiement d'un cluster Nutanix by OVHcloud; ce mot de passe est créé à l'identique de celui de Prism Central mais il peut être changé par la suite).
 
@@ -354,7 +354,7 @@ Vous disposez maintenant de Prism Central en mode X-LARGE avec trois machines vi
 
 ## Aller plus loin <a name="gofurther"></a>
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.it-it.md
@@ -18,13 +18,13 @@ updated: 2023-12-18
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -355,6 +355,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.pl-pl.md
@@ -18,13 +18,13 @@ updated: 2023-12-18
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -355,6 +355,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/35-prism-central-expansion/guide.pt-pt.md
@@ -18,13 +18,13 @@ updated: 2023-12-18
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - You need to know the Prism Element admin password (when deploying a Nutanix cluster by OVHcloud this password is created in the same way as Prism Central but can be changed later)
 
@@ -355,6 +355,6 @@ You now have Prism Central in X-Large mode with three virtual machines.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.de-de.md
@@ -11,13 +11,13 @@ updated: 2024-05-13
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - Have Self Service (CALM) licences. These licences are available with the Nutanix on OVHcloud packaged service (with limitations for **Starter** pack)
 - An additional VLAN in your cluster that distributes IPAM IP addresses and has internet access
@@ -991,7 +991,7 @@ The application is completely deleted.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.en-ca.md
@@ -11,13 +11,13 @@ updated: 2024-05-13
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - Have Self Service (CALM) licences. These licences are available with the Nutanix on OVHcloud packaged service (with limitations for **Starter** pack)
 - An additional VLAN in your cluster that distributes IPAM IP addresses and has internet access
@@ -991,7 +991,7 @@ The application is completely deleted.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.en-gb.md
@@ -11,13 +11,13 @@ updated: 2024-05-13
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - Have Self Service (CALM) licences. These licences are available with the Nutanix on OVHcloud packaged service (with limitations for **Starter** pack)
 - An additional VLAN in your cluster that distributes IPAM IP addresses and has internet access
@@ -991,7 +991,7 @@ The application is completely deleted.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.en-ie.md
@@ -11,13 +11,13 @@ updated: 2024-05-13
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - Have Self Service (CALM) licences. These licences are available with the Nutanix on OVHcloud packaged service (with limitations for **Starter** pack)
 - An additional VLAN in your cluster that distributes IPAM IP addresses and has internet access
@@ -991,7 +991,7 @@ The application is completely deleted.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.en-us.md
@@ -11,13 +11,13 @@ updated: 2024-05-13
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - Have Self Service (CALM) licences. These licences are available with the Nutanix on OVHcloud packaged service (with limitations for **Starter** pack)
 - An additional VLAN in your cluster that distributes IPAM IP addresses and has internet access
@@ -991,7 +991,7 @@ The application is completely deleted.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.es-es.md
@@ -11,13 +11,13 @@ updated: 2024-05-13
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - Have Self Service (CALM) licences. These licences are available with the Nutanix on OVHcloud packaged service (with limitations for **Starter** pack)
 - An additional VLAN in your cluster that distributes IPAM IP addresses and has internet access
@@ -991,7 +991,7 @@ The application is completely deleted.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.es-us.md
@@ -11,13 +11,13 @@ updated: 2024-05-13
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - Have Self Service (CALM) licences. These licences are available with the Nutanix on OVHcloud packaged service (with limitations for **Starter** pack)
 - An additional VLAN in your cluster that distributes IPAM IP addresses and has internet access
@@ -991,7 +991,7 @@ The application is completely deleted.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.fr-ca.md
@@ -11,12 +11,12 @@ updated: 2024-05-13
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur le cluster via Prism Central.
 - Avoir des licences Self Service (CALM). Ces licences sont disponibles dans l'offre Nutanix on OVHcloud packagée (avec des limitations pour le pack **Starter**).
 - Posséder un VLAN supplémentaire dans votre cluster qui distribue des adresses IP en IPAM et possède un accès à Internet. 
@@ -990,7 +990,7 @@ L'application est maintenant supprimée.
 
 ## Aller plus loin <a name="gofurther"></a>
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.fr-fr.md
@@ -11,12 +11,12 @@ updated: 2024-05-13
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur le cluster via Prism Central.
 - Avoir des licences Self Service (CALM). Ces licences sont disponibles dans l'offre Nutanix on OVHcloud packagée (avec des limitations pour le pack **Starter**).
 - Posséder un VLAN supplémentaire dans votre cluster qui distribue des adresses IP en IPAM et possède un accès à Internet.
@@ -990,7 +990,7 @@ L'application est maintenant supprimée.
 
 ## Aller plus loin <a name="gofurther"></a>
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.it-it.md
@@ -11,13 +11,13 @@ updated: 2024-05-13
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - Have Self Service (CALM) licences. These licences are available with the Nutanix on OVHcloud packaged service (with limitations for **Starter** pack)
 - An additional VLAN in your cluster that distributes IPAM IP addresses and has internet access
@@ -991,7 +991,7 @@ The application is completely deleted.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.pl-pl.md
@@ -11,13 +11,13 @@ updated: 2024-05-13
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - Have Self Service (CALM) licences. These licences are available with the Nutanix on OVHcloud packaged service (with limitations for **Starter** pack)
 - An additional VLAN in your cluster that distributes IPAM IP addresses and has internet access
@@ -991,7 +991,7 @@ The application is completely deleted.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/36-self-service-calm/guide.pt-pt.md
@@ -11,13 +11,13 @@ updated: 2024-05-13
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - You must be connected to the cluster via Prism Central
 - Have Self Service (CALM) licences. These licences are available with the Nutanix on OVHcloud packaged service (with limitations for **Starter** pack)
 - An additional VLAN in your cluster that distributes IPAM IP addresses and has internet access
@@ -991,7 +991,7 @@ The application is completely deleted.
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.de-de.md
@@ -13,13 +13,13 @@ Nutanix Objects implements an **Object Storage** S3* compatible solution on your
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/de/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via Prism Central.
 
 ## Instructions
@@ -254,7 +254,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.en-ca.md
@@ -13,13 +13,13 @@ Nutanix Objects implements an **Object Storage** S3* compatible solution on your
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via Prism Central.
 
 ## Instructions
@@ -254,7 +254,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.en-gb.md
@@ -13,13 +13,13 @@ Nutanix Objects implements an **Object Storage** S3* compatible solution on your
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via Prism Central.
 
 ## Instructions
@@ -254,7 +254,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.en-ie.md
@@ -13,13 +13,13 @@ Nutanix Objects implements an **Object Storage** S3* compatible solution on your
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via Prism Central.
 
 ## Instructions
@@ -254,7 +254,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.en-us.md
@@ -13,13 +13,13 @@ Nutanix Objects implements an **Object Storage** S3* compatible solution on your
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via Prism Central.
 
 ## Instructions
@@ -254,7 +254,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.es-es.md
@@ -13,13 +13,13 @@ Nutanix Objects implements an **Object Storage** S3* compatible solution on your
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via Prism Central.
 
 ## Instructions
@@ -254,7 +254,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.es-us.md
@@ -13,13 +13,13 @@ Nutanix Objects implements an **Object Storage** S3* compatible solution on your
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/es/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via Prism Central.
 
 ## Instructions
@@ -254,7 +254,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.fr-ca.md
@@ -13,12 +13,12 @@ Nutanix Objects implémente une solution **Object Storage** Compatible S3* sur v
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur le cluster via Prism Central.
 
 ## En pratique
@@ -263,7 +263,7 @@ Vous voyez le bucket que vous avez créé en ligne de commande. Vous pouvez cré
 
 [Documentation Nutanix Objects](https://portal.nutanix.com/page/documents/details?targetId=Objects-v3_6:top-intro-c.html).
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.fr-fr.md
@@ -13,12 +13,12 @@ Nutanix Objects implémente une solution **Object Storage** Compatible S3* sur v
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur le cluster via Prism Central.
 
 ## En pratique
@@ -263,7 +263,7 @@ Vous voyez le bucket que vous avez créé en ligne de commande. Vous pouvez cré
 
 [Documentation Nutanix Objects](https://portal.nutanix.com/page/documents/details?targetId=Objects-v3_6:top-intro-c.html).
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.it-it.md
@@ -13,13 +13,13 @@ Nutanix Objects implements an **Object Storage** S3* compatible solution on your
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/it/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via Prism Central.
 
 ## Instructions
@@ -254,7 +254,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.pl-pl.md
@@ -13,13 +13,13 @@ Nutanix Objects implements an **Object Storage** S3* compatible solution on your
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via Prism Central.
 
 ## Instructions
@@ -254,7 +254,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/37-objects/guide.pt-pt.md
@@ -13,13 +13,13 @@ Nutanix Objects implements an **Object Storage** S3* compatible solution on your
 > [!warning]
 > This tutorial will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. You may need to adapt the instructions according to your situation.
 >
-> If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
+> If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with our community. You can find more information in the [Go further](#gofurther) section of this tutorial.
 >
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account.
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt).
+- Access to the [OVHcloud Control Panel](/links/manager).
 - You must be connected to the cluster via Prism Central.
 
 ## Instructions
@@ -254,7 +254,7 @@ You can see the bucket you created in the command line. You can create and delet
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.de-de.md
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/de/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
@@ -19,7 +19,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 - Multiple Nutanix clusters with either organisation:
     - Multiple Nutanix clusters at physically different sites at OVHcloud
     - A Nutanix cluster provided by OVHcloud and another Nutanix cluster from another provider
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A vRack or IPSEC VPN connection between the two clusters, as required
 
@@ -62,6 +62,6 @@ The management of disaster recovery plans can be improved via third-party tools 
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.en-ca.md
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
@@ -19,7 +19,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 - Multiple Nutanix clusters with either organisation:
     - Multiple Nutanix clusters at physically different sites at OVHcloud
     - A Nutanix cluster provided by OVHcloud and another Nutanix cluster from another provider
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A vRack or IPSEC VPN connection between the two clusters, as required
 
@@ -62,6 +62,6 @@ The management of disaster recovery plans can be improved via third-party tools 
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.en-gb.md
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
@@ -19,7 +19,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 - Multiple Nutanix clusters with either organisation:
     - Multiple Nutanix clusters at physically different sites at OVHcloud
     - A Nutanix cluster provided by OVHcloud and another Nutanix cluster from another provider
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A vRack or IPSEC VPN connection between the two clusters, as required
 
@@ -62,6 +62,6 @@ The management of disaster recovery plans can be improved via third-party tools 
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.en-ie.md
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
@@ -19,7 +19,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 - Multiple Nutanix clusters with either organisation:
     - Multiple Nutanix clusters at physically different sites at OVHcloud
     - A Nutanix cluster provided by OVHcloud and another Nutanix cluster from another provider
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A vRack or IPSEC VPN connection between the two clusters, as required
 
@@ -62,6 +62,6 @@ The management of disaster recovery plans can be improved via third-party tools 
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.en-us.md
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
@@ -19,7 +19,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 - Multiple Nutanix clusters with either organisation:
     - Multiple Nutanix clusters at physically different sites at OVHcloud
     - A Nutanix cluster provided by OVHcloud and another Nutanix cluster from another provider
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A vRack or IPSEC VPN connection between the two clusters, as required
 
@@ -62,6 +62,6 @@ The management of disaster recovery plans can be improved via third-party tools 
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.es-es.md
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
@@ -19,7 +19,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 - Multiple Nutanix clusters with either organisation:
     - Multiple Nutanix clusters at physically different sites at OVHcloud
     - A Nutanix cluster provided by OVHcloud and another Nutanix cluster from another provider
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A vRack or IPSEC VPN connection between the two clusters, as required
 
@@ -62,6 +62,6 @@ The management of disaster recovery plans can be improved via third-party tools 
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.es-us.md
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
@@ -19,7 +19,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 - Multiple Nutanix clusters with either organisation:
     - Multiple Nutanix clusters at physically different sites at OVHcloud
     - A Nutanix cluster provided by OVHcloud and another Nutanix cluster from another provider
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A vRack or IPSEC VPN connection between the two clusters, as required
 
@@ -62,6 +62,6 @@ The management of disaster recovery plans can be improved via third-party tools 
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.fr-ca.md
@@ -19,7 +19,7 @@ Ce guide vous présente les possibilités offertes par les clusters Nutanix inst
 - Disposer de plusieurs clusters Nutanix avec l'une et/ou l'autre de ces organisations :
     - plusieurs clusters Nutanix sur des sites physiquement différents chez OVHcloud;
     - un cluster Nutanix fourni par OVHcloud et un autre cluster Nutanix chez un autre fournisseur.
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté sur vos clusters via Prism Central.
 - Avoir une interconnexion de type vRack ou VPN IPSEC entre les deux clusters en fonction des besoins.
 
@@ -62,7 +62,7 @@ Il est possible d'améliorer la gestion des plans de reprise d'activité via des
 
 [Réplication asynchrone ou *NearSync* au travers de Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.fr-fr.md
@@ -19,7 +19,7 @@ Ce guide vous présente les possibilités offertes par les clusters Nutanix inst
 - Disposer de plusieurs clusters Nutanix avec l'une et/ou l'autre de ces organisations :
     - plusieurs clusters Nutanix sur des sites physiquement différents chez OVHcloud;
     - un cluster Nutanix fourni par OVHcloud et un autre cluster Nutanix chez un autre fournisseur.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté sur vos clusters via Prism Central.
 - Avoir une interconnexion de type vRack ou VPN IPSEC entre les deux clusters en fonction des besoins.
 
@@ -62,7 +62,7 @@ Il est possible d'améliorer la gestion des plans de reprise d'activité via des
 
 [Réplication asynchrone ou *NearSync* au travers de Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.it-it.md
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/it/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
@@ -19,7 +19,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 - Multiple Nutanix clusters with either organisation:
     - Multiple Nutanix clusters at physically different sites at OVHcloud
     - A Nutanix cluster provided by OVHcloud and another Nutanix cluster from another provider
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A vRack or IPSEC VPN connection between the two clusters, as required
 
@@ -62,6 +62,6 @@ The management of disaster recovery plans can be improved via third-party tools 
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.pl-pl.md
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
@@ -19,7 +19,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 - Multiple Nutanix clusters with either organisation:
     - Multiple Nutanix clusters at physically different sites at OVHcloud
     - A Nutanix cluster provided by OVHcloud and another Nutanix cluster from another provider
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A vRack or IPSEC VPN connection between the two clusters, as required
 
@@ -62,6 +62,6 @@ The management of disaster recovery plans can be improved via third-party tools 
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview/guide.pt-pt.md
@@ -11,7 +11,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
@@ -19,7 +19,7 @@ This guide will take you through the possibilities offered by Nutanix clusters i
 - Multiple Nutanix clusters with either organisation:
     - Multiple Nutanix clusters at physically different sites at OVHcloud
     - A Nutanix cluster provided by OVHcloud and another Nutanix cluster from another provider
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A vRack or IPSEC VPN connection between the two clusters, as required
 
@@ -62,6 +62,6 @@ The management of disaster recovery plans can be improved via third-party tools 
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.de-de.md
@@ -11,13 +11,13 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/de/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - Two Nutanix clusters provided by OVHcloud, on different sites
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A different private IP addressing scheme applied per cluster
 - Being familiar with uses for an IPsec VPN using the [Nutanix Disaster Recovery Plan guide](/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview)
@@ -122,7 +122,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -458,7 +458,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -974,6 +974,6 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.en-ca.md
@@ -11,13 +11,13 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - Two Nutanix clusters provided by OVHcloud, on different sites
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A different private IP addressing scheme applied per cluster
 - Being familiar with uses for an IPsec VPN using the [Nutanix Disaster Recovery Plan guide](/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview)
@@ -122,7 +122,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -458,7 +458,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -974,6 +974,6 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.en-gb.md
@@ -11,13 +11,13 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - Two Nutanix clusters provided by OVHcloud, on different sites
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A different private IP addressing scheme applied per cluster
 - Being familiar with uses for an IPsec VPN using the [Nutanix Disaster Recovery Plan guide](/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview)
@@ -122,7 +122,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -458,7 +458,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -974,6 +974,6 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.en-ie.md
@@ -11,13 +11,13 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - Two Nutanix clusters provided by OVHcloud, on different sites
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A different private IP addressing scheme applied per cluster
 - Being familiar with uses for an IPsec VPN using the [Nutanix Disaster Recovery Plan guide](/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview)
@@ -122,7 +122,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -458,7 +458,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -974,6 +974,6 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.en-us.md
@@ -11,13 +11,13 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - Two Nutanix clusters provided by OVHcloud, on different sites
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A different private IP addressing scheme applied per cluster
 - Being familiar with uses for an IPsec VPN using the [Nutanix Disaster Recovery Plan guide](/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview)
@@ -122,7 +122,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -458,7 +458,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -974,6 +974,6 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.es-es.md
@@ -11,13 +11,13 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - Two Nutanix clusters provided by OVHcloud, on different sites
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A different private IP addressing scheme applied per cluster
 - Being familiar with uses for an IPsec VPN using the [Nutanix Disaster Recovery Plan guide](/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview)
@@ -122,7 +122,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -458,7 +458,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -974,6 +974,6 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.es-us.md
@@ -11,13 +11,13 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - Two Nutanix clusters provided by OVHcloud, on different sites
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A different private IP addressing scheme applied per cluster
 - Being familiar with uses for an IPsec VPN using the [Nutanix Disaster Recovery Plan guide](/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview)
@@ -122,7 +122,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -458,7 +458,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -974,6 +974,6 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.fr-ca.md
@@ -18,7 +18,7 @@ Ce guide vous présente comment interconnecter deux clusters Nutanix Fournis par
 
 - Avoir pris connaissance des cas d'usages d'un VPN IPsec à l'aide du guide « [Plan de reprise d'activité sur Nutanix](/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview) ».
 - Disposer de deux clusters Nutanix fournis par OVHcloud, sur des sites différents.
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur vos clusters via Prism Central.
 - Utiliser un plan d'adressage IP privé différent par cluster.
 
@@ -122,7 +122,7 @@ Depuis le menu `More` en haut, cliquez sur `Soft Shutdown`{.action}.
 
 Récupérez les informations concernant les paramètres réseau de la passerelle OVHcloud.
 
-Connectez-vous à [l'espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc), sélectionnez votre cluster Nutanix et relevez l'information se trouvant dans le champ `IPFO`.
+Connectez-vous à [l'espace client OVHcloud](/links/manager), sélectionnez votre cluster Nutanix et relevez l'information se trouvant dans le champ `IPFO`.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -458,7 +458,7 @@ Depuis le menu `More` en haut, cliquez sur `Soft Shutdown`{.action}.
 
 Récupérez les informations concernant les paramètres réseau de la passerelle OVHcloud.
 
-Connectez-vous à [l'espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc), sélectionnez votre cluster Nutanix et relevez l'information se trouvant dans le champ `IPFO`.
+Connectez-vous à [l'espace client OVHcloud](/links/manager), sélectionnez votre cluster Nutanix et relevez l'information se trouvant dans le champ `IPFO`.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -974,6 +974,6 @@ Le paramétrage du VPN est terminé sur les deux clusters. Il est maintenant pos
 
 [Réplication asynchrone ou **NearSync** au travers de Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.fr-fr.md
@@ -18,7 +18,7 @@ Ce guide vous présente comment interconnecter deux clusters Nutanix Fournis par
 
 - Avoir pris connaissance des cas d'usages d'un VPN IPsec à l'aide du guide « [Plan de reprise d'activité sur Nutanix](/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview) ».
 - Disposer de deux clusters Nutanix fournis par OVHcloud, sur des sites différents.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur vos clusters via Prism Central.
 - Utiliser un plan d'adressage IP privé différent par cluster.
 
@@ -122,7 +122,7 @@ Depuis le menu `More` en haut, cliquez sur `Soft Shutdown`{.action}.
 
 Récupérez les informations concernant les paramètres réseau de la passerelle OVHcloud.
 
-Connectez-vous à [l'espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr), sélectionnez votre cluster Nutanix et relevez l'information se trouvant dans le champ `IPFO`.
+Connectez-vous à [l'espace client OVHcloud](/links/manager), sélectionnez votre cluster Nutanix et relevez l'information se trouvant dans le champ `IPFO`.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -458,7 +458,7 @@ Depuis le menu `More` en haut, cliquez sur `Soft Shutdown`{.action}.
 
 Récupérez les informations concernant les paramètres réseau de la passerelle OVHcloud.
 
-Connectez-vous à [l'espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr), sélectionnez votre cluster Nutanix et relevez l'information se trouvant dans le champ `IPFO`.
+Connectez-vous à [l'espace client OVHcloud](/links/manager), sélectionnez votre cluster Nutanix et relevez l'information se trouvant dans le champ `IPFO`.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -974,6 +974,6 @@ Le paramétrage du VPN est terminé sur les deux clusters. Il est maintenant pos
 
 [Réplication asynchrone ou **NearSync** au travers de Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.it-it.md
@@ -11,13 +11,13 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/it/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - Two Nutanix clusters provided by OVHcloud, on different sites
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A different private IP addressing scheme applied per cluster
 - Being familiar with uses for an IPsec VPN using the [Nutanix Disaster Recovery Plan guide](/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview)
@@ -122,7 +122,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -458,7 +458,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -974,6 +974,6 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.pl-pl.md
@@ -11,13 +11,13 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - Two Nutanix clusters provided by OVHcloud, on different sites
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A different private IP addressing scheme applied per cluster
 - Being familiar with uses for an IPsec VPN using the [Nutanix Disaster Recovery Plan guide](/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview)
@@ -122,7 +122,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -458,7 +458,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -974,6 +974,6 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection/guide.pt-pt.md
@@ -11,13 +11,13 @@ This guide will show you how to interconnect two Nutanix clusters, provided by O
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Requirements
 
 - Two Nutanix clusters provided by OVHcloud, on different sites
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - A different private IP addressing scheme applied per cluster
 - Being familiar with uses for an IPsec VPN using the [Nutanix Disaster Recovery Plan guide](/pages/hosted_private_cloud/nutanix_on_ovhcloud/43-disaster-recovery-plan-overview)
@@ -122,7 +122,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -458,7 +458,7 @@ From the `More` menu at the top, click `Soft Shutdown`{.action}.
 
 Retrieve information about the OVHcloud gateway network settings.
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt), select your Nutanix cluster, and find the information in the `IPFO` field.
+Log in to the [OVHcloud Control Panel](/links/manager), select your Nutanix cluster, and find the information in the `IPFO` field.
 
 ![Get IP Fail OVER](images/02-get-ipfailover.png){.thumbnail}
 
@@ -974,6 +974,6 @@ VPN setup is complete on both clusters. It is now possible to set up replicas th
 
 [Asynchronous or *NearSync* replication through Prism Element](/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.de-de.md
@@ -16,7 +16,7 @@ updated: 2022-09-28
 
 ## Requirements
 
-- You must be logged in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
+- You must be logged in to your [OVHcloud Control Panel](/links/manager).
 - You must be connected to your clusters via Prism Central.
 
 ## Instructions
@@ -73,7 +73,7 @@ Access to Prism Central is maintained using the Load Balancer.
 
 This operation involves deleting the vRack assignment in Roubaix and then extending the vRack from Gravelines to Roubaix. You can modify the vRack via the OVHcloud Control Panel. 
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de). 
+Log in to your [OVHcloud Control Panel](/links/manager). 
 
 #### Deleting Roubaix vRack elements.
 
@@ -206,6 +206,6 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 [Introduction to vRacks](https://www.ovh.de/loesungen/vrack/)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.en-ca.md
@@ -16,7 +16,7 @@ updated: 2022-09-28
 
 ## Requirements
 
-- You must be logged in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca).
+- You must be logged in to your [OVHcloud Control Panel](/links/manager).
 - You must be connected to your clusters via Prism Central.
 
 ## Instructions
@@ -73,7 +73,7 @@ Access to Prism Central is maintained using the Load Balancer.
 
 This operation involves deleting the vRack assignment in Roubaix and then extending the vRack from Gravelines to Roubaix. You can modify the vRack via the OVHcloud Control Panel. 
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca). 
+Log in to your [OVHcloud Control Panel](/links/manager). 
 
 #### Deleting Roubaix vRack elements.
 
@@ -206,7 +206,7 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 [Introduction to vRacks](https://www.ovh.com/ca/en/solutions/vrack/)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.en-gb.md
@@ -16,7 +16,7 @@ updated: 2022-09-28
 
 ## Requirements
 
-- You must be logged in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB).
+- You must be logged in to your [OVHcloud Control Panel](/links/manager).
 - You must be connected to your clusters via Prism Central.
 
 ## Instructions
@@ -73,7 +73,7 @@ Access to Prism Central is maintained using the Load Balancer.
 
 This operation involves deleting the vRack assignment in Roubaix and then extending the vRack from Gravelines to Roubaix. You can modify the vRack via the OVHcloud Control Panel. 
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB). 
+Log in to your [OVHcloud Control Panel](/links/manager). 
 
 #### Deleting Roubaix vRack elements.
 
@@ -206,7 +206,7 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 [Introduction to vRacks](https://www.ovh.co.uk/solutions/vrack/)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.en-ie.md
@@ -16,7 +16,7 @@ updated: 2022-09-28
 
 ## Requirements
 
-- You must be logged in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie).
+- You must be logged in to your [OVHcloud Control Panel](/links/manager).
 - You must be connected to your clusters via Prism Central.
 
 ## Instructions
@@ -73,7 +73,7 @@ Access to Prism Central is maintained using the Load Balancer.
 
 This operation involves deleting the vRack assignment in Roubaix and then extending the vRack from Gravelines to Roubaix. You can modify the vRack via the OVHcloud Control Panel. 
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie). 
+Log in to your [OVHcloud Control Panel](/links/manager). 
 
 #### Deleting Roubaix vRack elements.
 
@@ -206,7 +206,7 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 [Introduction to vRacks](https://www.ovh.ie/solutions/vrack/)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.en-us.md
@@ -16,7 +16,7 @@ updated: 2022-09-28
 
 ## Requirements
 
-- You must be logged in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we).
+- You must be logged in to your [OVHcloud Control Panel](/links/manager).
 - You must be connected to your clusters via Prism Central.
 
 ## Instructions
@@ -73,7 +73,7 @@ Access to Prism Central is maintained using the Load Balancer.
 
 This operation involves deleting the vRack assignment in Roubaix and then extending the vRack from Gravelines to Roubaix. You can modify the vRack via the OVHcloud Control Panel. 
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we). 
+Log in to your [OVHcloud Control Panel](/links/manager). 
 
 #### Deleting Roubaix vRack elements.
 
@@ -206,7 +206,7 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 [Introduction to vRacks](https://www.ovh.com/world/solutions/vrack/)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.es-es.md
@@ -16,7 +16,7 @@ updated: 2022-09-28
 
 ## Requirements
 
-- You must be logged in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es).
+- You must be logged in to your [OVHcloud Control Panel](/links/manager).
 - You must be connected to your clusters via Prism Central.
 
 ## Instructions
@@ -73,7 +73,7 @@ Access to Prism Central is maintained using the Load Balancer.
 
 This operation involves deleting the vRack assignment in Roubaix and then extending the vRack from Gravelines to Roubaix. You can modify the vRack via the OVHcloud Control Panel. 
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es). 
+Log in to your [OVHcloud Control Panel](/links/manager). 
 
 #### Deleting Roubaix vRack elements.
 
@@ -206,6 +206,6 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 [Introduction to vRacks](https://www.ovh.es/soluciones/vrack/)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.es-us.md
@@ -16,7 +16,7 @@ updated: 2022-09-28
 
 ## Requirements
 
-- You must be logged in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+- You must be logged in to your [OVHcloud Control Panel](/links/manager).
 - You must be connected to your clusters via Prism Central.
 
 ## Instructions
@@ -73,7 +73,7 @@ Access to Prism Central is maintained using the Load Balancer.
 
 This operation involves deleting the vRack assignment in Roubaix and then extending the vRack from Gravelines to Roubaix. You can modify the vRack via the OVHcloud Control Panel. 
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws). 
+Log in to your [OVHcloud Control Panel](/links/manager). 
 
 #### Deleting Roubaix vRack elements.
 
@@ -206,6 +206,6 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 [Introduction to vRacks](https://www.ovh.com/world/es/soluciones/vrack/)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.fr-ca.md
@@ -16,7 +16,7 @@ updated: 2022-09-28
 
 ## Prérequis
 
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur vos clusters via Prism Central.
 
 ## En pratique
@@ -73,7 +73,7 @@ L'accès à Prism Central est maintenu à l'aide du Load Balancer.
 
 Cette opération consiste à supprimer l'affectation du vRack à Roubaix et ensuite à étendre le vRack de Gravelines avec Roubaix. Les modifications du vRack se font au travers de l'espace client OVHcloud. 
 
-Connectez-vous à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc). 
+Connectez-vous à votre [espace client OVHcloud](/links/manager). 
 
 #### Suppression des éléments du vRack de Roubaix.
 
@@ -206,6 +206,6 @@ Le Load Balancer est relié au vRack commun aux deux sites et l'accès à Prism 
 
 [Présentation des vRack](https://www.ovh.com/ca/fr/solutions/vrack/)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.fr-fr.md
@@ -16,7 +16,7 @@ updated: 2022-09-28
 
 ## Prérequis
 
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur vos clusters via Prism Central.
 
 ## En pratique
@@ -73,7 +73,7 @@ L'accès à Prism Central est maintenu à l'aide du Load Balancer.
 
 Cette opération consiste à supprimer l'affectation du vRack à Roubaix et ensuite à étendre le vRack de Gravelines avec Roubaix. Les modifications du vRack se font au travers de l'espace client OVHcloud. 
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr). 
+Connectez-vous à votre [espace client OVHcloud](/links/manager). 
 
 #### Suppression des éléments du vRack de Roubaix.
 
@@ -206,7 +206,7 @@ Le Load Balancer est relié au vRack commun aux deux sites et l'accès à Prism 
 
 [Présentation des vRack](https://www.ovh.com/fr/solutions/vrack/)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.it-it.md
@@ -16,7 +16,7 @@ updated: 2022-09-28
 
 ## Requirements
 
-- You must be logged in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it).
+- You must be logged in to your [OVHcloud Control Panel](/links/manager).
 - You must be connected to your clusters via Prism Central.
 
 ## Instructions
@@ -73,7 +73,7 @@ Access to Prism Central is maintained using the Load Balancer.
 
 This operation involves deleting the vRack assignment in Roubaix and then extending the vRack from Gravelines to Roubaix. You can modify the vRack via the OVHcloud Control Panel. 
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it). 
+Log in to your [OVHcloud Control Panel](/links/manager). 
 
 #### Deleting Roubaix vRack elements.
 
@@ -206,6 +206,6 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 [Introduction to vRacks](https://www.ovh.it/soluzioni/vrack/)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.pl-pl.md
@@ -16,7 +16,7 @@ updated: 2022-09-28
 
 ## Requirements
 
-- You must be logged in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl).
+- You must be logged in to your [OVHcloud Control Panel](/links/manager).
 - You must be connected to your clusters via Prism Central.
 
 ## Instructions
@@ -73,7 +73,7 @@ Access to Prism Central is maintained using the Load Balancer.
 
 This operation involves deleting the vRack assignment in Roubaix and then extending the vRack from Gravelines to Roubaix. You can modify the vRack via the OVHcloud Control Panel. 
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl). 
+Log in to your [OVHcloud Control Panel](/links/manager). 
 
 #### Deleting Roubaix vRack elements.
 
@@ -206,6 +206,6 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 [Introduction to vRacks](https://www.ovh.pl/rozwiazania/vrack/)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/45-vrack-interconnection/guide.pt-pt.md
@@ -16,7 +16,7 @@ updated: 2022-09-28
 
 ## Requirements
 
-- You must be logged in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt).
+- You must be logged in to your [OVHcloud Control Panel](/links/manager).
 - You must be connected to your clusters via Prism Central.
 
 ## Instructions
@@ -73,7 +73,7 @@ Access to Prism Central is maintained using the Load Balancer.
 
 This operation involves deleting the vRack assignment in Roubaix and then extending the vRack from Gravelines to Roubaix. You can modify the vRack via the OVHcloud Control Panel. 
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt). 
+Log in to your [OVHcloud Control Panel](/links/manager). 
 
 #### Deleting Roubaix vRack elements.
 
@@ -206,6 +206,6 @@ The Load Balancer is connected to the vRack shared by both sites, and access to 
 
 [Introduction to vRacks](https://www.ovh.pt/solucoes/vrack/)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.de-de.md
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/de/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Introduction
@@ -31,7 +31,7 @@ Via **Prism Element**, you can:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, e.g. via an IPsec VPN
 
@@ -242,6 +242,6 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 [Nutanix Documentation on Data Protection and Disaster Recovery](https://portal.nutanix.com/page/documents/solutions/details?targetId=BP-2005-Data-Protection:top-backup-and-disaster-recovery-on-remote-sites.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.en-ca.md
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Introduction
@@ -31,7 +31,7 @@ Via **Prism Element**, you can:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, e.g. via an IPsec VPN
 
@@ -242,6 +242,6 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 [Nutanix Documentation on Data Protection and Disaster Recovery](https://portal.nutanix.com/page/documents/solutions/details?targetId=BP-2005-Data-Protection:top-backup-and-disaster-recovery-on-remote-sites.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.en-gb.md
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Introduction
@@ -31,7 +31,7 @@ Via **Prism Element**, you can:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, e.g. via an IPsec VPN
 
@@ -242,6 +242,6 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 [Nutanix Documentation on Data Protection and Disaster Recovery](https://portal.nutanix.com/page/documents/solutions/details?targetId=BP-2005-Data-Protection:top-backup-and-disaster-recovery-on-remote-sites.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.en-ie.md
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Introduction
@@ -31,7 +31,7 @@ Via **Prism Element**, you can:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, e.g. via an IPsec VPN
 
@@ -242,6 +242,6 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 [Nutanix Documentation on Data Protection and Disaster Recovery](https://portal.nutanix.com/page/documents/solutions/details?targetId=BP-2005-Data-Protection:top-backup-and-disaster-recovery-on-remote-sites.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.en-us.md
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/en/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Introduction
@@ -31,7 +31,7 @@ Via **Prism Element**, you can:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, e.g. via an IPsec VPN
 
@@ -242,6 +242,6 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 [Nutanix Documentation on Data Protection and Disaster Recovery](https://portal.nutanix.com/page/documents/solutions/details?targetId=BP-2005-Data-Protection:top-backup-and-disaster-recovery-on-remote-sites.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.es-es.md
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es-es/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Introduction
@@ -31,7 +31,7 @@ Via **Prism Element**, you can:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, e.g. via an IPsec VPN
 
@@ -242,6 +242,6 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 [Nutanix Documentation on Data Protection and Disaster Recovery](https://portal.nutanix.com/page/documents/solutions/details?targetId=BP-2005-Data-Protection:top-backup-and-disaster-recovery-on-remote-sites.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.es-us.md
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/es/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Introduction
@@ -31,7 +31,7 @@ Via **Prism Element**, you can:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, e.g. via an IPsec VPN
 
@@ -242,6 +242,6 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 [Nutanix Documentation on Data Protection and Disaster Recovery](https://portal.nutanix.com/page/documents/solutions/details?targetId=BP-2005-Data-Protection:top-backup-and-disaster-recovery-on-remote-sites.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.fr-ca.md
@@ -31,7 +31,7 @@ Via **Prism Element**, il est possible :
 ## Prérequis
 
 - Disposer de deux clusters Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté à vos clusters via **Prism Central**.
 - Avoir mis en place une interconnexion entre deux clusters, par exemple via un VPN IPsec.
 
@@ -242,6 +242,6 @@ Les machines virtuelles apparaîtront dans la console de **Prism Element** dans 
 
 [Documentation Nutanix sur Data Protection and Disaster Recovery](https://portal.nutanix.com/page/documents/solutions/details?targetId=BP-2005-Data-Protection:top-backup-and-disaster-recovery-on-remote-sites.html)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.fr-fr.md
@@ -31,7 +31,7 @@ Via **Prism Element**, il est possible :
 ## Prérequis
 
 - Disposer de deux clusters Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté à vos clusters via **Prism Central**.
 - Avoir mis en place une interconnexion entre deux clusters, par exemple via un VPN IPsec.
 
@@ -242,6 +242,6 @@ Les machines virtuelles apparaîtront dans la console de **Prism Element** dans 
 
 [Documentation Nutanix sur Data Protection and Disaster Recovery](https://portal.nutanix.com/page/documents/solutions/details?targetId=BP-2005-Data-Protection:top-backup-and-disaster-recovery-on-remote-sites.html)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.it-it.md
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/it/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Introduction
@@ -31,7 +31,7 @@ Via **Prism Element**, you can:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, e.g. via an IPsec VPN
 
@@ -242,6 +242,6 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 [Nutanix Documentation on Data Protection and Disaster Recovery](https://portal.nutanix.com/page/documents/solutions/details?targetId=BP-2005-Data-Protection:top-backup-and-disaster-recovery-on-remote-sites.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.pl-pl.md
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pl/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Introduction
@@ -31,7 +31,7 @@ Via **Prism Element**, you can:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, e.g. via an IPsec VPN
 
@@ -242,6 +242,6 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 [Nutanix Documentation on Data Protection and Disaster Recovery](https://portal.nutanix.com/page/documents/solutions/details?targetId=BP-2005-Data-Protection:top-backup-and-disaster-recovery-on-remote-sites.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/46-prism-element-replication/guide.pt-pt.md
@@ -11,7 +11,7 @@ This guide details how to set up cluster replication via Prism Element.
 > [!warning]
 > OVHcloud provides services for which you are responsible, with regard to their configuration and management. It is therefore your responsibility to ensure  that they function correctly.
 >
-> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](https://partner.ovhcloud.com/pt/directory/) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend contacting a [specialist service provider](/links/partner) or reaching out to [our community](https://community.ovh.com/en/) if you experience any issues.
 >
 
 ## Introduction
@@ -31,7 +31,7 @@ Via **Prism Element**, you can:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, e.g. via an IPsec VPN
 
@@ -242,6 +242,6 @@ The virtual machines will appear in the **Prism Element** console in the state o
 
 [Nutanix Documentation on Data Protection and Disaster Recovery](https://portal.nutanix.com/page/documents/solutions/details?targetId=BP-2005-Data-Protection:top-backup-and-disaster-recovery-on-remote-sites.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.de-de.md
@@ -26,11 +26,11 @@ Nutanix Leap allows:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, for example using these technologies:
     - via an IPsec VPN as detailed in the guide [Interconnecting IPsec between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
-    - or via a [vRack](https://www.ovhcloud.com/de/network/vrack/) connection.
+    - or via a [vRack](/links/network/vrack) connection.
 - **Prism Central** needs more resources depending on the mode:
     - Single Mode: 4GB additional RAM.
     - Scale Mode with 3 **Prism Central** virtual machines: 8 GB additional RAM per virtual machine.
@@ -505,10 +505,10 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 [IPsec interconnect between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
 
-[OVHcloud vRack](https://www.ovhcloud.com/de/network/vrack/)
+[OVHcloud vRack](/links/network/vrack)
 
 [Nutanix Leap documentation](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v6_1:Leap-Xi-Leap-Admin-Guide-v6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.en-ca.md
@@ -26,11 +26,11 @@ Nutanix Leap allows:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, for example using these technologies:
     - via an IPsec VPN as detailed in the guide [Interconnecting IPsec between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
-    - or via a [vRack](https://www.ovhcloud.com/en-ca/network/vrack/) connection.
+    - or via a [vRack](/links/network/vrack) connection.
 - **Prism Central** needs more resources depending on the mode:
     - Single Mode: 4GB additional RAM.
     - Scale Mode with 3 **Prism Central** virtual machines: 8 GB additional RAM per virtual machine.
@@ -505,10 +505,10 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 [IPsec interconnect between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
 
-[OVHcloud vRack](https://www.ovhcloud.com/en-ca/network/vrack/)
+[OVHcloud vRack](/links/network/vrack)
 
 [Nutanix Leap documentation](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v6_1:Leap-Xi-Leap-Admin-Guide-v6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.en-gb.md
@@ -26,11 +26,11 @@ Nutanix Leap allows:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, for example using these technologies:
     - via an IPsec VPN as detailed in the guide [Interconnecting IPsec between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
-    - or via a [vRack](https://www.ovhcloud.com/en-gb/network/vrack/) connection.
+    - or via a [vRack](/links/network/vrack) connection.
 - **Prism Central** needs more resources depending on the mode:
     - Single Mode: 4GB additional RAM.
     - Scale Mode with 3 **Prism Central** virtual machines: 8 GB additional RAM per virtual machine.
@@ -505,10 +505,10 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 [IPsec interconnect between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
 
-[OVHcloud vRack](https://www.ovhcloud.com/en-gb/network/vrack/)
+[OVHcloud vRack](/links/network/vrack)
 
 [Nutanix Leap documentation](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v6_1:Leap-Xi-Leap-Admin-Guide-v6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.en-ie.md
@@ -26,11 +26,11 @@ Nutanix Leap allows:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, for example using these technologies:
     - via an IPsec VPN as detailed in the guide [Interconnecting IPsec between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
-    - or via a [vRack](https://www.ovhcloud.com/en-ie/network/vrack/) connection.
+    - or via a [vRack](/links/network/vrack) connection.
 - **Prism Central** needs more resources depending on the mode:
     - Single Mode: 4GB additional RAM.
     - Scale Mode with 3 **Prism Central** virtual machines: 8 GB additional RAM per virtual machine.
@@ -505,10 +505,10 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 [IPsec interconnect between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
 
-[OVHcloud vRack](https://www.ovhcloud.com/en-ie/network/vrack/)
+[OVHcloud vRack](/links/network/vrack)
 
 [Nutanix Leap documentation](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v6_1:Leap-Xi-Leap-Admin-Guide-v6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.en-us.md
@@ -26,11 +26,11 @@ Nutanix Leap allows:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, for example using these technologies:
     - via an IPsec VPN as detailed in the guide [Interconnecting IPsec between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
-    - or via a [vRack](https://www.ovhcloud.com/en/network/vrack/) connection.
+    - or via a [vRack](/links/network/vrack) connection.
 - **Prism Central** needs more resources depending on the mode:
     - Single Mode: 4GB additional RAM.
     - Scale Mode with 3 **Prism Central** virtual machines: 8 GB additional RAM per virtual machine.
@@ -505,10 +505,10 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 [IPsec interconnect between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
 
-[OVHcloud vRack](https://www.ovhcloud.com/en/network/vrack/)
+[OVHcloud vRack](/links/network/vrack)
 
 [Nutanix Leap documentation](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v6_1:Leap-Xi-Leap-Admin-Guide-v6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.es-es.md
@@ -26,11 +26,11 @@ Nutanix Leap allows:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, for example using these technologies:
     - via an IPsec VPN as detailed in the guide [Interconnecting IPsec between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
-    - or via a [vRack](https://www.ovhcloud.com/es-es/network/vrack/) connection.
+    - or via a [vRack](/links/network/vrack) connection.
 - **Prism Central** needs more resources depending on the mode:
     - Single Mode: 4GB additional RAM.
     - Scale Mode with 3 **Prism Central** virtual machines: 8 GB additional RAM per virtual machine.
@@ -505,10 +505,10 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 [IPsec interconnect between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
 
-[OVHcloud vRack](https://www.ovhcloud.com/es-es/network/vrack/)
+[OVHcloud vRack](/links/network/vrack)
 
 [Nutanix Leap documentation](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v6_1:Leap-Xi-Leap-Admin-Guide-v6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.es-us.md
@@ -26,11 +26,11 @@ Nutanix Leap allows:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, for example using these technologies:
     - via an IPsec VPN as detailed in the guide [Interconnecting IPsec between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
-    - or via a [vRack](https://www.ovhcloud.com/es/network/vrack/) connection.
+    - or via a [vRack](/links/network/vrack) connection.
 - **Prism Central** needs more resources depending on the mode:
     - Single Mode: 4GB additional RAM.
     - Scale Mode with 3 **Prism Central** virtual machines: 8 GB additional RAM per virtual machine.
@@ -505,10 +505,10 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 [IPsec interconnect between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
 
-[OVHcloud vRack](https://www.ovhcloud.com/es/network/vrack/)
+[OVHcloud vRack](/links/network/vrack)
 
 [Nutanix Leap documentation](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v6_1:Leap-Xi-Leap-Admin-Guide-v6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.fr-ca.md
@@ -26,11 +26,11 @@ Nutanix Leap permet :
 ## Prérequis
 
 - Disposer de deux clusters Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté à vos clusters via **Prism Central**.
 - Avoir mis en place une interconnexion entre deux clusters, par exemple à l'aide de ces technologies :
     - via un VPN IPsec comme détaillé dans le guide « [Interconnexion IPsec entre deux sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection) »;
-    - ou via une connexion [vRack](https://www.ovhcloud.com/fr-ca/network/vrack/).
+    - ou via une connexion [vRack](/links/network/vrack).
 - **Prism Central** a besoin de plus de ressources en fonction du mode :
     - Single Mode : 4Go de RAM supplémentaires.
     - Scale Mode avec 3 machines virtuelles **Prism Central** : 8 Go de RAM supplémentaires par machine virtuelle.
@@ -505,10 +505,10 @@ La machine virtuelle membre du plan de reprise d'activité va démarrer sur le c
 
 [Interconnexion IPsec entre deux sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
 
-[OVHcloud vRack](https://www.ovhcloud.com/fr-ca/network/vrack/)
+[OVHcloud vRack](/links/network/vrack)
 
 [Documentation Nutanix Leap](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v6_1:Leap-Xi-Leap-Admin-Guide-v6)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.fr-fr.md
@@ -26,11 +26,11 @@ Nutanix Leap permet :
 ## Prérequis
 
 - Disposer de deux clusters Nutanix dans votre compte OVHcloud.
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté à vos clusters via **Prism Central**.
 - Avoir mis en place une interconnexion entre deux clusters, par exemple à l'aide de ces technologies :
     - via un VPN IPsec comme détaillé dans le guide « [Interconnexion IPsec entre deux sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection) »;
-    - ou via une connexion [vRack](https://www.ovhcloud.com/fr/network/vrack/).
+    - ou via une connexion [vRack](/links/network/vrack).
 - **Prism Central** a besoin de plus de ressources en fonction du mode :
     - Single Mode : 4Go de RAM supplémentaires.
     - Scale Mode avec 3 machines virtuelles **Prism Central** : 8 Go de RAM supplémentaires par machine virtuelle.
@@ -505,10 +505,10 @@ La machine virtuelle membre du plan de reprise d'activité va démarrer sur le c
 
 [Interconnexion IPsec entre deux sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
 
-[OVHcloud vRack](https://www.ovhcloud.com/fr/network/vrack/)
+[OVHcloud vRack](/links/network/vrack)
 
 [Documentation Nutanix Leap](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v6_1:Leap-Xi-Leap-Admin-Guide-v6)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.it-it.md
@@ -26,11 +26,11 @@ Nutanix Leap allows:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, for example using these technologies:
     - via an IPsec VPN as detailed in the guide [Interconnecting IPsec between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
-    - or via a [vRack](https://www.ovhcloud.com/it/network/vrack/) connection.
+    - or via a [vRack](/links/network/vrack) connection.
 - **Prism Central** needs more resources depending on the mode:
     - Single Mode: 4GB additional RAM.
     - Scale Mode with 3 **Prism Central** virtual machines: 8 GB additional RAM per virtual machine.
@@ -505,10 +505,10 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 [IPsec interconnect between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
 
-[OVHcloud vRack](https://www.ovhcloud.com/it/network/vrack/)
+[OVHcloud vRack](/links/network/vrack)
 
 [Nutanix Leap documentation](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v6_1:Leap-Xi-Leap-Admin-Guide-v6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.pl-pl.md
@@ -26,11 +26,11 @@ Nutanix Leap allows:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, for example using these technologies:
     - via an IPsec VPN as detailed in the guide [Interconnecting IPsec between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
-    - or via a [vRack](https://www.ovhcloud.com/pl/network/vrack/) connection.
+    - or via a [vRack](/links/network/vrack) connection.
 - **Prism Central** needs more resources depending on the mode:
     - Single Mode: 4GB additional RAM.
     - Scale Mode with 3 **Prism Central** virtual machines: 8 GB additional RAM per virtual machine.
@@ -505,10 +505,10 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 [IPsec interconnect between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
 
-[OVHcloud vRack](https://www.ovhcloud.com/pl/network/vrack/)
+[OVHcloud vRack](/links/network/vrack)
 
 [Nutanix Leap documentation](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v6_1:Leap-Xi-Leap-Admin-Guide-v6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap/guide.pt-pt.md
@@ -26,11 +26,11 @@ Nutanix Leap allows:
 ## Requirements
 
 - Two Nutanix clusters in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via **Prism Central**
 - An interconnection between two clusters, for example using these technologies:
     - via an IPsec VPN as detailed in the guide [Interconnecting IPsec between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
-    - or via a [vRack](https://www.ovhcloud.com/pt/network/vrack/) connection.
+    - or via a [vRack](/links/network/vrack) connection.
 - **Prism Central** needs more resources depending on the mode:
     - Single Mode: 4GB additional RAM.
     - Scale Mode with 3 **Prism Central** virtual machines: 8 GB additional RAM per virtual machine.
@@ -505,10 +505,10 @@ The virtual machine that is a member of the disaster recovery plan will boot to 
 
 [IPsec interconnect between two sites](/pages/hosted_private_cloud/nutanix_on_ovhcloud/44-ipsec-interconnection)
 
-[OVHcloud vRack](https://www.ovhcloud.com/pt/network/vrack/)
+[OVHcloud vRack](/links/network/vrack)
 
 [Nutanix Leap documentation](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v6_1:Leap-Xi-Leap-Admin-Guide-v6)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.de-de.md
@@ -16,7 +16,7 @@ updated: 2024-05-13
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - You need to have 3 Nutanix clusters within the OVHcloud infrastructure with **Pro** or **Ultimate** packs if you have a Nutanix on OVHcloud packaged service on both clusters in the P.R.A. These 3 clusters will need to be at remote sites for maximum security.
 - You must have less than 5 ms of latency between the two replicated clusters. Please note that latency is not covered by SLAs.
@@ -1084,10 +1084,10 @@ The list of events appears, click `Close`{.action} to close.
 
 [Advanced replication with Leap](/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap)
 
-[Introduction to vRacks](https://www.ovhcloud.com/de/network/vrack/)
+[Introduction to vRacks](/links/network/vrack)
 
 [Documentation Nutanix AHV Metro - Witness Option](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v2022_6:ecd-ecdr-witness-syncrep-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.en-ca.md
@@ -16,7 +16,7 @@ updated: 2024-05-13
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - You need to have 3 Nutanix clusters within the OVHcloud infrastructure with **Pro** or **Ultimate** packs if you have a Nutanix on OVHcloud packaged service on both clusters in the P.R.A. These 3 clusters will need to be at remote sites for maximum security.
 - You must have less than 5 ms of latency between the two replicated clusters. Please note that latency is not covered by SLAs.
@@ -1084,10 +1084,10 @@ The list of events appears, click `Close`{.action} to close.
 
 [Advanced replication with Leap](/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap)
 
-[Introduction to vRacks](https://www.ovhcloud.com/en-ca/network/vrack/)
+[Introduction to vRacks](/links/network/vrack)
 
 [Documentation Nutanix AHV Metro - Witness Option](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v2022_6:ecd-ecdr-witness-syncrep-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.en-gb.md
@@ -16,7 +16,7 @@ updated: 2024-05-13
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - You need to have 3 Nutanix clusters within the OVHcloud infrastructure with **Pro** or **Ultimate** packs if you have a Nutanix on OVHcloud packaged service on both clusters in the P.R.A. These 3 clusters will need to be at remote sites for maximum security.
 - You must have less than 5 ms of latency between the two replicated clusters. Please note that latency is not covered by SLAs.
@@ -1084,10 +1084,10 @@ The list of events appears, click `Close`{.action} to close.
 
 [Advanced replication with Leap](/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap)
 
-[Introduction to vRacks](https://www.ovhcloud.com/en-gb/network/vrack/)
+[Introduction to vRacks](/links/network/vrack)
 
 [Documentation Nutanix AHV Metro - Witness Option](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v2022_6:ecd-ecdr-witness-syncrep-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.en-ie.md
@@ -16,7 +16,7 @@ updated: 2024-05-13
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - You need to have 3 Nutanix clusters within the OVHcloud infrastructure with **Pro** or **Ultimate** packs if you have a Nutanix on OVHcloud packaged service on both clusters in the P.R.A. These 3 clusters will need to be at remote sites for maximum security.
 - You must have less than 5 ms of latency between the two replicated clusters. Please note that latency is not covered by SLAs.
@@ -1084,10 +1084,10 @@ The list of events appears, click `Close`{.action} to close.
 
 [Advanced replication with Leap](/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap)
 
-[Introduction to vRacks](https://www.ovhcloud.com/en-ie/network/vrack/)
+[Introduction to vRacks](/links/network/vrack)
 
 [Documentation Nutanix AHV Metro - Witness Option](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v2022_6:ecd-ecdr-witness-syncrep-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.en-us.md
@@ -16,7 +16,7 @@ updated: 2024-05-13
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - You need to have 3 Nutanix clusters within the OVHcloud infrastructure with **Pro** or **Ultimate** packs if you have a Nutanix on OVHcloud packaged service on both clusters in the P.R.A. These 3 clusters will need to be at remote sites for maximum security.
 - You must have less than 5 ms of latency between the two replicated clusters. Please note that latency is not covered by SLAs.
@@ -1084,10 +1084,10 @@ The list of events appears, click `Close`{.action} to close.
 
 [Advanced replication with Leap](/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap)
 
-[Introduction to vRacks](https://www.ovhcloud.com/en/network/vrack/)
+[Introduction to vRacks](/links/network/vrack)
 
 [Documentation Nutanix AHV Metro - Witness Option](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v2022_6:ecd-ecdr-witness-syncrep-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.es-es.md
@@ -16,7 +16,7 @@ updated: 2024-05-13
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - You need to have 3 Nutanix clusters within the OVHcloud infrastructure with **Pro** or **Ultimate** packs if you have a Nutanix on OVHcloud packaged service on both clusters in the P.R.A. These 3 clusters will need to be at remote sites for maximum security.
 - You must have less than 5 ms of latency between the two replicated clusters. Please note that latency is not covered by SLAs.
@@ -1084,10 +1084,10 @@ The list of events appears, click `Close`{.action} to close.
 
 [Advanced replication with Leap](/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap)
 
-[Introduction to vRacks](https://www.ovhcloud.com/es-es/network/vrack/)
+[Introduction to vRacks](/links/network/vrack)
 
 [Documentation Nutanix AHV Metro - Witness Option](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v2022_6:ecd-ecdr-witness-syncrep-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.es-us.md
@@ -16,7 +16,7 @@ updated: 2024-05-13
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - You need to have 3 Nutanix clusters within the OVHcloud infrastructure with **Pro** or **Ultimate** packs if you have a Nutanix on OVHcloud packaged service on both clusters in the P.R.A. These 3 clusters will need to be at remote sites for maximum security.
 - You must have less than 5 ms of latency between the two replicated clusters. Please note that latency is not covered by SLAs.
@@ -1084,10 +1084,10 @@ The list of events appears, click `Close`{.action} to close.
 
 [Advanced replication with Leap](/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap)
 
-[Introduction to vRacks](https://www.ovhcloud.com/es/network/vrack/)
+[Introduction to vRacks](/links/network/vrack)
 
 [Documentation Nutanix AHV Metro - Witness Option](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v2022_6:ecd-ecdr-witness-syncrep-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.fr-ca.md
@@ -16,7 +16,7 @@ updated: 2024-05-13
 
 ## Prérequis
 
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur vos clusters via Prism Central.
 - Avoir 3 clusters Nutanix au sein de l'infrastructure OVHcloud avec des licences des packs **Pro** ou **Ultimate** si vous avez une offre Nutanix on OVHcloud packagée sur les deux clusters du P.R.A. Ces 3 clusters devront être sur des sites distants pour obtenir un maximum de sûreté.
 - Avoir une latence de moins de 5 ms entre les deux clusters répliqués. Veuillez noter que la latence n'est pas couverte par les SLA.
@@ -1088,6 +1088,6 @@ La liste des événements survenus apparaît, cliquez sur `Close`{.action} pour 
 
 [Documentation Nutanix AHV Metro - Witness Option](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v2022_6:ecd-ecdr-witness-syncrep-pc-c.html)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.fr-fr.md
@@ -16,7 +16,7 @@ updated: 2024-05-13
 
 ## Prérequis
 
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr).
+- Être connecté à votre [espace client OVHcloud](/links/manager).
 - Être connecté sur vos clusters via Prism Central.
 - Avoir 3 clusters Nutanix au sein de l'infrastructure OVHcloud avec des licences des packs **Pro** ou **Ultimate** si vous avez une offre Nutanix on OVHcloud packagée sur les deux clusters du P.R.A. Ces 3 clusters devront être sur des sites distants pour obtenir un maximum de sûreté.
 - Avoir une latence de moins de 5 ms entre les deux clusters répliqués. Veuillez noter que la latence n'est pas couverte par les SLA.
@@ -1088,6 +1088,6 @@ La liste des événements survenus apparaît, cliquez sur `Close`{.action} pour 
 
 [Documentation Nutanix AHV Metro - Witness Option](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v2022_6:ecd-ecdr-witness-syncrep-pc-c.html)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.it-it.md
@@ -16,7 +16,7 @@ updated: 2024-05-13
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - You need to have 3 Nutanix clusters within the OVHcloud infrastructure with **Pro** or **Ultimate** packs if you have a Nutanix on OVHcloud packaged service on both clusters in the P.R.A. These 3 clusters will need to be at remote sites for maximum security.
 - You must have less than 5 ms of latency between the two replicated clusters. Please note that latency is not covered by SLAs.
@@ -1084,10 +1084,10 @@ The list of events appears, click `Close`{.action} to close.
 
 [Advanced replication with Leap](/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap)
 
-[Introduction to vRacks](https://www.ovhcloud.com/it/network/vrack/)
+[Introduction to vRacks](/links/network/vrack)
 
 [Documentation Nutanix AHV Metro - Witness Option](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v2022_6:ecd-ecdr-witness-syncrep-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.pl-pl.md
@@ -16,7 +16,7 @@ updated: 2024-05-13
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - You need to have 3 Nutanix clusters within the OVHcloud infrastructure with **Pro** or **Ultimate** packs if you have a Nutanix on OVHcloud packaged service on both clusters in the P.R.A. These 3 clusters will need to be at remote sites for maximum security.
 - You must have less than 5 ms of latency between the two replicated clusters. Please note that latency is not covered by SLAs.
@@ -1084,10 +1084,10 @@ The list of events appears, click `Close`{.action} to close.
 
 [Advanced replication with Leap](/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap)
 
-[Introduction to vRacks](https://www.ovhcloud.com/pl/network/vrack/)
+[Introduction to vRacks](/links/network/vrack)
 
 [Documentation Nutanix AHV Metro - Witness Option](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v2022_6:ecd-ecdr-witness-syncrep-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/48-metro-availability/guide.pt-pt.md
@@ -16,7 +16,7 @@ updated: 2024-05-13
 
 ## Requirements
 
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Access to your clusters via Prism Central
 - You need to have 3 Nutanix clusters within the OVHcloud infrastructure with **Pro** or **Ultimate** packs if you have a Nutanix on OVHcloud packaged service on both clusters in the P.R.A. These 3 clusters will need to be at remote sites for maximum security.
 - You must have less than 5 ms of latency between the two replicated clusters. Please note that latency is not covered by SLAs.
@@ -1084,10 +1084,10 @@ The list of events appears, click `Close`{.action} to close.
 
 [Advanced replication with Leap](/pages/hosted_private_cloud/nutanix_on_ovhcloud/47-nutanix-leap)
 
-[Introduction to vRacks](https://www.ovhcloud.com/pt/network/vrack/)
+[Introduction to vRacks](/links/network/vrack)
 
 [Documentation Nutanix AHV Metro - Witness Option](https://portal.nutanix.com/page/documents/details?targetId=Leap-Xi-Leap-Admin-Guide-v2022_6:ecd-ecdr-witness-syncrep-pc-c.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.de-de.md
@@ -206,6 +206,6 @@ nutanix@CVMN's password:
 
 [Logbay Nutanix documentation](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LM3BCAW)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.en-ca.md
@@ -206,6 +206,6 @@ nutanix@CVMN's password:
 
 [Logbay Nutanix documentation](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LM3BCAW)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.en-gb.md
@@ -206,6 +206,6 @@ nutanix@CVMN's password:
 
 [Logbay Nutanix documentation](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LM3BCAW)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.en-ie.md
@@ -206,6 +206,6 @@ nutanix@CVMN's password:
 
 [Logbay Nutanix documentation](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LM3BCAW)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.en-us.md
@@ -206,6 +206,6 @@ nutanix@CVMN's password:
 
 [Logbay Nutanix documentation](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LM3BCAW)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.es-es.md
@@ -206,6 +206,6 @@ nutanix@CVMN's password:
 
 [Logbay Nutanix documentation](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LM3BCAW)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.es-us.md
@@ -206,6 +206,6 @@ nutanix@CVMN's password:
 
 [Logbay Nutanix documentation](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LM3BCAW)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.fr-ca.md
@@ -206,6 +206,6 @@ nutanix@CVMN's password:
 
 [Documentation Nutanix sur Logbay](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LM3BCAW)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.fr-fr.md
@@ -206,6 +206,6 @@ nutanix@CVMN's password:
 
 [Documentation Nutanix sur Logbay](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LM3BCAW)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.it-it.md
@@ -206,6 +206,6 @@ nutanix@CVMN's password:
 
 [Logbay Nutanix documentation](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LM3BCAW)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.pl-pl.md
@@ -206,6 +206,6 @@ nutanix@CVMN's password:
 
 [Logbay Nutanix documentation](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LM3BCAW)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/50-cluster-information/guide.pt-pt.md
@@ -206,6 +206,6 @@ nutanix@CVMN's password:
 
 [Logbay Nutanix documentation](https://portal.nutanix.com/page/documents/kbs/details?targetId=kA00e000000LM3BCAW)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.de-de.md
@@ -11,14 +11,14 @@ This article provides you with the steps to update Nutanix cluster's firmwares b
 Our services will take over to apply updates and firmwares and will restart the node thereafter.
 
 > [!warning]
-> Before following the steps below, log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
+> Before following the steps below, log in to your [OVHcloud Control Panel](/links/manager) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
 
 **This guide explains how to update your Nutanix cluster firmware.**
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
@@ -137,7 +137,7 @@ The CVM is now shut down.
 
 ### Reboot to rescue mode
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
 
 ![OVHcloud Control Panel - cluster access](images/nutanix-cluster-fw-update-11.png){.thumbnail}
 
@@ -221,6 +221,6 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.en-ca.md
@@ -11,14 +11,14 @@ This article provides you with the steps to update Nutanix cluster's firmwares b
 Our services will take over to apply updates and firmwares and will restart the node thereafter.
 
 > [!warning]
-> Before following the steps below, log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
+> Before following the steps below, log in to your [OVHcloud Control Panel](/links/manager) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
 
 **This guide explains how to update your Nutanix cluster firmware.**
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
@@ -137,7 +137,7 @@ The CVM is now shut down.
 
 ### Reboot to rescue mode
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
 
 ![OVHcloud Control Panel - cluster access](images/nutanix-cluster-fw-update-11.png){.thumbnail}
 
@@ -221,6 +221,6 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.en-gb.md
@@ -11,14 +11,14 @@ This article provides you with the steps to update Nutanix cluster's firmwares b
 Our services will take over to apply updates and firmwares and will restart the node thereafter.
 
 > [!warning]
-> Before following the steps below, log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
+> Before following the steps below, log in to your [OVHcloud Control Panel](/links/manager) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
 
 **This guide explains how to update your Nutanix cluster firmware.**
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
@@ -137,7 +137,7 @@ The CVM is now shut down.
 
 ### Reboot to rescue mode
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
 
 ![OVHcloud Control Panel - cluster access](images/nutanix-cluster-fw-update-11.png){.thumbnail}
 
@@ -221,6 +221,6 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.en-ie.md
@@ -11,14 +11,14 @@ This article provides you with the steps to update Nutanix cluster's firmwares b
 Our services will take over to apply updates and firmwares and will restart the node thereafter.
 
 > [!warning]
-> Before following the steps below, log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
+> Before following the steps below, log in to your [OVHcloud Control Panel](/links/manager) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
 
 **This guide explains how to update your Nutanix cluster firmware.**
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
@@ -137,7 +137,7 @@ The CVM is now shut down.
 
 ### Reboot to rescue mode
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
 
 ![OVHcloud Control Panel - cluster access](images/nutanix-cluster-fw-update-11.png){.thumbnail}
 
@@ -221,6 +221,6 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.en-us.md
@@ -11,14 +11,14 @@ This article provides you with the steps to update Nutanix cluster's firmwares b
 Our services will take over to apply updates and firmwares and will restart the node thereafter.
 
 > [!warning]
-> Before following the steps below, log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
+> Before following the steps below, log in to your [OVHcloud Control Panel](/links/manager) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
 
 **This guide explains how to update your Nutanix cluster firmware.**
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
@@ -137,7 +137,7 @@ The CVM is now shut down.
 
 ### Reboot to rescue mode
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
 
 ![OVHcloud Control Panel - cluster access](images/nutanix-cluster-fw-update-11.png){.thumbnail}
 
@@ -221,6 +221,6 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.es-es.md
@@ -11,14 +11,14 @@ This article provides you with the steps to update Nutanix cluster's firmwares b
 Our services will take over to apply updates and firmwares and will restart the node thereafter.
 
 > [!warning]
-> Before following the steps below, log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
+> Before following the steps below, log in to your [OVHcloud Control Panel](/links/manager) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
 
 **This guide explains how to update your Nutanix cluster firmware.**
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
@@ -137,7 +137,7 @@ The CVM is now shut down.
 
 ### Reboot to rescue mode
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
 
 ![OVHcloud Control Panel - cluster access](images/nutanix-cluster-fw-update-11.png){.thumbnail}
 
@@ -221,6 +221,6 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.es-us.md
@@ -11,14 +11,14 @@ This article provides you with the steps to update Nutanix cluster's firmwares b
 Our services will take over to apply updates and firmwares and will restart the node thereafter.
 
 > [!warning]
-> Before following the steps below, log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
+> Before following the steps below, log in to your [OVHcloud Control Panel](/links/manager) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
 
 **This guide explains how to update your Nutanix cluster firmware.**
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
@@ -137,7 +137,7 @@ The CVM is now shut down.
 
 ### Reboot to rescue mode
 
-Log in to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
 
 ![OVHcloud Control Panel - cluster access](images/nutanix-cluster-fw-update-11.png){.thumbnail}
 
@@ -221,6 +221,6 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.fr-ca.md
@@ -11,14 +11,14 @@ Ce guide vous présente les étapes de mise à jour des firmwares des clusters N
 Nos services prendront le relais pour appliquer les mises à jour des firmwares et redémarreront le noeud une fois cela fait.
 
 > [!warning]
-> Avant d'entamer toute action, connectez-vous à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc) et créez un ticket de demande d'assistance pour demander une mise à jour du firmware et communiquer aux équipes d'assistance OVHcloud les éléments techniques concernant votre cluster.
+> Avant d'entamer toute action, connectez-vous à votre [espace client OVHcloud](/links/manager) et créez un ticket de demande d'assistance pour demander une mise à jour du firmware et communiquer aux équipes d'assistance OVHcloud les éléments techniques concernant votre cluster.
 
 **Découvrez comment mettre à jour le firmware de votre cluster Nutanix.**
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Consulter le guide [Premiers pas avec les API OVHcloud](/pages/manage_and_operate/api/first-steps) pour vous familiariser avec l'utilisation des APIv6 OVHcloud.
 
 ## En pratique
@@ -137,7 +137,7 @@ Le CVM est à présent arrêté.
 
 ### Redémarrer en mode rescue
 
-Connectez-vous à l'[espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc), accédez à l'onglet `Hosted Private Cloud`{.action}, choisissez `Nutanix`{.action} et sélectionnez votre cluster.
+Connectez-vous à l'[espace client OVHcloud](/links/manager), accédez à l'onglet `Hosted Private Cloud`{.action}, choisissez `Nutanix`{.action} et sélectionnez votre cluster.
 
 ![Espace client - accès au cluster](images/nutanix-cluster-fw-update-11.png){.thumbnail}
 
@@ -221,6 +221,6 @@ Merci de ne pas ouvrir de nouveau ticket, il suffit de rajouter des commentaires
 
 ## Aller plus loin <a name="go further"></a>
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.fr-fr.md
@@ -11,14 +11,14 @@ Ce guide vous présente les étapes de mise à jour des firmwares des clusters N
 Nos services prendront le relais pour appliquer les mises à jour des firmwares et redémarreront le noeud une fois cela fait.
 
 > [!warning]
-> Avant d'entamer toute action, connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) et créez un ticket de demande d'assistance pour demander une mise à jour du firmware et communiquer aux équipes d'assistance OVHcloud les éléments techniques concernant votre cluster.
+> Avant d'entamer toute action, connectez-vous à votre [espace client OVHcloud](/links/manager) et créez un ticket de demande d'assistance pour demander une mise à jour du firmware et communiquer aux équipes d'assistance OVHcloud les éléments techniques concernant votre cluster.
 
 **Découvrez comment mettre à jour le firmware de votre cluster Nutanix.**
 
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Consulter le guide [Premiers pas avec les API OVHcloud](/pages/manage_and_operate/api/first-steps) pour vous familiariser avec l'utilisation des APIv6 OVHcloud.
 
 ## En pratique
@@ -137,7 +137,7 @@ Le CVM est à présent arrêté.
 
 ### Redémarrer en mode rescue
 
-Connectez-vous à l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr), accédez à l'onglet `Hosted Private Cloud`{.action}, choisissez `Nutanix`{.action} et sélectionnez votre cluster.
+Connectez-vous à l'[espace client OVHcloud](/links/manager), accédez à l'onglet `Hosted Private Cloud`{.action}, choisissez `Nutanix`{.action} et sélectionnez votre cluster.
 
 ![Espace client - accès au cluster](images/nutanix-cluster-fw-update-11.png){.thumbnail}
 
@@ -221,6 +221,6 @@ Merci de ne pas ouvrir de nouveau ticket, il suffit de rajouter des commentaires
 
 ## Aller plus loin <a name="go further"></a>
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.it-it.md
@@ -11,14 +11,14 @@ This article provides you with the steps to update Nutanix cluster's firmwares b
 Our services will take over to apply updates and firmwares and will restart the node thereafter.
 
 > [!warning]
-> Before following the steps below, log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
+> Before following the steps below, log in to your [OVHcloud Control Panel](/links/manager) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
 
 **This guide explains how to update your Nutanix cluster firmware.**
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
@@ -137,7 +137,7 @@ The CVM is now shut down.
 
 ### Reboot to rescue mode
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
 
 ![OVHcloud Control Panel - cluster access](images/nutanix-cluster-fw-update-11.png){.thumbnail}
 
@@ -221,6 +221,6 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.pl-pl.md
@@ -11,14 +11,14 @@ This article provides you with the steps to update Nutanix cluster's firmwares b
 Our services will take over to apply updates and firmwares and will restart the node thereafter.
 
 > [!warning]
-> Before following the steps below, log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
+> Before following the steps below, log in to your [OVHcloud Control Panel](/links/manager) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
 
 **This guide explains how to update your Nutanix cluster firmware.**
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
@@ -137,7 +137,7 @@ The CVM is now shut down.
 
 ### Reboot to rescue mode
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
 
 ![OVHcloud Control Panel - cluster access](images/nutanix-cluster-fw-update-11.png){.thumbnail}
 
@@ -221,6 +221,6 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/70-cluster-firmware-update/guide.pt-pt.md
@@ -11,14 +11,14 @@ This article provides you with the steps to update Nutanix cluster's firmwares b
 Our services will take over to apply updates and firmwares and will restart the node thereafter.
 
 > [!warning]
-> Before following the steps below, log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
+> Before following the steps below, log in to your [OVHcloud Control Panel](/links/manager) and create a support ticket, requesting a firmware update. Make sure to provide the OVHcloud support teams with all technical information regarding your cluster.
 
 **This guide explains how to update your Nutanix cluster firmware.**
 
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to the [OVHcloud Control Panel](/links/manager)
 - Consulting the guide [First steps to use the OVHcloud API](/pages/manage_and_operate/api/first-steps) (to familiarise yourself with the OVHcloud API)
 
 ## Instructions
@@ -137,7 +137,7 @@ The CVM is now shut down.
 
 ### Reboot to rescue mode
 
-Log in to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
+Log in to the [OVHcloud Control Panel](/links/manager), go to the `Hosted Private Cloud`{.action}, choose the `Nutanix`{.action} solution and select your cluster.
 
 ![OVHcloud Control Panel - cluster access](images/nutanix-cluster-fw-update-11.png){.thumbnail}
 
@@ -221,6 +221,6 @@ Please do not open a new ticket, just add comments on the same ticket for each n
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.de-de.md
@@ -14,7 +14,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 > [!warning]
 > OVHcloud provides services for which you are responsible, responsible and responsible for their configuration. You are therefore responsible for ensuring that it works properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](https://www.ovhcloud.com/de/professional-services/) or a [specialist provider](https://partner.ovhcloud.com/de/directory/) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
+> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](/links/professional-services) or a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
 >
 
 **Find out how to get started with your Nutanix cluster.**
@@ -22,7 +22,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
+- Access to your [OVHcloud Control Panel](/links/manager)
 - You must be logged in to Prism Central on the cluster
 
 > [!warning]
@@ -147,7 +147,7 @@ Open the console after restarting the VM. You can see that the VM has taken the 
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de). Open the Nutanix Cluster configuration page.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page.
 
 In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
@@ -411,7 +411,7 @@ In the system settings, enable "Remote Desktop".
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
 ![Configure Load Balancer 01 RDP](images/config-lb1-rdp.PNG){.thumbnail}
 
@@ -496,6 +496,6 @@ You can also [secure access to Prism Central](/pages/hosted_private_cloud/nutani
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.en-ca.md
@@ -14,7 +14,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 > [!warning]
 > OVHcloud provides services for which you are responsible, responsible and responsible for their configuration. You are therefore responsible for ensuring that it works properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ca/professional-services/) or a [specialist provider](https://partner.ovhcloud.com/en-ca/directory/) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
+> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](/links/professional-services) or a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
 >
 
 **Find out how to get started with your Nutanix cluster.**
@@ -22,7 +22,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to your [OVHcloud Control Panel](/links/manager)
 - You must be logged in to Prism Central on the cluster
 
 > [!warning]
@@ -147,7 +147,7 @@ Open the console after restarting the VM. You can see that the VM has taken the 
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca). Open the Nutanix Cluster configuration page.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page.
 
 In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
@@ -411,7 +411,7 @@ In the system settings, enable "Remote Desktop".
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
 ![Configure Load Balancer 01 RDP](images/config-lb1-rdp.PNG){.thumbnail}
 
@@ -496,6 +496,6 @@ You can also [secure access to Prism Central](/pages/hosted_private_cloud/nutani
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.en-gb.md
@@ -14,7 +14,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 > [!warning]
 > OVHcloud provides services for which you are responsible, responsible and responsible for their configuration. You are therefore responsible for ensuring that it works properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-gb/professional-services/) or a [specialist provider](https://partner.ovhcloud.com/en-gb/directory/) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
+> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](/links/professional-services) or a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
 >
 
 **Find out how to get started with your Nutanix cluster.**
@@ -22,7 +22,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to your [OVHcloud Control Panel](/links/manager)
 - You must be logged in to Prism Central on the cluster
 
 > [!warning]
@@ -147,7 +147,7 @@ Open the console after restarting the VM. You can see that the VM has taken the 
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB). Open the Nutanix Cluster configuration page.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page.
 
 In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
@@ -411,7 +411,7 @@ In the system settings, enable "Remote Desktop".
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
 ![Configure Load Balancer 01 RDP](images/config-lb1-rdp.PNG){.thumbnail}
 
@@ -496,6 +496,6 @@ You can also [secure access to Prism Central](/pages/hosted_private_cloud/nutani
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.en-ie.md
@@ -14,7 +14,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 > [!warning]
 > OVHcloud provides services for which you are responsible, responsible and responsible for their configuration. You are therefore responsible for ensuring that it works properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](https://www.ovhcloud.com/en-ie/professional-services/) or a [specialist provider](https://partner.ovhcloud.com/en-ie/directory/) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
+> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](/links/professional-services) or a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
 >
 
 **Find out how to get started with your Nutanix cluster.**
@@ -22,7 +22,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to your [OVHcloud Control Panel](/links/manager)
 - You must be logged in to Prism Central on the cluster
 
 > [!warning]
@@ -147,7 +147,7 @@ Open the console after restarting the VM. You can see that the VM has taken the 
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie). Open the Nutanix Cluster configuration page.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page.
 
 In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
@@ -411,7 +411,7 @@ In the system settings, enable "Remote Desktop".
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
 ![Configure Load Balancer 01 RDP](images/config-lb1-rdp.PNG){.thumbnail}
 
@@ -496,6 +496,6 @@ You can also [secure access to Prism Central](/pages/hosted_private_cloud/nutani
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.en-us.md
@@ -14,7 +14,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 > [!warning]
 > OVHcloud provides services for which you are responsible, responsible and responsible for their configuration. You are therefore responsible for ensuring that it works properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](https://www.ovhcloud.com/en/professional-services/) or a [specialist provider](https://partner.ovhcloud.com/en/directory/) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
+> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](/links/professional-services) or a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
 >
 
 **Find out how to get started with your Nutanix cluster.**
@@ -22,7 +22,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to your [OVHcloud Control Panel](/links/manager)
 - You must be logged in to Prism Central on the cluster
 
 > [!warning]
@@ -147,7 +147,7 @@ Open the console after restarting the VM. You can see that the VM has taken the 
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we). Open the Nutanix Cluster configuration page.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page.
 
 In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
@@ -411,7 +411,7 @@ In the system settings, enable "Remote Desktop".
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
 ![Configure Load Balancer 01 RDP](images/config-lb1-rdp.PNG){.thumbnail}
 
@@ -496,6 +496,6 @@ You can also [secure access to Prism Central](/pages/hosted_private_cloud/nutani
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.es-es.md
@@ -14,7 +14,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 > [!warning]
 > OVHcloud provides services for which you are responsible, responsible and responsible for their configuration. You are therefore responsible for ensuring that it works properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](https://www.ovhcloud.com/es-es/professional-services/) or a [specialist provider](https://partner.ovhcloud.com/es-es/directory/) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
+> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](/links/professional-services) or a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
 >
 
 **Find out how to get started with your Nutanix cluster.**
@@ -22,7 +22,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Access to your [OVHcloud Control Panel](/links/manager)
 - You must be logged in to Prism Central on the cluster
 
 > [!warning]
@@ -147,7 +147,7 @@ Open the console after restarting the VM. You can see that the VM has taken the 
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es). Open the Nutanix Cluster configuration page.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page.
 
 In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
@@ -411,7 +411,7 @@ In the system settings, enable "Remote Desktop".
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
 ![Configure Load Balancer 01 RDP](images/config-lb1-rdp.PNG){.thumbnail}
 
@@ -496,6 +496,6 @@ You can also [secure access to Prism Central](/pages/hosted_private_cloud/nutani
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.es-us.md
@@ -14,7 +14,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 > [!warning]
 > OVHcloud provides services for which you are responsible, responsible and responsible for their configuration. You are therefore responsible for ensuring that it works properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](https://www.ovhcloud.com/es/professional-services/) or a [specialist provider](https://partner.ovhcloud.com/es/directory/) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
+> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](/links/professional-services) or a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
 >
 
 **Find out how to get started with your Nutanix cluster.**
@@ -22,7 +22,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Access to your [OVHcloud Control Panel](/links/manager)
 - You must be logged in to Prism Central on the cluster
 
 > [!warning]
@@ -147,7 +147,7 @@ Open the console after restarting the VM. You can see that the VM has taken the 
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws). Open the Nutanix Cluster configuration page.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page.
 
 In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
@@ -411,7 +411,7 @@ In the system settings, enable "Remote Desktop".
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
 ![Configure Load Balancer 01 RDP](images/config-lb1-rdp.PNG){.thumbnail}
 
@@ -496,6 +496,6 @@ You can also [secure access to Prism Central](/pages/hosted_private_cloud/nutani
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.fr-ca.md
@@ -14,7 +14,7 @@ Ce guide vous présente les opérations que vous devez réaliser pour bien débu
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr-ca/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 **Découvrez les premières opérations à réaliser sur votre cluster Nutanix.**
@@ -22,7 +22,7 @@ Ce guide vous présente les opérations que vous devez réaliser pour bien débu
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté à Prism Central sur le cluster
 
 > [!warning]
@@ -147,7 +147,7 @@ Ouvrez la console après le redémarrage de la VM. Vous pouvez voir que la VM a 
 
 ##### Configuration du Load Balancer
 
-Connectez-vous à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc). Ouvrez la page de configuration du Nutanix Cluster. 
+Connectez-vous à votre [espace client OVHcloud](/links/manager). Ouvrez la page de configuration du Nutanix Cluster. 
 
 Dans le cadre `Réseau du cluster` en bas de page, cliquez sur le Load Balancer.
 
@@ -411,7 +411,7 @@ Dans les paramètres du système, activez le "bureau à distance".
 
 ##### Configuration du Load Balancer
 
-Connectez-vous à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc). Ouvrez la page de configuration du Nutanix Cluster. Dans le cadre `Réseau du cluster` en bas de page, cliquez sur le Load Balancer.
+Connectez-vous à votre [espace client OVHcloud](/links/manager). Ouvrez la page de configuration du Nutanix Cluster. Dans le cadre `Réseau du cluster` en bas de page, cliquez sur le Load Balancer.
 
 ![Configure Load Balancer 01 RDP](images/config-lb1-rdp.PNG){.thumbnail}
 
@@ -496,6 +496,6 @@ Vous pouvez également [sécuriser l'accès à Prism Central](/pages/hosted_priv
 
 ## Aller plus loin <a name="go further"></a>
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.fr-fr.md
@@ -14,7 +14,7 @@ Ce guide vous présente les opérations que vous devez réaliser pour bien débu
 > [!warning]
 > OVHcloud vous met à disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous appartient donc de ce fait d’en assurer le bon fonctionnement.
 >
-> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](https://www.ovhcloud.com/fr/professional-services/) ou à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
+> Ce guide a pour but de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à l'équipe [Professional Services OVHcloud](/links/professional-services) ou à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur.
 >
 
 **Découvrez les premières opérations à réaliser sur votre cluster Nutanix.**
@@ -22,7 +22,7 @@ Ce guide vous présente les opérations que vous devez réaliser pour bien débu
 ## Prérequis
 
 - Disposer d'un cluster Nutanix dans votre compte OVHcloud
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 - Être connecté à Prism Central sur le cluster
 
 > [!warning]
@@ -147,7 +147,7 @@ Ouvrez la console après le redémarrage de la VM. Vous pouvez voir que la VM a 
 
 ##### Configuration du Load Balancer
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr). Ouvrez la page de configuration du Nutanix Cluster. 
+Connectez-vous à votre [espace client OVHcloud](/links/manager). Ouvrez la page de configuration du Nutanix Cluster. 
 
 Dans le cadre `Réseau du cluster` en bas de page, cliquez sur le Load Balancer.
 
@@ -411,7 +411,7 @@ Dans les paramètres du système, activez le "bureau à distance".
 
 ##### Configuration du Load Balancer
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr). Ouvrez la page de configuration du Nutanix Cluster. Dans le cadre `Réseau du cluster` en bas de page, cliquez sur le Load Balancer.
+Connectez-vous à votre [espace client OVHcloud](/links/manager). Ouvrez la page de configuration du Nutanix Cluster. Dans le cadre `Réseau du cluster` en bas de page, cliquez sur le Load Balancer.
 
 ![Configure Load Balancer 01 RDP](images/config-lb1-rdp.PNG){.thumbnail}
 
@@ -496,6 +496,6 @@ Vous pouvez également [sécuriser l'accès à Prism Central](/pages/hosted_priv
 
 ## Aller plus loin <a name="go further"></a>
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.it-it.md
@@ -14,7 +14,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 > [!warning]
 > OVHcloud provides services for which you are responsible, responsible and responsible for their configuration. You are therefore responsible for ensuring that it works properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](https://www.ovhcloud.com/it/professional-services/) or a [specialist provider](https://partner.ovhcloud.com/it/directory/) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
+> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](/links/professional-services) or a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
 >
 
 **Find out how to get started with your Nutanix cluster.**
@@ -22,7 +22,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Access to your [OVHcloud Control Panel](/links/manager)
 - You must be logged in to Prism Central on the cluster
 
 > [!warning]
@@ -147,7 +147,7 @@ Open the console after restarting the VM. You can see that the VM has taken the 
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it). Open the Nutanix Cluster configuration page.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page.
 
 In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
@@ -411,7 +411,7 @@ In the system settings, enable "Remote Desktop".
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
 ![Configure Load Balancer 01 RDP](images/config-lb1-rdp.PNG){.thumbnail}
 
@@ -496,6 +496,6 @@ You can also [secure access to Prism Central](/pages/hosted_private_cloud/nutani
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.pl-pl.md
@@ -14,7 +14,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 > [!warning]
 > OVHcloud provides services for which you are responsible, responsible and responsible for their configuration. You are therefore responsible for ensuring that it works properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](https://www.ovhcloud.com/pl/professional-services/) or a [specialist provider](https://partner.ovhcloud.com/pl/directory/) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
+> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](/links/professional-services) or a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
 >
 
 **Find out how to get started with your Nutanix cluster.**
@@ -22,7 +22,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Access to your [OVHcloud Control Panel](/links/manager)
 - You must be logged in to Prism Central on the cluster
 
 > [!warning]
@@ -147,7 +147,7 @@ Open the console after restarting the VM. You can see that the VM has taken the 
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl). Open the Nutanix Cluster configuration page.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page.
 
 In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
@@ -411,7 +411,7 @@ In the system settings, enable "Remote Desktop".
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
 ![Configure Load Balancer 01 RDP](images/config-lb1-rdp.PNG){.thumbnail}
 
@@ -496,6 +496,6 @@ You can also [secure access to Prism Central](/pages/hosted_private_cloud/nutani
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/80-first-steps/guide.pt-pt.md
@@ -14,7 +14,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 > [!warning]
 > OVHcloud provides services for which you are responsible, responsible and responsible for their configuration. You are therefore responsible for ensuring that it works properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](https://www.ovhcloud.com/pt/professional-services/) or a [specialist provider](https://partner.ovhcloud.com/pt/directory/) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
+> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting the [OVHcloud Professional Services team](/links/professional-services) or a [specialist provider](/links/partner) if you experience any difficulties or doubts when it comes to administering, using or setting up a service on a server.
 >
 
 **Find out how to get started with your Nutanix cluster.**
@@ -22,7 +22,7 @@ This guide will outline the steps you need to take to get started with your Nuta
 ## Requirements
 
 - A Nutanix cluster in your OVHcloud account
-- Access to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
+- Access to your [OVHcloud Control Panel](/links/manager)
 - You must be logged in to Prism Central on the cluster
 
 > [!warning]
@@ -147,7 +147,7 @@ Open the console after restarting the VM. You can see that the VM has taken the 
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt). Open the Nutanix Cluster configuration page.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page.
 
 In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
@@ -411,7 +411,7 @@ In the system settings, enable "Remote Desktop".
 
 #### Load Balancer configuration
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
+Log in to your [OVHcloud Control Panel](/links/manager). Open the Nutanix Cluster configuration page. In the `Cluster network` box at the bottom of the page, click on the Load Balancer.
 
 ![Configure Load Balancer 01 RDP](images/config-lb1-rdp.PNG){.thumbnail}
 
@@ -496,6 +496,6 @@ You can also [secure access to Prism Central](/pages/hosted_private_cloud/nutani
 
 ## Go further <a name="gofurther"></a>
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their /links values.

Example: replace all https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB links with /links/manager.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.