### PR TITLE
Fix global links in Storage and backup block storage

### DIFF
--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.de-de.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.de-de.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-asia.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-asia.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-au.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-au.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-ca.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-gb.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-gb.md
@@ -123,6 +123,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-ie.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-ie.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-sg.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-sg.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.en-us.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.es-es.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.es-es.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.es-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.es-us.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.fr-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.fr-ca.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.fr-fr.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.fr-fr.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.it-it.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.it-it.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.pl-pl.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.pl-pl.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.pt-pt.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_cephfs/guide.pt-pt.md
@@ -114,6 +114,6 @@ mount -t ceph -o name=CEPHFS_USER :/ /mnt/cephfs/
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.de-de.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.de-de.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-asia.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-asia.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-au.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-au.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-ca.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-gb.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-gb.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-ie.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-ie.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-sg.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-sg.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.en-us.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.es-es.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.es-es.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.es-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.es-us.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.fr-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.fr-ca.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Rendez-vous sur notre chaîne Discord dédiée : <https://discord.gg/ovhcloud>. Posez des questions, fournissez des commentaires et interagissez directement avec l'équipe qui construit nos services de stockage et de sauvegarde.
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.fr-fr.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.fr-fr.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Rendez-vous sur notre chaîne Discord dédiée : <https://discord.gg/ovhcloud>. Posez des questions, fournissez des commentaires et interagissez directement avec l'équipe qui construit nos services de stockage et de sauvegarde.
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.it-it.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.it-it.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.pl-pl.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.pl-pl.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.pt-pt.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_change_user_rights/guide.pt-pt.md
@@ -52,6 +52,6 @@ GET /dedicated/ceph/98d166d8-7c88-47b7-9cb6-63acd5a59c15/user
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.de-de.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.de-de.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-asia.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-asia.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-au.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-au.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-ca.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-gb.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-gb.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-ie.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-ie.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-sg.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-sg.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.en-us.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.es-es.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.es-es.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.es-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.es-us.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.fr-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.fr-ca.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.fr-fr.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.fr-fr.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.it-it.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.it-it.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.pl-pl.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.pl-pl.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.pt-pt.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_check_cluster_status/guide.pt-pt.md
@@ -155,6 +155,6 @@ Get Ceph cluster health:
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.de-de.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.de-de.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-asia.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-asia.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-au.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-au.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-ca.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-gb.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-gb.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-ie.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-ie.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-sg.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-sg.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.en-us.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.es-es.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.es-es.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.es-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.es-us.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.fr-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.fr-ca.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.fr-fr.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.fr-fr.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.it-it.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.it-it.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.pl-pl.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.pl-pl.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.pt-pt.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_faq/guide.pt-pt.md
@@ -59,6 +59,6 @@ In case of 2 replica failures, client access is blocked to the degraded objects 
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.de-de.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.de-de.md
@@ -104,6 +104,6 @@ fio --name=test-1 --ioengine=rbd --pool=rbd --rbdname=test-image --numjobs=1 \
 
 Besuchen Sie unseren speziellen Discord-Kanal: <https://discord.gg/ovhcloud>. Stellen Sie Fragen, geben Sie Feedback und interagieren Sie direkt mit dem Team, das unsere Speicher- und Sicherungsdienste entwickelt.
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Treten Sie unserer Benutzergemeinschaft auf <https://community.ovh.com/en/> bei.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-asia.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-asia.md
@@ -104,6 +104,6 @@ To measure Cloud Disk Array performance we are running test on a 32 images, each
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-au.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-au.md
@@ -104,6 +104,6 @@ To measure Cloud Disk Array performance we are running test on a 32 images, each
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-ca.md
@@ -104,6 +104,6 @@ To measure Cloud Disk Array performance we are running test on a 32 images, each
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-gb.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-gb.md
@@ -104,6 +104,6 @@ To measure Cloud Disk Array performance we are running test on a 32 images, each
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-ie.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-ie.md
@@ -104,6 +104,6 @@ To measure Cloud Disk Array performance we are running test on a 32 images, each
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-sg.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-sg.md
@@ -104,6 +104,6 @@ To measure Cloud Disk Array performance we are running test on a 32 images, each
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.en-us.md
@@ -104,6 +104,6 @@ To measure Cloud Disk Array performance we are running test on a 32 images, each
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.es-es.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.es-es.md
@@ -106,6 +106,6 @@ En este caso, para medir el rendimiento de Cloud Disk Array, hemos realizado tes
 
 Visite nuestro canal dedicado de Discord: <https://discord.gg/ovhcloud>. Haga preguntas, proporcione comentarios e interactúe directamente con el equipo que crea nuestros servicios de almacenamiento y copia de seguridad.
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Únase a nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.es-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.es-us.md
@@ -106,6 +106,6 @@ En este caso, para medir el rendimiento de Cloud Disk Array, hemos realizado tes
 
 Visite nuestro canal dedicado de Discord: <https://discord.gg/ovhcloud>. Haga preguntas, proporcione comentarios e interactúe directamente con el equipo que crea nuestros servicios de almacenamiento y copia de seguridad.
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Únase a nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.fr-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.fr-ca.md
@@ -108,6 +108,6 @@ Pour mesurer les performances d'une baie de disques virtuels, nous effectuons de
 
 Rendez-vous sur notre chaîne Discord dédiée : <https://discord.gg/ovhcloud>. Posez des questions, fournissez des commentaires et interagissez directement avec l'équipe qui construit nos services de stockage et de sauvegarde.
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.fr-fr.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.fr-fr.md
@@ -108,6 +108,6 @@ Pour mesurer les performances d'une baie de disques virtuels, nous effectuons de
 
 Rendez-vous sur notre chaîne Discord dédiée : <https://discord.gg/ovhcloud>. Posez des questions, fournissez des commentaires et interagissez directement avec l'équipe qui construit nos services de stockage et de sauvegarde.
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.it-it.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.it-it.md
@@ -106,6 +106,6 @@ Per calcolare le performance del servizio Cloud Disk Array, effettueremo test su
 
 Visita il nostro canale Discord dedicato: <https://discord.gg/ovhcloud>. Poni domande, fornisci feedback e interagisci direttamente con il team che crea i nostri servizi di archiviazione e backup.
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Unisciti alla nostra community di utenti su <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.pl-pl.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.pl-pl.md
@@ -111,6 +111,6 @@ Przyłącz się do społeczności naszych użytkowników na stronie <https://com
 
 Odwiedź nasz dedykowany kanał na Discordzie: <https://discord.gg/ovhcloud>. Zadawaj pytania, przesyłaj opinie i kontaktuj się bezpośrednio z zespołem, który tworzy nasze usługi przechowywania i tworzenia kopii zapasowych.
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do naszej społeczności użytkowników na <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.pt-pt.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_io_benchmarking/guide.pt-pt.md
@@ -106,6 +106,6 @@ Para medir o desempenho do Cloud Disk Array, realizamos testes em 32 imagens (ca
 
 Visite nosso canal Discord dedicado: <https://discord.gg/ovhcloud>. Faça perguntas, forneça feedback e interaja diretamente com a equipe que desenvolve nossos serviços de armazenamento e backup.
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Junte-se à nossa comunidade de utilizadores em <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.de-de.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.de-de.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-asia.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-asia.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-au.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-au.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-ca.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-gb.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-gb.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-ie.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-ie.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-sg.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-sg.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.en-us.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.es-es.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.es-es.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.es-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.es-us.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.fr-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.fr-ca.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.fr-fr.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.fr-fr.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.it-it.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.it-it.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.pl-pl.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.pl-pl.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.pt-pt.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_ceph_with_proxmox/guide.pt-pt.md
@@ -109,6 +109,6 @@ Once a template has been downloaded, you can start using it to create containers
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.de-de.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.de-de.md
@@ -115,6 +115,6 @@ You can now use your Ceph cluster!
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-asia.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-asia.md
@@ -115,6 +115,6 @@ You can now use your Ceph cluster!
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-au.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-au.md
@@ -115,6 +115,6 @@ You can now use your Ceph cluster!
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-ca.md
@@ -115,6 +115,6 @@ You can now use your Ceph cluster!
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-gb.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-gb.md
@@ -115,6 +115,6 @@ You can now use your Ceph cluster!
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-ie.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-ie.md
@@ -115,6 +115,6 @@ You can now use your Ceph cluster!
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-sg.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-sg.md
@@ -115,6 +115,6 @@ You can now use your Ceph cluster!
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.en-us.md
@@ -115,6 +115,6 @@ You can now use your Ceph cluster!
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.es-es.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.es-es.md
@@ -115,6 +115,6 @@ You can now use your Ceph cluster!
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.es-us.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.es-us.md
@@ -115,6 +115,6 @@ You can now use your Ceph cluster!
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.fr-ca.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.fr-ca.md
@@ -55,7 +55,7 @@ Créer le fichier `/etc/ceph/ceph.client.<ceph_user_name>.keyring`
 key = <my_user_key>
 ```
 
-`<mon_X_IP>` doit être remplacé par des moniteurs IP que vous pouvez trouver sur le gestionnaire du [Cloud Disk Array](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc). Sous "Plateformes et services", sélectionnez votre groupe Ceph.
+`<mon_X_IP>` doit être remplacé par des moniteurs IP que vous pouvez trouver sur le gestionnaire du [Cloud Disk Array](/links/manager). Sous "Plateformes et services", sélectionnez votre groupe Ceph.
 
 `<my_user_key>` doit être remplacée par la clé d'utilisateur que vous pouvez trouver sur le gestionnaire de votre Cloud Disk Array.
 
@@ -125,6 +125,6 @@ Vous pouvez maintenant utiliser votre grappe Ceph !
 
 Rendez-vous sur notre chaîne Discord dédiée : <https://discord.gg/ovhcloud>. Posez des questions, fournissez des commentaires et interagissez directement avec l'équipe qui construit nos services de stockage et de sauvegarde.
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.fr-fr.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.fr-fr.md
@@ -55,7 +55,7 @@ Créer le fichier `/etc/ceph/ceph.client.<ceph_user_name>.keyring`
 key = <my_user_key>
 ```
 
-`<mon_X_IP>` doit être remplacé par des moniteurs IP que vous pouvez trouver sur le gestionnaire du [Cloud Disk Array](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr){.external}. Sous "Plateformes et services", sélectionnez votre groupe Ceph.
+`<mon_X_IP>` doit être remplacé par des moniteurs IP que vous pouvez trouver sur le gestionnaire du [Cloud Disk Array](/links/manager){.external}. Sous "Plateformes et services", sélectionnez votre groupe Ceph.
 
 `<my_user_key>` doit être remplacée par la clé d'utilisateur que vous pouvez trouver sur le gestionnaire de votre Cloud Disk Array.
 
@@ -125,6 +125,6 @@ Vous pouvez maintenant utiliser votre grappe Ceph !
 
 Rendez-vous sur notre chaîne Discord dédiée : <https://discord.gg/ovhcloud>. Posez des questions, fournissez des commentaires et interagissez directement avec l'équipe qui construit nos services de stockage et de sauvegarde.
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.it-it.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.it-it.md
@@ -115,6 +115,6 @@ You can now use your Ceph cluster!
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.pl-pl.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.pl-pl.md
@@ -115,6 +115,6 @@ You can now use your Ceph cluster!
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.pt-pt.md
+++ b/pages/storage_and_backup/block_storage/cloud_disk_array/ceph_use_your_cluster_with_rbd/guide.pt-pt.md
@@ -115,6 +115,6 @@ You can now use your Ceph cluster!
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our Storage and Backup services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their /links values.

Example: replace all https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB links with /links/manager.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.