### PR TITLE
Fix global links in Public cloud public cloud network services

### DIFF
--- a/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.de-de.md
@@ -90,6 +90,6 @@ Im nächsten Schritt muss die IP-Adresse in Ihrem Betriebssystem konfiguriert we
 
 ## Weiterführende Informationen
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.es-es.md
@@ -92,6 +92,6 @@ El siguiente paso es configurar la IP en el sistema operativo. Consulte [nuestra
 
 [Configurar una Additional IP](/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.es-us.md
@@ -92,6 +92,6 @@ El siguiente paso es configurar la IP en el sistema operativo. Consulte [nuestra
 
 [Configurar una Additional IP](/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.fr-ca.md
@@ -87,6 +87,6 @@ La prochaine étape consiste à configurer l’IP dans votre système d'exploita
 
 [Configurer une Additional IP](/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.fr-fr.md
@@ -87,6 +87,6 @@ La prochaine étape consiste à configurer l’IP dans votre système d'exploita
 
 [Configurer une Additional IP](/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.it-it.md
@@ -92,6 +92,6 @@ Il prossimo step consiste nel configurare l'IP nel tuo sistema operativo. Consul
 
 [Configura un Additional IP](/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance)
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.pl-pl.md
@@ -92,7 +92,7 @@ Następnym krokiem jest konfiguracja IP w systemie operacyjnym. Zapoznaj się [z
 
 [Konfiguracja Additional IP](/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance)
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-buy/guide.pt-pt.md
@@ -92,6 +92,6 @@ O próximo passo consiste em configurar o IP no seu sistema operativo. Consulte 
 
 [Configurar um Additional IP](/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance)
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Fale com nossa comunidade de utilizadores: <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.de-de.md
@@ -25,7 +25,7 @@ Im OVHcloud Kundencenter können Sie eine Additional IP-Adresse, die mit einem a
 
 - Sie haben ein [Public Cloud Projekt](https://www.ovhcloud.com/de/public-cloud) in Ihrem Kunden-Account.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
-- Sie verfügen über eine [Additional IP-Adresse](https://www.ovhcloud.com/de/bare-metal/ip/).
+- Sie verfügen über eine [Additional IP-Adresse](/links/bare-metal/ip).
 
 > [!warning]
 > Diese Funktion ist derzeit für Metal Instanzen nicht verfügbar.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-asia.md
@@ -23,9 +23,9 @@ Instead of buying additional ones, you can import an Additional IP address that 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An [Additional IP address](https://www.ovhcloud.com/asia/bare-metal/ip/)
+- An [Additional IP address](/links/bare-metal/ip)
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-au.md
@@ -23,9 +23,9 @@ Instead of buying additional ones, you can import an Additional IP address that 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An [Additional IP address](https://www.ovhcloud.com/en-au/bare-metal/ip/)
+- An [Additional IP address](/links/bare-metal/ip)
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-ca.md
@@ -23,9 +23,9 @@ Instead of buying additional ones, you can import an Additional IP address that 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An [Additional IP address](https://www.ovhcloud.com/en-ca/bare-metal/ip/)
+- An [Additional IP address](/links/bare-metal/ip)
 
 > [!warning]
 > This feature is not currently available for Metal instances.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-gb.md
@@ -23,9 +23,9 @@ Instead of buying more public IP addresses, you can import an Additional IP addr
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An [Additional IP address](https://www.ovhcloud.com/en-gb/bare-metal/ip/)
+- An [Additional IP address](/links/bare-metal/ip)
 
 > [!warning]
 > This feature is not currently available for Metal instances.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-ie.md
@@ -23,9 +23,9 @@ Instead of buying additional ones, you can import an Additional IP address that 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An [Additional IP address](https://www.ovhcloud.com/en-ie/bare-metal/ip/)
+- An [Additional IP address](/links/bare-metal/ip)
 
 > [!warning]
 > This feature is not currently available for Metal instances.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-sg.md
@@ -23,9 +23,9 @@ Instead of buying additional ones, you can import an Additional IP address that 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An [Additional IP address](https://www.ovhcloud.com/en-sg/bare-metal/ip/)
+- An [Additional IP address](/links/bare-metal/ip)
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.en-us.md
@@ -23,9 +23,9 @@ Instead of buying additional ones, you can import an Additional IP address that 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
-- An [Additional IP address](https://www.ovhcloud.com/en/bare-metal/ip/)
+- An [Additional IP address](/links/bare-metal/ip)
 
 > [!warning]
 > This feature is not currently available for Metal instances.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.es-es.md
@@ -23,9 +23,9 @@ Puede importar una dirección Additional IP que esté asociada a otro servicio d
 
 ## Requisitos
 
-- Tener un [proyecto de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud
+- Tener un [proyecto de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
 - Tener acceso al [área de cliente de OVHcloud](/links/manager)
-- Tener una [dirección Additional IP](https://www.ovhcloud.com/es-es/bare-metal/ip/)
+- Tener una [dirección Additional IP](/links/bare-metal/ip)
 
 > [!warning]
 > Esta funcionalidad no está actualmente disponible para instancias Metal.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.es-us.md
@@ -23,9 +23,9 @@ Puede importar una dirección Additional IP que esté asociada a otro servicio d
 
 ## Requisitos
 
-- Tener un [proyecto de Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud
+- Tener un [proyecto de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
 - Tener acceso al [área de cliente de OVHcloud](/links/manager)
-- Tener una [dirección Additional IP](https://www.ovhcloud.com/es/bare-metal/ip/)
+- Tener una [dirección Additional IP](/links/bare-metal/ip)
 
 > [!warning]
 > Esta funcionalidad no está actualmente disponible para instancias Metal.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.fr-ca.md
@@ -23,9 +23,9 @@ Il est possible d’importer une adresse Additional IP liée à un autre service
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud.
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - Être connecté à votre [espace client OVHcloud](/links/manager).
-- Avoir [une Additional IP](https://www.ovhcloud.com/fr-ca/bare-metal/ip/).
+- Avoir [une Additional IP](/links/bare-metal/ip).
 
 > [!warning]
 > Cette fonctionnalité n'est actuellement pas disponible pour les instances Metal.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.fr-fr.md
@@ -23,9 +23,9 @@ Il est possible d’importer une adresse Additional IP liée à un autre service
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud.
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - Être connecté à votre [espace client OVHcloud](/links/manager).
-- Avoir [une Additional IP](https://www.ovhcloud.com/fr/bare-metal/ip/).
+- Avoir [une Additional IP](/links/bare-metal/ip).
 
 > [!warning]
 > Cette fonctionnalité n'est actuellement pas disponible pour les instances Metal.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.it-it.md
@@ -23,9 +23,9 @@ Per configurare un indirizzo Additional IP sulle tue istanze Public Cloud, ad es
 
 ## Prerequisiti
 
-- Un [progetto Public Cloud](https://www.ovhcloud.com/it/public-cloud/) nel tuo account OVHcloud
+- Un [progetto Public Cloud](/links/public-cloud/public-cloud) nel tuo account OVHcloud
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
-- Un [indirizzo Additional IP](https://www.ovhcloud.com/it/bare-metal/ip/)
+- Un [indirizzo Additional IP](/links/bare-metal/ip)
 
 > [!warning]
 > Questa funzionalità al momento non è disponibile per le istanze Metal.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.pl-pl.md
@@ -23,9 +23,9 @@ Można zaimportować adres Additional IP powiązany z inną usługą OVHcloud.
 
 ## Wymagania początkowe
 
-- [Projekt Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na koncie OVHcloud
+- [Projekt Public Cloud](/links/public-cloud/public-cloud) na koncie OVHcloud
 - Dostęp do [Panelu klienta OVHcloud](/links/manager)
-- [Adres Additional IP](https://www.ovhcloud.com/pl/bare-metal/ip/)
+- [Adres Additional IP](/links/bare-metal/ip)
 
 > [!warning]
 > Ta funkcja nie jest aktualnie dostępna dla instancji Metal.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-import/guide.pt-pt.md
@@ -23,9 +23,9 @@ Pode importar um endereço Additional IP associado a outro serviço OVHcloud.
 
 ## Requisitos
 
-- Um [projeto Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) criado na sua conta OVHcloud
+- Um [projeto Public Cloud](/links/public-cloud/public-cloud) criado na sua conta OVHcloud
 - Acesso à [Área de Cliente OVHcloud](/links/manager)
-- Um [endereço Additional IP](https://www.ovhcloud.com/pt/bare-metal/ip/)
+- Um [endereço Additional IP](/links/bare-metal/ip)
 
 > [!warning]
 > Esta funcionalidade não está atualmente disponível para as instâncias Metal.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.de-de.md
@@ -69,6 +69,6 @@ Die Additional IP kann vor oder nach der Migration auf dem Zielserver konfigurie
 
 [Additional IP importieren](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-asia.md
@@ -17,7 +17,7 @@ Being able to migrate IP addresses generally limits or removes the possibility t
 
 ## Prerequisites
 
-- At least two [Public Cloud instances](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- At least two [Public Cloud instances](/links/public-cloud/public-cloud) in your OVHcloud account
 - An Additional IP address
 - Access to the [OVHcloud Control Panel](/links/manager)
 

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-au.md
@@ -17,7 +17,7 @@ Being able to migrate IP addresses generally limits or removes the possibility t
 
 ## Prerequisites
 
-- At least two [Public Cloud instances](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- At least two [Public Cloud instances](/links/public-cloud/public-cloud) in your OVHcloud account
 - An Additional IP address
 - Access to the [OVHcloud Control Panel](/links/manager)
 
@@ -59,6 +59,6 @@ The Additional IP can be configured on the destination server before or after ca
 
 [Importing an Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-ca.md
@@ -17,7 +17,7 @@ Being able to migrate IP addresses generally limits or removes the possibility t
 
 ## Prerequisites
 
-- At least two [Public Cloud instances](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- At least two [Public Cloud instances](/links/public-cloud/public-cloud) in your OVHcloud account
 - An Additional IP address
 - Access to the [OVHcloud Control Panel](/links/manager)
 
@@ -63,6 +63,6 @@ The Additional IP can be configured on the destination server before or after ca
 
 [Importing an Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-gb.md
@@ -17,7 +17,7 @@ Being able to migrate IP addresses generally limits or removes the possibility t
 
 ## Prerequisites
 
-- At least two [Public Cloud instances](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- At least two [Public Cloud instances](/links/public-cloud/public-cloud) in your OVHcloud account
 - An Additional IP address
 - Access to the [OVHcloud Control Panel](/links/manager)
 
@@ -63,6 +63,6 @@ The Additional IP can be configured on the destination server before or after ca
 
 [Importing an Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-ie.md
@@ -17,7 +17,7 @@ Being able to migrate IP addresses generally limits or removes the possibility t
 
 ## Prerequisites
 
-- At least two [Public Cloud instances](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- At least two [Public Cloud instances](/links/public-cloud/public-cloud) in your OVHcloud account
 - An Additional IP address
 - Access to the [OVHcloud Control Panel](/links/manager)
 
@@ -63,6 +63,6 @@ The Additional IP can be configured on the destination server before or after ca
 
 [Importing an Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-sg.md
@@ -17,7 +17,7 @@ Being able to migrate IP addresses generally limits or removes the possibility t
 
 ## Prerequisites
 
-- At least two [Public Cloud instances](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- At least two [Public Cloud instances](/links/public-cloud/public-cloud) in your OVHcloud account
 - An Additional IP address
 - Access to the [OVHcloud Control Panel](/links/manager)
 
@@ -59,6 +59,6 @@ The Additional IP can be configured on the destination server before or after ca
 
 [Importing an Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.en-us.md
@@ -17,7 +17,7 @@ Being able to migrate IP addresses generally limits or removes the possibility t
 
 ## Prerequisites
 
-- At least two [Public Cloud instances](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- At least two [Public Cloud instances](/links/public-cloud/public-cloud) in your OVHcloud account
 - An Additional IP address
 - Access to the [OVHcloud Control Panel](/links/manager)
 
@@ -63,6 +63,6 @@ The Additional IP can be configured on the destination server before or after ca
 
 [Importing an Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.es-es.md
@@ -67,6 +67,6 @@ La Additional IP puede configurarse en el servidor de destino antes o después d
 
 [Importar una Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.es-us.md
@@ -67,6 +67,6 @@ La Additional IP puede configurarse en el servidor de destino antes o después d
 
 [Importar una Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.fr-ca.md
@@ -62,6 +62,6 @@ L’Additional IP peut être configurée sur le serveur de destination avant ou 
 
 [Importer une Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.fr-fr.md
@@ -62,6 +62,6 @@ L’Additional IP peut être configurée sur le serveur de destination avant ou 
 
 [Importer une Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.it-it.md
@@ -67,6 +67,6 @@ L'Additional IP può essere configurato sul server di destinazione prima o dopo 
 
 [Importa un Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.pl-pl.md
@@ -68,7 +68,7 @@ Additional IP może być skonfigurowany na serwerze docelowym przed lub po migra
 
 [Importowanie adresu Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
  
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/additional-ip-migrate/guide.pt-pt.md
@@ -21,7 +21,7 @@ Este guia explica como poderá migrar um Additional IP de uma instância para ou
 
 ## Requisitos
 
-- Dispor de, no mínimo, duas instâncias [Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) iniciadas
+- Dispor de, no mínimo, duas instâncias [Public Cloud](/links/public-cloud/public-cloud) iniciadas
 - Um Additional IP
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager)
 
@@ -67,6 +67,6 @@ O Additional IP pode ser configurado no servidor de destino antes ou depois da m
 
 [Importar um Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-import)
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Fale com nossa comunidade de utilizadores: <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.de-de.md
@@ -18,12 +18,12 @@ Sie können einen sekundären Server hinzufügen oder diese Konfiguration durch 
 > [!warning]
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 > 
-> Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#gofurther).
+> Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Implementierung der Dienste auf einem Server haben. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#gofurther).
 >
 
 ## Voraussetzungen
 
-- Sie haben eine [Public Cloud Instanz](https://www.ovhcloud.com/de/public-cloud/) in Ihrem Kunden-Account.
+- Sie haben eine [Public Cloud Instanz](/links/public-cloud/public-cloud) in Ihrem Kunden-Account.
 - Sie haben administrativen Zugriff auf Ihre Instanz über SSH oder RDP.
 - Grundlegende Kenntnisse der Netzwerkverwaltung.
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-asia.md
@@ -13,12 +13,12 @@ The default DNS server configured on instances you create will be the OVHcloud s
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/asia/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Administrative access to the instance via SSH or RDP
 - Basic networking and administration knowledge
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-au.md
@@ -13,12 +13,12 @@ The default DNS server configured on instances you create will be the OVHcloud s
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-au/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Administrative access to the instance via SSH or RDP
 - Basic networking and administration knowledge
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-ca.md
@@ -13,12 +13,12 @@ The default DNS server configured on instances you create will be the OVHcloud s
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Administrative access to the instance via SSH or RDP
 - Basic networking and administration knowledge
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-gb.md
@@ -13,12 +13,12 @@ The default DNS server configured on instances you create will be the OVHcloud s
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Administrative access to the instance via SSH or RDP
 - Basic networking and administration knowledge
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-ie.md
@@ -13,12 +13,12 @@ The default DNS server configured on instances you create will be the OVHcloud s
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Administrative access to the instance via SSH or RDP
 - Basic networking and administration knowledge
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-sg.md
@@ -13,12 +13,12 @@ The default DNS server configured on instances you create will be the OVHcloud s
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Administrative access to the instance via SSH or RDP
 - Basic networking and administration knowledge
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.en-us.md
@@ -13,12 +13,12 @@ The default DNS server configured on instances you create will be the OVHcloud s
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server. You can find more information in the [Go further](#gofurther) section of this guide.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Administrative access to the instance via SSH or RDP
 - Basic networking and administration knowledge
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.es-es.md
@@ -23,7 +23,7 @@ Puede añadir un servidor secundario o sustituir esta configuración por la suya
 
 ## Requisitos
 
-- Tener una [instancia de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud.
+- Tener una [instancia de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud.
 - Tener acceso de administrador a la instancia a través de SSH o RDP.
 - Conocimientos básicos de red y administración.
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.es-us.md
@@ -23,7 +23,7 @@ Puede añadir un servidor secundario o sustituir esta configuración por la suya
 
 ## Requisitos
 
-- Tener una [instancia de Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud.
+- Tener una [instancia de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud.
 - Tener acceso de administrador a la instancia a través de SSH o RDP.
 - Conocimientos básicos de red y administración.
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.fr-ca.md
@@ -14,12 +14,12 @@ Vous pouvez ajouter un serveur secondaire ou remplacer cette configuration par l
 > [!warning]
 > OVHcloud vous fournit des services dont la configuration et la gestion relèvent de votre responsabilité. Il vous incombe par conséquent de veiller à ce que ces services fonctionnent correctement.
 >
-> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr-ca/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur. Plus d’informations dans la section [Aller plus loin](#gofurther) de ce guide.
+> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur. Plus d’informations dans la section [Aller plus loin](#gofurther) de ce guide.
 >
 
 ## Prérequis
 
-- Disposer d'une [instance Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud.
+- Disposer d'une [instance Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - Disposer d’un accès administrateur à l’instance via SSH ou RDP.
 - Des connaissances de base en réseau et administration.
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.fr-fr.md
@@ -14,12 +14,12 @@ Vous pouvez ajouter un serveur secondaire ou remplacer cette configuration par l
 > [!warning]
 > OVHcloud vous fournit des services dont la configuration et la gestion relèvent de votre responsabilité. Il vous incombe par conséquent de veiller à ce que ces services fonctionnent correctement.
 >
-> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](https://partner.ovhcloud.com/fr/directory/) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur. Plus d’informations dans la section [Aller plus loin](#gofurther) de ce guide.
+> Nous mettons ce guide à votre disposition afin de vous accompagner au mieux sur les tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) si vous éprouvez des difficultés ou des doutes concernant l’administration, l’utilisation ou la mise en place d’un service sur un serveur. Plus d’informations dans la section [Aller plus loin](#gofurther) de ce guide.
 >
 
 ## Prérequis
 
-- Disposer d'une [instance Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud.
+- Disposer d'une [instance Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - Disposer d’un accès administrateur à l’instance via SSH ou RDP.
 - Des connaissances de base en réseau et administration.
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.it-it.md
@@ -23,7 +23,7 @@ Di default, il server DNS configurato sulle istanze Public Cloud è quello di OV
 
 ## Prerequisiti
 
-- Disporre di un'[istanza Public Cloud](https://www.ovhcloud.com/it/public-cloud/) nel proprio account OVHcloud
+- Disporre di un'[istanza Public Cloud](/links/public-cloud/public-cloud) nel proprio account OVHcloud
 - Avere accesso amministratore all'istanza via SSH o RDP
 - Conoscenze di base in rete e amministrazione
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.pl-pl.md
@@ -23,7 +23,7 @@ Możesz dodać serwer zapasowy lub zastąpić tę konfigurację Twoją. Serwery 
 
 ## Wymagania początkowe
 
-- Posiadanie [instancji Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na koncie OVHcloud
+- Posiadanie [instancji Public Cloud](/links/public-cloud/public-cloud) na koncie OVHcloud
 - Dostęp administratora do instancji przez SSH lub RDP
 - Podstawowa wiedza w zakresie sieci i administracji
 

--- a/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/changing_dns_servers_of_an_instance/guide.pt-pt.md
@@ -18,12 +18,12 @@ Pode adicionar um servidor secundário ou substituir esta configuração pela su
 > [!warning]
 > A OVHcloud fornece-lhe serviços cuja configuração e gestão são da sua responsabilidade. Por conseguinte, é da sua responsabilidade garantir que estes serviços funcionam corretamente.
 >
-> Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de um serviço num servidor, recomendamos que recorra a um [prestador de serviços especializado](https://partner.ovhcloud.com/pt/directory/). Para mais informações, aceda à secção [Quer saber mais](#gofurther).
+> Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se encontrar dificuldades ou dúvidas relativamente à administração, utilização ou implementação de um serviço num servidor, recomendamos que recorra a um [prestador de serviços especializado](/links/partner). Para mais informações, aceda à secção [Quer saber mais](#gofurther).
 >
 
 ## Requisitos
 
-- Ter uma [instância Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud.
+- Ter uma [instância Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud.
 - Dispor de um acesso de administrador à instância através de SSH ou RDP.
 - Conhecimentos básicos de rede e administração.
 

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.de-de.md
@@ -30,7 +30,7 @@ More information about configuring Additional IP addresses is available in [this
 
 ### Floating IP
 
-This type of public IP address is only available for [Public Cloud services](https://www.ovhcloud.com/de/public-cloud/), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
+This type of public IP address is only available for [Public Cloud services](/links/public-cloud/public-cloud), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
 
 The backend (instance/Load Balancer) system configuration when using Floating IP is entirely automatic (via DHCP protocol), no manual setup is needed. However, they require a Gateway in order to map a public IP address to an instance or network service.
 
@@ -55,6 +55,6 @@ Depending on your choice, you can select from the different regions and further 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-asia.md
@@ -30,7 +30,7 @@ More information about configuring Additional IP addresses is available in [this
 
 ### Floating IP
 
-This type of public IP address is only available for [Public Cloud services](https://www.ovhcloud.com/asia/public-cloud/), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
+This type of public IP address is only available for [Public Cloud services](/links/public-cloud/public-cloud), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
 
 The backend (instance/Load Balancer) system configuration when using Floating IP is entirely automatic (via DHCP protocol), no manual setup is needed. However, they require a Gateway in order to map a public IP address to an instance or network service.
 
@@ -55,6 +55,6 @@ Depending on your choice, you can select from the different regions and further 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-au.md
@@ -30,7 +30,7 @@ More information about configuring Additional IP addresses is available in [this
 
 ### Floating IP
 
-This type of public IP address is only available for [Public Cloud services](https://www.ovhcloud.com/en-au/public-cloud/), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
+This type of public IP address is only available for [Public Cloud services](/links/public-cloud/public-cloud), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
 
 The backend (instance/Load Balancer) system configuration when using Floating IP is entirely automatic (via DHCP protocol), no manual setup is needed. However, they require a Gateway in order to map a public IP address to an instance or network service.
 
@@ -55,6 +55,6 @@ Depending on your choice, you can select from the different regions and further 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-ca.md
@@ -30,7 +30,7 @@ More information about configuring Additional IP addresses is available in [this
 
 ### Floating IP
 
-This type of public IP address is only available for [Public Cloud services](https://www.ovhcloud.com/en-ca/public-cloud/), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
+This type of public IP address is only available for [Public Cloud services](/links/public-cloud/public-cloud), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
 
 The backend (instance/Load Balancer) system configuration when using Floating IP is entirely automatic (via DHCP protocol), no manual setup is needed. However, they require a Gateway in order to map a public IP address to an instance or network service.
 
@@ -55,6 +55,6 @@ Depending on your choice, you can select from the different regions and further 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-gb.md
@@ -30,7 +30,7 @@ More information about configuring Additional IP addresses is available in [this
 
 ### Floating IP
 
-This type of public IP address is only available for [Public Cloud services](https://www.ovhcloud.com/en-gb/public-cloud/), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
+This type of public IP address is only available for [Public Cloud services](/links/public-cloud/public-cloud), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
 
 The backend (instance/Load Balancer) system configuration when using Floating IP is entirely automatic (via DHCP protocol), no manual setup is needed. However, they require a Gateway in order to map a public IP address to an instance or network service.
 
@@ -55,6 +55,6 @@ Depending on your choice, you can select from the different regions and further 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-ie.md
@@ -30,7 +30,7 @@ More information about configuring Additional IP addresses is available in [this
 
 ### Floating IP
 
-This type of public IP address is only available for [Public Cloud services](https://www.ovhcloud.com/en-ie/public-cloud/), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
+This type of public IP address is only available for [Public Cloud services](/links/public-cloud/public-cloud), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
 
 The backend (instance/Load Balancer) system configuration when using Floating IP is entirely automatic (via DHCP protocol), no manual setup is needed. However, they require a Gateway in order to map a public IP address to an instance or network service.
 
@@ -55,6 +55,6 @@ Depending on your choice, you can select from the different regions and further 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-sg.md
@@ -30,7 +30,7 @@ More information about configuring Additional IP addresses is available in [this
 
 ### Floating IP
 
-This type of public IP address is only available for [Public Cloud services](https://www.ovhcloud.com/en-sg/public-cloud/), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
+This type of public IP address is only available for [Public Cloud services](/links/public-cloud/public-cloud), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
 
 The backend (instance/Load Balancer) system configuration when using Floating IP is entirely automatic (via DHCP protocol), no manual setup is needed. However, they require a Gateway in order to map a public IP address to an instance or network service.
 
@@ -55,6 +55,6 @@ Depending on your choice, you can select from the different regions and further 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.en-us.md
@@ -30,7 +30,7 @@ More information about configuring Additional IP addresses is available in [this
 
 ### Floating IP
 
-This type of public IP address is only available for [Public Cloud services](https://www.ovhcloud.com/en/public-cloud/), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
+This type of public IP address is only available for [Public Cloud services](/links/public-cloud/public-cloud), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
 
 The backend (instance/Load Balancer) system configuration when using Floating IP is entirely automatic (via DHCP protocol), no manual setup is needed. However, they require a Gateway in order to map a public IP address to an instance or network service.
 
@@ -55,6 +55,6 @@ Depending on your choice, you can select from the different regions and further 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.es-es.md
@@ -30,7 +30,7 @@ More information about configuring Additional IP addresses is available in [this
 
 ### Floating IP
 
-This type of public IP address is only available for [Public Cloud services](https://www.ovhcloud.com/es-es/public-cloud/), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
+This type of public IP address is only available for [Public Cloud services](/links/public-cloud/public-cloud), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
 
 The backend (instance/Load Balancer) system configuration when using Floating IP is entirely automatic (via DHCP protocol), no manual setup is needed. However, they require a Gateway in order to map a public IP address to an instance or network service.
 
@@ -55,6 +55,6 @@ Depending on your choice, you can select from the different regions and further 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.es-us.md
@@ -30,7 +30,7 @@ More information about configuring Additional IP addresses is available in [this
 
 ### Floating IP
 
-This type of public IP address is only available for [Public Cloud services](https://www.ovhcloud.com/es/public-cloud/), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
+This type of public IP address is only available for [Public Cloud services](/links/public-cloud/public-cloud), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
 
 The backend (instance/Load Balancer) system configuration when using Floating IP is entirely automatic (via DHCP protocol), no manual setup is needed. However, they require a Gateway in order to map a public IP address to an instance or network service.
 
@@ -55,6 +55,6 @@ Depending on your choice, you can select from the different regions and further 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.fr-ca.md
@@ -30,7 +30,7 @@ Retrouvez plus d'informations sur la configuration d'adresses Additional IP dans
 
 ### Floating IP
 
-Ce type d’adresse IP publique est disponible uniquement pour les [services Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) conçus pour les cas d’usages cloud native et notamment l’automatisation (ex : Terraform, Ansible). Ils servent à exposer une instance privée ou un service de réseau privé (un Load Balancer par exemple) sur le réseau public.
+Ce type d’adresse IP publique est disponible uniquement pour les [services Public Cloud](/links/public-cloud/public-cloud) conçus pour les cas d’usages cloud native et notamment l’automatisation (ex : Terraform, Ansible). Ils servent à exposer une instance privée ou un service de réseau privé (un Load Balancer par exemple) sur le réseau public.
 
 La configuration du système backend (instance/Load Balancer) lors de l'utilisation de l'adresse Floating IP est entièrement automatique (via le protocole DHCP), aucune configuration manuelle n'est nécessaire. Cependant, une passerelle est nécessaire pour mapper une adresse IP publique à une instance ou un service réseau.
 
@@ -54,6 +54,6 @@ En fonction de votre choix, vous pouvez faire votre sélection parmi les différ
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.fr-fr.md
@@ -30,7 +30,7 @@ Retrouvez plus d'informations sur la configuration d'adresses Additional IP dans
 
 ### Floating IP
 
-Ce type d’adresse IP publique est disponible uniquement pour les [services Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) conçus pour les cas d’usages cloud native et notamment l’automatisation (ex : Terraform, Ansible). Ils servent à exposer une instance privée ou un service de réseau privé (un Load Balancer par exemple) sur le réseau public.
+Ce type d’adresse IP publique est disponible uniquement pour les [services Public Cloud](/links/public-cloud/public-cloud) conçus pour les cas d’usages cloud native et notamment l’automatisation (ex : Terraform, Ansible). Ils servent à exposer une instance privée ou un service de réseau privé (un Load Balancer par exemple) sur le réseau public.
 
 La configuration du système backend (instance/Load Balancer) lors de l'utilisation de l'adresse Floating IP est entièrement automatique (via le protocole DHCP), aucune configuration manuelle n'est nécessaire. Cependant, une passerelle est nécessaire pour mapper une adresse IP publique à une instance ou un service réseau.
 
@@ -54,6 +54,6 @@ En fonction de votre choix, vous pouvez faire votre sélection parmi les différ
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.it-it.md
@@ -30,7 +30,7 @@ More information about configuring Additional IP addresses is available in [this
 
 ### Floating IP
 
-This type of public IP address is only available for [Public Cloud services](https://www.ovhcloud.com/it/public-cloud/), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
+This type of public IP address is only available for [Public Cloud services](/links/public-cloud/public-cloud), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
 
 The backend (instance/Load Balancer) system configuration when using Floating IP is entirely automatic (via DHCP protocol), no manual setup is needed. However, they require a Gateway in order to map a public IP address to an instance or network service.
 
@@ -55,6 +55,6 @@ Depending on your choice, you can select from the different regions and further 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.pl-pl.md
@@ -30,7 +30,7 @@ More information about configuring Additional IP addresses is available in [this
 
 ### Floating IP
 
-This type of public IP address is only available for [Public Cloud services](https://www.ovhcloud.com/pl/public-cloud/), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
+This type of public IP address is only available for [Public Cloud services](/links/public-cloud/public-cloud), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
 
 The backend (instance/Load Balancer) system configuration when using Floating IP is entirely automatic (via DHCP protocol), no manual setup is needed. However, they require a Gateway in order to map a public IP address to an instance or network service.
 
@@ -55,6 +55,6 @@ Depending on your choice, you can select from the different regions and further 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip/guide.pt-pt.md
@@ -30,7 +30,7 @@ More information about configuring Additional IP addresses is available in [this
 
 ### Floating IP
 
-This type of public IP address is only available for [Public Cloud services](https://www.ovhcloud.com/pt/public-cloud/), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
+This type of public IP address is only available for [Public Cloud services](/links/public-cloud/public-cloud), designed for cloud-native use cases and especially automation (e.g. Terraform, Ansible). They serve to expose a private instance or a private network service (Load Balancer for example) to the public network.
 
 The backend (instance/Load Balancer) system configuration when using Floating IP is entirely automatic (via DHCP protocol), no manual setup is needed. However, they require a Gateway in order to map a public IP address to an instance or network service.
 
@@ -55,6 +55,6 @@ Depending on your choice, you can select from the different regions and further 
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.de-de.md
@@ -144,6 +144,6 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 - An exhaustive technical documentation on [OpenStack project page](https://docs.openstack.org/octavia/latest/).
 - Configure your first load balancer with this [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-asia.md
@@ -144,6 +144,6 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 - An exhaustive technical documentation on [OpenStack project page](https://docs.openstack.org/octavia/latest/).
 - Configure your first load balancer with this [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-au.md
@@ -144,6 +144,6 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 - An exhaustive technical documentation on [OpenStack project page](https://docs.openstack.org/octavia/latest/).
 - Configure your first load balancer with this [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-ca.md
@@ -144,6 +144,6 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 - An exhaustive technical documentation on [OpenStack project page](https://docs.openstack.org/octavia/latest/).
 - Configure your first load balancer with this [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-gb.md
@@ -144,6 +144,6 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 - An exhaustive technical documentation on [OpenStack project page](https://docs.openstack.org/octavia/latest/).
 - Configure your first load balancer with this [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-ie.md
@@ -144,6 +144,6 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 - An exhaustive technical documentation on [OpenStack project page](https://docs.openstack.org/octavia/latest/).
 - Configure your first load balancer with this [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-sg.md
@@ -144,6 +144,6 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 - An exhaustive technical documentation on [OpenStack project page](https://docs.openstack.org/octavia/latest/).
 - Configure your first load balancer with this [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.en-us.md
@@ -144,6 +144,6 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 - An exhaustive technical documentation on [OpenStack project page](https://docs.openstack.org/octavia/latest/).
 - Configure your first load balancer with this [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.es-es.md
@@ -144,6 +144,6 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 - An exhaustive technical documentation on [OpenStack project page](https://docs.openstack.org/octavia/latest/).
 - Configure your first load balancer with this [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.es-us.md
@@ -144,6 +144,6 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 - An exhaustive technical documentation on [OpenStack project page](https://docs.openstack.org/octavia/latest/).
 - Configure your first load balancer with this [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.fr-ca.md
@@ -149,6 +149,6 @@ La formulation est légèrement différente entre OpenStack et OVHcloud. Le tabl
 
 - Configurez votre premier load balancer avec ce [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.fr-fr.md
@@ -149,6 +149,6 @@ La formulation est légèrement différente entre OpenStack et OVHcloud. Le tabl
 
 - Configurez votre premier load balancer avec ce [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.it-it.md
@@ -144,6 +144,6 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 - An exhaustive technical documentation on [OpenStack project page](https://docs.openstack.org/octavia/latest/).
 - Configure your first load balancer with this [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.pl-pl.md
@@ -144,6 +144,6 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 - An exhaustive technical documentation on [OpenStack project page](https://docs.openstack.org/octavia/latest/).
 - Configure your first load balancer with this [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/concepts-03-loadbalancer/guide.pt-pt.md
@@ -144,6 +144,6 @@ The wording is slightly different between OpenStack and OVHcloud: the following 
 - An exhaustive technical documentation on [OpenStack project page](https://docs.openstack.org/octavia/latest/).
 - Configure your first load balancer with this [guide](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service).
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.de-de.md
@@ -12,7 +12,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} tool installed on your working environment
 - A [Public Cloud Floating IP](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -149,6 +149,6 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-asia.md
@@ -12,7 +12,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} tool installed on your working environment
 - A [Public Cloud Floating IP](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -149,6 +149,6 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-au.md
@@ -12,7 +12,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} tool installed on your working environment
 - A [Public Cloud Floating IP](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -149,6 +149,6 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-ca.md
@@ -12,7 +12,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} tool installed on your working environment
 - A [Public Cloud Floating IP](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -149,6 +149,6 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-gb.md
@@ -12,7 +12,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} tool installed on your working environment
 - A [Public Cloud Floating IP](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -149,6 +149,6 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-ie.md
@@ -12,7 +12,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} tool installed on your working environment
 - A [Public Cloud Floating IP](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -149,6 +149,6 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-sg.md
@@ -12,7 +12,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} tool installed on your working environment
 - A [Public Cloud Floating IP](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -149,6 +149,6 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.en-us.md
@@ -12,7 +12,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} tool installed on your working environment
 - A [Public Cloud Floating IP](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -149,6 +149,6 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.es-es.md
@@ -12,7 +12,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} tool installed on your working environment
 - A [Public Cloud Floating IP](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -149,6 +149,6 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.es-us.md
@@ -12,7 +12,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} tool installed on your working environment
 - A [Public Cloud Floating IP](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -149,6 +149,6 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.fr-ca.md
@@ -10,7 +10,7 @@ L'objectif de ce guide est d'expliquer ce qu'est le service SNAT fourni par les 
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - L'outil [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} installé sur votre environnement (local)
 - Une [Floating IP des services L3](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -145,6 +145,6 @@ La VM **vmpriv** a un accès externe à Internet tout en étant connectée à un
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.fr-fr.md
@@ -10,7 +10,7 @@ L'objectif de ce guide est d'expliquer ce qu'est le service SNAT fourni par les 
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - L'outil [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} installé sur votre environnement (local)
 - Une [Floating IP des services L3](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -145,6 +145,6 @@ La VM **vmpriv** a un accès externe à Internet tout en étant connectée à un
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.it-it.md
@@ -12,7 +12,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} tool installed on your working environment
 - A [Public Cloud Floating IP](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -149,6 +149,6 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.pl-pl.md
@@ -12,7 +12,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} tool installed on your working environment
 - A [Public Cloud Floating IP](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -149,6 +149,6 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-01-snat-configuration/guide.pt-pt.md
@@ -12,7 +12,7 @@ The purpose of this guide is to describe the Secure Network Address Translation 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - The [Openstack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html){.external} tool installed on your working environment
 - A [Public Cloud Floating IP](/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance)
 
@@ -149,6 +149,6 @@ The result shows that VM **vmpriv** has external access to the Internet while be
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.de-de.md
@@ -327,6 +327,6 @@ Zögern Sie jedenfalls nicht, sich mit Testergebnissen zu den oben erwähnten An
 
 ## Weiterführende Informationen
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-asia.md
@@ -306,6 +306,6 @@ In any case, please feel free to reach out to our support team with the elements
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-au.md
@@ -306,6 +306,6 @@ In any case, please feel free to reach out to our support team with the elements
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-ca.md
@@ -306,6 +306,6 @@ In any case, please feel free to reach out to our support team with the elements
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-gb.md
@@ -306,7 +306,7 @@ In any case, please feel free to reach out to our support team with the elements
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-ie.md
@@ -306,6 +306,6 @@ In any case, please feel free to reach out to our support team with the elements
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-sg.md
@@ -306,6 +306,6 @@ In any case, please feel free to reach out to our support team with the elements
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.en-us.md
@@ -306,6 +306,6 @@ In any case, please feel free to reach out to our support team with the elements
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.es-es.md
@@ -321,6 +321,6 @@ Si el problema persiste, puede ponerse en contacto con nuestro equipo de soporte
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.es-us.md
@@ -321,6 +321,6 @@ Si el problema persiste, puede ponerse en contacto con nuestro equipo de soporte
 
 ## Más información
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.fr-ca.md
@@ -301,6 +301,6 @@ Dans tous les cas, n'hésitez pas à effectuer une demande au support avec les �
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.fr-fr.md
@@ -301,6 +301,6 @@ Dans tous les cas, n'hésitez pas à effectuer une demande au support avec les �
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.it-it.md
@@ -324,6 +324,6 @@ In ogni caso, se necessario, invia una richiesta di assistenza con gli elementi 
 
 ## Per saperne di più
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.pl-pl.md
@@ -326,6 +326,6 @@ W każdym przypadku warto skontaktować się z działem pomocy technicznej, poda
 
 ## Sprawdź również
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-02-how-to-configure-ipv6/guide.pt-pt.md
@@ -326,6 +326,6 @@ De qualquer forma, não hesite em contactar o suporte com os elementos testados 
 
 ## Quer saber mais?
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Fale com nossa comunidade de utilizadores: <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.de-de.md
@@ -14,7 +14,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
 
@@ -121,6 +121,6 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-asia.md
@@ -14,7 +14,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
 
@@ -121,6 +121,6 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-au.md
@@ -14,7 +14,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
 
@@ -121,6 +121,6 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-ca.md
@@ -14,7 +14,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
 
@@ -121,6 +121,6 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-gb.md
@@ -14,7 +14,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
 
@@ -121,6 +121,6 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-ie.md
@@ -14,7 +14,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
 
@@ -121,6 +121,6 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-sg.md
@@ -14,7 +14,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
 
@@ -121,6 +121,6 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.en-us.md
@@ -14,7 +14,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
 
@@ -121,6 +121,6 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.es-es.md
@@ -14,7 +14,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
 
@@ -121,6 +121,6 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.es-us.md
@@ -14,7 +14,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
 
@@ -121,6 +121,6 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.fr-ca.md
@@ -14,7 +14,7 @@ La taille de MTU sera la même pour tous les services utilisant des IPs sur le m
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Utiliser l'[environnement de ligne de commande OpenStack](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - L’outil [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) installé sur votre environnement de travail
 
@@ -121,6 +121,6 @@ A la suite de la mise à jour de la valeur MTU sur un réseau sur lequel des ins
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.fr-fr.md
@@ -14,7 +14,7 @@ La taille de MTU sera la même pour tous les services utilisant des IPs sur le m
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Utiliser l'[environnement de ligne de commande OpenStack](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - L’outil [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) installé sur votre environnement de travail
 
@@ -121,6 +121,6 @@ A la suite de la mise à jour de la valeur MTU sur un réseau sur lequel des ins
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.it-it.md
@@ -14,7 +14,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
 
@@ -121,6 +121,6 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.pl-pl.md
@@ -14,7 +14,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
 
@@ -121,6 +121,6 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-03-change-mtu-size/guide.pt-pt.md
@@ -14,7 +14,7 @@ The MTU size will be the same for all services using IPs in the same network.
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Using the [OpenStack command line environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - The [OpenStack Command Line Interface](https://docs.openstack.org/newton/user-guide/common/cli-install-openstack-command-line-clients.html) tool installed on your working environment
 
@@ -121,6 +121,6 @@ Updating the MTU value for an existing network with instances plugged into it re
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.de-de.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-asia.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-au.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-ca.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-gb.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-ie.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-sg.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.en-us.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.es-es.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.es-us.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.fr-ca.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.fr-fr.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.it-it.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.pl-pl.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/configuration-04-update_subnet/guide.pt-pt.md
@@ -170,6 +170,6 @@ You can check that the subnet has been updated:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our [community of users](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.de-de.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objective
 
-Floating IPs are public IP addresses for [Public Cloud](https://www.ovhcloud.com/de/public-cloud/), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
+Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/public-cloud), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
 
 **This guide explains how to attach Floating IP addresses to your instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-asia.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objective
 
-Floating IPs are public IP addresses for [Public Cloud](https://www.ovhcloud.com/asia/public-cloud/), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
+Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/public-cloud), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
 
 **This guide explains how to attach Floating IP addresses to your instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-au.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objective
 
-Floating IPs are public IP addresses for [Public Cloud](https://www.ovhcloud.com/en-au/public-cloud/), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
+Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/public-cloud), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
 
 **This guide explains how to attach Floating IP addresses to your instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-ca.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objective
 
-Floating IPs are public IP addresses for [Public Cloud](https://www.ovhcloud.com/en-ca/public-cloud/), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
+Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/public-cloud), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
 
 **This guide explains how to attach Floating IP addresses to your instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-gb.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objective
 
-Floating IPs are public IP addresses for [Public Cloud](https://www.ovhcloud.com/en-gb/public-cloud/), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
+Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/public-cloud), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
 
 **This guide explains how to attach Floating IP addresses to your instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-ie.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objective
 
-Floating IPs are public IP addresses for [Public Cloud](https://www.ovhcloud.com/en-ie/public-cloud/), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
+Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/public-cloud), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
 
 **This guide explains how to attach Floating IP addresses to your instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-sg.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objective
 
-Floating IPs are public IP addresses for [Public Cloud](https://www.ovhcloud.com/en-sg/public-cloud/), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
+Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/public-cloud), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
 
 **This guide explains how to attach Floating IP addresses to your instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.en-us.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objective
 
-Floating IPs are public IP addresses for [Public Cloud](https://www.ovhcloud.com/en/public-cloud/), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
+Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/public-cloud), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
 
 **This guide explains how to attach Floating IP addresses to your instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.es-es.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objective
 
-Floating IPs are public IP addresses for [Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
+Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/public-cloud), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
 
 **This guide explains how to attach Floating IP addresses to your instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.es-us.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objective
 
-Floating IPs are public IP addresses for [Public Cloud](https://www.ovhcloud.com/es/public-cloud/), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
+Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/public-cloud), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
 
 **This guide explains how to attach Floating IP addresses to your instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.fr-ca.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objectif
 
-Les Floating IP sont des adresses IP publiques sur [Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/), utilisées pour exposer une instance privée ou un service de réseau privé sur le réseau public. Retrouvez plus d'informations sur [notre page concepts](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip) dédiée.
+Les Floating IP sont des adresses IP publiques sur [Public Cloud](/links/public-cloud/public-cloud), utilisées pour exposer une instance privée ou un service de réseau privé sur le réseau public. Retrouvez plus d'informations sur [notre page concepts](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip) dédiée.
 
 **Découvrez comment attacher des adresses Floating IP à vos instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.fr-fr.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objectif
 
-Les Floating IP sont des adresses IP publiques sur [Public Cloud](https://www.ovhcloud.com/fr/public-cloud/), utilisées pour exposer une instance privée ou un service de réseau privé sur le réseau public. Retrouvez plus d'informations sur [notre page concepts](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip) dédiée.
+Les Floating IP sont des adresses IP publiques sur [Public Cloud](/links/public-cloud/public-cloud), utilisées pour exposer une instance privée ou un service de réseau privé sur le réseau public. Retrouvez plus d'informations sur [notre page concepts](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip) dédiée.
 
 **Découvrez comment attacher des adresses Floating IP à vos instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.it-it.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objective
 
-Floating IPs are public IP addresses for [Public Cloud](https://www.ovhcloud.com/it/public-cloud/), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
+Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/public-cloud), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
 
 **This guide explains how to attach Floating IP addresses to your instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.pl-pl.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objective
 
-Floating IPs are public IP addresses for [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
+Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/public-cloud), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
 
 **This guide explains how to attach Floating IP addresses to your instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-03-attach-floating-ip-to-instance/guide.pt-pt.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objective
 
-Floating IPs are public IP addresses for [Public Cloud](https://www.ovhcloud.com/pt/public-cloud/), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
+Floating IPs are public IP addresses for [Public Cloud](/links/public-cloud/public-cloud), used to expose a private instance or a private network service to the public network. You can read more about it on our dedicated [concepts page](/pages/public_cloud/public_cloud_network_services/concepts-02-additional-ip-vs-floating-ip).
 
 **This guide explains how to attach Floating IP addresses to your instances.**
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.de-de.md
@@ -22,13 +22,13 @@ Es kann nowendig werden, Additional IPs auf Ihren Instanzen konfigurieren, zum B
 > [!warning]
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für die Sie die alleinige Verantwortung tragen. Da wir keinen Zugriff auf diese Dienste haben, können wir hierfür keinerlei Administrator-Aufgaben übernehmen oder sonstige Hilfeleistung anbieten. Es liegt daher in Ihrer Verantwortung, das Softwaremanagement und die tägliche Sicherheit zu gewährleisten.
 >
-> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](https://partner.ovhcloud.com/de/directory/) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Dienstes haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovh.com/en/) wenden, um sich mit anderen Benutzern auszutauschen.
+> Wir stellen Ihnen diese Anleitung zur Verfügung, um Ihnen bei der Bewältigung alltäglicher Verwaltungsaufgaben zu helfen. Wir empfehlen Ihnen jedoch, sich an einen [spezialisierten Dienstleister](/links/partner) zu wenden, wenn Sie Schwierigkeiten oder Zweifel hinsichtlich der Verwaltung, Nutzung oder Sicherheit eines Dienstes haben. Sie können sich auch jederzeit an unsere [Community](https://community.ovh.com/en/) wenden, um sich mit anderen Benutzern auszutauschen.
 >
 
 ## Voraussetzungen
 
-- Sie haben eine [Public Cloud Instanz](https://www.ovhcloud.com/de/public-cloud/) in Ihrem OVHcloud Account.
-- Sie verfügen über eine [Additional IP](https://www.ovhcloud.com/de/bare-metal/ip/)-Adresse oder einen Additional IP-Block.
+- Sie haben eine [Public Cloud Instanz](/links/public-cloud/public-cloud) in Ihrem OVHcloud Account.
+- Sie verfügen über eine [Additional IP](/links/bare-metal/ip)-Adresse oder einen Additional IP-Block.
 - Sie haben administrativen Zugriff (sudo) auf Ihre Instanz über SSH oder GUI. 
 - Sie haben Grundkenntnisse in Administration und Netzwerkkonfiguration.
 
@@ -312,6 +312,6 @@ Um die Verbindung zu testen senden Sie einfach von außerhalb einen Ping an Ihre
 
 [Umzug einer Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](https://www.ovhcloud.com/de/professional-services/), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
+Wenn Sie Schulungen oder technische Unterstützung bei der Implementierung unserer Lösungen benötigen, wenden Sie sich an Ihren Vertriebsmitarbeiter oder klicken Sie auf [diesen Link](/links/professional-services), um einen Kostenvoranschlag zu erhalten und eine persönliche Analyse Ihres Projekts durch unsere Experten des Professional Services Teams anzufordern.
 
 Für den Austausch mit unserer User Community gehen Sie auf <https://community.ovh.com/en/>

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-asia.md
@@ -18,13 +18,13 @@ You may need to configure Additional IP addresses on your instances, for example
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/asia/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/asia/bare-metal/ip/) or an Additional IP block
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip) or an Additional IP block
 - Administrative access (sudo) via SSH or GUI to your instance
 - Basic networking and administration knowledge
 
@@ -299,6 +299,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Migrating an Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-au.md
@@ -18,13 +18,13 @@ You may need to configure Additional IP addresses on your instances, for example
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-au/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/en-au/bare-metal/ip/) or an Additional IP block
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip) or an Additional IP block
 - Administrative access (sudo) via SSH or GUI to your instance
 - Basic networking and administration knowledge
 
@@ -299,6 +299,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Migrating an Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-ca.md
@@ -18,13 +18,13 @@ You may need to configure Additional IP addresses on your instances, for example
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/en-ca/bare-metal/ip/) or an Additional IP block
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip) or an Additional IP block
 - Administrative access (sudo) via SSH or GUI to your instance
 - Basic networking and administration knowledge
 
@@ -303,6 +303,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Migrating an Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-gb.md
@@ -18,13 +18,13 @@ You may need to configure Additional IP addresses on your instances, for example
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/en-gb/bare-metal/ip/) or an Additional IP block
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip) or an Additional IP block
 - Administrative access (sudo) via SSH or GUI to your instance
 - Basic networking and administration knowledge
 
@@ -303,6 +303,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Migrating an Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-ie.md
@@ -18,13 +18,13 @@ You may need to configure Additional IP addresses on your instances, for example
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/en-ie/bare-metal/ip/) or an Additional IP block
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip) or an Additional IP block
 - Administrative access (sudo) via SSH or GUI to your instance
 - Basic networking and administration knowledge
 
@@ -303,6 +303,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Migrating an Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-sg.md
@@ -18,13 +18,13 @@ You may need to configure Additional IP addresses on your instances, for example
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/en-sg/bare-metal/ip/) or an Additional IP block
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip) or an Additional IP block
 - Administrative access (sudo) via SSH or GUI to your instance
 - Basic networking and administration knowledge
 
@@ -299,6 +299,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Migrating an Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.en-us.md
@@ -18,13 +18,13 @@ You may need to configure Additional IP addresses on your instances, for example
 > [!warning]
 >OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
+>This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of services on a server.
 >
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
-- An [Additional IP address](https://www.ovhcloud.com/en/bare-metal/ip/) or an Additional IP block
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
+- An [Additional IP address](/links/bare-metal/ip) or an Additional IP block
 - Administrative access (sudo) via SSH or GUI to your instance
 - Basic networking and administration knowledge
 
@@ -303,6 +303,6 @@ To test the connection, simply ping your Additional IP from the outside. If it r
 
 [Migrating an Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.es-es.md
@@ -27,8 +27,8 @@ Es posible que necesite configurar direcciones Additional IP en sus instancias, 
 
 ## Requisitos
 
-- una [instancia de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud
-- una [dirección Additional IP](https://www.ovhcloud.com/es-es/bare-metal/ip/) o un bloque Additional IP
+- una [instancia de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
+- una [dirección Additional IP](/links/bare-metal/ip) o un bloque Additional IP
 - acceso de administrador (sudo) a su instancia por SSH o GUI
 - conocimientos básicos de redes y administración
 
@@ -312,6 +312,6 @@ Para probar la conexión, solo tiene que enviar un ping a su dirección Addition
 
 [Migrar una Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es-es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.es-us.md
@@ -27,8 +27,8 @@ Es posible que necesite configurar direcciones Additional IP en sus instancias, 
 
 ## Requisitos
 
-- una [instancia de Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud
-- una [dirección Additional IP](https://www.ovhcloud.com/es/bare-metal/ip/) o un bloque Additional IP
+- una [instancia de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
+- una [dirección Additional IP](/links/bare-metal/ip) o un bloque Additional IP
 - acceso de administrador (sudo) a su instancia por SSH o GUI
 - conocimientos básicos de redes y administración
 
@@ -312,6 +312,6 @@ Para probar la conexión, solo tiene que enviar un ping a su dirección Addition
 
 [Migrar una Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](https://www.ovhcloud.com/es/professional-services/) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
+Si necesita formación o asistencia técnica para implantar nuestras soluciones, póngase en contacto con su representante de ventas o haga clic en [este enlace](/links/professional-services) para obtener un presupuesto y solicitar un análisis personalizado de su proyecto a nuestros expertos del equipo de Servicios Profesionales.
 
 Interactúe con nuestra comunidad de usuarios en <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.fr-ca.md
@@ -23,8 +23,8 @@ Vous devrez peut-être configurer des adresses Additional IP sur vos instances, 
 
 ## Prérequis
 
-- une [instance Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud
-- une [adresse Additional IP](https://www.ovhcloud.com/fr-ca/bare-metal/ip/) ou un bloc Additional IP
+- une [instance Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
+- une [adresse Additional IP](/links/bare-metal/ip) ou un bloc Additional IP
 - un accès administrateur (sudo) via SSH ou GUI à votre instance
 - des connaissances de base sur les réseaux et leur administration
 
@@ -303,6 +303,6 @@ Pour tester la connexion, il vous suffit d'envoyer un ping à votre adresse Addi
 
 [Basculer une Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.fr-fr.md
@@ -23,8 +23,8 @@ Vous devrez peut-être configurer des adresses Additional IP sur vos instances, 
 
 ## Prérequis
 
-- une [instance Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
-- une [adresse Additional IP](https://www.ovhcloud.com/fr/bare-metal/ip/) ou un bloc Additional IP
+- une [instance Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
+- une [adresse Additional IP](/links/bare-metal/ip) ou un bloc Additional IP
 - un accès administrateur (sudo) via SSH ou GUI à votre instance
 - des connaissances de base sur les réseaux et leur administration
 
@@ -308,6 +308,6 @@ Pour tester la connexion, il vous suffit d'envoyer un ping à votre adresse Addi
 
 [Basculer une Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.it-it.md
@@ -27,8 +27,8 @@ Potrai configurare indirizzi Additional IP sulle tue istanze, ad esempio se ospi
 
 ## Prerequisiti
 
-- un'[istanza Public Cloud](https://www.ovhcloud.com/it/public-cloud/) nel tuo account OVHcloud
-- un [indirizzo Additional IP](https://www.ovhcloud.com/it/bare-metal/ip/) o un blocco Additional IP
+- un'[istanza Public Cloud](/links/public-cloud/public-cloud) nel tuo account OVHcloud
+- un [indirizzo Additional IP](/links/bare-metal/ip) o un blocco Additional IP
 - un accesso amministratore (sudo) via SSH o GUI alla tua istanza
 - conoscenze di base sulle reti e la loro amministrazione
 
@@ -312,6 +312,6 @@ Per testare la connessione, ti basta inviare un ping al tuo indirizzo Additional
 
 [Trasferisci un Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](https://www.ovhcloud.com/it/professional-services/) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
+Se avete bisogno di formazione o di assistenza tecnica per implementare le nostre soluzioni, contattate il vostro rappresentante o cliccate su [questo link](/links/professional-services) per ottenere un preventivo e richiedere un'analisi personalizzata del vostro progetto da parte dei nostri esperti del team Professional Services.
 
 Contatta la nostra Community di utenti all’indirizzo <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.pl-pl.md
@@ -27,8 +27,8 @@ Być może będziesz musiał skonfigurować adresy Additional IP na Twoich insta
 
 ## Wymagania początkowe
 
-- instancji [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na Twoim koncie OVHcloud
-- adresu [Additional IP](https://www.ovhcloud.com/pl/bare-metal/ip/) lub bloku Additional IP
+- instancji [Public Cloud](/links/public-cloud/public-cloud) na Twoim koncie OVHcloud
+- adresu [Additional IP](/links/bare-metal/ip) lub bloku Additional IP
 - dostęp administratora (sudo) przez SSH lub GUI do Twojej instancji
 - podstawowa wiedza o sieciach i ich administrowaniu
 
@@ -312,6 +312,6 @@ Aby przetestować połączenie, wystarczy wysłać ping na adres Additional IP z
 
 [Przenieś Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](https://www.ovhcloud.com/pl/professional-services/), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
+Jeśli potrzebujesz szkolenia lub pomocy technicznej w celu wdrożenia naszych rozwiązań, skontaktuj się z przedstawicielem handlowym lub kliknij [ten link](/links/professional-services), aby uzyskać wycenę i poprosić o spersonalizowaną analizę projektu od naszych ekspertów z zespołu Professional Services.
 
 Dołącz do społeczności naszych użytkowników na stronie <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-04-configure-additional-ip-to-instance/guide.pt-pt.md
@@ -27,8 +27,8 @@ Poderá ter de configurar endereços Additional IP nas suas instâncias, por exe
 
 ## Requisitos
 
-- uma [instância Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud
-- um [endereço Additional IP](https://www.ovhcloud.com/pt/bare-metal/ip/) ou um bloco Additional IP
+- uma [instância Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud
+- um [endereço Additional IP](/links/bare-metal/ip) ou um bloco Additional IP
 - um acesso administrador (sudo) através de SSH ou GUI à sua instância
 - conhecimentos básicos sobre as redes e a sua administração
 
@@ -312,6 +312,6 @@ Para testar a ligação, basta enviar um ping ao seu endereço Additional IP a p
 
 [Migrar um Additional IP](/pages/public_cloud/public_cloud_network_services/additional-ip-migrate)
 
-Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](https://www.ovhcloud.com/pt/professional-services/) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
+Se precisar de formação ou de assistência técnica para implementar as nossas soluções, contacte o seu representante comercial ou clique em [esta ligação](/links/professional-services) para obter um orçamento e solicitar uma análise personalizada do seu projecto aos nossos especialistas da equipa de Serviços Profissionais.
 
 Fale com nossa comunidade de utilizadores: <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-asia.md
@@ -47,11 +47,11 @@ Please refer to [this guide](/pages/public_cloud/public_cloud_cross_functional/i
 
 ### OVHcloud APIv6
 
-Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](https://ca.api.ovh.com/). It even offers more possibilities than the graphical interface.
+Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](/links/api). It even offers more possibilities than the graphical interface.
 
 The API interface is less visual than the OVHcloud Control Panel but will allow you to perform a large number of actions. You can manage and customise your VLAN, add interfaces to your instances, or create highly customised servers.
 
-You can simply access it from [our web page](https://ca.api.ovh.com/) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
+You can simply access it from [our web page](/links/api) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
 
 You may need to retrieve various information before using some API calls because a specific input is required.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-au.md
@@ -47,11 +47,11 @@ Please refer to [this guide](/pages/public_cloud/public_cloud_cross_functional/i
 
 ### OVHcloud APIv6
 
-Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](https://ca.api.ovh.com/). It even offers more possibilities than the graphical interface.
+Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](/links/api). It even offers more possibilities than the graphical interface.
 
 The API interface is less visual than the OVHcloud Control Panel but will allow you to perform a large number of actions. You can manage and customise your VLAN, add interfaces to your instances, or create highly customised servers.
 
-You can simply access it from [our web page](https://ca.api.ovh.com/) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
+You can simply access it from [our web page](/links/api) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
 
 You may need to retrieve various information before using some API calls because a specific input is required.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-ca.md
@@ -47,11 +47,11 @@ Please refer to [this guide](/pages/public_cloud/public_cloud_cross_functional/i
 
 ### OVHcloud APIv6
 
-Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](https://ca.api.ovh.com/). It even offers more possibilities than the graphical interface.
+Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](/links/api). It even offers more possibilities than the graphical interface.
 
 The API interface is less visual than the OVHcloud Control Panel but will allow you to perform a large number of actions. You can manage and customise your VLAN, add interfaces to your instances, or create highly customised servers.
 
-You can simply access it from [our web page](https://ca.api.ovh.com/) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
+You can simply access it from [our web page](/links/api) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
 
 You may need to retrieve various information before using some API calls because a specific input is required.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-gb.md
@@ -47,11 +47,11 @@ Please refer to [this guide](/pages/public_cloud/public_cloud_cross_functional/i
 
 ### OVHcloud APIv6
 
-Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](https://eu.api.ovh.com/). It even offers more possibilities than the graphical interface.
+Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](/links/api). It even offers more possibilities than the graphical interface.
 
 The API interface is less visual than the OVHcloud Control Panel but will allow you to perform a large number of actions. You can manage and customise your VLAN, add interfaces to your instances, or create highly customised servers.
 
-You can simply access it from [our web page](https://eu.api.ovh.com/) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
+You can simply access it from [our web page](/links/api) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
 
 You may need to retrieve various information before using some API calls because a specific input is required.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-ie.md
@@ -47,11 +47,11 @@ Please refer to [this guide](/pages/public_cloud/public_cloud_cross_functional/i
 
 ### OVHcloud APIv6
 
-Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](https://eu.api.ovh.com/). It even offers more possibilities than the graphical interface.
+Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](/links/api). It even offers more possibilities than the graphical interface.
 
 The API interface is less visual than the OVHcloud Control Panel but will allow you to perform a large number of actions. You can manage and customise your VLAN, add interfaces to your instances, or create highly customised servers.
 
-You can simply access it from [our web page](https://eu.api.ovh.com/) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
+You can simply access it from [our web page](/links/api) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
 
 You may need to retrieve various information before using some API calls because a specific input is required.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-sg.md
@@ -47,11 +47,11 @@ Please refer to [this guide](/pages/public_cloud/public_cloud_cross_functional/i
 
 ### OVHcloud APIv6
 
-Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](https://ca.api.ovh.com/). It even offers more possibilities than the graphical interface.
+Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](/links/api). It even offers more possibilities than the graphical interface.
 
 The API interface is less visual than the OVHcloud Control Panel but will allow you to perform a large number of actions. You can manage and customise your VLAN, add interfaces to your instances, or create highly customised servers.
 
-You can simply access it from [our web page](https://ca.api.ovh.com/) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
+You can simply access it from [our web page](/links/api) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
 
 You may need to retrieve various information before using some API calls because a specific input is required.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.en-us.md
@@ -47,11 +47,11 @@ Please refer to [this guide](/pages/public_cloud/public_cloud_cross_functional/i
 
 ### OVHcloud APIv6
 
-Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](https://ca.api.ovh.com/). It even offers more possibilities than the graphical interface.
+Every action you take in your OVHcloud Control Panel can be called with the [OVHcloud APIv6](/links/api). It even offers more possibilities than the graphical interface.
 
 The API interface is less visual than the OVHcloud Control Panel but will allow you to perform a large number of actions. You can manage and customise your VLAN, add interfaces to your instances, or create highly customised servers.
 
-You can simply access it from [our web page](https://ca.api.ovh.com/) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
+You can simply access it from [our web page](/links/api) but also use it to create your PHP or Python scripts. This way, you can freely automate basic tasks with scripts, optimise your own functions and much more.
 
 You may need to retrieve various information before using some API calls because a specific input is required.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.es-es.md
@@ -48,14 +48,14 @@ Consulte la guía [Conectarse a Horizon](/pages/public_cloud/public_cloud_cross_
 
 ### OVHcloud APIv6
 
-Cada acción que realice en el área de cliente de OVHcloud recurre a las [APIv6 de OVHcloud](https://eu.api.ovh.com/).
+Cada acción que realice en el área de cliente de OVHcloud recurre a las [APIv6 de OVHcloud](/links/api).
 Puede incluso ir más lejos en las API que en el área de cliente.
 
 La interfaz es menos visual que el área de cliente de OVHcloud, pero le permitirá realizar un gran número de acciones. De este modo, podrá gestionar y personalizar sus VLAN, añadir interfaces a sus instancias o crear servidores altamente personalizados.
 
 A veces deberá obtener más información antes de utilizar una API específica.
 
-Solo tiene que acceder a las API desde [nuestra página web](https://eu.api.ovh.com/), pero también puede crear sus scripts PHP o Python para llamar.
+Solo tiene que acceder a las API desde [nuestra página web](/links/api), pero también puede crear sus scripts PHP o Python para llamar.
 
 De este modo, podrá automatizar libremente las tareas básicas mediante scripts, optimizar sus propias funciones, etc.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.es-us.md
@@ -47,14 +47,14 @@ Consulte la guía [Conectarse a Horizon](/pages/public_cloud/public_cloud_cross_
 
 ### OVHcloud APIv6
 
-Cada acción que realice en el área de cliente de OVHcloud recurre a las [APIv6 de OVHcloud](https://ca.api.ovh.com/).
+Cada acción que realice en el área de cliente de OVHcloud recurre a las [APIv6 de OVHcloud](/links/api).
 Puede incluso ir más lejos en las API que en el área de cliente.
 
 La interfaz es menos visual que el área de cliente de OVHcloud, pero le permitirá realizar un gran número de acciones. De este modo, podrá gestionar y personalizar sus VLAN, añadir interfaces a sus instancias o crear servidores altamente personalizados.
 
 A veces deberá obtener más información antes de utilizar una API específica.
 
-Solo tiene que acceder a las API desde [nuestra página web](https://ca.api.ovh.com/), pero también puede crear sus scripts PHP o Python para llamar.
+Solo tiene que acceder a las API desde [nuestra página web](/links/api), pero también puede crear sus scripts PHP o Python para llamar.
 
 De este modo, podrá automatizar libremente las tareas básicas mediante scripts, optimizar sus propias funciones, etc.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.fr-ca.md
@@ -47,14 +47,14 @@ Consultez le guide [Accéder à l'interface Horizon](/pages/public_cloud/public_
 
 ### APIv6 OVHcloud
 
-Chaque action que vous effectuez dans l'espace client OVHcloud fait appel aux [APIv6 OVHcloud](https://ca.api.ovh.com/). 
+Chaque action que vous effectuez dans l'espace client OVHcloud fait appel aux [APIv6 OVHcloud](/links/api). 
 Vous pouvez même aller plus loin dans les API que dans votre espace client.
 
 L'interface est moins visuelle que l'espace client OVHcloud mais vous permettra d'effectuer un grand nombre d'actions. Vous pourrez par ce biais gérer et personnaliser vos VLAN, ajouter des interfaces à vos instances ou encore créer des serveurs hautement personnalisés.
 
 Il vous sera parfois nécessaire de récupérer plusieurs informations avant l'utilisation d'une API spécifique.
 
-Vous pouvez simplement accéder aux API depuis [notre page web](https://ca.api.ovh.com/), mais aussi créer vos scripts PHP ou Python pour y faire appel.
+Vous pouvez simplement accéder aux API depuis [notre page web](/links/api), mais aussi créer vos scripts PHP ou Python pour y faire appel.
 
 Ainsi, il vous sera possible de librement automatiser les tâches de base au moyen de scripts, optimiser vos propres fonctions, etc.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack/guide.fr-fr.md
@@ -47,14 +47,14 @@ Consultez le guide [Accéder à l'interface Horizon](/pages/public_cloud/public_
 
 ### APIv6 OVHcloud
 
-Chaque action que vous effectuez dans l'espace client OVHcloud fait appel aux [APIv6 OVHcloud](https://eu.api.ovh.com/). 
+Chaque action que vous effectuez dans l'espace client OVHcloud fait appel aux [APIv6 OVHcloud](/links/api). 
 Vous pouvez même aller plus loin dans les API que dans votre espace client.
 
 L'interface est moins visuelle que l'espace client OVHcloud mais vous permettra d'effectuer un grand nombre d'actions. Vous pourrez par ce biais gérer et personnaliser vos VLAN, ajouter des interfaces à vos instances ou encore créer des serveurs hautement personnalisés.
 
 Il vous sera parfois nécessaire de récupérer plusieurs informations avant l'utilisation d'une API spécifique.
 
-Vous pouvez simplement accéder aux API depuis [notre page web](https://eu.api.ovh.com/), mais aussi créer vos scripts PHP ou Python pour y faire appel.
+Vous pouvez simplement accéder aux API depuis [notre page web](/links/api), mais aussi créer vos scripts PHP ou Python pour y faire appel.
 
 Ainsi, il vous sera possible de librement automatiser les tâches de base au moyen de scripts, optimiser vos propres fonctions, etc.
 

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.de-de.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objective
 
-The [vRack](https://www.ovh.de/loesungen/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](https://www.ovhcloud.com/de/public-cloud/) to your private network to create an infrastructure of physical and virtual resources.
+The [vRack](https://www.ovh.de/loesungen/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](/links/public-cloud/public-cloud) to your private network to create an infrastructure of physical and virtual resources.
 
 **This guide provides some basic information on creating and configuring the vRack on Public Cloud using the OVHcloud API.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Basic networking knowledge
 - Consulting the guide [Configuring the vRack on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) (to understand the different methods to manage the vRack with the Public Cloud)
@@ -190,7 +190,7 @@ Using the OVHcloud APIv6, you can customise all settings: IP range (10.0.0.0/16 
 > Because OpenStack is not located at the same level, you will not be able to customise VLANs through the Horizon interface or OpenStack APIs.
 >
 
-Once logged in to the [OVHcloud APIv6 interface](https://eu.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 #### Retrieving the required information
 
@@ -311,7 +311,7 @@ There are two possible scenarios:
 
 #### In case of a new instance
 
-Once logged in to the [OVHcloud APIv6 interface](https://eu.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 ##### **Retrieving the required information**
 
@@ -509,6 +509,6 @@ You will need to fill in at least the following fields:
 
 [First steps with the OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-asia.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objective
 
-The [vRack](https://www.ovh.com/asia/solutions/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](https://www.ovhcloud.com/asia/public-cloud/) to your private network to create an infrastructure of physical and virtual resources.
+The [vRack](https://www.ovh.com/asia/solutions/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](/links/public-cloud/public-cloud) to your private network to create an infrastructure of physical and virtual resources.
 
 **This guide provides some basic information on creating and configuring the vRack on Public Cloud using the OVHcloud API.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Basic networking knowledge
 - Consulting the guide [Configuring the vRack on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) (to understand the different methods to manage the vRack with the Public Cloud)
@@ -190,7 +190,7 @@ Using the OVHcloud APIv6, you can customise all settings: IP range (10.0.0.0/16 
 > Because OpenStack is not located at the same level, you will not be able to customise VLANs through the Horizon interface or OpenStack APIs.
 >
 
-Once logged in to the [OVHcloud APIv6 interface](https://ca.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 #### Retrieving the required information <a name="vlansetup"></a>
 
@@ -311,7 +311,7 @@ There are two possible scenarios:
 
 #### In case of a new instance
 
-Once logged in to the [OVHcloud APIv6 interface](https://ca.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 ##### **Retrieving the required information**
 
@@ -509,6 +509,6 @@ You will need to fill in at least the following fields:
 
 [First steps with the OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-au.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objective
 
-The [vRack](https://www.ovh.com.au/solutions/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](https://www.ovhcloud.com/en-au/public-cloud/) to your private network to create an infrastructure of physical and virtual resources.
+The [vRack](https://www.ovh.com.au/solutions/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](/links/public-cloud/public-cloud) to your private network to create an infrastructure of physical and virtual resources.
 
 **This guide provides some basic information on creating and configuring the vRack on Public Cloud using the OVHcloud API.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Basic networking knowledge
 - Consulting the guide [Configuring the vRack on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) (to understand the different methods to manage the vRack with the Public Cloud)
@@ -190,7 +190,7 @@ Using the OVHcloud APIv6, you can customise all settings: IP range (10.0.0.0/16 
 > Because OpenStack is not located at the same level, you will not be able to customise VLANs through the Horizon interface or OpenStack APIs.
 >
 
-Once logged in to the [OVHcloud APIv6 interface](https://ca.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 #### Retrieving the required information
 
@@ -311,7 +311,7 @@ There are two possible scenarios:
 
 #### In case of a new instance
 
-Once logged in to the [OVHcloud APIv6 interface](https://ca.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 ##### **Retrieving the required information**
 
@@ -509,6 +509,6 @@ You will need to fill in at least the following fields:
 
 [First steps with the OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-ca.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objective
 
-The [vRack](https://www.ovh.com/ca/en/solutions/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](https://www.ovhcloud.com/en-ca/public-cloud/) to your private network to create an infrastructure of physical and virtual resources.
+The [vRack](https://www.ovh.com/ca/en/solutions/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](/links/public-cloud/public-cloud) to your private network to create an infrastructure of physical and virtual resources.
 
 **This guide provides some basic information on creating and configuring the vRack on Public Cloud using the OVHcloud API.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Basic networking knowledge
 - Consulting the guide [Configuring the vRack on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) (to understand the different methods to manage the vRack with the Public Cloud)
@@ -190,7 +190,7 @@ Using the OVHcloud APIv6, you can customise all settings: IP range (10.0.0.0/16 
 > Because OpenStack is not located at the same level, you will not be able to customise VLANs through the Horizon interface or OpenStack APIs.
 >
 
-Once logged in to the [OVHcloud APIv6 interface](https://ca.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 #### Retrieving the required information
 
@@ -311,7 +311,7 @@ There are two possible scenarios:
 
 #### In case of a new instance
 
-Once logged in to the [OVHcloud APIv6 interface](https://ca.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 ##### **Retrieving the required information**
 
@@ -509,6 +509,6 @@ You will need to fill in at least the following fields:
 
 [First steps with the OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-gb.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objective
 
-OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/) is a private network solution that enables our customers to route traffic between OVHcloud dedicated servers as well as other OVHcloud services. At the same time, it allows you to add [Public Cloud instances](https://www.ovhcloud.com/en-gb/public-cloud/) to your private network to create an infrastructure of physical and virtual resources.
+OVHcloud [vRack](https://www.ovh.co.uk/solutions/vrack/) is a private network solution that enables our customers to route traffic between OVHcloud dedicated servers as well as other OVHcloud services. At the same time, it allows you to add [Public Cloud instances](/links/public-cloud/public-cloud) to your private network to create an infrastructure of physical and virtual resources.
 
 **This guide explains how to configure Public Cloud instances within your vRack using the OVHcloud APIv6.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Basic networking knowledge
 - Consulting the guide [Configuring the vRack on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) (to understand the different methods to manage the vRack with the Public Cloud)
@@ -509,6 +509,6 @@ You will need to fill in at least the following fields:
 
 [First steps with the OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-ie.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objective
 
-OVHcloud [vRack](https://www.ovh.ie/solutions/vrack/) is a private network solution that enables our customers to route traffic between OVHcloud dedicated servers as well as other OVHcloud services. At the same time, it allows you to add [Public Cloud instances](https://www.ovhcloud.com/en-ie/public-cloud/) to your private network to create an infrastructure of physical and virtual resources.
+OVHcloud [vRack](https://www.ovh.ie/solutions/vrack/) is a private network solution that enables our customers to route traffic between OVHcloud dedicated servers as well as other OVHcloud services. At the same time, it allows you to add [Public Cloud instances](/links/public-cloud/public-cloud) to your private network to create an infrastructure of physical and virtual resources.
 
 **This guide explains how to configure Public Cloud instances within your vRack using the OVHcloud APIv6.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Basic networking knowledge
 - Consulting the guide [Configuring the vRack on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) (to understand the different methods to manage the vRack with the Public Cloud)
@@ -509,6 +509,6 @@ You will need to fill in at least the following fields:
 
 [First steps with the OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-sg.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objective
 
-The [vRack](https://www.ovh.com/sg/solutions/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](https://www.ovhcloud.com/en-sg/public-cloud/) to your private network to create an infrastructure of physical and virtual resources.
+The [vRack](https://www.ovh.com/sg/solutions/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](/links/public-cloud/public-cloud) to your private network to create an infrastructure of physical and virtual resources.
 
 **This guide provides some basic information on creating and configuring the vRack on Public Cloud using the OVHcloud API.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Basic networking knowledge
 - Consulting the guide [Configuring the vRack on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) (to understand the different methods to manage the vRack with the Public Cloud)
@@ -190,7 +190,7 @@ Using the OVHcloud APIv6, you can customise all settings: IP range (10.0.0.0/16 
 > Because OpenStack is not located at the same level, you will not be able to customise VLANs through the Horizon interface or OpenStack APIs.
 >
 
-Once logged in to the [OVHcloud APIv6 interface](https://ca.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 #### Retrieving the required information
 
@@ -311,7 +311,7 @@ There are two possible scenarios:
 
 #### In case of a new instance
 
-Once logged in to the [OVHcloud APIv6 interface](https://ca.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 ##### **Retrieving the required information**
 
@@ -509,6 +509,6 @@ You will need to fill in at least the following fields:
 
 [First steps with the OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.en-us.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objective
 
-The [vRack](https://www.ovh.com/world/solutions/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](https://www.ovhcloud.com/en/public-cloud/) to your private network to create an infrastructure of physical and virtual resources.
+The [vRack](https://www.ovh.com/world/solutions/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](/links/public-cloud/public-cloud) to your private network to create an infrastructure of physical and virtual resources.
 
 **This guide provides some basic information on creating and configuring the vRack on Public Cloud using the OVHcloud API.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Basic networking knowledge
 - Consulting the guide [Configuring the vRack on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) (to understand the different methods to manage the vRack with the Public Cloud)
@@ -190,7 +190,7 @@ Using the OVHcloud APIv6, you can customise all settings: IP range (10.0.0.0/16 
 > Because OpenStack is not located at the same level, you will not be able to customise VLANs through the Horizon interface or OpenStack APIs.
 >
 
-Once logged in to the [OVHcloud APIv6 interface](https://ca.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 #### Retrieving the required information
 
@@ -311,7 +311,7 @@ There are two possible scenarios:
 
 #### In case of a new instance
 
-Once logged in to the [OVHcloud APIv6 interface](https://ca.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 ##### **Retrieving the required information**
 
@@ -509,6 +509,6 @@ You will need to fill in at least the following fields:
 
 [First steps with the OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.es-es.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objective
 
-The [vRack](https://www.ovh.es/soluciones/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](https://www.ovhcloud.com/es-es/public-cloud/) to your private network to create an infrastructure of physical and virtual resources.
+The [vRack](https://www.ovh.es/soluciones/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](/links/public-cloud/public-cloud) to your private network to create an infrastructure of physical and virtual resources.
 
 **This guide provides some basic information on creating and configuring the vRack on Public Cloud using the OVHcloud API.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Basic networking knowledge
 - Consulting the guide [Configuring the vRack on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) (to understand the different methods to manage the vRack with the Public Cloud)
@@ -190,7 +190,7 @@ Using the OVHcloud APIv6, you can customise all settings: IP range (10.0.0.0/16 
 > Because OpenStack is not located at the same level, you will not be able to customise VLANs through the Horizon interface or OpenStack APIs.
 >
 
-Once logged in to the [OVHcloud APIv6 interface](https://eu.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 #### Retrieving the required information
 
@@ -311,7 +311,7 @@ There are two possible scenarios:
 
 #### In case of a new instance
 
-Once logged in to the [OVHcloud APIv6 interface](https://eu.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 ##### **Retrieving the required information**
 
@@ -509,6 +509,6 @@ You will need to fill in at least the following fields:
 
 [First steps with the OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.es-us.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objective
 
-The [vRack](https://www.ovh.com/world/es/soluciones/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](https://www.ovhcloud.com/es/public-cloud/) to your private network to create an infrastructure of physical and virtual resources.
+The [vRack](https://www.ovh.com/world/es/soluciones/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](/links/public-cloud/public-cloud) to your private network to create an infrastructure of physical and virtual resources.
 
 **This guide provides some basic information on creating and configuring the vRack on Public Cloud using the OVHcloud API.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Basic networking knowledge
 - Consulting the guide [Configuring the vRack on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) (to understand the different methods to manage the vRack with the Public Cloud)
@@ -190,7 +190,7 @@ Using the OVHcloud APIv6, you can customise all settings: IP range (10.0.0.0/16 
 > Because OpenStack is not located at the same level, you will not be able to customise VLANs through the Horizon interface or OpenStack APIs.
 >
 
-Once logged in to the [OVHcloud APIv6 interface](https://ca.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 #### Retrieving the required information
 
@@ -311,7 +311,7 @@ There are two possible scenarios:
 
 #### In case of a new instance
 
-Once logged in to the [OVHcloud APIv6 interface](https://ca.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 ##### **Retrieving the required information**
 
@@ -509,6 +509,6 @@ You will need to fill in at least the following fields:
 
 [First steps with the OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.fr-ca.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objectif
 
-Le [vRack](https://www.ovh.com/ca/fr/solutions/vrack/) est un réseau privé qui vous permet de configurer l’adressage entre deux ou plusieurs serveurs dédiés OVHcloud. Mais il vous permet également d’ajouter des [instances Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) à votre réseau privé afin de créer une infrastructure de ressources physiques et virtuelles.
+Le [vRack](https://www.ovh.com/ca/fr/solutions/vrack/) est un réseau privé qui vous permet de configurer l’adressage entre deux ou plusieurs serveurs dédiés OVHcloud. Mais il vous permet également d’ajouter des [instances Public Cloud](/links/public-cloud/public-cloud) à votre réseau privé afin de créer une infrastructure de ressources physiques et virtuelles.
 
 **Découvrez comment activer et gérer un vRack Public Cloud depuis les APIv6 OVHcloud.**
 
 ## Prérequis
 
-- Posséder un [projet Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud.
+- Posséder un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - [Avoir créer un utilisateur OpenStack](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon#creer-un-compte-utilisateur-openstack).
 - [Avoir créer un utilisateur OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user).
 - Connaissances réseaux élémentaires.
@@ -193,7 +193,7 @@ Depuis les APIv6 OVHcloud, vous pourrez personnaliser l'ensemble des paramètres
 >OpenStack n'étant pas située au même niveau de l'infrastructure, vous ne pourrez pas personnaliser les vLan au travers de l'interface Horizon ou des API OpenStack.
 >
 
-Une fois connecté à l'[APIv6 OVHcloud](https://ca.api.ovh.com/), exécutez les commandes suivantes dans l'ordre.
+Une fois connecté à l'[APIv6 OVHcloud](/links/api), exécutez les commandes suivantes dans l'ordre.
 
 #### Récupération des informations nécessaires : <a name="vlansetup"></a>
 
@@ -314,7 +314,7 @@ Deux situations peuvent se présenter à vous :
 
 #### Cas d'une nouvelle instance
 
-Une fois connecté à l'[APIv6 OVHcloud](https://ca.api.ovh.com/), exécutez les commandes suivantes dans l'ordre.
+Une fois connecté à l'[APIv6 OVHcloud](/links/api), exécutez les commandes suivantes dans l'ordre.
 
 ##### **Récupération des informations nécessaires**
 
@@ -512,6 +512,6 @@ Vous devrez renseigner a minima les champs suivants :
 
 [Premiers pas avec les API OVHcloud](/pages/manage_and_operate/api/first-steps)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.fr-fr.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objectif
 
-Le [vRack](https://www.ovh.com/fr/solutions/vrack/) est un réseau privé qui vous permet de configurer l’adressage entre deux ou plusieurs serveurs dédiés OVHcloud. Mais il vous permet également d’ajouter des [instances Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) à votre réseau privé afin de créer une infrastructure de ressources physiques et virtuelles.
+Le [vRack](https://www.ovh.com/fr/solutions/vrack/) est un réseau privé qui vous permet de configurer l’adressage entre deux ou plusieurs serveurs dédiés OVHcloud. Mais il vous permet également d’ajouter des [instances Public Cloud](/links/public-cloud/public-cloud) à votre réseau privé afin de créer une infrastructure de ressources physiques et virtuelles.
 
 **Découvrez comment activer et gérer un vRack Public Cloud depuis les APIv6 OVHcloud.**
 
 ## Prérequis
 
-- Posséder un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud.
+- Posséder un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - [Avoir créer un utilisateur OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user).
 - Connaissances réseaux élémentaires.
 - Consulter le guide [Configuration du vRack Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) pour connaître les différentes méthodes proposées pour gérer le vRack Public Cloud OVHcloud.
@@ -511,6 +511,6 @@ Vous devrez renseigner a minima les champs suivants :
 
 [Premiers pas avec les API OVHcloud](/pages/manage_and_operate/api/first-steps)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.it-it.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objective
 
-The [vRack](https://www.ovh.it/soluzioni/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](https://www.ovhcloud.com/it/public-cloud/) to your private network to create an infrastructure of physical and virtual resources.
+The [vRack](https://www.ovh.it/soluzioni/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](/links/public-cloud/public-cloud) to your private network to create an infrastructure of physical and virtual resources.
 
 **This guide provides some basic information on creating and configuring the vRack on Public Cloud using the OVHcloud API.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Basic networking knowledge
 - Consulting the guide [Configuring the vRack on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) (to understand the different methods to manage the vRack with the Public Cloud)
@@ -190,7 +190,7 @@ Using the OVHcloud APIv6, you can customise all settings: IP range (10.0.0.0/16 
 > Because OpenStack is not located at the same level, you will not be able to customise VLANs through the Horizon interface or OpenStack APIs.
 >
 
-Once logged in to the [OVHcloud APIv6 interface](https://eu.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 #### Retrieving the required information
 
@@ -311,7 +311,7 @@ There are two possible scenarios:
 
 #### In case of a new instance
 
-Once logged in to the [OVHcloud APIv6 interface](https://eu.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 ##### **Retrieving the required information**
 
@@ -509,6 +509,6 @@ You will need to fill in at least the following fields:
 
 [First steps with the OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.pl-pl.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objective
 
-The [vRack](https://www.ovh.pl/rozwiazania/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](https://www.ovhcloud.com/pl/public-cloud/) to your private network to create an infrastructure of physical and virtual resources.
+The [vRack](https://www.ovh.pl/rozwiazania/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](/links/public-cloud/public-cloud) to your private network to create an infrastructure of physical and virtual resources.
 
 **This guide provides some basic information on creating and configuring the vRack on Public Cloud using the OVHcloud API.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Basic networking knowledge
 - Consulting the guide [Configuring the vRack on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) (to understand the different methods to manage the vRack with the Public Cloud)
@@ -190,7 +190,7 @@ Using the OVHcloud APIv6, you can customise all settings: IP range (10.0.0.0/16 
 > Because OpenStack is not located at the same level, you will not be able to customise VLANs through the Horizon interface or OpenStack APIs.
 >
 
-Once logged in to the [OVHcloud APIv6 interface](https://eu.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 #### Retrieving the required information
 
@@ -311,7 +311,7 @@ There are two possible scenarios:
 
 #### In case of a new instance
 
-Once logged in to the [OVHcloud APIv6 interface](https://eu.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 ##### **Retrieving the required information**
 
@@ -509,6 +509,6 @@ You will need to fill in at least the following fields:
 
 [First steps with the OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/getting-started-08-creating-vrack-with-api/guide.pt-pt.md
@@ -6,13 +6,13 @@ updated: 2022-11-02
 
 ## Objective
 
-The [vRack](https://www.ovh.pt/solucoes/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](https://www.ovhcloud.com/pt/public-cloud/) to your private network to create an infrastructure of physical and virtual resources.
+The [vRack](https://www.ovh.pt/solucoes/vrack/) is a private network that allows you to configure addressing between two or more compatible OVHcloud services. It also allows you to add [Public Cloud instances](/links/public-cloud/public-cloud) to your private network to create an infrastructure of physical and virtual resources.
 
 **This guide provides some basic information on creating and configuring the vRack on Public Cloud using the OVHcloud API.**
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Basic networking knowledge
 - Consulting the guide [Configuring the vRack on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) (to understand the different methods to manage the vRack with the Public Cloud)
@@ -190,7 +190,7 @@ Using the OVHcloud APIv6, you can customise all settings: IP range (10.0.0.0/16 
 > Because OpenStack is not located at the same level, you will not be able to customise VLANs through the Horizon interface or OpenStack APIs.
 >
 
-Once logged in to the [OVHcloud APIv6 interface](https://eu.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 #### Retrieving the required information
 
@@ -311,7 +311,7 @@ There are two possible scenarios:
 
 #### In case of a new instance
 
-Once logged in to the [OVHcloud APIv6 interface](https://eu.api.ovh.com/), follow these steps:
+Once logged in to the [OVHcloud APIv6 interface](/links/api), follow these steps:
 
 ##### **Retrieving the required information**
 
@@ -509,6 +509,6 @@ You will need to fill in at least the following fields:
 
 [First steps with the OVHcloud API](/pages/manage_and_operate/api/first-steps)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.de-de.md
@@ -13,7 +13,7 @@ This tutorial explains the following Load Balancer configurations:
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [private network](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configured in your project
 - [Prepare the environment to use the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)
@@ -323,7 +323,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-asia.md
@@ -13,7 +13,7 @@ This tutorial explains the following Load Balancer configurations:
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [private network](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configured in your project
 - [Prepare the environment to use the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)
@@ -323,7 +323,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-au.md
@@ -13,7 +13,7 @@ This tutorial explains the following Load Balancer configurations:
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [private network](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configured in your project
 - [Prepare the environment to use the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)
@@ -323,7 +323,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-ca.md
@@ -13,7 +13,7 @@ This tutorial explains the following Load Balancer configurations:
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [private network](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configured in your project
 - [Prepare the environment to use the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)
@@ -323,7 +323,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-gb.md
@@ -13,7 +13,7 @@ This tutorial explains the following Load Balancer configurations:
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [private network](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configured in your project
 - [Prepare the environment to use the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)
@@ -323,7 +323,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-ie.md
@@ -13,7 +13,7 @@ This tutorial explains the following Load Balancer configurations:
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [private network](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configured in your project
 - [Prepare the environment to use the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)
@@ -323,7 +323,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-sg.md
@@ -13,7 +13,7 @@ This tutorial explains the following Load Balancer configurations:
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [private network](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configured in your project
 - [Prepare the environment to use the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)
@@ -323,7 +323,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.en-us.md
@@ -13,7 +13,7 @@ This tutorial explains the following Load Balancer configurations:
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [private network](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configured in your project
 - [Prepare the environment to use the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)
@@ -323,7 +323,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.es-es.md
@@ -13,7 +13,7 @@ This tutorial explains the following Load Balancer configurations:
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [private network](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configured in your project
 - [Prepare the environment to use the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)
@@ -323,7 +323,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.es-us.md
@@ -13,7 +13,7 @@ This tutorial explains the following Load Balancer configurations:
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [private network](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configured in your project
 - [Prepare the environment to use the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)
@@ -323,7 +323,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.fr-ca.md
@@ -13,7 +13,7 @@ Vous trouverez ici les configurations d'un Load Balancer:
 
 ## Prérequis
 
-- Avoir un [projet Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud
+- Avoir un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Avoir un [réseau privé](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configuré dans votre projet
 - [Préparer l’environnement pour utiliser l’API OpenStack](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api) en installant python-swiftclient.
 - [Charger les variables d’environnement OpenStack](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables).
@@ -318,7 +318,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html).
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.fr-fr.md
@@ -13,7 +13,7 @@ Vous trouverez ici les configurations d'un Load Balancer:
 
 ## Prérequis
 
-- Avoir un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
+- Avoir un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Avoir un [réseau privé](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configuré dans votre projet
 - [Préparer l’environnement pour utiliser l’API OpenStack](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api) en installant python-swiftclient.
 - [Charger les variables d’environnement OpenStack](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables).
@@ -318,7 +318,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html).
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.it-it.md
@@ -13,7 +13,7 @@ This tutorial explains the following Load Balancer configurations:
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [private network](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configured in your project
 - [Prepare the environment to use the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)
@@ -323,7 +323,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.pl-pl.md
@@ -13,7 +13,7 @@ This tutorial explains the following Load Balancer configurations:
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [private network](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configured in your project
 - [Prepare the environment to use the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)
@@ -323,7 +323,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-01-using-lbaas-in-openstack-environment/guide.pt-pt.md
@@ -13,7 +13,7 @@ This tutorial explains the following Load Balancer configurations:
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [private network](/pages/public_cloud/public_cloud_network_services/getting-started-07-creating-vrack) configured in your project
 - [Prepare the environment to use the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)
@@ -323,7 +323,7 @@ openstack loadbalancer delete [--cascade] [--wait] <load_balancer>
 
 [OpenStack Floating IP](https://docs.openstack.org/ocata/user-guide/cli-manage-ip-addresses.html)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.
 

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.de-de.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-asia.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-au.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-ca.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-gb.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-ie.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-sg.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.en-us.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.es-es.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.es-us.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.fr-ca.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr-ca/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.fr-fr.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/fr/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.it-it.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.pl-pl.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-02-octavia-monitoring-prometheus/guide.pt-pt.md
@@ -335,6 +335,6 @@ If you are interested in automating this scenario with terraform and with our ma
 
 Visit our dedicated Discord channel: <https://discord.gg/ovhcloud>. Ask questions, provide feedback and interact directly with the team that builds our databases services.
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.de-de.md
@@ -203,6 +203,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-asia.md
@@ -203,6 +203,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-au.md
@@ -203,6 +203,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-ca.md
@@ -203,6 +203,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-gb.md
@@ -203,6 +203,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-ie.md
@@ -203,6 +203,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-sg.md
@@ -203,6 +203,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.en-us.md
@@ -203,6 +203,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.es-es.md
@@ -203,6 +203,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.es-us.md
@@ -203,6 +203,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.fr-ca.md
@@ -202,6 +202,6 @@ Pour supprimer votre abonnement, vous pouvez utiliser l'appel API suivant :
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.fr-fr.md
@@ -202,6 +202,6 @@ Pour supprimer votre abonnement, vous pouvez utiliser l'appel API suivant :
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.it-it.md
@@ -203,6 +203,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.pl-pl.md
@@ -203,6 +203,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers/guide.pt-pt.md
@@ -203,6 +203,6 @@ To delete your subscription you can use the following API call:
 
 ## Go further
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.de-de.md
@@ -14,7 +14,7 @@ After setting up your Load Balancer, you can configure it with a certificate in 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Preparing your environment for using the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [OpenStack Octavia client](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) and [OpenStack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html) set up
 - A Load Balancer running in your project
@@ -115,6 +115,6 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 [Getting started with Load Balancer on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/de/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-asia.md
@@ -14,7 +14,7 @@ After setting up your Load Balancer, you can configure it with a certificate in 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Preparing your environment for using the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [OpenStack Octavia client](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) and [OpenStack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html) set up
 - A Load Balancer running in your project
@@ -115,6 +115,6 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 [Getting started with Load Balancer on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/asia/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-au.md
@@ -14,7 +14,7 @@ After setting up your Load Balancer, you can configure it with a certificate in 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Preparing your environment for using the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [OpenStack Octavia client](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) and [OpenStack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html) set up
 - A Load Balancer running in your project
@@ -115,6 +115,6 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 [Getting started with Load Balancer on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-au/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-ca.md
@@ -14,7 +14,7 @@ After setting up your Load Balancer, you can configure it with a certificate in 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Preparing your environment for using the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [OpenStack Octavia client](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) and [OpenStack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html) set up
 - A Load Balancer running in your project
@@ -115,6 +115,6 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 [Getting started with Load Balancer on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ca/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-gb.md
@@ -14,7 +14,7 @@ After setting up your Load Balancer, you can configure it with a certificate in 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Preparing your environment for using the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [OpenStack Octavia client](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) and [OpenStack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html) set up
 - A Load Balancer running in your project
@@ -115,6 +115,6 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 [Getting started with Load Balancer on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-gb/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-ie.md
@@ -14,7 +14,7 @@ After setting up your Load Balancer, you can configure it with a certificate in 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Preparing your environment for using the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [OpenStack Octavia client](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) and [OpenStack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html) set up
 - A Load Balancer running in your project
@@ -115,6 +115,6 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 [Getting started with Load Balancer on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-ie/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-sg.md
@@ -14,7 +14,7 @@ After setting up your Load Balancer, you can configure it with a certificate in 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Preparing your environment for using the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [OpenStack Octavia client](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) and [OpenStack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html) set up
 - A Load Balancer running in your project
@@ -115,6 +115,6 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 [Getting started with Load Balancer on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en-sg/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.en-us.md
@@ -14,7 +14,7 @@ After setting up your Load Balancer, you can configure it with a certificate in 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Preparing your environment for using the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [OpenStack Octavia client](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) and [OpenStack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html) set up
 - A Load Balancer running in your project
@@ -115,6 +115,6 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 [Getting started with Load Balancer on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/en/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.es-es.md
@@ -14,7 +14,7 @@ After setting up your Load Balancer, you can configure it with a certificate in 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Preparing your environment for using the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [OpenStack Octavia client](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) and [OpenStack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html) set up
 - A Load Balancer running in your project
@@ -115,6 +115,6 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 [Getting started with Load Balancer on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es-es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.es-us.md
@@ -14,7 +14,7 @@ After setting up your Load Balancer, you can configure it with a certificate in 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Preparing your environment for using the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [OpenStack Octavia client](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) and [OpenStack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html) set up
 - A Load Balancer running in your project
@@ -115,6 +115,6 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 [Getting started with Load Balancer on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/es/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.fr-ca.md
@@ -14,7 +14,7 @@ Une fois votre Load Balancer mis en place, vous pouvez le configurer avec un cer
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/)
+- Un [projet Public Cloud](/links/public-cloud/public-cloud)
 - Utiliser l'environnement de commande d'Openstack ([Tutoriel](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api))
 - Avoir installé le [client Openstack Octavia](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) et [Openstack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html)
 - Un Load Balancer actif dans votre projet
@@ -115,6 +115,6 @@ Vous pouvez maintenant accéder à votre Load Balancer de manière sécurisée a
 
 [Cookbook Openstack Octavia](https://docs.openstack.org/octavia/latest/user/guides/basic-cookbook.html)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr-ca/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.fr-fr.md
@@ -14,7 +14,7 @@ Une fois votre Load Balancer mis en place, vous pouvez le configurer avec un cer
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/)
+- Un [projet Public Cloud](/links/public-cloud/public-cloud)
 - Utiliser l'environnement de commande d'Openstack ([Tutoriel](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api))
 - Avoir installé le [client Openstack Octavia](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) et [Openstack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html)
 - Un Load Balancer actif dans votre projet
@@ -115,6 +115,6 @@ Vous pouvez maintenant accéder à votre Load Balancer de manière sécurisée a
 
 [Cookbook Openstack Octavia](https://docs.openstack.org/octavia/latest/user/guides/basic-cookbook.html)
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](https://www.ovhcloud.com/fr/professional-services/) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l’équipe Professional Services. 
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.it-it.md
@@ -14,7 +14,7 @@ After setting up your Load Balancer, you can configure it with a certificate in 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Preparing your environment for using the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [OpenStack Octavia client](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) and [OpenStack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html) set up
 - A Load Balancer running in your project
@@ -115,6 +115,6 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 [Getting started with Load Balancer on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/it/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.pl-pl.md
@@ -14,7 +14,7 @@ After setting up your Load Balancer, you can configure it with a certificate in 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Preparing your environment for using the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [OpenStack Octavia client](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) and [OpenStack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html) set up
 - A Load Balancer running in your project
@@ -115,6 +115,6 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 [Getting started with Load Balancer on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pl/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.

--- a/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_network_services/tutorials-01-secure-lb-letsencrypt/guide.pt-pt.md
@@ -14,7 +14,7 @@ After setting up your Load Balancer, you can configure it with a certificate in 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Preparing your environment for using the OpenStack API](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [OpenStack Octavia client](https://docs.openstack.org/python-octaviaclient/latest/install/index.html) and [OpenStack Barbican](https://docs.openstack.org/python-barbicanclient/latest/install/index.html) set up
 - A Load Balancer running in your project
@@ -115,6 +115,6 @@ You can now securely access your Load Balancer with Let's Encrypt. Be careful, y
 
 [Getting started with Load Balancer on Public Cloud](/pages/public_cloud/public_cloud_network_services/getting-started-01-create-lb-service)
 
-If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](https://www.ovhcloud.com/pt/professional-services/) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for assisting you on your specific use case of your project.
 
 Join our community of users on <https://community.ovh.com/en/>.


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their /links values.

Example: replace all https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB links with /links/manager.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.