### PR TITLE
Cross-link IPLB Logs-to-Customers doc in LDP Logs-to-Customers doc

### DIFF
--- a/pages/manage_and_operate/observability/logs_data_platform/introduction_to_services_logs/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/introduction_to_services_logs/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction to OVHcloud Service Logs with Logs Data Platform
 excerpt: Discover how to retrieve your OVHcloud managed products logs in Logs Data Platform
-updated: 2025-06-18
+updated: 2025-07-09
 ---
 
 ## Objective
@@ -62,7 +62,7 @@ Our ambition is to make all OVHcloud products compatible with OVHcloud Service L
 | Hosting & Collaboration - Microsoft Private Exchange | API only | Beta | - |
 | Hosting & Collaboration - Microsoft Trusted Exchange | API only | Beta | - |
 | Infrastructure solutions - OVHcloud Connect | API only | Beta | - |
-| Infrastructure solutions - OVHcloud Load Balancer | API only | Beta | - |
+| Infrastructure solutions - OVHcloud Load Balancer | API only | Beta | [OVHcloud Load Balancer TCP / HTTP / HTTPS Logs Forwarding](/pages/network/load_balancer/use_api_logs_2_customers) |
 
 ## Instructions
 


### PR DESCRIPTION
## What type of Pull Request is this?

- Update of existing guide(s)

## Description

As IPLB team made a new documentation page about IPLB + Logs-to-Customers ([here](https://help.ovhcloud.com/csm/en-ie-load-balancer-api-logs-2-customers?id=kb_article_view&sysparm_article=KB0070838)), this PR cross-link this doc in the "generic" documentation of Logs-to-Customers [here](https://help.ovhcloud.com/csm/fr-logs-data-platform-service-logs?id=kb_article_view&sysparm_article=KB0070575)

## Mandatory information

- This Pull Request can be merged as soon as possible.
- This Pull Request content should be replicated for the US OVHcloud documentation : **NO**, the feature is currently being deployed in US, but *not* deployed yet