### PR TITLE
Fix global links in Storage and backup file storage

### DIFF
--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.de-de.md
@@ -10,7 +10,7 @@ updated: 2022-11-30
 
 ## Ziel
 
-Auf dieser Seite finden Sie die Konzepte zur Bereitstellung, Überwachung und Überprüfung der Performance von [Enterprise File Storage](https://www.ovhcloud.com/de/storage-solutions/enterprise-file-storage/).
+Auf dieser Seite finden Sie die Konzepte zur Bereitstellung, Überwachung und Überprüfung der Performance von [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## In der praktischen Anwendung
 
@@ -31,7 +31,7 @@ Diese Information ist wichtig, wenn Sie Ihre Storage-Architektur entwerfen. Drei
 
 - **Beispiel 2**: Ihre Infrastruktur benötigt **4500 IOPS** und ein Datenvolumen von **1 TB**. Daher müssen Sie **2 TB** reservieren, um die erforderlichen **4500 IOPS**  zu erreichen. In diesem Fall verfügen Sie über **8000 IOPS** über die im Voraus provisionierte Kapazität. Es geht also darum, Ihren Dienst überzuprovisionieren, um das gewünschte Leistungsniveau zu gewährleisten.
 
-- **Beispiel 3**: Ihre Anwendung benötigt keine bestimmte Leistung, aber ein Speichervolumen von mehr als **60 TB**. In diesem Fall ist es ratsam, auf den kostengünstigeren Speicherdienst [HA-NAS](https://www.ovhcloud.com/de/storage-solutions/nas-ha/) zu wechseln, der Kapazitäten von mehr als 58 TB pro Dienst ermöglicht.
+- **Beispiel 3**: Ihre Anwendung benötigt keine bestimmte Leistung, aber ein Speichervolumen von mehr als **60 TB**. In diesem Fall ist es ratsam, auf den kostengünstigeren Speicherdienst [HA-NAS](/links/storage/nas-ha) zu wechseln, der Kapazitäten von mehr als 58 TB pro Dienst ermöglicht.
 
 ### Volumes und Dienstqualität (QoS)
 
@@ -74,6 +74,6 @@ Weitere Informationen finden Sie in [FIO-Dokumentation](https://fio.readthedocs.
 
 ## Weiterführende Informationen
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Treten Sie unserer Benutzergemeinschaft auf Discord bei: <https://discord.gg/jW2FgBJ72h>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-asia.md
@@ -6,7 +6,7 @@ updated: 2022-11-30
 
 ## Objective
 
-Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](https://www.ovhcloud.com/asia/storage-solutions/enterprise-file-storage/).
+Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## Instructions
 
@@ -27,7 +27,7 @@ This information is important when you design your storage architecture. Let’s
 
 - **Example 2**: Your infrastructure requires **4500 IOPS** and a data volume of **1 TB**. To do this, you need to provision **2 TB** to get the **required 4500 IOPS**. Specifically, you will get **8000 IOPS** on provisioned capacity. This involves overprovisioning your service to ensure the level of performance you want.
 
-- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](https://www.ovhcloud.com/asia/storage-solutions/nas-ha/), which can reach capacities higher than 58 TB per service.
+- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](/links/storage/nas-ha), which can reach capacities higher than 58 TB per service.
 
 ### Volumes and quality of services (QoS)
 
@@ -70,6 +70,6 @@ For more information, see [the FIO documentation](https://fio.readthedocs.io/en/
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of Discord users: <https://discord.gg/jW2FgBJ72h>

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-au.md
@@ -6,7 +6,7 @@ updated: 2022-11-30
 
 ## Objective
 
-Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](https://www.ovhcloud.com/en-au/storage-solutions/enterprise-file-storage/).
+Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## Instructions
 
@@ -27,7 +27,7 @@ This information is important when you design your storage architecture. Let’s
 
 - **Example 2**: Your infrastructure requires **4500 IOPS** and a data volume of **1 TB**. To do this, you need to provision **2 TB** to get the **required 4500 IOPS**. Specifically, you will get **8000 IOPS** on provisioned capacity. This involves overprovisioning your service to ensure the level of performance you want.
 
-- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](https://www.ovhcloud.com/en-au/storage-solutions/nas-ha/), which can reach capacities higher than 58 TB per service.
+- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](/links/storage/nas-ha), which can reach capacities higher than 58 TB per service.
 
 ### Volumes and quality of services (QoS)
 
@@ -70,6 +70,6 @@ For more information, see [the FIO documentation](https://fio.readthedocs.io/en/
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of Discord users: <https://discord.gg/jW2FgBJ72h>

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-ca.md
@@ -6,7 +6,7 @@ updated: 2022-11-30
 
 ## Objective
 
-Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](https://www.ovhcloud.com/en-ca/storage-solutions/enterprise-file-storage/).
+Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## Instructions
 
@@ -27,7 +27,7 @@ This information is important when you design your storage architecture. Let’s
 
 - **Example 2**: Your infrastructure requires **4500 IOPS** and a data volume of **1 TB**. To do this, you need to provision **2 TB** to get the **required 4500 IOPS**. Specifically, you will get **8000 IOPS** on provisioned capacity. This involves overprovisioning your service to ensure the level of performance you want.
 
-- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](https://www.ovhcloud.com/en-ca/storage-solutions/nas-ha/), which can reach capacities higher than 58 TB per service.
+- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](/links/storage/nas-ha), which can reach capacities higher than 58 TB per service.
 
 ### Volumes and quality of services (QoS)
 
@@ -70,6 +70,6 @@ For more information, see [the FIO documentation](https://fio.readthedocs.io/en/
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of Discord users: <https://discord.gg/jW2FgBJ72h>

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-gb.md
@@ -6,7 +6,7 @@ updated: 2022-11-30
 
 ## Objective
 
-Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](https://www.ovhcloud.com/en-gb/storage-solutions/enterprise-file-storage/).
+Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## Instructions
 
@@ -27,7 +27,7 @@ This information is important when you design your storage architecture. Let’s
 
 - **Example 2**: Your infrastructure requires **4500 IOPS** and a data volume of **1 TB**. To do this, you need to provision **2 TB** to get the **required 4500 IOPS**. Specifically, you will get **8000 IOPS** on provisioned capacity. This involves overprovisioning your service to ensure the level of performance you want.
 
-- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60 TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](https://www.ovhcloud.com/en-gb/storage-solutions/nas-ha/), which can reach capacities higher than 58 TB per service.
+- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60 TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](/links/storage/nas-ha), which can reach capacities higher than 58 TB per service.
 
 ### Volumes and quality of services (QoS)
 
@@ -70,6 +70,6 @@ For more information, see [the FIO documentation](https://fio.readthedocs.io/en/
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of Discord users: <https://discord.gg/jW2FgBJ72h>

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-ie.md
@@ -6,7 +6,7 @@ updated: 2022-11-30
 
 ## Objective
 
-Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](https://www.ovhcloud.com/en-ie/storage-solutions/enterprise-file-storage/).
+Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## Instructions
 
@@ -27,7 +27,7 @@ This information is important when you design your storage architecture. Let’s
 
 - **Example 2**: Your infrastructure requires **4500 IOPS** and a data volume of **1 TB**. To do this, you need to provision **2 TB** to get the **required 4500 IOPS**. Specifically, you will get **8000 IOPS** on provisioned capacity. This involves overprovisioning your service to ensure the level of performance you want.
 
-- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](https://www.ovhcloud.com/en-ie/storage-solutions/nas-ha/), which can reach capacities higher than 58 TB per service.
+- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](/links/storage/nas-ha), which can reach capacities higher than 58 TB per service.
 
 ### Volumes and quality of services (QoS)
 
@@ -70,6 +70,6 @@ For more information, see [the FIO documentation](https://fio.readthedocs.io/en/
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of Discord users: <https://discord.gg/jW2FgBJ72h>

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-sg.md
@@ -6,7 +6,7 @@ updated: 2022-11-30
 
 ## Objective
 
-Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](https://www.ovhcloud.com/en-sg/storage-solutions/enterprise-file-storage/).
+Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## Instructions
 
@@ -27,7 +27,7 @@ This information is important when you design your storage architecture. Let’s
 
 - **Example 2**: Your infrastructure requires **4500 IOPS** and a data volume of **1 TB**. To do this, you need to provision **2 TB** to get the **required 4500 IOPS**. Specifically, you will get **8000 IOPS** on provisioned capacity. This involves overprovisioning your service to ensure the level of performance you want.
 
-- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](https://www.ovhcloud.com/en-sg/storage-solutions/nas-ha/), which can reach capacities higher than 58 TB per service.
+- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](/links/storage/nas-ha), which can reach capacities higher than 58 TB per service.
 
 ### Volumes and quality of services (QoS)
 
@@ -70,6 +70,6 @@ For more information, see [the FIO documentation](https://fio.readthedocs.io/en/
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of Discord users: <https://discord.gg/jW2FgBJ72h>

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.en-us.md
@@ -6,7 +6,7 @@ updated: 2022-11-30
 
 ## Objective
 
-Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](https://www.ovhcloud.com/en/storage-solutions/enterprise-file-storage/).
+Learn about the concepts of provisioning, tracking, and performance testing for [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## Instructions
 
@@ -27,7 +27,7 @@ This information is important when you design your storage architecture. Let’s
 
 - **Example 2**: Your infrastructure requires **4500 IOPS** and a data volume of **1 TB**. To do this, you need to provision **2 TB** to get the **required 4500 IOPS**. Specifically, you will get **8000 IOPS** on provisioned capacity. This involves overprovisioning your service to ensure the level of performance you want.
 
-- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](https://www.ovhcloud.com/en/storage-solutions/nas-ha/), which can reach capacities higher than 58 TB per service.
+- **Example 3**: Your application does not require any particular performance but a storage volume of more than **60TB**. In this case, it is best to switch to the more economical storage service [HA-NAS](/links/storage/nas-ha), which can reach capacities higher than 58 TB per service.
 
 ### Volumes and quality of services (QoS)
 
@@ -70,6 +70,6 @@ For more information, see [the FIO documentation](https://fio.readthedocs.io/en/
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of Discord users: <https://discord.gg/jW2FgBJ72h>

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.es-es.md
@@ -10,7 +10,7 @@ updated: 2022-11-30
 
 ## Objetivo
 
-Descubra los conceptos relacionados con el aprovisionamiento, el seguimiento y la prueba del rendimiento de la solución [Enterprise File Storage](https://www.ovhcloud.com/es-es/storage-solutions/enterprise-file-storage/).
+Descubra los conceptos relacionados con el aprovisionamiento, el seguimiento y la prueba del rendimiento de la solución [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## Procedimiento
 
@@ -31,7 +31,7 @@ Esta información es importante al diseñar la arquitectura de almacenamiento. V
 
 - **Ejemplo n°2**: su infraestructura necesita **4500 IOPS** y un volumen de datos de **1 TB**. Para ello, debe aprovisionar **2 TB** para obtener las **4500 IOPS necesarias**. Más específicamente en este caso, disfrutará de **8000 IOPS** sobre la capacidad aprovisionada. Por lo tanto, el objetivo es recargar el servicio para garantizar el nivel de rendimiento deseado.
 
-- **Ejemplo n°3**: su aplicación no necesita un rendimiento en particular, pero un volumen de almacenamiento de más de **60 TB**. En ese caso, es preferible optar por el servicio de almacenamiento [NAS-HA](https://www.ovhcloud.com/es-es/storage-solutions/nas-ha/), más económico y que permite alcanzar una capacidad superior a 58 TB por servicio.
+- **Ejemplo n°3**: su aplicación no necesita un rendimiento en particular, pero un volumen de almacenamiento de más de **60 TB**. En ese caso, es preferible optar por el servicio de almacenamiento [NAS-HA](/links/storage/nas-ha), más económico y que permite alcanzar una capacidad superior a 58 TB por servicio.
 
 ### volúmenes y calidad de servicios (QoS)
 
@@ -74,6 +74,6 @@ Más información sobre [la documentación de FIO](https://fio.readthedocs.io/en
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en Discord : <https://discord.gg/jW2FgBJ72h>

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.es-us.md
@@ -10,7 +10,7 @@ updated: 2022-11-30
 
 ## Objetivo
 
-Descubra los conceptos relacionados con el aprovisionamiento, el seguimiento y la prueba del rendimiento de la solución [Enterprise File Storage](https://www.ovhcloud.com/es/storage-solutions/enterprise-file-storage/).
+Descubra los conceptos relacionados con el aprovisionamiento, el seguimiento y la prueba del rendimiento de la solución [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## Procedimiento
 
@@ -31,7 +31,7 @@ Esta información es importante al diseñar la arquitectura de almacenamiento. V
 
 - **Ejemplo n°2**: su infraestructura necesita **4500 IOPS** y un volumen de datos de **1 TB**. Para ello, debe aprovisionar **2 TB** para obtener las **4500 IOPS necesarias**. Más específicamente en este caso, disfrutará de **8000 IOPS** sobre la capacidad aprovisionada. Por lo tanto, el objetivo es recargar el servicio para garantizar el nivel de rendimiento deseado.
 
-- **Ejemplo n°3**: su aplicación no necesita un rendimiento en particular, pero un volumen de almacenamiento de más de **60 TB**. En ese caso, es preferible optar por el servicio de almacenamiento [NAS-HA](https://www.ovhcloud.com/es/storage-solutions/nas-ha/), más económico y que permite alcanzar una capacidad superior a 58 TB por servicio.
+- **Ejemplo n°3**: su aplicación no necesita un rendimiento en particular, pero un volumen de almacenamiento de más de **60 TB**. En ese caso, es preferible optar por el servicio de almacenamiento [NAS-HA](/links/storage/nas-ha), más económico y que permite alcanzar una capacidad superior a 58 TB por servicio.
 
 ### volúmenes y calidad de servicios (QoS)
 
@@ -74,6 +74,6 @@ Más información sobre [la documentación de FIO](https://fio.readthedocs.io/en
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en Discord : <https://discord.gg/jW2FgBJ72h>

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.fr-ca.md
@@ -6,7 +6,7 @@ updated: 2022-11-30
 
 ## Objectif
 
-Découvrez les concepts liés au provisionnement, au suivi ainsi qu'au test des performances de la solution [Enterprise File Storage](https://www.ovhcloud.com/fr-ca/storage-solutions/enterprise-file-storage/).
+Découvrez les concepts liés au provisionnement, au suivi ainsi qu'au test des performances de la solution [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## En pratique
 
@@ -27,7 +27,7 @@ Cette information est importante lorsque vous concevez votre architecture de sto
 
 - **Exemple n°2** : votre infrastructure nécessite **4500 IOPS** et un volume de données de **1 To**. Pour cela, vous devez provisionner **2 To** pour obtenir les **4500 IOPS nécessaires**. Plus spécifiquement dans ce cas, vous bénéficierez de **8000 IOPS** sur la capacité provisionnée. Il s’agit donc de sur-provisionner votre service afin d’assurer le niveau de performances souhaité.
 
-- **Exemple n°3** : votre application ne nécessite pas de performance en particulier mais un volume de stockage de plus de **60 To**. Dans ce cas, il est préférable de s’orienter vers le service de stockage [NAS-HA](https://www.ovhcloud.com/fr-ca/storage-solutions/nas-ha/), plus économique et permettant d’atteindre des capacités supérieures à 58 To par service.
+- **Exemple n°3** : votre application ne nécessite pas de performance en particulier mais un volume de stockage de plus de **60 To**. Dans ce cas, il est préférable de s’orienter vers le service de stockage [NAS-HA](/links/storage/nas-ha), plus économique et permettant d’atteindre des capacités supérieures à 58 To par service.
 
 ### Volumes et qualité de services (QoS)
 
@@ -70,7 +70,7 @@ Retrouvez plus d'informations sur [la documentation de FIO](https://fio.readthed
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre communauté d’utilisateurs sur Discord : <https://discord.gg/jW2FgBJ72h>
 

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.fr-fr.md
@@ -6,7 +6,7 @@ updated: 2022-11-30
 
 ## Objectif
 
-Découvrez les concepts liés au provisionnement, au suivi ainsi qu'au test des performances de la solution [Enterprise File Storage](https://www.ovhcloud.com/fr/storage-solutions/enterprise-file-storage/).
+Découvrez les concepts liés au provisionnement, au suivi ainsi qu'au test des performances de la solution [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## En pratique
 
@@ -27,7 +27,7 @@ Cette information est importante lorsque vous concevez votre architecture de sto
 
 - **Exemple n°2** : votre infrastructure nécessite **4500 IOPS** et un volume de données de **1 To**. Pour cela, vous devez provisionner **2 To** pour obtenir les **4500 IOPS nécessaires**. Plus spécifiquement dans ce cas, vous bénéficierez de **8000 IOPS** sur la capacité provisionnée. Il s’agit donc de sur-provisionner votre service afin d’assurer le niveau de performances souhaité.
 
-- **Exemple n°3** : votre application ne nécessite pas de performance en particulier mais un volume de stockage de plus de **60 To**. Dans ce cas, il est préférable de s’orienter vers le service de stockage [NAS-HA](https://www.ovhcloud.com/fr/storage-solutions/nas-ha/), plus économique et permettant d’atteindre des capacités supérieures à 58 To par service.
+- **Exemple n°3** : votre application ne nécessite pas de performance en particulier mais un volume de stockage de plus de **60 To**. Dans ce cas, il est préférable de s’orienter vers le service de stockage [NAS-HA](/links/storage/nas-ha), plus économique et permettant d’atteindre des capacités supérieures à 58 To par service.
 
 ### Volumes et qualité de services (QoS)
 
@@ -70,7 +70,7 @@ Retrouvez plus d'informations sur [la documentation de FIO](https://fio.readthed
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre communauté d’utilisateurs sur Discord : <https://discord.gg/jW2FgBJ72h>
 

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.it-it.md
@@ -11,7 +11,7 @@ updated: 2022-11-30
 
 ## Obiettivo
 
-Scopri i concetti di approvvigionamento, monitoraggio e test delle performance della soluzione [Enterprise File Storage](https://www.ovhcloud.com/it/storage-solutions/enterprise-file-storage/).
+Scopri i concetti di approvvigionamento, monitoraggio e test delle performance della soluzione [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## Procedura
 
@@ -32,7 +32,7 @@ Questa informazione è importante quando progettate l'architettura di storage. P
 
 - **Esempio n°2**: la tua infrastruttura richiede **4500 IOPS** e un volume di dati di **1 TB**. Per effettuare questa operazione è necessario disporre **2 TB** per ottenere **4500 IOPS necessari**. In particolare, usufruisci di **8000 IOPS** sulla capacità attivata. Per garantire il livello di prestazioni desiderato, è necessario sovrintendere il servizio.
 
-- **Esempio n. 3**: le performance delle applicazioni non sono particolarmente elevate ma un volume di storage superiore a **60 TB**. In questo caso, è preferibile orientarsi verso il servizio di archiviazione [NAS-HA](https://www.ovhcloud.com/it/storage-solutions/nas-ha/), più economico e che permette di raggiungere capacità superiori a 58 TB per servizio.
+- **Esempio n. 3**: le performance delle applicazioni non sono particolarmente elevate ma un volume di storage superiore a **60 TB**. In questo caso, è preferibile orientarsi verso il servizio di archiviazione [NAS-HA](/links/storage/nas-ha), più economico e che permette di raggiungere capacità superiori a 58 TB per servizio.
 
 ### Volumi e qualità dei servizi (QoS)
 
@@ -75,6 +75,6 @@ Per maggiori informazioni, consulta la [documentazione di FIO](https://fio.readt
 
 ## Per saperne di più
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti su Discord: <https://discord.gg/jW2FgBJ72h>

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.pl-pl.md
@@ -10,7 +10,7 @@ updated: 2022-11-30
 
 ## Wprowadzenie
 
-Poznaj pojęcia związane z tworzeniem rezerw, monitorowaniem oraz testowaniem wydajności rozwiązania [Enterprise File Storage](https://www.ovhcloud.com/pl/storage-solutions/enterprise-file-storage/).
+Poznaj pojęcia związane z tworzeniem rezerw, monitorowaniem oraz testowaniem wydajności rozwiązania [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## W praktyce
 
@@ -31,7 +31,7 @@ Informacja ta jest ważna w przypadku architektury przestrzeni dyskowej. Przytoc
 
 - **Przykład nr 2**: Twoja infrastruktura wymaga **4500 IOPS** i ilości danych **1 TB**. W tym celu należy zapewnić zapasy **2 TB**, aby otrzymać **niezbędne 4500 IOPS**. W tym przypadku skorzystasz z **8000 IOPS** w przypadku wykorzystania dodatkowej pojemności. Chodzi zatem o nadmierne dostarczanie usługi, aby zapewnić pożądany poziom wydajności.
 
-- **Przykład nr 3**: Twoja aplikacja nie wymaga szczególnie dużej wydajności, ale przestrzeni dyskowej większej niż **60 TB**. W takim przypadku lepiej jest wybrać usługę przestrzeni dyskowej [NAS-HA](https://www.ovhcloud.com/pl/storage-solutions/nas-ha/), która jest bardziej ekonomiczna i pozwala na osiągnięcie wydajności przekraczającej 58 TB na usługę.
+- **Przykład nr 3**: Twoja aplikacja nie wymaga szczególnie dużej wydajności, ale przestrzeni dyskowej większej niż **60 TB**. W takim przypadku lepiej jest wybrać usługę przestrzeni dyskowej [NAS-HA](/links/storage/nas-ha), która jest bardziej ekonomiczna i pozwala na osiągnięcie wydajności przekraczającej 58 TB na usługę.
 
 ### Liczba woluminów i jakości usług (QoS)
 
@@ -74,6 +74,6 @@ Więcej informacji znajduje się na stronie [dokumentacja FIO](https://fio.readt
 
 ## Sprawdź również
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Przyłącz się do społeczności naszych użytkowników na Discord: <https://discord.gg/jW2FgBJ72h>

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_concepts_performances/guide.pt-pt.md
@@ -10,7 +10,7 @@ updated: 2022-11-30
 
 ## Objetivo
 
-Descubra os conceitos relacionados com o aprovisionamento, o acompanhamento e o teste de desempenho da solução [Enterprise File Storage](https://www.ovhcloud.com/pt/storage-solutions/enterprise-file-storage/).
+Descubra os conceitos relacionados com o aprovisionamento, o acompanhamento e o teste de desempenho da solução [Enterprise File Storage](/links/storage/enterprise-file-storage).
 
 ## Instruções
 
@@ -31,7 +31,7 @@ Esta informação é importante quando desenvolve a sua arquitetura de armazenam
 
 - **Exemplo n°2**: a sua infraestrutura requer **4500 IOPS** e um volume de dados de **1 TB**. Para isso, é necessário aprovisionar **2 TB** para obter os **4500 IOPS necessários**. Mais especificamente neste caso, beneficiará de **8000 IOPS** sobre a capacidade provisionada. Trata-se de aprovisionar o seu serviço de forma a assegurar o nível de desempenho desejado.
 
-- **Exemplo n°3**: a sua aplicação não requer performance particular, mas um volume de armazenamento superior a **60 TB**. Neste caso, é preferível orientar-se para o serviço de armazenamento [NAS-HA](https://www.ovhcloud.com/pt/storage-solutions/nas-ha/), mais económico e que permite atingir capacidades superiores a 58 TB por serviço.
+- **Exemplo n°3**: a sua aplicação não requer performance particular, mas um volume de armazenamento superior a **60 TB**. Neste caso, é preferível orientar-se para o serviço de armazenamento [NAS-HA](/links/storage/nas-ha), mais económico e que permite atingir capacidades superiores a 58 TB por serviço.
 
 ### volumes e qualidade de serviços (QoS)
 
@@ -74,6 +74,6 @@ Encontre mais informações sobre [a documentação do FIO](https://fio.readthed
 
 ## Quer saber mais?
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Fale com a nossa comunidade de utilizadores no Discord: <https://discord.gg/jW2FgBJ72h>

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_control_panel/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_control_panel/guide.es-us.md
@@ -16,12 +16,12 @@ Los servicios Enterprise File Storage pueden administrarse [a través de la API 
 
 ## Requisitos
 
-- Tener un servicio Enterprise File Storage en su cuenta de OVHcloud. El servicio puede contratarse desde la [página del producto](https://www.ovhcloud.com/es/storage-solutions/enterprise-file-storage/) o desde el [área de cliente de OVHcloud](https://www.ovh.com/manager/#/dedicated/netapp/new).
-- Tienes acceso a tu [Panel de configuración de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws).
+- Tener un servicio Enterprise File Storage en su cuenta de OVHcloud. El servicio puede contratarse desde la [página del producto](/links/storage/enterprise-file-storage) o desde el [área de cliente de OVHcloud](https://www.ovh.com/manager/#/dedicated/netapp/new).
+- Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager).
 
 ## Procedimiento <a name="instructions"></a>
 
-Conéctese al [Panel de configuración de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) y seleccione `Bare Metal Cloud`{.action} en la barra de navegación superior. Abra `Storage y Backup`{.action}, luego `Enterprise File Storage`{.action} en el menú de la izquierda y seleccione su servicio de la lista.
+Conéctese al [Panel de configuración de OVHcloud](/links/manager) y seleccione `Bare Metal Cloud`{.action} en la barra de navegación superior. Abra `Storage y Backup`{.action}, luego `Enterprise File Storage`{.action} en el menú de la izquierda y seleccione su servicio de la lista.
 
 ![Información general](images/manage_enterprise01.png){.thumbnail}
 
@@ -148,6 +148,6 @@ Si no está familiarizado con la solución Enterprise File Storage, puede seguir
 
 [Enterprise File Storage - Gestión de snapshots de volúmenes](/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_control_panel/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_control_panel/guide.pl-pl.md
@@ -17,7 +17,7 @@ Usługi Enterprise File Storage mogą być zarządzane [za pośrednictwem API OV
 
 ## W praktyce <a name="instructions"></a>
 
-Zaloguj się do [Panelu client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) i wybierz `Bare Metal Cloud`{.action} na górnym pasku nawigacji. Otwórz `Storage i Backup`{.action}, a następnie `Enterprise File Storage`{.action} w menu po lewej stronie i wybierz Twoją usługę z listy.
+Zaloguj się do [Panelu client OVHcloud](/links/manager) i wybierz `Bare Metal Cloud`{.action} na górnym pasku nawigacji. Otwórz `Storage i Backup`{.action}, a następnie `Enterprise File Storage`{.action} w menu po lewej stronie i wybierz Twoją usługę z listy.
 
 ![Informacje ogólne](images/manage_enterprise01.png){.thumbnail}
 

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_control_panel/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_control_panel/guide.pt-pt.md
@@ -212,7 +212,7 @@ Se não está familiarizado com a utilização da solução Enterprise File Stor
 
 [Enterprise File Storage - Gestão das snapshots de volumes](/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots)
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
 

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.de-de.md
@@ -28,7 +28,7 @@ Mit dieser Lösung können auch komplexere praktische Fälle wie "on-premise" Wo
 
 ### Kann Enterprise File Storage über das Kundencenter verwaltet werden?
 
-Ja, diese Dienstleistung ist direkt über Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) erreichbar, im Bereich `Bare Metal Cloud`{.action}, dann `Storage und Backup`{.action}.
+Ja, diese Dienstleistung ist direkt über Ihr [OVHcloud Kundencenter](/links/manager) erreichbar, im Bereich `Bare Metal Cloud`{.action}, dann `Storage und Backup`{.action}.
 
 ## Verfügbarkeit
 
@@ -136,6 +136,6 @@ Enterprise File Storage ist ein Dienst, der monatlich nach Volumen abgerechnet w
 
 ## Weiterführende Informationen
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.en-asia.md
@@ -24,7 +24,7 @@ This solution can also be used to address more complex, practical cases, such as
 
 ### Can Enterprise File Storage be managed from the OVHcloud Control Panel?
 
-Yes, you can access this service directly from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) by going to the `Bare Metal Cloud`{.action} section, then `Storage and Backup`{.action}.
+Yes, you can access this service directly from your [OVHcloud Control Panel](/links/manager) by going to the `Bare Metal Cloud`{.action} section, then `Storage and Backup`{.action}.
 
 ## Availability
 
@@ -132,6 +132,6 @@ Enterprise File Storage is a service that is billed monthly by volume (from 1 TB
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.en-au.md
@@ -24,7 +24,7 @@ This solution can also be used to address more complex, practical cases, such as
 
 ### Can Enterprise File Storage be managed from the OVHcloud Control Panel?
 
-Yes, you can access this service directly from your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) by going to the `Bare Metal Cloud`{.action} section, then `Storage and Backup`{.action}.
+Yes, you can access this service directly from your [OVHcloud Control Panel](/links/manager) by going to the `Bare Metal Cloud`{.action} section, then `Storage and Backup`{.action}.
 
 ## Availability
 
@@ -132,6 +132,6 @@ Enterprise File Storage is a service that is billed monthly by volume (from 1 TB
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.es-es.md
@@ -28,7 +28,7 @@ Esta solución también permite dar respuesta a casos prácticos más complejos,
 
 ### ¿Se puede gestionar Enterprise File Storage desde el área de cliente?
 
-Sí, puede acceder directamente a este servicio desde el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es), en la sección `Bare Metal Cloud`{.action} y, seguidamente, en la sección `Almacenamiento y Backup`{.action}".
+Sí, puede acceder directamente a este servicio desde el [área de cliente de OVHcloud](/links/manager), en la sección `Bare Metal Cloud`{.action} y, seguidamente, en la sección `Almacenamiento y Backup`{.action}".
 
 ## Disponibilidad
 
@@ -136,6 +136,6 @@ Enterprise File Storage es un servicio con facturación mensual por volumen (de 
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.es-us.md
@@ -28,7 +28,7 @@ Esta solución también permite dar respuesta a casos prácticos más complejos,
 
 ### ¿Se puede gestionar Enterprise File Storage desde el área de cliente?
 
-Sí, puede acceder directamente a este servicio desde el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws), en la sección `Bare Metal Cloud`{.action} y, seguidamente, en la sección `Almacenamiento y Backup`{.action}".
+Sí, puede acceder directamente a este servicio desde el [área de cliente de OVHcloud](/links/manager), en la sección `Bare Metal Cloud`{.action} y, seguidamente, en la sección `Almacenamiento y Backup`{.action}".
 
 ## Disponibilidad
 
@@ -136,6 +136,6 @@ Enterprise File Storage es un servicio con facturación mensual por volumen (de 
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.fr-ca.md
@@ -24,7 +24,7 @@ Cette solution permet également de répondre à des cas pratiques plus complexe
 
 ### Peut-on gérer Enterprise File Storage depuis l’espace client ?
 
-Oui, ce service est directement accessible depuis votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc), dans la rubrique `Bare Metal Cloud`{.action} puis `Storage et Backup`{.action}.
+Oui, ce service est directement accessible depuis votre [espace client OVHcloud](/links/manager), dans la rubrique `Bare Metal Cloud`{.action} puis `Storage et Backup`{.action}.
 
 ## Disponibilité
 
@@ -132,6 +132,6 @@ Enterprise File Storage est un service facturé mensuellement au volume (de 1 à
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.it-it.md
@@ -28,7 +28,7 @@ Questa soluzione permette anche di rispondere a casi pratici più complessi, com
 
 ### È possibile gestire Enterprise File Storage dallo Spazio Cliente OVH?
 
-Sì, il servizio è direttamente accessibile dallo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it), nella sezione `Bare Metal Cloud`{.action}, poi `Storage e Backup`{.action}.
+Sì, il servizio è direttamente accessibile dallo [Spazio Cliente OVHcloud](/links/manager), nella sezione `Bare Metal Cloud`{.action}, poi `Storage e Backup`{.action}.
 
 ## Disponibilità
 
@@ -136,6 +136,6 @@ Enterprise File Storage è un servizio fatturato mensilmente al volume (da 1 a 5
 
 ## Per saperne di più
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.pl-pl.md
@@ -28,7 +28,7 @@ Rozwiązanie to pozwala również na rozwiązanie bardziej złożonych problemó
 
 ### Czy można zarządzać Enterprise File Storage w Panelu klienta?
 
-Tak, usługa ta jest dostępna bezpośrednio w [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl), w sekcji `Bare Metal Cloud`{.action}, następnie `Storage i Backup`{.action}.
+Tak, usługa ta jest dostępna bezpośrednio w [Panelu klienta OVHcloud](/links/manager), w sekcji `Bare Metal Cloud`{.action}, następnie `Storage i Backup`{.action}.
 
 ## Dostępność
 
@@ -136,6 +136,6 @@ Enterprise File Storage to usługa płatna co miesiąc za wolumen (od 1 do 58 TB
 
 ## Sprawdź również
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na stronie<https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_faq/guide.pt-pt.md
@@ -28,7 +28,7 @@ Esta solução permite igualmente responder a casos práticos mais complexos, qu
 
 ### Posso gerir o Enterprise File Storage a partir da Área de Cliente?
 
-Sim, este serviço está diretamente acessível a partir da sua [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt), na secção `Bare Metal Cloud`{.action} e depois `Armazenamento e Backup`{.action}.
+Sim, este serviço está diretamente acessível a partir da sua [Área de Cliente OVHcloud](/links/manager), na secção `Bare Metal Cloud`{.action} e depois `Armazenamento e Backup`{.action}.
 
 ## Disponibilidade
 
@@ -136,6 +136,6 @@ Enterprise File Storage é um serviço faturado mensalmente ao volume (de 1 a 58
 
 ## Saiba mais
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Fale com a nossa comunidade de utilizadores em <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_nfs_client_considerations/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_nfs_client_considerations/guide.it-it.md
@@ -52,6 +52,6 @@ Tuttavia, se si verificano errori di tipo "invalid device error" durante alcune 
 
 ## Per saperne di più
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra [Community di utenti](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.de-de.md
@@ -238,6 +238,6 @@ Sie können Ihr Volume mit folgender Route löschen:
 
 ## Weiterführende Informationen
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-asia.md
@@ -234,6 +234,6 @@ You can remove your volume using the following route:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-au.md
@@ -234,6 +234,6 @@ You can remove your volume using the following route:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-ca.md
@@ -234,6 +234,6 @@ You can remove your volume using the following route:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-gb.md
@@ -234,6 +234,6 @@ You can remove your volume using the following route:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-ie.md
@@ -234,6 +234,6 @@ You can remove your volume using the following route:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-sg.md
@@ -234,6 +234,6 @@ You can remove your volume using the following route:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.en-us.md
@@ -234,6 +234,6 @@ You can remove your volume using the following route:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.es-es.md
@@ -238,6 +238,6 @@ Puede eliminar el volumen utilizando la siguiente ruta de la API:
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.es-us.md
@@ -17,7 +17,7 @@ Esta guía explica cómo empezar con Enterprise File Storage.
 ## Requisitos
 
 - Tener contratado un plan Enterprise File Storage de OVHcloud.
-- Estar conectado a la página de las [API de OVHcloud](https://ca.api.ovh.com/)
+- Estar conectado a la página de las [API de OVHcloud](/links/api)
 - Saber [montar un NAS mediante NFS](/pages/storage_and_backup/file_storage/ha_nas/nas_nfs)
 
 ## Lo esencial
@@ -238,6 +238,6 @@ Puede eliminar el volumen utilizando la siguiente ruta de la API:
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.fr-ca.md
@@ -13,7 +13,7 @@ Dans ce guide de démarrage rapide, découvrez comment débuter sur votre offre 
 ## Prérequis
 
 - Disposer d'une offre OVHcloud Enterprise File Storage
-- Être connecté sur la page des [API OVHcloud](https://ca.api.ovh.com/)
+- Être connecté sur la page des [API OVHcloud](/links/api)
 - Savoir [monter un partage NFS](/pages/storage_and_backup/file_storage/ha_nas/nas_nfs)
 
 ## L'essentiel
@@ -234,6 +234,6 @@ Vous pouvez supprimer votre volume à l'aide de la route API suivante :
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.fr-fr.md
@@ -234,6 +234,6 @@ Vous pouvez supprimer votre volume à l'aide de la route API suivante :
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.it-it.md
@@ -238,6 +238,6 @@ Puoi eliminare il tuo volume utilizzando la strada API seguente:
 
 ## Per saperne di più
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.pl-pl.md
@@ -238,6 +238,6 @@ Możesz usunąć wolumen za pomocą następującej drogi API:
 
 ## Sprawdź również
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_quick_start/guide.pt-pt.md
@@ -238,6 +238,6 @@ Pode eliminar o seu volume através da seguinte rota API:
 
 ## Quer saber mais?
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Fale com a nossa comunidade de utilizadores: <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.de-de.md
@@ -16,7 +16,7 @@ Sie können ein Volume mithilfe der Funktion *snapshot revert* auf den Stand des
 
 ## Voraussetzungen
 
-- Sie nutzen [OVHcloud Enterprise File Storage](https://www.ovhcloud.com/en-gb/storage-solutions/enterprise-file-storage/) und verfügen über ein Volume.
+- Sie nutzen [OVHcloud Enterprise File Storage](/links/storage/enterprise-file-storage) und verfügen über ein Volume.
 - Sie können sich in der [OVHcloud API-Konsole](https://api.ovh.com/) einloggen.
 
 ## Grundlagen
@@ -149,6 +149,6 @@ Das Volume wird jetzt auf den ausgewählten Snapshot zurückgesetzt.
 
 ## Weiterführende Informationen <a name="go-further"></a>
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-asia.md
@@ -13,7 +13,7 @@ In this guide, we will provide an overview of how you can revert a volume to its
 ## Requirements
 
 - An OVHcloud Enterprise File Storage service with an available volume
-- Access to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API](/links/api)
 
 ## Basics
 
@@ -145,6 +145,6 @@ The volume is now restored to the selected snapshot.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-au.md
@@ -13,7 +13,7 @@ In this guide, we will provide an overview of how you can revert a volume to its
 ## Requirements
 
 - An OVHcloud Enterprise File Storage service with an available volume
-- Access to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API](/links/api)
 
 ## Basics
 
@@ -145,6 +145,6 @@ The volume is now restored to the selected snapshot.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-ca.md
@@ -13,7 +13,7 @@ In this guide, we will provide an overview of how you can revert a volume to its
 ## Requirements
 
 - An OVHcloud Enterprise File Storage service with an available volume
-- Access to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API](/links/api)
 
 ## Basics
 
@@ -145,6 +145,6 @@ The volume is now restored to the selected snapshot.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-gb.md
@@ -145,6 +145,6 @@ The volume is now restored to the selected snapshot.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-ie.md
@@ -145,6 +145,6 @@ The volume is now restored to the selected snapshot.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-sg.md
@@ -13,7 +13,7 @@ In this guide, we will provide an overview of how you can revert a volume to its
 ## Requirements
 
 - An OVHcloud Enterprise File Storage service with an available volume
-- Access to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API](/links/api)
 
 ## Basics
 
@@ -145,6 +145,6 @@ The volume is now restored to the selected snapshot.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.en-us.md
@@ -13,7 +13,7 @@ In this guide, we will provide an overview of how you can revert a volume to its
 ## Requirements
 
 - An OVHcloud Enterprise File Storage service with an available volume
-- Access to the [OVHcloud API](https://ca.api.ovh.com/)
+- Access to the [OVHcloud API](/links/api)
 
 ## Basics
 
@@ -145,6 +145,6 @@ The volume is now restored to the selected snapshot.
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.es-es.md
@@ -149,6 +149,6 @@ El volumen se restaurará en el snapshot seleccionado.
 
 ## Más información <a name="go-further"></a>
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.es-us.md
@@ -17,7 +17,7 @@ Esta guía explica cómo restaurar un volumen a su último snapshot utilizando l
 ## Requisitos
 
 - Disponer de una solución OVHcloud Enterprise File Storage con un volumen
-- Estar conectado a la [API de OVHcloud](https://ca.api.ovh.com/)
+- Estar conectado a la [API de OVHcloud](/links/api)
 
 ## Principios básicos
 
@@ -149,6 +149,6 @@ El volumen se restaurará en el snapshot seleccionado.
 
 ## Más información <a name="go-further"></a>
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.fr-ca.md
@@ -13,7 +13,7 @@ Dans ce guide, nous allons expliquer comment restaurer un volume à son dernier 
 ## Prérequis
 
 - Disposer d'une offre OVHcloud Enterprise File Storage avec un volume
-- Être connecté à l’[API OVHcloud](https://ca.api.ovh.com/)
+- Être connecté à l’[API OVHcloud](/links/api)
 
 ## Principes de base
 
@@ -145,6 +145,6 @@ Le volume est maintenant restauré au snapshot sélectionné.
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.fr-fr.md
@@ -145,6 +145,6 @@ Le volume est maintenant restauré au snapshot sélectionné.
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.it-it.md
@@ -149,6 +149,6 @@ A questo punto il volume verrà ripristinato allo Snapshot selezionato.
 
 ## Per saperne di più <a name="go-further"></a>
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all'indirizzo <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.pl-pl.md
@@ -149,6 +149,6 @@ Wolumen jest teraz przywracany do wybranego snapshota.
 
 ## Sprawdź również <a name="go-further"></a>
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_revert_snapshot/guide.pt-pt.md
@@ -149,6 +149,6 @@ O volume será restaurado para a snapshot selecionada.
 
 ## Quer saber mais? <a name="go-further"></a>
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Fale com nossa comunidade de utilizadores: <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.de-de.md
@@ -15,7 +15,7 @@ In dieser Anleitung geben wir Ihnen einen Überblick über die Verwaltung Ihrer 
 **Diese Anleitung erklärt, wie Sie eine Snapshot-Policy erstellen, auf Ihr Volume anwenden, auf Ihr Volume anwenden, modifizieren und löschen.**
 
 - Sie verfügen über einen OVHcloud Enterprise File Storage mit verfügbarem Volume.
-- Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
+- Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 ## Grundlagen
 
@@ -26,7 +26,7 @@ Eine Snapshot-Policy erlaubt es, die Erstellung von Snapshots anhand verschieden
 
 ## In der praktischen Anwendung
 
-Loggen Sie sich in Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de) ein und wählen Sie `Bare Metal Cloud`{.action} in der oberen Navigationsleiste aus. Öffnen Sie `Storage und Backup`{.action}, dann `Enterprise File Storage`{.action} im linken Menü und wählen Sie Ihre Dienstleistung in der Liste aus.
+Loggen Sie sich in Ihr [OVHcloud Kundencenter](/links/manager) ein und wählen Sie `Bare Metal Cloud`{.action} in der oberen Navigationsleiste aus. Öffnen Sie `Storage und Backup`{.action}, dann `Enterprise File Storage`{.action} im linken Menü und wählen Sie Ihre Dienstleistung in der Liste aus.
 
 ### Snapshot-Policy erstellen
 
@@ -90,6 +90,6 @@ So löschen Sie eine Snapshot-Policy:
 
 ## Weiterführende Informationen
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-asia.md
@@ -12,7 +12,7 @@ Learn how to create a snapshot policy, apply it to your volume, modify and delet
 ## Requirements
 
 - An OVHcloud Enterprise File Storage service with an available volume
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Basics
 
@@ -22,7 +22,7 @@ A snapshot policy allows you to automate the snapshot creation using different p
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
+Log in to your [OVHcloud Control Panel](/links/manager) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
 
 ### Creating your snapshot policy
 
@@ -86,6 +86,6 @@ To delete a snapshot policy:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-au.md
@@ -12,7 +12,7 @@ Learn how to create a snapshot policy, apply it to your volume, modify and delet
 ## Requirements
 
 - An OVHcloud Enterprise File Storage service with an available volume
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Basics
 
@@ -22,7 +22,7 @@ A snapshot policy allows you to automate the snapshot creation using different p
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
+Log in to your [OVHcloud Control Panel](/links/manager) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
 
 ### Creating your snapshot policy
 
@@ -86,6 +86,6 @@ To delete a snapshot policy:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-ca.md
@@ -12,7 +12,7 @@ Learn how to create a snapshot policy, apply it to your volume, modify and delet
 ## Requirements
 
 - An OVHcloud Enterprise File Storage service with an available volume
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Basics
 
@@ -22,7 +22,7 @@ A snapshot policy allows you to automate the snapshot creation using different p
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
+Log in to your [OVHcloud Control Panel](/links/manager) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
 
 ### Creating your snapshot policy
 
@@ -86,6 +86,6 @@ To delete a snapshot policy:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-gb.md
@@ -12,7 +12,7 @@ Learn how to create a snapshot policy, apply it to your volume, modify and delet
 ## Requirements
 
 - An OVHcloud Enterprise File Storage service with an available volume
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Basics
 
@@ -22,7 +22,7 @@ A snapshot policy allows you to automate the snapshot creation using different p
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
+Log in to your [OVHcloud Control Panel](/links/manager) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
 
 ### Creating your snapshot policy
 
@@ -86,6 +86,6 @@ To delete a snapshot policy:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-ie.md
@@ -12,7 +12,7 @@ Learn how to create a snapshot policy, apply it to your volume, modify and delet
 ## Requirements
 
 - An OVHcloud Enterprise File Storage service with an available volume
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Basics
 
@@ -22,7 +22,7 @@ A snapshot policy allows you to automate the snapshot creation using different p
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
+Log in to your [OVHcloud Control Panel](/links/manager) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
 
 ### Creating your snapshot policy
 
@@ -86,6 +86,6 @@ To delete a snapshot policy:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-sg.md
@@ -12,7 +12,7 @@ Learn how to create a snapshot policy, apply it to your volume, modify and delet
 ## Requirements
 
 - An OVHcloud Enterprise File Storage service with an available volume
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Basics
 
@@ -22,7 +22,7 @@ A snapshot policy allows you to automate the snapshot creation using different p
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
+Log in to your [OVHcloud Control Panel](/links/manager) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
 
 ### Creating your snapshot policy
 
@@ -86,6 +86,6 @@ To delete a snapshot policy:
 
 ## Go further
   
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.en-us.md
@@ -12,7 +12,7 @@ Learn how to create a snapshot policy, apply it to your volume, modify and delet
 ## Requirements
 
 - An OVHcloud Enterprise File Storage service with an available volume
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
+- Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Basics
 
@@ -22,7 +22,7 @@ A snapshot policy allows you to automate the snapshot creation using different p
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
+Log in to your [OVHcloud Control Panel](/links/manager) and switch to `Bare Metal Cloud`{.action} in the top navigation bar. Open `Storage and Backup`{.action} and `Enterprise File Storage`{.action} in the left-hand menu, then select your service from the list.
 
 ### Creating your snapshot policy
 
@@ -86,6 +86,6 @@ To delete a snapshot policy:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.es-es.md
@@ -17,7 +17,7 @@ Esta guía explica cómo gestionar las políticas de snapshots para los volúmen
 ## Requisitos
 
 - Un servicio Enterprise File Storage de OVHcloud con un volumen disponible
-- Estar conectado a su [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
+- Estar conectado a su [área de cliente de OVHcloud](/links/manager)
 
 ## Principios básicos
 
@@ -27,7 +27,7 @@ Una política de snapshots permite automatizar la creación de snapshots utiliza
 
 ## Procedimiento
 
-Conéctese a su [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es) y seleccione la pestaña `Bare Metal Cloud`{.action} en la barra de navegación superior. Abra `Almacenamiento y backup`{.action} y luego `Enterprise File Storage`{.action} en el menú de la izquierda y seleccione su servicio en la lista.
+Conéctese a su [área de cliente de OVHcloud](/links/manager) y seleccione la pestaña `Bare Metal Cloud`{.action} en la barra de navegación superior. Abra `Almacenamiento y backup`{.action} y luego `Enterprise File Storage`{.action} en el menú de la izquierda y seleccione su servicio en la lista.
 
 ### Crear una política de snapshots
 
@@ -91,6 +91,6 @@ Para eliminar una política de snapshots:
 
 ## Más información <a name="go-further"></a>
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.es-us.md
@@ -17,7 +17,7 @@ Esta guía explica cómo gestionar las políticas de snapshots para los volúmen
 ## Requisitos
 
 - Un servicio Enterprise File Storage de OVHcloud con un volumen disponible
-- Estar conectado a su [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
+- Estar conectado a su [área de cliente de OVHcloud](/links/manager)
 
 ## Principios básicos
 
@@ -27,7 +27,7 @@ Una política de snapshots permite automatizar la creación de snapshots utiliza
 
 ## Procedimiento
 
-Conéctese a su [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws) y seleccione la pestaña `Bare Metal Cloud`{.action} en la barra de navegación superior. Abra `Almacenamiento y backup`{.action} y luego `Enterprise File Storage`{.action} en el menú de la izquierda y seleccione su servicio en la lista.
+Conéctese a su [área de cliente de OVHcloud](/links/manager) y seleccione la pestaña `Bare Metal Cloud`{.action} en la barra de navegación superior. Abra `Almacenamiento y backup`{.action} y luego `Enterprise File Storage`{.action} en el menú de la izquierda y seleccione su servicio en la lista.
 
 ### Crear una política de snapshots
 
@@ -91,6 +91,6 @@ Para eliminar una política de snapshots:
 
 ## Más información <a name="go-further"></a>
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.fr-ca.md
@@ -13,7 +13,7 @@ Dans ce guide, nous allons vous donner un aperçu de la gestion de vos politique
 ## Prérequis
 
 - Un service Enterprise File Storage OVHcloud avec un volume disponible
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## Principes de base
 
@@ -23,7 +23,7 @@ Une politique de snapshot permet d'automatiser la création de snapshots à l'ai
 
 ## En pratique
 
-Connectez-vous à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc) et sélectionnez l'onglet `Bare Metal Cloud`{.action} dans la barre de navigation supérieure. Ouvrez `Storage et sauvegarde`{.action} puis `Enterprise File Storage`{.action} dans le menu de gauche et sélectionnez votre service dans la liste.
+Connectez-vous à votre [espace client OVHcloud](/links/manager) et sélectionnez l'onglet `Bare Metal Cloud`{.action} dans la barre de navigation supérieure. Ouvrez `Storage et sauvegarde`{.action} puis `Enterprise File Storage`{.action} dans le menu de gauche et sélectionnez votre service dans la liste.
 
 ### Créer votre politique de snapshot
 
@@ -87,6 +87,6 @@ Pour supprimer une politique de snapshot :
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.fr-fr.md
@@ -13,7 +13,7 @@ Dans ce guide, nous allons vous donner un aperçu de la gestion de vos politique
 ## Prérequis
 
 - Un service Enterprise File Storage OVHcloud avec un volume disponible
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
+- Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## Principes de base
 
@@ -23,7 +23,7 @@ Une politique de snapshot permet d'automatiser la création de snapshots à l'ai
 
 ## En pratique
 
-Connectez-vous à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr) et sélectionnez l'onglet `Bare Metal Cloud`{.action} dans la barre de navigation supérieure. Ouvrez `Storage et sauvegarde`{.action} puis `Enterprise File Storage`{.action} dans le menu de gauche et sélectionnez votre service dans la liste.
+Connectez-vous à votre [espace client OVHcloud](/links/manager) et sélectionnez l'onglet `Bare Metal Cloud`{.action} dans la barre de navigation supérieure. Ouvrez `Storage et sauvegarde`{.action} puis `Enterprise File Storage`{.action} dans le menu de gauche et sélectionnez votre service dans la liste.
 
 ### Créer votre politique de snapshot
 
@@ -87,6 +87,6 @@ Pour supprimer une politique de snapshot :
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.it-it.md
@@ -17,7 +17,7 @@ Questa guida ti mostra la gestione delle politiche di Snapshot per i volumi Ente
 ## Prerequisiti
 
 - Un servizio Enterprise File Storage OVHcloud con un volume disponibile
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 ## Nozioni di base
 
@@ -27,7 +27,7 @@ Una politica di Snapshot permette di automatizzare la creazione degli Snapshot u
 
 ## Procedura
 
-Accedi allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it) e seleziona la scheda `Bare Metal Cloud`{.action} nella barra di navigazione superiore. Apri `Storage e Backup`{.action} poi `Enterprise File Storage`{.action} nel menu a sinistra e seleziona il servizio dalla lista.
+Accedi allo [Spazio Cliente OVHcloud](/links/manager) e seleziona la scheda `Bare Metal Cloud`{.action} nella barra di navigazione superiore. Apri `Storage e Backup`{.action} poi `Enterprise File Storage`{.action} nel menu a sinistra e seleziona il servizio dalla lista.
 
 ### Crea la tua politica di Snapshot
 
@@ -91,6 +91,6 @@ Per eliminare una politica di Snapshot:
 
 ## Per saperne di più <a name="go-further"></a>
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all'indirizzo <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.pl-pl.md
@@ -17,7 +17,7 @@ W niniejszym przewodniku wyjaśnimy, jak zarządzać politykami wykonywania snap
 ## Wymagania początkowe
 
 - Usługa Enterprise File Storage od OVHcloud z dostępnym wolumenem
-- Dostęp do [Panelu client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
+- Dostęp do [Panelu client OVHcloud](/links/manager)
 
 ## Podstawowe zasady
 
@@ -27,7 +27,7 @@ Polityka wykonywania snapshotów pozwala na zautomatyzowanie tworzenia snapshot�
 
 ## W praktyce
 
-Zaloguj się do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl) i na górnym pasku nawigacji wybierz zakładkę `Bare Metal Cloud`{.action}. Otwórz `Storage i Backup`{.action}, następnie `Enterprise File Storage`{.action} w menu po lewej stronie i wybierz swoją usługę z listy.
+Zaloguj się do [Panelu klienta OVHcloud](/links/manager) i na górnym pasku nawigacji wybierz zakładkę `Bare Metal Cloud`{.action}. Otwórz `Storage i Backup`{.action}, następnie `Enterprise File Storage`{.action} w menu po lewej stronie i wybierz swoją usługę z listy.
 
 ### Utwórz politykę wykonywania snapshotów
 
@@ -91,6 +91,6 @@ Aby usunąć politykę wykonywania snapshotów:
 
 ## Sprawdź również <a name="go-further"></a>
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_snapshot_policy/guide.pt-pt.md
@@ -17,7 +17,7 @@ Neste guia, vamos dar-lhe uma visão geral da gestão das suas políticas de sna
 ## Requisitos
 
 - Um serviço Enterprise File Storage da OVHcloud com um volume disponível
-- Ter acesso à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt).
+- Ter acesso à [Área de Cliente OVHcloud](/links/manager).
 
 ## Princípios básicos
 
@@ -27,7 +27,7 @@ Uma política de snapshot permite automatizar a criação de snapshots graças a
 
 ## Instruções
 
-Aceda à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt) e selecione o separador `Bare Metal Cloud`{.action} na barra de navegação superior. Abra o `Armazenamento e backup`{.action} e depois o `Enterprise File Storage`{.action} no menu à esquerda e selecione o seu serviço na lista.
+Aceda à [Área de Cliente OVHcloud](/links/manager) e selecione o separador `Bare Metal Cloud`{.action} na barra de navegação superior. Abra o `Armazenamento e backup`{.action} e depois o `Enterprise File Storage`{.action} no menu à esquerda e selecione o seu serviço na lista.
 
 ### Criar a política de snapshot
 
@@ -91,6 +91,6 @@ Para eliminar uma política de snapshots:
 
 ## Quer saber mais? <a name="go-further"></a>
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Fale com nossa comunidade de utilizadores: <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.de-de.md
@@ -146,6 +146,6 @@ Sie erhalten `aclRuleId` bei Erstellung der ACL oder indem Sie bestehende ACLs I
 
 ## Weiterführende Informationen
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-asia.md
@@ -142,6 +142,6 @@ You can get the `aclRuleId` either from the ACL creation body response or by lis
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-au.md
@@ -142,6 +142,6 @@ You can get the `aclRuleId` either from the ACL creation body response or by lis
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-ca.md
@@ -142,6 +142,6 @@ You can get the `aclRuleId` either from the ACL creation body response or by lis
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-gb.md
@@ -142,6 +142,6 @@ You can get the `aclRuleId` either from the ACL creation body response or by lis
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-ie.md
@@ -142,6 +142,6 @@ You can get the `aclRuleId` either from the ACL creation body response or by lis
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-sg.md
@@ -142,6 +142,6 @@ You can get the `aclRuleId` either from the ACL creation body response or by lis
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.en-us.md
@@ -142,6 +142,6 @@ You can get the `aclRuleId` either from the ACL creation body response or by lis
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.es-es.md
@@ -146,6 +146,6 @@ Puede obtener el `aclRuleId` a partir de la respuesta obtenida al crear el ACL o
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Únase a nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.es-us.md
@@ -17,7 +17,7 @@ Esta guía explica cómo gestionar las ACL de un volumen para la solución OVHcl
 ## Requisitos
 
 - Tener contratado un plan Enterprise File Storage de OVHcloud con un volumen.
-- Estar conectado a la página de las [API de OVHcloud](https://ca.api.ovh.com/).
+- Estar conectado a la página de las [API de OVHcloud](/links/api).
 
 ## Lo esencial
 
@@ -146,6 +146,6 @@ Puede obtener el `aclRuleId` a partir de la respuesta obtenida al crear el ACL o
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Únase a nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.fr-ca.md
@@ -13,7 +13,7 @@ Dans ce guide, découvrez comment gérer les ACL d'un volume pour l'offre OVHclo
 ## Prérequis
 
 - Disposer d'une offre OVHcloud Enterprise File Storage avec un volume
-- Être connecté sur la page des [API OVHcloud](https://ca.api.ovh.com/)
+- Être connecté sur la page des [API OVHcloud](/links/api)
 
 ## L'essentiel
 
@@ -142,6 +142,6 @@ Vous pouvez obtenir le `aclRuleId` à partir de la réponse obtenue lors de cré
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.fr-fr.md
@@ -142,6 +142,6 @@ Vous pouvez obtenir le `aclRuleId` à partir de la réponse obtenue lors de cré
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.it-it.md
@@ -145,6 +145,6 @@ Puoi ottenere il `aclRuleId` a partire dalla risposta ottenuta durante la creazi
 
 ## Per saperne di più
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.pl-pl.md
@@ -146,6 +146,6 @@ Możesz uzyskać `aclRuleId` na podstawie odpowiedzi uzyskanej podczas tworzenia
 
 ## Sprawdź również
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_acl/guide.pt-pt.md
@@ -146,6 +146,6 @@ Pode obter o `aclRuleId` a partir da resposta obtida aquando da criação do ACL
 
 ## Saiba mais
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Junte-se à nossa comunidade de utilizadores <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.de-de.md
@@ -171,6 +171,6 @@ Ersetzen Sie `serviceName` mit der ID Ihres Dienstes, `shareId` mit der Volume-I
 
 ## Weiterführende Informationen
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-asia.md
@@ -167,6 +167,6 @@ Replace `serviceName` with the ID of your service, `shareId` with your volume ID
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-au.md
@@ -167,6 +167,6 @@ Replace `serviceName` with the ID of your service, `shareId` with your volume ID
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-ca.md
@@ -167,6 +167,6 @@ Replace `serviceName` with the ID of your service, `shareId` with your volume ID
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-gb.md
@@ -167,6 +167,6 @@ Replace `serviceName` with the ID of your service, `shareId` with your volume ID
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-ie.md
@@ -167,6 +167,6 @@ Replace `serviceName` with the ID of your service, `shareId` with your volume ID
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-sg.md
@@ -167,6 +167,6 @@ Replace `serviceName` with the ID of your service, `shareId` with your volume ID
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.en-us.md
@@ -167,6 +167,6 @@ Replace `serviceName` with the ID of your service, `shareId` with your volume ID
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.es-es.md
@@ -171,6 +171,6 @@ Sustituya el `serviceName` por el ID del servicio, `shareId` por el ID del volum
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.es-us.md
@@ -17,7 +17,7 @@ Esta guía explica cómo gestionar los snapshots de los volúmenes de la soluci�
 ## Requisitos
 
 - Tener contratado un plan Enterprise File Storage de OVHcloud con un volumen.
-- Estar conectado a la página de las [API de OVHcloud](https://ca.api.ovh.com/)
+- Estar conectado a la página de las [API de OVHcloud](/links/api)
 
 ## Lo esencial
 
@@ -171,6 +171,6 @@ Sustituya el `serviceName` por el ID del servicio, `shareId` por el ID del volum
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.fr-ca.md
@@ -13,7 +13,7 @@ Dans ce guide, découvrez comment gérer les snapshots des volumes pour l'offre 
 ## Prérequis
 
 - Disposer d'une offre OVHcloud Enterprise File Storage avec un volume
-- Être connecté sur la page des [API OVHcloud](https://ca.api.ovh.com/)
+- Être connecté sur la page des [API OVHcloud](/links/api)
 
 ## L'essentiel
 
@@ -167,6 +167,6 @@ Remplacez `serviceName` par l'ID de votre service, `shareId` par l'ID du volume 
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.fr-fr.md
@@ -167,6 +167,6 @@ Remplacez `serviceName` par l'ID de votre service, `shareId` par l'ID du volume 
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.it-it.md
@@ -171,6 +171,6 @@ Sostituisci `serviceName` con l'ID del tuo servizio, `shareId` con l'ID del volu
 
 ## Per saperne di più
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.pl-pl.md
@@ -171,6 +171,6 @@ Zastąp `serviceName` ID Twojej usługi, `shareId` ID wolumenu i `snapshotId` ID
 
 ## Sprawdź również
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volume_snapshots/guide.pt-pt.md
@@ -171,6 +171,6 @@ Substitua o `serviceName` pelo ID do seu serviço, `shareId` pelo ID do volume e
 
 ## Quer saber mais?
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Fale com a nossa comunidade de utilizadores: <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.de-de.md
@@ -185,6 +185,6 @@ Ersetzen Sie `serviceName` mit der ID Ihres Dienstes und `shareId` mit der ID de
 
 [Erste Schritte mit der OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-asia.md
@@ -180,6 +180,6 @@ Replace `serviceName` with the ID of your service and `shareId` with your volume
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-au.md
@@ -180,6 +180,6 @@ Replace `serviceName` with the ID of your service and `shareId` with your volume
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-ca.md
@@ -180,6 +180,6 @@ Replace `serviceName` with the ID of your service and `shareId` with your volume
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-gb.md
@@ -180,6 +180,6 @@ Replace `serviceName` with the ID of your service and `shareId` with your volume
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-ie.md
@@ -180,6 +180,6 @@ Replace `serviceName` with the ID of your service and `shareId` with your volume
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-sg.md
@@ -180,6 +180,6 @@ Replace `serviceName` with the ID of your service and `shareId` with your volume
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.en-us.md
@@ -180,6 +180,6 @@ Replace `serviceName` with the ID of your service and `shareId` with your volume
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.es-es.md
@@ -185,6 +185,6 @@ Sustituya el `serviceName` por el ID de su servicio y `shareId` por el ID del vo
 
 [Primeros pasos con las API de OVHcloud](/pages/manage_and_operate/api/first-steps)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.es-us.md
@@ -185,6 +185,6 @@ Sustituya el `serviceName` por el ID de su servicio y `shareId` por el ID del vo
 
 [Primeros pasos con las API de OVHcloud](/pages/manage_and_operate/api/first-steps)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.fr-ca.md
@@ -13,7 +13,7 @@ Dans ce guide, découvrez comment gérer les volumes pour l'offre OVHcloud Enter
 ## Prérequis
 
 - Disposer d'une offre OVHcloud Enterprise File Storage
-- Être connecté sur la page des [API OVHcloud](https://ca.api.ovh.com/)
+- Être connecté sur la page des [API OVHcloud](/links/api)
 
 ## L'essentiel
 
@@ -181,6 +181,6 @@ Remplacez `serviceName` par l'ID de votre service et `shareId` par l'ID du volum
 
 [Premiers pas avec les API OVHcloud](/pages/manage_and_operate/api/first-steps)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.fr-fr.md
@@ -181,6 +181,6 @@ Remplacez `serviceName` par l'ID de votre service et `shareId` par l'ID du volum
 
 [Premiers pas avec les API OVHcloud](/pages/manage_and_operate/api/first-steps)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.it-it.md
@@ -185,6 +185,6 @@ Sostituisci `serviceName` con l'ID del tuo servizio e `shareId` con l'ID del vol
 
 [Iniziare a utilizzare le API OVHcloud](/pages/manage_and_operate/api/first-steps)
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.pl-pl.md
@@ -185,6 +185,6 @@ Zamień `serviceName` na ID usługi i `shareId` na ID wolumenu do usunięcia.
 
 [Pierwsze kroki z API OVHcloud](/pages/manage_and_operate/api/first-steps)
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/enterprise_file_storage/netapp_volumes/guide.pt-pt.md
@@ -185,6 +185,6 @@ Substitua o `serviceName` pelo ID do seu serviço e `shareId` pelo ID do volume 
 
 [Primeiros passos com as API OVHcloud](/pages/manage_and_operate/api/first-steps)(EN)
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Junte-se à nossa comunidade de utilizadores <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.de-de.md
@@ -14,7 +14,7 @@ Konfigurieren und mounten Sie einen OVHcloud HA-NAS-Speicherraum auf Ihrem Windo
 
 ## Voraussetzungen
 
-- Sie haben einen [Dedicated Server](https://www.ovhcloud.com/de/bare-metal/) **oder** einen [VPS](https://www.ovhcloud.com/de/vps/) **oder** eine [Public Cloud Instanz](https://www.ovhcloud.com/de/public-cloud/) mit einer Windows-Distribution in Ihrem Kunden-Account.
+- Sie haben einen [Dedicated Server](/links/bare-metal/bare-metal) **oder** einen [VPS](/links/bare-metal/vps) **oder** eine [Public Cloud Instanz](/links/public-cloud/public-cloud) mit einer Windows-Distribution in Ihrem Kunden-Account.
 - Sie verfügen über eine [HA-NAS Lösung](https://www.ovh.de/nas/).
 
 ### Einstellungen
@@ -47,6 +47,6 @@ net use z: \\10.16.101.8\zpool-000206_PARTITION_NAME_1
 
 [Häufig gestellte Fragen zu HA-NAS](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-asia.md
@@ -10,7 +10,7 @@ Configure and mount an OVHcloud HA-NAS storage space on your Windows Server usin
 
 ## Requirements
 
-- a [Dedicated Server](https://www.ovhcloud.com/asia/bare-metal/) **or** a [VPS](https://www.ovhcloud.com/asia/vps/) **or** a [Public Cloud Instance](https://www.ovhcloud.com/asia/public-cloud/) with a Windows distribution
+- a [Dedicated Server](/links/bare-metal/bare-metal) **or** a [VPS](/links/bare-metal/vps) **or** a [Public Cloud Instance](/links/public-cloud/public-cloud) with a Windows distribution
 - a [HA-NAS solution](https://www.ovh.co.uk/nas/)
 
 ### Settings
@@ -43,6 +43,6 @@ net use z: \\10.16.101.8\zpool-000206_PARTITION_NAME_1
 
 [NAS - Frequently Asked Questions](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-au.md
@@ -10,7 +10,7 @@ Configure and mount an OVHcloud HA-NAS storage space on your Windows Server usin
 
 ## Requirements
 
-- a [Dedicated Server](https://www.ovhcloud.com/en-au/bare-metal/) **or** a [VPS](https://www.ovhcloud.com/en-au/vps/) **or** a [Public Cloud Instance](https://www.ovhcloud.com/en-au/public-cloud/) with a Windows distribution
+- a [Dedicated Server](/links/bare-metal/bare-metal) **or** a [VPS](/links/bare-metal/vps) **or** a [Public Cloud Instance](/links/public-cloud/public-cloud) with a Windows distribution
 - a [HA-NAS solution](https://www.ovh.co.uk/nas/)
 
 ### Settings
@@ -43,6 +43,6 @@ net use z: \\10.16.101.8\zpool-000206_PARTITION_NAME_1
 
 [NAS - Frequently Asked Questions](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-ca.md
@@ -10,8 +10,8 @@ Configure and mount an OVHcloud HA-NAS storage space on your Windows Server usin
 
 ## Requirements
 
-- a [Dedicated Server](https://www.ovhcloud.com/en-ca/bare-metal/) **or** a [VPS](https://www.ovhcloud.com/en-ca/vps/) **or** a [Public Cloud Instance](https://www.ovhcloud.com/en-ca/public-cloud/) with a Windows distribution
-- a [HA-NAS solution](https://www.ovhcloud.com/en-ca/)
+- a [Dedicated Server](/links/bare-metal/bare-metal) **or** a [VPS](/links/bare-metal/vps) **or** a [Public Cloud Instance](/links/public-cloud/public-cloud) with a Windows distribution
+- a [HA-NAS solution](/links/website)
 
 ### Settings
 
@@ -43,6 +43,6 @@ net use z: \\10.16.101.8\zpool-000206_PARTITION_NAME_1
 
 [NAS - Frequently Asked Questions](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-gb.md
@@ -10,7 +10,7 @@ Configure and mount an OVHcloud HA-NAS storage space on your Windows Server usin
 
 ## Requirements
 
-- a [Dedicated Server](https://www.ovhcloud.com/en-gb/bare-metal/) **or** a [VPS](https://www.ovhcloud.com/en-gb/vps/) **or** a [Public Cloud Instance](https://www.ovhcloud.com/en-gb/public-cloud/) with a Windows distribution
+- a [Dedicated Server](/links/bare-metal/bare-metal) **or** a [VPS](/links/bare-metal/vps) **or** a [Public Cloud Instance](/links/public-cloud/public-cloud) with a Windows distribution
 - a [HA-NAS solution](https://www.ovh.co.uk/nas/)
 
 ### Settings
@@ -43,6 +43,6 @@ net use z: \\10.16.101.8\zpool-000206_PARTITION_NAME_1
 
 [NAS - Frequently Asked Questions](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-ie.md
@@ -10,7 +10,7 @@ Configure and mount an OVHcloud HA-NAS storage space on your Windows Server usin
 
 ## Requirements
 
-- a [Dedicated Server](https://www.ovhcloud.com/en-ie/bare-metal/) **or** a [VPS](https://www.ovhcloud.com/en-ie/vps/) **or** a [Public Cloud Instance](https://www.ovhcloud.com/en-ie/public-cloud/) with a Windows distribution
+- a [Dedicated Server](/links/bare-metal/bare-metal) **or** a [VPS](/links/bare-metal/vps) **or** a [Public Cloud Instance](/links/public-cloud/public-cloud) with a Windows distribution
 - a [HA-NAS solution](https://www.ovh.ie/nas/)
 
 ### Settings
@@ -43,6 +43,6 @@ net use z: \\10.16.101.8\zpool-000206_PARTITION_NAME_1
 
 [NAS - Frequently Asked Questions](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-sg.md
@@ -10,7 +10,7 @@ Configure and mount an OVHcloud HA-NAS storage space on your Windows Server usin
 
 ## Requirements
 
-- a [Dedicated Server](https://www.ovhcloud.com/en-sg/bare-metal/) **or** a [VPS](https://www.ovhcloud.com/en-sg/vps/) **or** a [Public Cloud Instance](https://www.ovhcloud.com/en-sg/public-cloud/) with a Windows distribution
+- a [Dedicated Server](/links/bare-metal/bare-metal) **or** a [VPS](/links/bare-metal/vps) **or** a [Public Cloud Instance](/links/public-cloud/public-cloud) with a Windows distribution
 - a [HA-NAS solution](https://www.ovh.co.uk/nas/)
 
 ### Settings
@@ -43,6 +43,6 @@ net use z: \\10.16.101.8\zpool-000206_PARTITION_NAME_1
 
 [NAS - Frequently Asked Questions](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.en-us.md
@@ -10,7 +10,7 @@ Configure and mount an OVHcloud HA-NAS storage space on your Windows Server usin
 
 ## Requirements
 
-- a [Dedicated Server](https://www.ovhcloud.com/en/bare-metal/) **or** a [VPS](https://www.ovhcloud.com/en/vps/) **or** a [Public Cloud Instance](https://www.ovhcloud.com/en/public-cloud/) with a Windows distribution
+- a [Dedicated Server](/links/bare-metal/bare-metal) **or** a [VPS](/links/bare-metal/vps) **or** a [Public Cloud Instance](/links/public-cloud/public-cloud) with a Windows distribution
 - a [HA-NAS solution](https://www.ovh.com/world/nas/)
 
 ### Settings
@@ -43,6 +43,6 @@ net use z: \\10.16.101.8\zpool-000206_PARTITION_NAME_1
 
 [NAS - Frequently Asked Questions](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.es-es.md
@@ -14,7 +14,7 @@ Configure e monte su espacio de almacenamiento NAS-HA OVHcloud en Windows Server
 
 ## Requisitos
 
-- Un [servidor dedicado](https://www.ovhcloud.com/es-es/bare-metal/) **o** un [VPS](https://www.ovhcloud.com/es-es/vps/) **o** una [instancia de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) con una distribución Windows.
+- Un [servidor dedicado](/links/bare-metal/bare-metal) **o** un [VPS](/links/bare-metal/vps) **o** una [instancia de Public Cloud](/links/public-cloud/public-cloud) con una distribución Windows.
 - Una oferta [NAS-HA](https://www.ovh.es/nas/).
 
 ### Configuración
@@ -47,6 +47,6 @@ net use z: \\10.16.101.8\zpool-000206_PARTITION_NAME_1
 
 [Preguntas frecuentes sobre los NAS](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.es-us.md
@@ -14,7 +14,7 @@ Configure e monte su espacio de almacenamiento NAS-HA OVHcloud en Windows Server
 
 ## Requisitos
 
-- Un [servidor dedicado](https://www.ovhcloud.com/es/bare-metal/) **o** un [VPS](https://www.ovhcloud.com/es/vps/) **o** una [instancia de Public Cloud](https://www.ovhcloud.com/es/public-cloud/) con una distribución Windows.
+- Un [servidor dedicado](/links/bare-metal/bare-metal) **o** un [VPS](/links/bare-metal/vps) **o** una [instancia de Public Cloud](/links/public-cloud/public-cloud) con una distribución Windows.
 - Una oferta [NAS-HA](https://www.ovh.com/world/es/nas/).
 
 ### Configuración
@@ -47,6 +47,6 @@ net use z: \\10.16.101.8\zpool-000206_PARTITION_NAME_1
 
 [Preguntas frecuentes sobre los NAS](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.fr-ca.md
@@ -10,7 +10,7 @@ Configurez et montez votre espace de stockage NAS-HA OVHcloud sur Windows Server
 
 ## Prérequis
 
-- Un [serveur dédié](https://www.ovhcloud.com/fr-ca/bare-metal/) **ou** un [VPS](https://www.ovhcloud.com/fr-ca/vps/) **ou** une [instance Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) avec une distribution Windows.
+- Un [serveur dédié](/links/bare-metal/bare-metal) **ou** un [VPS](/links/bare-metal/vps) **ou** une [instance Public Cloud](/links/public-cloud/public-cloud) avec une distribution Windows.
 - Une offre [NAS-HA](https://www.ovh.com/ca/fr/nas/).
 
 ### Configuration
@@ -43,6 +43,6 @@ net use z: \\10.16.101.8\zpool-000206_NOM_PARTITION_1
 
 [Les questions fréquentes concernant le NAS](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.fr-fr.md
@@ -10,7 +10,7 @@ Configurez et montez votre espace de stockage NAS-HA OVHcloud sur Windows Server
 
 ## Prérequis
 
-- Un [serveur dédié](https://www.ovhcloud.com/fr/bare-metal/) **ou** un [VPS](https://www.ovhcloud.com/fr/vps/) **ou** une [instance Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) avec une distribution Windows.
+- Un [serveur dédié](/links/bare-metal/bare-metal) **ou** un [VPS](/links/bare-metal/vps) **ou** une [instance Public Cloud](/links/public-cloud/public-cloud) avec une distribution Windows.
 - Une offre [NAS-HA](https://www.ovh.com/fr/nas/).
 
 ### Configuration
@@ -43,6 +43,6 @@ net use z: \\10.16.101.8\zpool-000206_NOM_PARTITION_1
 
 [Les questions fréquentes concernant le NAS](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.it-it.md
@@ -14,7 +14,7 @@ Configura e monta il tuo spazio di storage NAS-HA OVHcloud su Windows Server tra
 
 ## Prerequisiti
 
-- Un [server dedicato](https://www.ovhcloud.com/it/bare-metal/) **o** un [VPS](https://www.ovhcloud.com/it/vps/) **o** un'[istanza Public Cloud](https://www.ovhcloud.com/it/public-cloud/) con distribuzione Windows.
+- Un [server dedicato](/links/bare-metal/bare-metal) **o** un [VPS](/links/bare-metal/vps) **o** un'[istanza Public Cloud](/links/public-cloud/public-cloud) con distribuzione Windows.
 - Un'offerta [NAS-HA](https://www.ovh.it/nas/).
 
 ### Configurazione
@@ -47,6 +47,6 @@ net use z: \\10.16.101.8\zpool-000206_PARTITION_NAME_1
 
 [Domande frequenti sul NAS](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.pl-pl.md
@@ -14,7 +14,7 @@ Konfiguracja i zamontowanie przestrzeni dyskowej NAS-HA OVHcloud na serwerze Win
 
 ## Wymagania początkowe
 
-- Posiadanie [Serwer dedykowany](https://www.ovhcloud.com/pl/bare-metal/), **lub**  [VPS](https://www.ovhcloud.com/pl/vps/) **lub** [instancja Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) z dystrybucją Windows.
+- Posiadanie [Serwer dedykowany](/links/bare-metal/bare-metal), **lub**  [VPS](/links/bare-metal/vps) **lub** [instancja Public Cloud](/links/public-cloud/public-cloud) z dystrybucją Windows.
 - Posiadanie usługi [NAS-HA](https://www.ovh.pl/nas/)
 
 ### Ustawienia
@@ -47,6 +47,6 @@ net use z: \\10.16.101.8\zpool-000206_PARTITION_NAME_1
 
 [Najczęściej zadawane pytania dotyczące technologii NAS](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_cifs/guide.pt-pt.md
@@ -14,7 +14,7 @@ Configure e monte o seu espaço de armazenamento NAS-HA OVHcloud no Windows Serv
 
 ## Requisitos
 
-- Um [servidor dedicado](https://www.ovhcloud.com/pt/bare-metal/) **ou** um [VPS]https://www.ovhcloud.com/pt/vps/) **ou** uma [instância Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) com uma distribuição Windows.
+- Um [servidor dedicado](/links/bare-metal/bare-metal) **ou** um [VPS]https://www.ovhcloud.com/pt/vps/) **ou** uma [instância Public Cloud](/links/public-cloud/public-cloud) com uma distribuição Windows.
 - Uma oferta [NAS-HA](https://www.ovh.pt/nas/).
 
 ### Configuração
@@ -47,6 +47,6 @@ net use z: \\10.16.101.8\zpool-000206_PARTITION_NAME_1
 
 [NAS - Perguntas Frequentes](/pages/storage_and_backup/file_storage/ha_nas/nas_faq)
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Fale com a nossa comunidade de utilizadores: <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.de-de.md
@@ -15,12 +15,12 @@ Ein NAS (Network Attached Storage) ist ein Dateiserver, der mit einem Netzwerk v
 ## Voraussetzungen
 
 - Sie verfügen über eine IP-Adresse, die an einen OVHcloud Dienst angebunden ist (Hosted Private Cloud, Dedicated Server, VPS, Public Cloud Instanz, etc.).
-- Sie haben ein [OVHcloud HA-NAS](https://www.ovhcloud.com/de/storage-solutions/nas-ha/) in Ihrem Kunden-Account.
-- Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
+- Sie haben ein [OVHcloud HA-NAS](/links/storage/nas-ha) in Ihrem Kunden-Account.
+- Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 ## In der praktischen Anwendung
 
-Die Verwaltung Ihres HA-NAS erfolgt über das [OVHcloud Kundencenter](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de).
+Die Verwaltung Ihres HA-NAS erfolgt über das [OVHcloud Kundencenter](/links/manager).
 
 Klicken Sie nach dem Login auf `Bare Metal Cloud`{.action} und dann im linken Menü auf `NAS und CDN`{.action}. Klicken Sie auf Ihre Dienstleistung, um Zugriff auf das Verwaltungsinterface zu erhalten.
 
@@ -116,6 +116,6 @@ Um eine Partition zu löschen, klicken Sie auf den `...`{.action} Button rechts 
 
 ## Weiterführende Informationen
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-asia.md
@@ -12,11 +12,11 @@ Network Attached Storage (NAS) is a file server connected to a network whose mai
 
 - An IP address attached to an OVHcloud service (Hosted Private Cloud, Dedicated Server, VPS, Public Cloud instance, etc.)
 - A [HA-NAS solution](https://www.ovh.co.uk/nas/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia){.external}
+- Access to the [OVHcloud Control Panel](/links/manager){.external}
 
 ## Instructions
 
-You can manage your HA-NAS via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia){.external}.
+You can manage your HA-NAS via the [OVHcloud Control Panel](/links/manager){.external}.
 
 Once you have logged in, click on `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} in the menu on the left. Click on your service to access the administration menu.
 
@@ -112,6 +112,6 @@ To delete a partition, click on the `...`{.action} button to the right of the ex
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-au.md
@@ -12,11 +12,11 @@ Network Attached Storage (NAS) is a file server connected to a network whose mai
 
 - An IP address attached to an OVHcloud service (Hosted Private Cloud, Dedicated Server, VPS, Public Cloud instance, etc.)
 - A [HA-NAS solution](https://www.ovh.co.uk/nas/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au){.external}
+- Access to the [OVHcloud Control Panel](/links/manager){.external}
 
 ## Instructions
 
-You can manage your HA-NAS via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au){.external}.
+You can manage your HA-NAS via the [OVHcloud Control Panel](/links/manager){.external}.
 
 Once you have logged in, click on `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} in the menu on the left. Click on your service to access the administration menu.
 
@@ -112,6 +112,6 @@ To delete a partition, click on the `...`{.action} button to the right of the ex
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-ca.md
@@ -12,11 +12,11 @@ Network Attached Storage (NAS) is a file server connected to a network whose mai
 
 - An IP address attached to an OVHcloud service (Hosted Private Cloud, Dedicated Server, VPS, Public Cloud instance, etc.)
 - A [HA-NAS solution](https://www.ovh.com/ca/en/nas/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca){.external}
+- Access to the [OVHcloud Control Panel](/links/manager){.external}
 
 ## Instructions
 
-You can manage your HA-NAS via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca){.external}.
+You can manage your HA-NAS via the [OVHcloud Control Panel](/links/manager){.external}.
 
 Once you have logged in, click on `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} in the menu on the left. Click on your service to access the administration menu.
 
@@ -112,6 +112,6 @@ To delete a partition, click on the `...`{.action} button to the right of the ex
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-gb.md
@@ -12,11 +12,11 @@ Network Attached Storage (NAS) is a file server connected to a network whose mai
 
 - An IP address attached to an OVHcloud service (Hosted Private Cloud, Dedicated Server, VPS, Public Cloud instance, etc.)
 - A [HA-NAS solution](https://www.ovh.co.uk/nas/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}
+- Access to the [OVHcloud Control Panel](/links/manager){.external}
 
 ## Instructions
 
-You can manage your HA-NAS via the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB){.external}.
+You can manage your HA-NAS via the [OVHcloud Control Panel](/links/manager){.external}.
 
 Once you have logged in, click on `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} in the menu on the left. Click on your service to access the administration menu.
 
@@ -112,6 +112,6 @@ To delete a partition, click on the `...`{.action} button to the right of the ex
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-ie.md
@@ -12,11 +12,11 @@ Network Attached Storage (NAS) is a file server connected to a network whose mai
 
 - An IP address attached to an OVHcloud service (Hosted Private Cloud, Dedicated Server, VPS, Public Cloud instance, etc.)
 - A [HA-NAS solution](https://www.ovh.ie/nas/)
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}
+- Access to the [OVHcloud Control Panel](/links/manager){.external}
 
 ## Instructions
 
-You can manage your HA-NAS via the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie){.external}.
+You can manage your HA-NAS via the [OVHcloud Control Panel](/links/manager){.external}.
 
 Once you have logged in, click on `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} in the menu on the left. Click on your service to access the administration menu.
 
@@ -112,6 +112,6 @@ To delete a partition, click on the `...`{.action} button to the right of the ex
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-sg.md
@@ -12,11 +12,11 @@ Network Attached Storage (NAS) is a file server connected to a network whose mai
 
 - An IP address attached to an OVHcloud service (Hosted Private Cloud, Dedicated Server, VPS, Public Cloud instance, etc.)
 - A [HA-NAS solution](https://www.ovh.co.uk/nas/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg){.external}
+- Access to the [OVHcloud Control Panel](/links/manager){.external}
 
 ## Instructions
 
-You can manage your HA-NAS via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg){.external}.
+You can manage your HA-NAS via the [OVHcloud Control Panel](/links/manager){.external}.
 
 Once you have logged in, click on `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} in the menu on the left. Click on your service to access the administration menu.
 
@@ -112,6 +112,6 @@ To delete a partition, click on the `...`{.action} button to the right of the ex
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.en-us.md
@@ -12,11 +12,11 @@ Network Attached Storage (NAS) is a file server connected to a network whose mai
 
 - An IP address attached to an OVHcloud service (Hosted Private Cloud, Dedicated Server, VPS, Public Cloud instance, etc.)
 - A [HA-NAS solution](https://www.ovh.com/world/nas/)
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we){.external}
+- Access to the [OVHcloud Control Panel](/links/manager){.external}
 
 ## Instructions
 
-You can manage your HA-NAS via the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we){.external}.
+You can manage your HA-NAS via the [OVHcloud Control Panel](/links/manager){.external}.
 
 Once you have logged in, click on `Bare Metal Cloud`{.action}, then `NAS and CDN`{.action} in the menu on the left. Click on your service to access the administration menu.
 
@@ -112,6 +112,6 @@ To delete a partition, click on the `...`{.action} button to the right of the ex
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.es-es.md
@@ -16,11 +16,11 @@ El NAS (Network Attached Storage) es un servidor de archivos conectado a una red
 
 - Disponer de una dirección IP asociada a un servicio de OVHcloud (Hosted Private Cloud, Servidor Dedicado, VPS, Instancia Public Cloud, etc.).
 - Tener un [NAS-HA](https://www.ovh.es/nas/)
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 
 ## Procedimiento
 
-El NAS-HA se gestiona desde el [área de cliente de OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es){.external}.
+El NAS-HA se gestiona desde el [área de cliente de OVHcloud](/links/manager){.external}.
 
 Una vez que se haya conectado, haga clic en `Bare Metal Cloud`{.action} y, seguidamente, en `NAS y CDN`{.action} en el menú de la izquierda. Haga clic en su servicio para acceder al menú de administración.
 
@@ -116,6 +116,6 @@ Para eliminar una partición, haga clic en el botón `(...)`{.action} situado a 
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.es-us.md
@@ -16,11 +16,11 @@ El NAS (Network Attached Storage) es un servidor de archivos conectado a una red
 
 - Disponer de una dirección IP asociada a un servicio de OVHcloud (Hosted Private Cloud, Servidor Dedicado, VPS, Instancia Public Cloud, etc.).
 - Tener un [NAS-HA](https://www.ovh.com/world/es/nas/)
-- Haber iniciado sesión en el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}.
+- Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager){.external}.
 
 ## Procedimiento
 
-El NAS-HA se gestiona desde el [área de cliente de OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws){.external}.
+El NAS-HA se gestiona desde el [área de cliente de OVHcloud](/links/manager){.external}.
 
 Una vez que se haya conectado, haga clic en `Bare Metal Cloud`{.action} y, seguidamente, en `NAS y CDN`{.action} en el menú de la izquierda. Haga clic en su servicio para acceder al menú de administración.
 
@@ -116,6 +116,6 @@ Para eliminar una partición, haga clic en el botón `(...)`{.action} situado a 
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.fr-ca.md
@@ -12,11 +12,11 @@ Le NAS (Network Attached Storage) est un serveur de fichiers relié à un résea
 
 - Disposer d'une adresse IP attachée à un service OVHcloud (Hosted Private Cloud, Serveur Dédié, VPS, Instance Public Cloud, etc...)
 - Disposer d'un [NAS-HA](https://www.ovh.com/ca/fr/nas/)
-- Être connecté à votre [espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 ## En pratique
 
-La gestion de votre NAS-HA s'effectue via l'[espace client OVHcloud](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc){.external}.
+La gestion de votre NAS-HA s'effectue via l'[espace client OVHcloud](/links/manager){.external}.
 
 Une fois connecté, cliquez sur `Bare Metal Cloud`{.action} puis sur `NAS and CDN`{.action} dans le menu à gauche. Cliquez sur votre service pour avoir accès au menu d'administration.
 
@@ -112,6 +112,6 @@ Pour supprimer une partition, cliquez sur le bouton `(...)`{.action} situé à d
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.fr-fr.md
@@ -12,11 +12,11 @@ Le NAS (Network Attached Storage) est un serveur de fichiers relié à un résea
 
 - Disposer d'une adresse IP attachée à un service OVHcloud (Hosted Private Cloud, Serveur Dédié, VPS, Instance Public Cloud, Offre Internet, etc...)
 - Disposer d'un [NAS-HA](https://www.ovh.com/fr/nas/)
-- Être connecté à votre [espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+- Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
 
 ## En pratique
 
-La gestion de votre NAS-HA s'effectue via l'[espace client OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}.
+La gestion de votre NAS-HA s'effectue via l'[espace client OVHcloud](/links/manager){.external}.
 
 Une fois connecté, cliquez sur `Bare Metal Cloud`{.action} puis sur `NAS and CDN`{.action} dans le menu à gauche. Cliquez sur votre service pour avoir accès au menu d'administration.
 
@@ -112,6 +112,6 @@ Pour supprimer une partition, cliquez sur le bouton `(...)`{.action} situé à d
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.it-it.md
@@ -16,11 +16,11 @@ Il NAS (Network Attached Storage) è un server di file collegato ad una rete la 
 
 - Disporre di un indirizzo IP associato a un servizio OVHcloud (Hosted Private Cloud, Server Dedicato, VPS, Istanza Public Cloud, ecc...)
 - Disporre di un [NAS-HA](https://www.ovh.it/nas/)
-- Avere accesso allo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}
+- Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}
 
 ## Procedura
 
-Il NAS-HA è gestito dallo [Spazio Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it){.external}.
+Il NAS-HA è gestito dallo [Spazio Cliente OVHcloud](/links/manager){.external}.
 
 Una volta connesso, clicca su `Bare Metal Cloud`{.action} e poi su `NAS e CDN`{.action} nel menu a sinistra. Clicca sul tuo servizio per accedere al menu di amministrazione.
 
@@ -116,6 +116,6 @@ Per eliminare una partizione, clicca sul pulsante `(...)`{.action} situato a des
 
 ## Per saperne di più
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.pl-pl.md
@@ -16,11 +16,11 @@ NAS (Network Attached Storage) jest serwerem plików podłączonym do sieci, kt�
 
 - Posiadanie adresu IP powiązanego z usługą OVHcloud (Hosted Private Cloud, Serwer dedykowany, VPS, Instancja Public Cloud, itp.)
 - Posiadanie usługi [NAS-HA](https://www.ovh.pl/nas/)
-- Dostęp do [Panelu klienta OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}.
+- Dostęp do [Panelu klienta OVHcloud](/links/manager){.external}.
 
 ## W praktyce
 
-Zarządzanie usługą NAS-HA odbywa się w [Panelu klienta](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl){.external}.
+Zarządzanie usługą NAS-HA odbywa się w [Panelu klienta](/links/manager){.external}.
 
 Po zalogowaniu kliknij `Bare Metal Cloud`{.action}, a następnie `NAS i CDN`{.action} w menu po lewej stronie. Kliknij Twoją usługę, aby uzyskać dostęp do menu administracyjnego.
 
@@ -116,6 +116,6 @@ Aby usunąć partycję, kliknij przycisk `(...)`{.action} znajdujący się po pr
 
 ## Sprawdź również
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_get_started/guide.pt-pt.md
@@ -16,11 +16,11 @@ O NAS (Network Attached Storage) é um servidor de ficheiros ligado a uma rede c
 
 - Dispor de um endereço IP associado a um serviço OVHcloud (Hosted Private Cloud, Servidor Dedicado, VPS, Instância Public Cloud, etc...)
 - Dispor de um [NAS-HA](https://www.ovh.pt/nas/)
-- Ter acesso à [Área de Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}.
+- Ter acesso à [Área de Cliente OVHcloud](/links/manager){.external}.
 
 ## Instruções
 
-A gestão do NAS-HA é realizada através da Área de [Cliente OVHcloud](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt){.external}.
+A gestão do NAS-HA é realizada através da Área de [Cliente OVHcloud](/links/manager){.external}.
 
 Uma vez ligado, clique em `Bare Metal Cloud`{.action} e, a seguir, em `NAS e CDN`{.action} no menu à esquerda. Clique no serviço para aceder ao menu de administração.
 
@@ -116,6 +116,6 @@ Para eliminar uma partição, clique no botão `(...)`{.action} situado à direi
 
 ## Saiba mais
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Fale com a nossa comunidade de utilizadores em <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.de-de.md
@@ -167,6 +167,6 @@ Um eine IP-Adresse oder einen Adressbereich aus der ACL zu löschen, verwenden S
 
 [NAS auf Windows Server über CIFS mounten](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-asia.md
@@ -163,6 +163,6 @@ To delete an IP address or address range from the ACL, use the following route:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-au.md
@@ -163,6 +163,6 @@ To delete an IP address or address range from the ACL, use the following route:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-ca.md
@@ -163,6 +163,6 @@ To delete an IP address or address range from the ACL, use the following route:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-gb.md
@@ -163,6 +163,6 @@ To delete an IP address or address range from the ACL, use the following route:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-ie.md
@@ -163,6 +163,6 @@ To delete an IP address or address range from the ACL, use the following route:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-sg.md
@@ -163,6 +163,6 @@ To delete an IP address or address range from the ACL, use the following route:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.en-us.md
@@ -163,6 +163,6 @@ To delete an IP address or address range from the ACL, use the following route:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.es-es.md
@@ -167,6 +167,6 @@ Para eliminar una dirección IP o un rango de direcciones de la ACL, utilice la 
 
 [Montar un NAS en Windows Server a través de CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.es-us.md
@@ -167,6 +167,6 @@ Para eliminar una dirección IP o un rango de direcciones de la ACL, utilice la 
 
 [Montar un NAS en Windows Server a través de CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.fr-ca.md
@@ -163,6 +163,6 @@ Pour supprimer une adresse IP ou une plage d'adresses de l'ACL, utilisez la rout
 
 [Montez votre NAS sur Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.fr-fr.md
@@ -163,6 +163,6 @@ Pour supprimer une adresse IP ou une plage d'adresses de l'ACL, utilisez la rout
 
 [Montez votre NAS sur Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.it-it.md
@@ -167,6 +167,6 @@ Per eliminare un indirizzo IP o una gamma di indirizzi dell'ACL, utilizza questa
 
 [Configura il tuo NAS su Windows Server tramite CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.pl-pl.md
@@ -167,6 +167,6 @@ Aby usunąć adres IP lub zakres adresów ACL, użyj następującej drogi:
 
 [Skonfigurować NAS na serwerze Windows poprzez CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Przyłącz się do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_manage_acls/guide.pt-pt.md
@@ -167,6 +167,6 @@ Para eliminar um endereço IP ou um intervalo de endereços do ACL, utilize a se
 
 [Configure o seu NAS no Windows Server através do CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Junte-se à nossa comunidade de utilizadores em <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.de-de.md
@@ -42,6 +42,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Weiterführende Informationen
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-asia.md
@@ -38,6 +38,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-au.md
@@ -38,6 +38,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-ca.md
@@ -38,6 +38,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-gb.md
@@ -38,6 +38,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-ie.md
@@ -38,6 +38,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-sg.md
@@ -38,6 +38,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.en-us.md
@@ -38,6 +38,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.es-es.md
@@ -44,6 +44,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/){.external}.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.es-us.md
@@ -44,6 +44,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en [https://community.ovh.com/en/](https://community.ovh.com/en/){.external}.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.fr-ca.md
@@ -40,6 +40,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.fr-fr.md
@@ -40,6 +40,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.it-it.md
@@ -44,6 +44,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Per saperne di più
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo [https://community.ovh.com/en/](https://community.ovh.com/en/){.external}.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.pl-pl.md
@@ -44,6 +44,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Sprawdź również
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na stronie [ https://community.ovh.com/en/](https://community.ovh.com/en/){.external}

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_migration/guide.pt-pt.md
@@ -44,6 +44,6 @@ rsync -Pva /mnt/SrcNas /mnt/DstNas
 
 ## Saiba mais
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Fale com a nossa comunidade de utilizadores: [https://community.ovh.com/en/](https://community.ovh.com/en/){.external}.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.de-de.md
@@ -282,6 +282,6 @@ Verwenden Sie die folgende Route, um eine Partition zu löschen:
 
 [NAS auf Windows Server über CIFS mounten](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-asia.md
@@ -278,6 +278,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-au.md
@@ -278,6 +278,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-ca.md
@@ -278,6 +278,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-gb.md
@@ -278,6 +278,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-ie.md
@@ -278,6 +278,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-sg.md
@@ -278,6 +278,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.en-us.md
@@ -278,6 +278,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.es-es.md
@@ -282,6 +282,6 @@ Utilice la siguiente ruta para eliminar una partición:
 
 [Montar un NAS en Windows Server a través de CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.es-us.md
@@ -282,6 +282,6 @@ Utilice la siguiente ruta para eliminar una partición:
 
 [Montar un NAS en Windows Server a través de CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.fr-ca.md
@@ -278,6 +278,6 @@ Utilisez la route suivante pour supprimer une partition :
 
 [Montez votre NAS sur Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.fr-fr.md
@@ -278,6 +278,6 @@ Utilisez la route suivante pour supprimer une partition :
 
 [Montez votre NAS sur Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.it-it.md
@@ -282,6 +282,6 @@ Per eliminare una partizione, utilizza questa pagina:
 
 [Configura il tuo NAS su Windows Server tramite CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.pl-pl.md
@@ -282,6 +282,6 @@ Użyj następującej drogi, aby usunąć partycję:
 
 [Skonfigurować NAS na serwerze Windows poprzez CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Przyłącz się do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_partitions_api/guide.pt-pt.md
@@ -282,6 +282,6 @@ Utilize a seguinte rota para eliminar uma partição:
 
 [Configure o seu NAS no Windows Server através do CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Junte-se à nossa comunidade de utilizadores em <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.de-de.md
@@ -208,6 +208,6 @@ Verwenden Sie die folgende Route, um eine Partition zu löschen:
 
 [NAS auf Windows Server über CIFS mounten](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-asia.md
@@ -204,6 +204,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-au.md
@@ -204,6 +204,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-ca.md
@@ -204,6 +204,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-gb.md
@@ -204,6 +204,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-ie.md
@@ -204,6 +204,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-sg.md
@@ -204,6 +204,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.en-us.md
@@ -204,6 +204,6 @@ Use the following route to delete a partition:
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.es-es.md
@@ -208,6 +208,6 @@ Utilice la siguiente ruta para eliminar una partition:
 
 [Montar un NAS en Windows Server a través de CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.es-us.md
@@ -208,6 +208,6 @@ Utilice la siguiente ruta para eliminar una partition:
 
 [Montar un NAS en Windows Server a través de CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.fr-ca.md
@@ -204,6 +204,6 @@ Utilisez la route suivante pour supprimer une partition :
 
 [Montez votre NAS sur Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.fr-fr.md
@@ -204,6 +204,6 @@ Utilisez la route suivante pour supprimer une partition :
 
 [Montez votre NAS sur Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.it-it.md
@@ -208,6 +208,6 @@ Per eliminare una partizione, utilizza questa pagina:
 
 [Configura il tuo NAS su Windows Server tramite CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.pl-pl.md
@@ -208,6 +208,6 @@ Użyj następującej drogi, aby usunąć partycję:
 
 [Skonfigurować NAS na serwerze Windows poprzez CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Przyłącz się do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_quick_api/guide.pt-pt.md
@@ -208,6 +208,6 @@ Utilize a seguinte rota para eliminar uma partição:
 
 [Configure o seu NAS no Windows Server através do CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Junte-se à nossa comunidade de utilizadores em <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.de-de.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.de-de.md
@@ -295,6 +295,6 @@ Zusätzliche Hilfe finden Sie unter "[Weiterführende Informationen](#gofurther)
 
 [NAS auf Windows Server über CIFS mounten](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-asia.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-asia.md
@@ -291,6 +291,6 @@ You can find more information in the [Go further](#gofurther) section of this gu
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-au.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-au.md
@@ -291,6 +291,6 @@ You can find more information in the [Go further](#gofurther) section of this gu
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-ca.md
@@ -291,6 +291,6 @@ You can find more information in the [Go further](#gofurther) section of this gu
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-gb.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-gb.md
@@ -291,6 +291,6 @@ You can find more information in the [Go further](#gofurther) section of this gu
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-ie.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-ie.md
@@ -291,6 +291,6 @@ You can find more information in the [Go further](#gofurther) section of this gu
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-sg.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-sg.md
@@ -291,6 +291,6 @@ You can find more information in the [Go further](#gofurther) section of this gu
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.en-us.md
@@ -291,6 +291,6 @@ You can find more information in the [Go further](#gofurther) section of this gu
 
 [Mount your NAS on Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.es-es.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.es-es.md
@@ -295,6 +295,6 @@ Para más información, consulte el apartado [Más información](#gofurther) de 
 
 [Montar un NAS en Windows Server a través de CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.es-us.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.es-us.md
@@ -295,6 +295,6 @@ Para más información, consulte el apartado [Más información](#gofurther) de 
 
 [Montar un NAS en Windows Server a través de CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.fr-ca.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.fr-ca.md
@@ -291,6 +291,6 @@ Plus d’informations dans la section [Aller plus loin](#gofurther) de ce guide.
 
 [Montez votre NAS sur Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.fr-fr.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.fr-fr.md
@@ -291,6 +291,6 @@ Plus d’informations dans la section [Aller plus loin](#gofurther) de ce guide.
 
 [Montez votre NAS sur Windows Server via CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.it-it.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.it-it.md
@@ -295,6 +295,6 @@ Per maggiori informazioni consulta la sezione [Per saperne di più](#gofurther) 
 
 [Configura il tuo NAS su Windows Server tramite CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.pl-pl.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.pl-pl.md
@@ -295,6 +295,6 @@ Więcej informacji znajduje się w sekcji [Sprawdź również](#gofurther) ten p
 
 [Skonfigurować NAS na serwerze Windows poprzez CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Przyłącz się do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.pt-pt.md
+++ b/pages/storage_and_backup/file_storage/ha_nas/nas_snapshots_api/guide.pt-pt.md
@@ -295,6 +295,6 @@ Para mais informações, aceda à secção [Quer saber mais](#gofurther).
 
 [Configure o seu NAS no Windows Server através do CIFS](/pages/storage_and_backup/file_storage/ha_nas/nas_cifs)
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Junte-se à nossa comunidade de utilizadores em <https://community.ovh.com/en/>.


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their /links values.

Example: replace all https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB links with /links/manager.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.