### PR TITLE
Fix global links in Public cloud public cloud cross functional

### DIFF
--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.de-de.md
@@ -56,7 +56,7 @@ Die Ressourcen sind in unseren verschiedenen Rechenzentren weltweit verfügbar. 
 
 ### Cloud-Anbieter auf einem ausgereiften Markt
 
-Die OVHcloud Public Cloud ist neben bekannten Cloud-Anbietern wie AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (von Microsoft) oder Alibaba Cloud positioniert. Unser Angebot zeichnet sich durch [besonders günstige Preise](https://www.ovhcloud.com/de/public-cloud/prices/) und die Verwendung von Standard-APIs aus, die unseren Nutzern Änderungen erlauben, ohne sich einer einzelnen proprietären Technologie unterwerfen zu müssen.
+Die OVHcloud Public Cloud ist neben bekannten Cloud-Anbietern wie AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (von Microsoft) oder Alibaba Cloud positioniert. Unser Angebot zeichnet sich durch [besonders günstige Preise](/links/public-cloud/prices) und die Verwendung von Standard-APIs aus, die unseren Nutzern Änderungen erlauben, ohne sich einer einzelnen proprietären Technologie unterwerfen zu müssen.
 
 ## Konkreter Ansatz <a name="concrete-approach"></a>
 
@@ -126,7 +126,7 @@ Nachfolgend finden Sie grundlegende Wissensressourcen, die Ihnen bei Ihrem Start
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Die häufigsten Fragen zur Public Cloud.|
 |[Glossar](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|Die Konzepte und Definitionen zur fortgeschrittenen Nutzung.|
-|[Verfügbarkeit der Dienste nach Standort](https://www.ovhcloud.com/de/public-cloud/regions-availability/)|Verfügbarkeitstabellen der Dienste an den verschiedenen Standorten.|
+|[Verfügbarkeit der Dienste nach Standort](/links/public-cloud/regions-pci)|Verfügbarkeitstabellen der Dienste an den verschiedenen Standorten.|
 
 Verwenden Sie folgende Anleitungen, um Informationen zum praktischen Vorgehen zu erhalten:
 
@@ -146,8 +146,8 @@ Einer der großen Vorteile der Verwendung von Standard- und Open-Source-Technolo
 
 |Dokumentation|Beschreibung|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|Die vollständige Dokumentation des essentiellen OpenStack Clients in der Kommandozeile. Dokumentation für die Version "Stein": Nutzen Sie [die Verfügbarkeitstabelle](https://www.ovhcloud.com/de/public-cloud/regions-availability/), um zu sehen, welche Dienstleistungen verfügbar sind.|
-|[OpenStack API](https://docs.openstack.org/stein/api/) (EN)|Die vollständige Dokumentation zu OpenStack für die "Stein"-Version. Nutzen Sie [die Verfügbarkeitstabelle](https://www.ovhcloud.com/de/public-cloud/regions-availability/), um zu sehen, welche Dienstleistungen verfügbar sind.|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|Die vollständige Dokumentation des essentiellen OpenStack Clients in der Kommandozeile. Dokumentation für die Version "Stein": Nutzen Sie [die Verfügbarkeitstabelle](/links/public-cloud/regions-pci), um zu sehen, welche Dienstleistungen verfügbar sind.|
+|[OpenStack API](https://docs.openstack.org/stein/api/) (EN)|Die vollständige Dokumentation zu OpenStack für die "Stein"-Version. Nutzen Sie [die Verfügbarkeitstabelle](/links/public-cloud/regions-pci), um zu sehen, welche Dienstleistungen verfügbar sind.|
 |[Benutzer-Dokumentation](https://docs.openstack.org/stein/user/) (EN)|Vollständige Dokumentation für OpenStack-Benutzer in der Version "Stein".|
 |[Entwickler-Dokumentation](https://developer.openstack.org/) (EN)|Dokumentation für Entwickler, die ihre Anwendung mit der OpenStack API verbinden möchten, unter Verwendung der verfügbaren Bibliotheken/SDKs.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/) (EN)| Dokumentation des essentiellen CLI-Clients *kubectl*.|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-asia.md
@@ -52,7 +52,7 @@ These resources are available in our various data centres across the globe. OVHc
 
 ### A cloud service provider in a mature market
 
-OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](https://www.ovhcloud.com/asia/public-cloud/prices/) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
+OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](/links/public-cloud/prices) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
 
 ## Practical approach <a name="concrete-approach"></a>
 
@@ -121,7 +121,7 @@ Here are some general resources that will help you get started with the Public C
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Frequently asked questions about Public Cloud.|
 |[Glossary](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|The concepts and definitions you will need to move forward.|
-|[Availability of services by location](https://www.ovhcloud.com/fr/public-cloud/regions-availability/)|Service availability tables across different locations.|
+|[Availability of services by location](/links/public-cloud/regions-pci)|Service availability tables across different locations.|
 
 Here are some guides to help you with the first steps:
 
@@ -140,8 +140,8 @@ One of the big advantages of using standard and open technologies, like OpenStac
 
 |Documentation|Details|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
 |[End user documentation](https://docs.openstack.org/stein/user/)|The full documentation for the OpenStack user, in Stein version.|
 |[Developer documentation](https://developer.openstack.org/)|The documentation for developers who want to connect their application to OpenStack APIs using the available libraries/SDKs.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/)| The documentation for the essential command line client 'kubectl'.|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-au.md
@@ -52,7 +52,7 @@ These resources are available in our various data centres across the globe. OVHc
 
 ### A cloud service provider in a mature market
 
-OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](https://www.ovhcloud.com/en-au/public-cloud/prices/) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
+OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](/links/public-cloud/prices) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
 
 ## Practical approach <a name="concrete-approach"></a>
 
@@ -121,7 +121,7 @@ Here are some general resources that will help you get started with the Public C
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Frequently asked questions about Public Cloud.|
 |[Glossary](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|The concepts and definitions you will need to move forward.|
-|[Availability of services by location](https://www.ovhcloud.com/fr/public-cloud/regions-availability/)|Service availability tables across different locations.|
+|[Availability of services by location](/links/public-cloud/regions-pci)|Service availability tables across different locations.|
 
 Here are some guides to help you with the first steps:
 
@@ -140,8 +140,8 @@ One of the big advantages of using standard and open technologies, like OpenStac
 
 |Documentation|Details|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
 |[End user documentation](https://docs.openstack.org/stein/user/)|The full documentation for the OpenStack user, in Stein version.|
 |[Developer documentation](https://developer.openstack.org/)|The documentation for developers who want to connect their application to OpenStack APIs using the available libraries/SDKs.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/)| The documentation for the essential command line client 'kubectl'.|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-ca.md
@@ -52,7 +52,7 @@ These resources are available in our various data centres across the globe. OVHc
 
 ### A cloud service provider in a mature market
 
-OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](https://www.ovhcloud.com/en-ca/public-cloud/prices/) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
+OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](/links/public-cloud/prices) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
 
 ## Practical approach <a name="concrete-approach"></a>
 
@@ -121,7 +121,7 @@ Here are some general resources that will help you get started with the Public C
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Frequently asked questions about Public Cloud.|
 |[Glossary](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|The concepts and definitions you will need to move forward.|
-|[Availability of services by location](https://www.ovhcloud.com/fr/public-cloud/regions-availability/)|Service availability tables across different locations.|
+|[Availability of services by location](/links/public-cloud/regions-pci)|Service availability tables across different locations.|
 
 Here are some guides to help you with the first steps:
 
@@ -140,8 +140,8 @@ One of the big advantages of using standard and open technologies, like OpenStac
 
 |Documentation|Details|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
 |[End user documentation](https://docs.openstack.org/stein/user/)|The full documentation for the OpenStack user, in Stein version.|
 |[Developer documentation](https://developer.openstack.org/)|The documentation for developers who want to connect their application to OpenStack APIs using the available libraries/SDKs.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/)| The documentation for the essential command line client 'kubectl'.|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-gb.md
@@ -52,7 +52,7 @@ These resources are available in our various data centres across the globe. OVHc
 
 ### A cloud service provider in a mature market
 
-OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](https://www.ovhcloud.com/en-gb/public-cloud/prices/) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
+OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](/links/public-cloud/prices) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
 
 ## Practical approach <a name="concrete-approach"></a>
 
@@ -121,7 +121,7 @@ Here are some general resources that will help you get started with the Public C
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Frequently asked questions about Public Cloud.|
 |[Glossary](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|The concepts and definitions you will need to move forward.|
-|[Availability of services by location](https://www.ovhcloud.com/fr/public-cloud/regions-availability/)|Service availability tables across different locations.|
+|[Availability of services by location](/links/public-cloud/regions-pci)|Service availability tables across different locations.|
 
 Here are some guides to help you with the first steps:
 
@@ -140,8 +140,8 @@ One of the big advantages of using standard and open technologies, like OpenStac
 
 |Documentation|Details|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
 |[End user documentation](https://docs.openstack.org/stein/user/)|The full documentation for the OpenStack user, in Stein version.|
 |[Developer documentation](https://developer.openstack.org/)|The documentation for developers who want to connect their application to OpenStack APIs using the available libraries/SDKs.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/)| The documentation for the essential command line client 'kubectl'.|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-ie.md
@@ -52,7 +52,7 @@ These resources are available in our various data centres across the globe. OVHc
 
 ### A cloud service provider in a mature market
 
-OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](https://www.ovhcloud.com/en-ie/public-cloud/prices/) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
+OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](/links/public-cloud/prices) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
 
 ## Practical approach <a name="concrete-approach"></a>
 
@@ -121,7 +121,7 @@ Here are some general resources that will help you get started with the Public C
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Frequently asked questions about Public Cloud.|
 |[Glossary](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|The concepts and definitions you will need to move forward.|
-|[Availability of services by location](https://www.ovhcloud.com/fr/public-cloud/regions-availability/)|Service availability tables across different locations.|
+|[Availability of services by location](/links/public-cloud/regions-pci)|Service availability tables across different locations.|
 
 Here are some guides to help you with the first steps:
 
@@ -140,8 +140,8 @@ One of the big advantages of using standard and open technologies, like OpenStac
 
 |Documentation|Details|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
 |[End user documentation](https://docs.openstack.org/stein/user/)|The full documentation for the OpenStack user, in Stein version.|
 |[Developer documentation](https://developer.openstack.org/)|The documentation for developers who want to connect their application to OpenStack APIs using the available libraries/SDKs.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/)| The documentation for the essential command line client 'kubectl'.|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-sg.md
@@ -52,7 +52,7 @@ These resources are available in our various data centres across the globe. OVHc
 
 ### A cloud service provider in a mature market
 
-OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](https://www.ovhcloud.com/en-sg/public-cloud/prices/) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
+OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](/links/public-cloud/prices) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
 
 ## Practical approach <a name="concrete-approach"></a>
 
@@ -121,7 +121,7 @@ Here are some general resources that will help you get started with the Public C
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Frequently asked questions about Public Cloud.|
 |[Glossary](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|The concepts and definitions you will need to move forward.|
-|[Availability of services by location](https://www.ovhcloud.com/fr/public-cloud/regions-availability/)|Service availability tables across different locations.|
+|[Availability of services by location](/links/public-cloud/regions-pci)|Service availability tables across different locations.|
 
 Here are some guides to help you with the first steps:
 
@@ -140,8 +140,8 @@ One of the big advantages of using standard and open technologies, like OpenStac
 
 |Documentation|Details|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
 |[End user documentation](https://docs.openstack.org/stein/user/)|The full documentation for the OpenStack user, in Stein version.|
 |[Developer documentation](https://developer.openstack.org/)|The documentation for developers who want to connect their application to OpenStack APIs using the available libraries/SDKs.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/)| The documentation for the essential command line client 'kubectl'.|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.en-us.md
@@ -52,7 +52,7 @@ These resources are available in our various data centres across the globe. OVHc
 
 ### A cloud service provider in a mature market
 
-OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](https://www.ovhcloud.com/en/public-cloud/prices/) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
+OVHcloud Public Cloud is positioned alongside well-known cloud providers such as AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (from Microsoft) and Alibaba Cloud. Our offer is distinguished by [the particularly advantageous rates](/links/public-cloud/prices) and the use of standard APIs that leave our users free to change, without adhering to any proprietary technology.
 
 ## Practical approach <a name="concrete-approach"></a>
 
@@ -121,7 +121,7 @@ Here are some general resources that will help you get started with the Public C
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Frequently asked questions about Public Cloud.|
 |[Glossary](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|The concepts and definitions you will need to move forward.|
-|[Availability of services by location](https://www.ovhcloud.com/fr/public-cloud/regions-availability/)|Service availability tables across different locations.|
+|[Availability of services by location](/links/public-cloud/regions-pci)|Service availability tables across different locations.|
 
 Here are some guides to help you with the first steps:
 
@@ -140,8 +140,8 @@ One of the big advantages of using standard and open technologies, like OpenStac
 
 |Documentation|Details|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) to find out what services are available.|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient)|Extensive documentation for the essential openstack command-line client. Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/)|Extensive documentation of OpenStack APIs Documentation for the Stein version, please refer to the [availability table](/links/public-cloud/regions-pci) to find out what services are available.|
 |[End user documentation](https://docs.openstack.org/stein/user/)|The full documentation for the OpenStack user, in Stein version.|
 |[Developer documentation](https://developer.openstack.org/)|The documentation for developers who want to connect their application to OpenStack APIs using the available libraries/SDKs.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/)| The documentation for the essential command line client 'kubectl'.|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.es-es.md
@@ -56,7 +56,7 @@ Estos recursos están disponibles en nuestros distintos datacenters repartidos p
 
 ### Un proveedor de servicios cloud en un mercado maduro
 
-El Public Cloud de OVHcloud se posiciona junto a proveedores cloud muy conocidos como AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (de Microsoft) o Alibaba Cloud. Nuestra oferta se distingue por [tarifas especialmente ventajosas](https://www.ovhcloud.com/es-es/public-cloud/prices/) y el uso de API estándar que permiten a los usuarios libertad de cambio, sin adherencia a ninguna tecnología propietaria.
+El Public Cloud de OVHcloud se posiciona junto a proveedores cloud muy conocidos como AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (de Microsoft) o Alibaba Cloud. Nuestra oferta se distingue por [tarifas especialmente ventajosas](/links/public-cloud/prices) y el uso de API estándar que permiten a los usuarios libertad de cambio, sin adherencia a ninguna tecnología propietaria.
 
 ## Enfoque práctico <a name="concrete-approach"></a>
 
@@ -126,7 +126,7 @@ Estos son algunos recursos generales que le ayudarán a empezar en Public Cloud:
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Preguntas más frecuentes sobre Public Cloud.|
 |[Valor](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|Conceptos y definiciones que necesitará para avanzar.|
-|[Disponibilidad de los servicios por localización](https://www.ovhcloud.com/fr/public-cloud/regions-availability/)|Las tablas de disponibilidad de los servicios a través de las diferentes localizaciones.|
+|[Disponibilidad de los servicios por localización](/links/public-cloud/regions-pci)|Las tablas de disponibilidad de los servicios a través de las diferentes localizaciones.|
 
 En la práctica, a continuación le ofrecemos algunas guías que le ayudarán en el inicio:
 
@@ -146,8 +146,8 @@ Una de las grandes ventajas de utilizar tecnologías estándares y abiertas, com
 
 |Documentación|Detalles|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|Documentación completa del cliente imprescindible en línea de comandos "openstack". Para consultar la versión Stein, consulte la [tabla de disponibilidad](https://www.ovhcloud.com/fr/public-cloud/regions-availability/).|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|Documentación completa de las API de OpenStack. Para consultar la versión Stein, consulte la [tabla de disponibilidad](https://www.ovhcloud.com/fr/public-cloud/regions-availability/).|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|Documentación completa del cliente imprescindible en línea de comandos "openstack". Para consultar la versión Stein, consulte la [tabla de disponibilidad](/links/public-cloud/regions-pci).|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|Documentación completa de las API de OpenStack. Para consultar la versión Stein, consulte la [tabla de disponibilidad](/links/public-cloud/regions-pci).|
 |[End user documentation](https://docs.openstack.org/stein/user/) (EN)|Documentación completa para el usuario de OpenStack, en versión Stein.|
 |[Developer documentation](https://developer.openstack.org/) (EN)|Documentación para los desarrolladores que quieran conectar su aplicación a las API de OpenStack utilizando las librerías/SDK disponibles.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/) (EN)| Documentación del cliente imprescindible en línea de comandos "kubectl".|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.es-us.md
@@ -56,7 +56,7 @@ Estos recursos están disponibles en nuestros distintos datacenters repartidos p
 
 ### Un proveedor de servicios cloud en un mercado maduro
 
-El Public Cloud de OVHcloud se posiciona junto a proveedores cloud muy conocidos como AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (de Microsoft) o Alibaba Cloud. Nuestra oferta se distingue por [tarifas especialmente ventajosas](https://www.ovhcloud.com/es-es/public-cloud/prices/) y el uso de API estándar que permiten a los usuarios libertad de cambio, sin adherencia a ninguna tecnología propietaria.
+El Public Cloud de OVHcloud se posiciona junto a proveedores cloud muy conocidos como AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (de Microsoft) o Alibaba Cloud. Nuestra oferta se distingue por [tarifas especialmente ventajosas](/links/public-cloud/prices) y el uso de API estándar que permiten a los usuarios libertad de cambio, sin adherencia a ninguna tecnología propietaria.
 
 ## Enfoque práctico <a name="concrete-approach"></a>
 
@@ -126,7 +126,7 @@ Estos son algunos recursos generales que le ayudarán a empezar en Public Cloud:
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Preguntas más frecuentes sobre Public Cloud.|
 |[Valor](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|Conceptos y definiciones que necesitará para avanzar.|
-|[Disponibilidad de los servicios por localización](https://www.ovhcloud.com/fr/public-cloud/regions-availability/)|Las tablas de disponibilidad de los servicios a través de las diferentes localizaciones.|
+|[Disponibilidad de los servicios por localización](/links/public-cloud/regions-pci)|Las tablas de disponibilidad de los servicios a través de las diferentes localizaciones.|
 
 En la práctica, a continuación le ofrecemos algunas guías que le ayudarán en el inicio:
 
@@ -146,8 +146,8 @@ Una de las grandes ventajas de utilizar tecnologías estándares y abiertas, com
 
 |Documentación|Detalles|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|Documentación completa del cliente imprescindible en línea de comandos "openstack". Para consultar la versión Stein, consulte la [tabla de disponibilidad](https://www.ovhcloud.com/fr/public-cloud/regions-availability/).|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|Documentación completa de las API de OpenStack. Para consultar la versión Stein, consulte la [tabla de disponibilidad](https://www.ovhcloud.com/fr/public-cloud/regions-availability/).|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|Documentación completa del cliente imprescindible en línea de comandos "openstack". Para consultar la versión Stein, consulte la [tabla de disponibilidad](/links/public-cloud/regions-pci).|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|Documentación completa de las API de OpenStack. Para consultar la versión Stein, consulte la [tabla de disponibilidad](/links/public-cloud/regions-pci).|
 |[End user documentation](https://docs.openstack.org/stein/user/) (EN)|Documentación completa para el usuario de OpenStack, en versión Stein.|
 |[Developer documentation](https://developer.openstack.org/) (EN)|Documentación para los desarrolladores que quieran conectar su aplicación a las API de OpenStack utilizando las librerías/SDK disponibles.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/) (EN)| Documentación del cliente imprescindible en línea de comandos "kubectl".|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.fr-ca.md
@@ -52,7 +52,7 @@ Ces ressources sont disponibles dans nos différents datacenters répartis dans 
 
 ### Un fournisseur de service cloud sur un marché mature
 
-Le Public Cloud OVHcloud se positionne aux côtés de fournisseurs cloud bien connus comme AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (de Microsoft) ou encore Alibaba Cloud. Notre offre se distingue par [des tarifs particulièrement avantageux](https://www.ovhcloud.com/fr-ca/public-cloud/prices/) et l'utilisation d'APIs standards laissant nos utilisateurs libres des changements, sans adhérence à l'une ou l'autre technologie propriétaire.
+Le Public Cloud OVHcloud se positionne aux côtés de fournisseurs cloud bien connus comme AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (de Microsoft) ou encore Alibaba Cloud. Notre offre se distingue par [des tarifs particulièrement avantageux](/links/public-cloud/prices) et l'utilisation d'APIs standards laissant nos utilisateurs libres des changements, sans adhérence à l'une ou l'autre technologie propriétaire.
 
 ## Approche concrète <a name="concrete-approach"></a>
 
@@ -121,7 +121,7 @@ Voici quelques ressources générales qui vous aideront dans votre démarrage su
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Les questions les plus fréquentes au sujet de Public Cloud.|
 |[Lexique](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|Les concepts et définitions dont vous aurez besoin pour avancer.|
-|[Disponibilité des services par localisation](https://www.ovhcloud.com/fr-ca/public-cloud/regions-availability/)|Les tableaux de disponibilité des services à travers les différentes localisations.|
+|[Disponibilité des services par localisation](/links/public-cloud/regions-pci)|Les tableaux de disponibilité des services à travers les différentes localisations.|
 
 Dans la pratique, voici également quelques guides qui vous aideront au démarrage :
 
@@ -141,8 +141,8 @@ Un des gros avantages d'utiliser des technologies standards et ouvertes, comme O
 
 |Documentation|Détails|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|La documentation exhaustive de l'incontournable client en ligne de commande 'openstack'. Documentation pour la version Stein, référez-vous au [tableau de disponibilité](https://www.ovhcloud.com/fr-ca/public-cloud/regions-availability/) pour savoir quels sont les services disponibles.|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|La documentation exhaustive des APIs d'OpenStack. Documentation pour la version Stein, référez-vous au [tableau de disponibilité](https://www.ovhcloud.com/fr-ca/public-cloud/regions-availability/) pour savoir quels sont les services disponibles.|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|La documentation exhaustive de l'incontournable client en ligne de commande 'openstack'. Documentation pour la version Stein, référez-vous au [tableau de disponibilité](/links/public-cloud/regions-pci) pour savoir quels sont les services disponibles.|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|La documentation exhaustive des APIs d'OpenStack. Documentation pour la version Stein, référez-vous au [tableau de disponibilité](/links/public-cloud/regions-pci) pour savoir quels sont les services disponibles.|
 |[End user documentation](https://docs.openstack.org/stein/user/) (EN)|La documentation complète pour l'utilisateur d'OpenStack, en version Stein.|
 |[Developer documentation](https://developer.openstack.org/) (EN)|La documentation pour les développeurs qui souhaitent connecter leur application aux APIs d'OpenStack en utilisant les librairies/SDK disponibles.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/) (EN)| La documentation de l'incontournable client en ligne de commande 'kubctl'.|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.fr-fr.md
@@ -52,7 +52,7 @@ Ces ressources sont disponibles dans nos différents datacenters répartis dans 
 
 ### Un fournisseur de service cloud sur un marché mature
 
-Le Public Cloud OVHcloud se positionne aux côtés de fournisseurs cloud bien connus comme AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (de Microsoft) ou encore Alibaba Cloud. Notre offre se distingue par [des tarifs particulièrement avantageux](https://www.ovhcloud.com/fr/public-cloud/prices/) et l'utilisation d'APIs standards laissant nos utilisateurs libres des changements, sans adhérence à l'une ou l'autre technologie propriétaire.
+Le Public Cloud OVHcloud se positionne aux côtés de fournisseurs cloud bien connus comme AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (de Microsoft) ou encore Alibaba Cloud. Notre offre se distingue par [des tarifs particulièrement avantageux](/links/public-cloud/prices) et l'utilisation d'APIs standards laissant nos utilisateurs libres des changements, sans adhérence à l'une ou l'autre technologie propriétaire.
 
 ## Approche concrète <a name="concrete-approach"></a>
 
@@ -121,7 +121,7 @@ Voici quelques ressources générales qui vous aideront dans votre démarrage su
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Les questions les plus fréquentes au sujet de Public Cloud.|
 |[Lexique](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|Les concepts et définitions dont vous aurez besoin pour avancer.|
-|[Disponibilité des services par localisation](https://www.ovhcloud.com/fr/public-cloud/regions-availability/)|Les tableaux de disponibilité des services à travers les différentes localisations.|
+|[Disponibilité des services par localisation](/links/public-cloud/regions-pci)|Les tableaux de disponibilité des services à travers les différentes localisations.|
 
 Dans la pratique, voici également quelques guides qui vous aideront au démarrage :
 
@@ -141,8 +141,8 @@ Un des gros avantages d'utiliser des technologies standards et ouvertes, comme O
 
 |Documentation|Détails|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|La documentation exhaustive de l'incontournable client en ligne de commande 'openstack'. Documentation pour la version Stein, référez-vous au [tableau de disponibilité](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) pour savoir quels sont les services disponibles.|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|La documentation exhaustive des APIs d'OpenStack. Documentation pour la version Stein, référez-vous au [tableau de disponibilité](https://www.ovhcloud.com/fr/public-cloud/regions-availability/) pour savoir quels sont les services disponibles.|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|La documentation exhaustive de l'incontournable client en ligne de commande 'openstack'. Documentation pour la version Stein, référez-vous au [tableau de disponibilité](/links/public-cloud/regions-pci) pour savoir quels sont les services disponibles.|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|La documentation exhaustive des APIs d'OpenStack. Documentation pour la version Stein, référez-vous au [tableau de disponibilité](/links/public-cloud/regions-pci) pour savoir quels sont les services disponibles.|
 |[End user documentation](https://docs.openstack.org/stein/user/) (EN)|La documentation complète pour l'utilisateur d'OpenStack, en version Stein.|
 |[Developer documentation](https://developer.openstack.org/) (EN)|La documentation pour les développeurs qui souhaitent connecter leur application aux APIs d'OpenStack en utilisant les librairies/SDK disponibles.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/) (EN)| La documentation de l'incontournable client en ligne de commande 'kubctl'.|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.it-it.md
@@ -56,7 +56,7 @@ Queste risorse sono disponibili nei diversi datacenter localizzati nel mondo OVH
 
 ### Un provider di servizi Cloud su un mercato maturo
 
-Il Public Cloud OVHcloud è posizionato insieme a provider Cloud conosciuti come AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (Microsoft) o Alibaba Cloud. La nostra offerta si distingue per [tariffe particolarmente vantaggiose](https://www.ovhcloud.com/it/public-cloud/prices/) e l'utilizzo di API standard che lasciano i nostri utenti liberi di cambiare, senza aderire ad una delle due tecnologie proprietarie.
+Il Public Cloud OVHcloud è posizionato insieme a provider Cloud conosciuti come AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (Microsoft) o Alibaba Cloud. La nostra offerta si distingue per [tariffe particolarmente vantaggiose](/links/public-cloud/prices) e l'utilizzo di API standard che lasciano i nostri utenti liberi di cambiare, senza aderire ad una delle due tecnologie proprietarie.
 
 ## Approccio pratico <a name="concrete-approach"></a>
 
@@ -125,7 +125,7 @@ Ecco alcune risorse generali che ti aiuteranno nel tuo lancio sul Public Cloud:
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Le domande più frequenti su Public Cloud|
 |[Lessico](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|I concetti e le definizioni di cui avete bisogno per progredire.|
-|[Disponibilità dei servizi per localizzazione](https://www.ovhcloud.com/it/public-cloud/regions-availability/)|Le tabelle di disponibilità dei servizi attraverso le diverse localizzazioni.|
+|[Disponibilità dei servizi per localizzazione](/links/public-cloud/regions-pci)|Le tabelle di disponibilità dei servizi attraverso le diverse localizzazioni.|
 
 Nella pratica, ecco alcune guide che ti aiuteranno ad avviare:
 
@@ -145,8 +145,8 @@ Uno dei principali vantaggi dell'utilizzo di tecnologie standard e aperte, come 
 
 |Documentazione|Descrizione|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|La documentazione completa dell'indispensabile client online d'ordine 'openstack'. Documentazione per la versione Stein, consulta la [tabella di disponibilità](https://www.ovhcloud.com/it/public-cloud/regions-availability/) per sapere quali servizi sono disponibili.|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|La documentazione completa delle API di OpenStack. Documentazione per la versione Stein, consulta la [tabella di disponibilità](https://www.ovhcloud.com/it/public-cloud/regions-availability/) per sapere quali servizi sono disponibili.|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|La documentazione completa dell'indispensabile client online d'ordine 'openstack'. Documentazione per la versione Stein, consulta la [tabella di disponibilità](/links/public-cloud/regions-pci) per sapere quali servizi sono disponibili.|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|La documentazione completa delle API di OpenStack. Documentazione per la versione Stein, consulta la [tabella di disponibilità](/links/public-cloud/regions-pci) per sapere quali servizi sono disponibili.|
 |[End user Documents](https://docs.openstack.org/stein/user/) (EN)|La documentazione completa per l'utente OpenStack, in versione Stein.|
 |[Developer Documents](https://developer.openstack.org/) (EN)|La documentazione per gli sviluppatori che desiderano connettere la loro applicazione alle API di OpenStack utilizzando le librerie/SDK disponibili.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/) (EN)| La documentazione dell'indispensabile client da riga di comando 'kubctl'.|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.pl-pl.md
@@ -56,7 +56,7 @@ Zasoby te są dostępne w naszych centrach danych na całym świecie. OVHcloud o
 
 ### Dostawca usług cloud na dojrzałym rynku
 
-Public Cloud OVHcloud znajduje się obok znanych dostawców usług cloud, takich jak AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (Microsoft) czy Alibaba Cloud. Oferta OVH wyróżnia się [szczególnie korzystnymi](https://www.ovhcloud.com/pl/public-cloud/prices/) cenami oraz standardowym API, które pozwalają naszym użytkownikom na swobodne wprowadzanie zmian, bez konieczności korzystania z jednej lub kilku technologii będących jej właścicielem.
+Public Cloud OVHcloud znajduje się obok znanych dostawców usług cloud, takich jak AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (Microsoft) czy Alibaba Cloud. Oferta OVH wyróżnia się [szczególnie korzystnymi](/links/public-cloud/prices) cenami oraz standardowym API, które pozwalają naszym użytkownikom na swobodne wprowadzanie zmian, bez konieczności korzystania z jednej lub kilku technologii będących jej właścicielem.
 
 ## Konkretne podejście <a name="concrete-approach"></a>
 
@@ -122,7 +122,7 @@ Oto kilka zasobów ogólnych, które pomogą Ci w uruchomieniu usługi Public Cl
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|Najczęstsze pytania dotyczące usługi Public Cloud.|
 |[Słowniczek](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|Koncepcje i definicje, które będą potrzebne, aby iść naprzód.|
-|[Dostępność usług według lokalizacji](https://www.ovhcloud.com/pl/public-cloud/regions-availability/)|Tabele dostępności usług w różnych lokalizacjach.|
+|[Dostępność usług według lokalizacji](/links/public-cloud/regions-pci)|Tabele dostępności usług w różnych lokalizacjach.|
 
 W praktyce znajdziesz tutaj również przewodniki, które pomogą Ci zacząć:
 
@@ -142,8 +142,8 @@ Jedną z największych zalet korzystania ze standardowych i otwartych technologi
 
 |Dokumentacja|Szczegóły|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|Pełna dokumentacja dotycząca najważniejszego klienta z linii poleceń 'openstack'. Dokumentacja dotycząca wersji Stein, zapoznaj się z [tabelą dostępności](https://www.ovhcloud.com/pl/public-cloud/regions-availability/), aby dowiedzieć się, jakie usługi są dostępne.|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|Pełna dokumentacja API OpenStack. Dokumentacja dotycząca wersji Stein, zapoznaj się z [tabelą dostępności](https://www.ovhcloud.com/pl/public-cloud/regions-availability/), aby dowiedzieć się, jakie usługi są dostępne.|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|Pełna dokumentacja dotycząca najważniejszego klienta z linii poleceń 'openstack'. Dokumentacja dotycząca wersji Stein, zapoznaj się z [tabelą dostępności](/links/public-cloud/regions-pci), aby dowiedzieć się, jakie usługi są dostępne.|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|Pełna dokumentacja API OpenStack. Dokumentacja dotycząca wersji Stein, zapoznaj się z [tabelą dostępności](/links/public-cloud/regions-pci), aby dowiedzieć się, jakie usługi są dostępne.|
 |[End user dokumentacje](https://docs.openstack.org/stein/user/) (EN)|Pełna dokumentacja dotycząca użytkownika OpenStack w wersji Stein.|
 |[Developer Documents](https://developer.openstack.org/) (EN)|Dokumentacja dla programistów, którzy chcą podłączyć aplikację do API OpenStack, korzystając z dostępnych bibliotek/SDK.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/) (EN)| Dokumentacja dotycząca najważniejszego klienta w wierszu poleceń "kubectl".|

--- a/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_cross_functional/00-essential-info-to-get-started-on-public-cloud/guide.pt-pt.md
@@ -56,7 +56,7 @@ Estes recursos estão disponíveis nos nossos diferentes datacenters espalhados 
 
 ### Um fornecedor de serviços cloud num mercado maduro
 
-O Public Cloud da OVHcloud posiciona-se ao lado de fornecedores cloud bem conhecidos como AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (da Microsoft) ou ainda Alibaba Cloud. A nossa oferta distingue-se por tarifas particularmente vantajosas [e pela utilização](https://www.ovhcloud.com/pt/public-cloud/prices/) das APIs standard, que permitem que os nossos utilizadores sejam livres de mudar, sem aderência a uma ou outra tecnologia proprietária.
+O Public Cloud da OVHcloud posiciona-se ao lado de fornecedores cloud bem conhecidos como AWS (Amazon Web Services), GCP (Google Cloud Platform), Azure (da Microsoft) ou ainda Alibaba Cloud. A nossa oferta distingue-se por tarifas particularmente vantajosas [e pela utilização](/links/public-cloud/prices) das APIs standard, que permitem que os nossos utilizadores sejam livres de mudar, sem aderência a uma ou outra tecnologia proprietária.
 
 ## Abordagem concreta <a name="concrete-approach"></a>
 
@@ -123,7 +123,7 @@ Veja aqui alguns recursos gerais que o ajudarão no arranque do Public Cloud:
 |---|---|
 |[FAQ](/pages/public_cloud/public_cloud_cross_functional/faq_pci)|As questões mais frequentes sobre o Public Cloud.|
 |[Léxico](/pages/public_cloud/public_cloud_cross_functional/introduction_about_instances)|Os conceitos e definições de que necessitará para avançar.|
-|[Disponibilidade dos serviços por localização](https://www.ovhcloud.com/pt/public-cloud/regions-availability/)|Os quadros de disponibilidade dos serviços através das diferentes localizações.|
+|[Disponibilidade dos serviços por localização](/links/public-cloud/regions-pci)|Os quadros de disponibilidade dos serviços através das diferentes localizações.|
 
 Na prática, pode consultar os seguintes manuais:
 
@@ -143,8 +143,8 @@ Uma das grandes vantagens de utilizar tecnologias standard e abertas, como OpenS
 
 |Documentação|Detalhes|
 |---|---|
-|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|A documentação exaustiva do incontornável cliente em linha de comandos 'openstack'. Documentação para a versão Stein, consulte a [tabela de disponibilidade](https://www.ovhcloud.com/pt/public-cloud/regions-availability/) para saber quais os serviços disponíveis.|
-|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|A documentação exaustiva das API do OpenStack. Documentação para a versão Stein, consulte a [tabela de disponibilidade](https://www.ovhcloud.com/pt/public-cloud/regions-availability/) para saber quais os serviços disponíveis.|
+|[OpenStack CLI](https://docs.openstack.org/python-openstackclient/stein/#using-openstackclient) (EN)|A documentação exaustiva do incontornável cliente em linha de comandos 'openstack'. Documentação para a versão Stein, consulte a [tabela de disponibilidade](/links/public-cloud/regions-pci) para saber quais os serviços disponíveis.|
+|[APIs OpenStack](https://docs.openstack.org/stein/api/) (EN)|A documentação exaustiva das API do OpenStack. Documentação para a versão Stein, consulte a [tabela de disponibilidade](/links/public-cloud/regions-pci) para saber quais os serviços disponíveis.|
 |[End user Documentation](https://docs.openstack.org/stein/user/) (EN)|A documentação completa para o utilizador do OpenStack, em versão Stein.|
 |[Desenvolver documentação](https://developer.openstack.org/) (EN)|A documentação para os programadores que desejem ligar a sua aplicação às API do OpenStack utilizando as bibliotecas/SDK disponíveis.|
 |[Kubernetes CLI Overview](https://kubernetes.io/docs/reference/kubectl/overview/) (EN)| A documentação do incontornável cliente em linha de comandos 'kubectl'.|

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.de-de.md
@@ -17,7 +17,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ## Requirements
 
 - You must be logged in to your [OVHcloud Control Panel](/links/manager){.external}.
-- You must have signed up to the [Business or Enterprise level of support](https://www.ovhcloud.com/de/support-levels/) for your OVHcloud account.
+- You must have signed up to the [Business or Enterprise level of support](/links/support) for your OVHcloud account.
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-asia.md
@@ -17,7 +17,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ## Requirements
 
 - You must be logged in to your [OVHcloud Control Panel](/links/manager){.external}.
-- You must have signed up to the [Business or Enterprise level of support](https://www.ovhcloud.com/asia/support-levels/) for your OVHcloud account.
+- You must have signed up to the [Business or Enterprise level of support](/links/support) for your OVHcloud account.
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-au.md
@@ -17,7 +17,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ## Requirements
 
 - You must be logged in to your [OVHcloud Control Panel](/links/manager){.external}.
-- You must have signed up to the [Business or Enterprise level of support](https://www.ovhcloud.com/en-au/support-levels/) for your OVHcloud account.
+- You must have signed up to the [Business or Enterprise level of support](/links/support) for your OVHcloud account.
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-ca.md
@@ -17,7 +17,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ## Requirements
 
 - You must be logged in to your [OVHcloud Control Panel](/links/manager){.external}.
-- You must have signed up to the [Business or Enterprise level of support](https://www.ovhcloud.com/en-ca/support-levels/) for your OVHcloud account.
+- You must have signed up to the [Business or Enterprise level of support](/links/support) for your OVHcloud account.
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-gb.md
@@ -17,7 +17,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ## Requirements
 
 - You must be logged in to your [OVHcloud Control Panel](/links/manager){.external}.
-- You must have signed up to the [Business or Enterprise level of support](https://www.ovhcloud.com/en-gb/support-levels/) for your OVHcloud account.
+- You must have signed up to the [Business or Enterprise level of support](/links/support) for your OVHcloud account.
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-ie.md
@@ -17,7 +17,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ## Requirements
 
 - You must be logged in to your [OVHcloud Control Panel](/links/manager){.external}.
-- You must have signed up to the [Business or Enterprise level of support](https://www.ovhcloud.com/en-ie/support-levels/) for your OVHcloud account.
+- You must have signed up to the [Business or Enterprise level of support](/links/support) for your OVHcloud account.
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-sg.md
@@ -17,7 +17,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ## Requirements
 
 - You must be logged in to your [OVHcloud Control Panel](/links/manager){.external}.
-- You must have signed up to the [Business or Enterprise level of support](https://www.ovhcloud.com/en-sg/support-levels/) for your OVHcloud account.
+- You must have signed up to the [Business or Enterprise level of support](/links/support) for your OVHcloud account.
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.en-us.md
@@ -17,7 +17,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ## Requirements
 
 - You must be logged in to your [OVHcloud Control Panel](/links/manager){.external}.
-- You must have signed up to the [Business or Enterprise level of support](https://www.ovhcloud.com/en/support-levels/) for your OVHcloud account.
+- You must have signed up to the [Business or Enterprise level of support](/links/support) for your OVHcloud account.
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.es-es.md
@@ -17,7 +17,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ## Requirements
 
 - You must be logged in to your [OVHcloud Control Panel](/links/manager){.external}.
-- You must have signed up to the [Business or Enterprise level of support](https://www.ovhcloud.com/es-es/support-levels/) for your OVHcloud account.
+- You must have signed up to the [Business or Enterprise level of support](/links/support) for your OVHcloud account.
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.es-us.md
@@ -17,7 +17,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ## Requirements
 
 - You must be logged in to your [OVHcloud Control Panel](/links/manager){.external}.
-- You must have signed up to the [Business or Enterprise level of support](https://www.ovhcloud.com/es/support-levels/) for your OVHcloud account.
+- You must have signed up to the [Business or Enterprise level of support](/links/support) for your OVHcloud account.
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.fr-ca.md
@@ -17,7 +17,7 @@ La liste des produits OVHcloud certifiés est disponible sur la page « [OVHclou
 ## Prérequis
 
 - Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
-- Avoir souscrit au [niveau de support Business ou Enterprise](https://www.ovhcloud.com/fr-ca/support-levels/) pour votre compte OVHcloud.
+- Avoir souscrit au [niveau de support Business ou Enterprise](/links/support) pour votre compte OVHcloud.
 
 ## En pratique
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.fr-fr.md
@@ -17,7 +17,7 @@ La liste des produits OVHcloud certifiés est disponible sur la page « [OVHclou
 ## Prérequis
 
 - Être connecté à votre [espace client OVHcloud](/links/manager){.external}.
-- Avoir souscrit au [niveau de support Business ou Enterprise](https://www.ovhcloud.com/fr/support-levels/) pour votre compte OVHcloud.
+- Avoir souscrit au [niveau de support Business ou Enterprise](/links/support) pour votre compte OVHcloud.
 
 ## En pratique
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.it-it.md
@@ -17,7 +17,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ## Requirements
 
 - You must be logged in to your [OVHcloud Control Panel](/links/manager){.external}.
-- You must have signed up to the [Business or Enterprise level of support](https://www.ovhcloud.com/it/support-levels/) for your OVHcloud account.
+- You must have signed up to the [Business or Enterprise level of support](/links/support) for your OVHcloud account.
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.pl-pl.md
@@ -17,7 +17,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ## Requirements
 
 - You must be logged in to your [OVHcloud Control Panel](/links/manager){.external}.
-- You must have signed up to the [Business or Enterprise level of support](https://www.ovhcloud.com/pl/support-levels/) for your OVHcloud account.
+- You must have signed up to the [Business or Enterprise level of support](/links/support) for your OVHcloud account.
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_cross_functional/activate-hds-certification/guide.pt-pt.md
@@ -17,7 +17,7 @@ The list of certified OVHcloud products is available on the page “[OVHcloud pr
 ## Requirements
 
 - You must be logged in to your [OVHcloud Control Panel](/links/manager){.external}.
-- You must have signed up to the [Business or Enterprise level of support](https://www.ovhcloud.com/pt/support-levels/) for your OVHcloud account.
+- You must have signed up to the [Business or Enterprise level of support](/links/support) for your OVHcloud account.
 
 ## Instructions
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.de-de.md
@@ -10,7 +10,7 @@ updated: 2025-04-28
 
 ## Ziel
 
-Das Erstellen eines Projekts ist die Voraussetzung, um [Public Cloud Instanzen](https://www.ovhcloud.com/de/public-cloud/) verwenden zu können.
+Das Erstellen eines Projekts ist die Voraussetzung, um [Public Cloud Instanzen](/links/public-cloud/public-cloud) verwenden zu können.
 
 **Diese Anleitung erklärt die Schritte zur Erstellung Ihres ersten Public Cloud Projekts.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-asia.md
@@ -6,7 +6,7 @@ updated: 2025-04-28
 
 ## Objective
 
-Creating a project is the first step in deploying [Public Cloud instances](https://www.ovhcloud.com/asia/public-cloud/).
+Creating a project is the first step in deploying [Public Cloud instances](/links/public-cloud/public-cloud).
 
 **This guide will take you through the steps of creating your first Public Cloud project.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-au.md
@@ -6,7 +6,7 @@ updated: 2025-04-28
 
 ## Objective
 
-Creating a project is the first step in deploying [Public Cloud instances](https://www.ovhcloud.com/en-au/public-cloud/).
+Creating a project is the first step in deploying [Public Cloud instances](/links/public-cloud/public-cloud).
 
 **This guide will take you through the steps of creating your first Public Cloud project.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-ca.md
@@ -6,7 +6,7 @@ updated: 2025-04-28
 
 ## Objective
 
-Creating a project is the first step in deploying [Public Cloud instances](https://www.ovhcloud.com/en-ca/public-cloud/).
+Creating a project is the first step in deploying [Public Cloud instances](/links/public-cloud/public-cloud).
 
 **This guide will take you through the steps of creating your first Public Cloud project.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-gb.md
@@ -6,7 +6,7 @@ updated: 2025-04-28
 
 ## Objective
 
-Creating a project is the first step in deploying [Public Cloud instances](https://www.ovhcloud.com/en-gb/public-cloud/).
+Creating a project is the first step in deploying [Public Cloud instances](/links/public-cloud/public-cloud).
 
 **This guide will take you through the steps of creating your first Public Cloud project.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-ie.md
@@ -6,7 +6,7 @@ updated: 2025-04-28
 
 ## Objective
 
-Creating a project is the first step in deploying [Public Cloud instances](https://www.ovhcloud.com/en-ie/public-cloud/).
+Creating a project is the first step in deploying [Public Cloud instances](/links/public-cloud/public-cloud).
 
 **This guide will take you through the steps of creating your first Public Cloud project.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-sg.md
@@ -6,7 +6,7 @@ updated: 2025-04-28
 
 ## Objective
 
-Creating a project is the first step in deploying [Public Cloud instances](https://www.ovhcloud.com/en-sg/public-cloud/).
+Creating a project is the first step in deploying [Public Cloud instances](/links/public-cloud/public-cloud).
 
 **This guide will take you through the steps of creating your first Public Cloud project.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.en-us.md
@@ -6,7 +6,7 @@ updated: 2025-04-28
 
 ## Objective
 
-Creating a project is the first step in deploying [Public Cloud instances](https://www.ovhcloud.com/en/public-cloud/).
+Creating a project is the first step in deploying [Public Cloud instances](/links/public-cloud/public-cloud).
 
 **This guide will take you through the steps of creating your first Public Cloud project.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.es-es.md
@@ -10,7 +10,7 @@ updated: 2025-04-28
 
 ## Objetivo
 
-Crear un proyecto es el primer paso para implementar [instancias Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/).
+Crear un proyecto es el primer paso para implementar [instancias Public Cloud](/links/public-cloud/public-cloud).
 
 **Esta guía le guiará a través de los pasos para crear su primer proyecto de Public Cloud.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.es-us.md
@@ -10,7 +10,7 @@ updated: 2025-04-28
 
 ## Objetivo
 
-Crear un proyecto es el primer paso para implementar [instancias Public Cloud](https://www.ovhcloud.com/es/public-cloud/).
+Crear un proyecto es el primer paso para implementar [instancias Public Cloud](/links/public-cloud/public-cloud).
 
 **Esta guía le guiará a través de los pasos para crear su primer proyecto de Public Cloud.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.fr-ca.md
@@ -6,7 +6,7 @@ updated: 2025-04-28
 
 ## Objectif
 
-La création d’un projet est la première étape indispensable pour déployer des [instances Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/).
+La création d’un projet est la première étape indispensable pour déployer des [instances Public Cloud](/links/public-cloud/public-cloud).
 
 **Ce guide vous guidera à travers les étapes de création de votre premier projet Public Cloud.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.fr-fr.md
@@ -6,7 +6,7 @@ updated: 2025-04-28
 
 ## Objectif
 
-La création d’un projet est la première étape indispensable pour déployer des [instances Public Cloud](https://www.ovhcloud.com/fr/public-cloud/).
+La création d’un projet est la première étape indispensable pour déployer des [instances Public Cloud](/links/public-cloud/public-cloud).
 
 **Ce guide vous guidera à travers les étapes de création de votre premier projet Public Cloud.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.it-it.md
@@ -10,7 +10,7 @@ updated: 2025-04-28
 
 ## Obiettivo
 
-La creazione di un progetto è il primo passo nella distribuzione delle [istanze Public Cloud](https://www.ovhcloud.com/it/public-cloud/).
+La creazione di un progetto è il primo passo nella distribuzione delle [istanze Public Cloud](/links/public-cloud/public-cloud).
 
 **Questa guida ti guiderà attraverso i passi della creazione del tuo primo progetto di Public Cloud.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.pl-pl.md
@@ -10,7 +10,7 @@ updated: 2025-04-28
 
 ## Objective
 
-Utworzenie projekt jest pierwszym krokiem we wdrażaniu [instancji Public Cloud](https://www.ovhcloud.com/pl/public-cloud/).
+Utworzenie projekt jest pierwszym krokiem we wdrażaniu [instancji Public Cloud](/links/public-cloud/public-cloud).
 
 **Dowiedz się, jak utworzyć pierwszy projekt Public Cloud.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_cross_functional/create_a_public_cloud_project/guide.pt-pt.md
@@ -10,7 +10,7 @@ updated: 2025-04-28
 
 ## Objetivo
 
-A criação de um projeto é a primeira etapa na implantação de [instâncias Public Cloud](https://www.ovhcloud.com/pt/public-cloud/).
+A criação de um projeto é a primeira etapa na implantação de [instâncias Public Cloud](/links/public-cloud/public-cloud).
 
 **Este guia o levará através das etapas de criação do seu primeiro projeto Public Cloud.**
 

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.de-de.md
@@ -17,7 +17,7 @@ Zu diesem Zweck können Sie anderen OVHcloud Kunden-Accounts Lese- oder Schreibr
 
 ## Voraussetzungen
 
-- Sie haben eine [Public Cloud](https://www.ovhcloud.com/de/public-cloud/) Instanz in Ihrem OVHcloud Account.
+- Sie haben eine [Public Cloud](/links/public-cloud/public-cloud) Instanz in Ihrem OVHcloud Account.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 
 ## In der praktischen Anwendung 

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-asia.md
@@ -14,7 +14,7 @@ To this end, you can delegate read-only or read/write permissions for your proje
 
 ### Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-au.md
@@ -14,7 +14,7 @@ To this end, you can delegate read-only or read/write permissions for your proje
 
 ### Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-ca.md
@@ -14,7 +14,7 @@ To this end, you can delegate read-only or read/write permissions for your proje
 
 ### Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-gb.md
@@ -14,7 +14,7 @@ To this end, you can delegate read-only or read/write permissions for your proje
 
 ### Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-ie.md
@@ -14,7 +14,7 @@ To this end, you can delegate read-only or read/write permissions for your proje
 
 ### Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-sg.md
@@ -14,7 +14,7 @@ To this end, you can delegate read-only or read/write permissions for your proje
 
 ### Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.en-us.md
@@ -14,7 +14,7 @@ To this end, you can delegate read-only or read/write permissions for your proje
 
 ### Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.es-es.md
@@ -17,7 +17,7 @@ Para ello, puede delegar en otras cuentas de cliente de OVHcloud permisos de lec
 
 ## Requisitos
 
-- Tener una instancia de [Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud.
+- Tener una instancia de [Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud.
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager).
 
 ## Procedimiento 

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.es-us.md
@@ -17,7 +17,7 @@ Para ello, puede delegar en otras cuentas de cliente de OVHcloud permisos de lec
 
 ## Requisitos
 
-- Tener una instancia de [Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud.
+- Tener una instancia de [Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud.
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager).
 
 ## Procedimiento 

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.fr-ca.md
@@ -13,7 +13,7 @@ Dans cet objectif, vous pouvez déléguer à d'autres comptes client OVHcloud de
 
 ## Prérequis
 
-- Avoir une instance [Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud.
+- Avoir une instance [Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - Être connecté à votre [espace client OVHcloud](/links/manager).
 
 ## En pratique 

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.fr-fr.md
@@ -13,7 +13,7 @@ Dans cet objectif, vous pouvez déléguer à d'autres comptes client OVHcloud de
 
 ## Prérequis
 
-- Avoir une instance [Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud.
+- Avoir une instance [Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - Être connecté à votre [espace client OVHcloud](/links/manager).
 
 ## En pratique 

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.it-it.md
@@ -17,7 +17,7 @@ A questo scopo, è possibile delegare ad altri account cliente OVHcloud diritti 
 
 ## Prerequisiti
 
-- Disporre di un'istanza [Public Cloud](https://www.ovhcloud.com/it/public-cloud/) sul proprio account OVHcloud
+- Disporre di un'istanza [Public Cloud](/links/public-cloud/public-cloud) sul proprio account OVHcloud
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 ## Procedura 

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.pl-pl.md
@@ -17,7 +17,7 @@ W tym celu możesz przekazać innym kontom klienta OVHcloud uprawnienia do odczy
 
 ## Wymagania początkowe
 
-- Posiadanie instancji [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na Twoim koncie OVHcloud
+- Posiadanie instancji [Public Cloud](/links/public-cloud/public-cloud) na Twoim koncie OVHcloud
 - Dostęp do [Panelu klienta OVHcloud](/links/manager)
 
 ## W praktyce 

--- a/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delegate_projects/guide.pt-pt.md
@@ -17,7 +17,7 @@ Para isso, pode delegar noutras contas de cliente da OVHcloud direitos de leitur
 
 ## Requisitos
 
-- Ter uma instância [Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud
+- Ter uma instância [Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager)
 
 ## Instruções 

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-asia.md
@@ -6,7 +6,7 @@ updated: 2022-10-14
 
 ## Objective
 
-When you no longer need your [Public Cloud](https://www.ovhcloud.com/asia/public-cloud/) project, you can delete it from the [OVHcloud Control Panel](/links/manager).
+When you no longer need your [Public Cloud](/links/public-cloud/public-cloud) project, you can delete it from the [OVHcloud Control Panel](/links/manager).
 
 When you delete your Public Cloud project, a final invoice is issued for the outstanding amount.
 
@@ -19,7 +19,7 @@ Please note that deleting a project is not the same as deactivating your Public 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-au.md
@@ -6,7 +6,7 @@ updated: 2022-10-14
 
 ## Objective
 
-When you no longer need your [Public Cloud](https://www.ovhcloud.com/en-au/public-cloud/) project, you can delete it directly from the [OVHcloud Control Panel](/links/manager).
+When you no longer need your [Public Cloud](/links/public-cloud/public-cloud) project, you can delete it directly from the [OVHcloud Control Panel](/links/manager).
 
 When you delete your Public Cloud project, a final invoice is issued for the outstanding amount.
 
@@ -19,7 +19,7 @@ Please note that deleting a project is not the same as deactivating your Public 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-ca.md
@@ -6,7 +6,7 @@ updated: 2022-10-14
 
 ## Objective
 
-When you no longer need your [Public Cloud](https://www.ovhcloud.com/en-ca/public-cloud/) project, you can delete it directly from the [OVHcloud Control Panel](/links/manager).
+When you no longer need your [Public Cloud](/links/public-cloud/public-cloud) project, you can delete it directly from the [OVHcloud Control Panel](/links/manager).
 
 When you delete your Public Cloud project, a final invoice is issued for the outstanding amount.
 
@@ -19,7 +19,7 @@ Please note that deleting a project is not the same as deactivating your Public 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-gb.md
@@ -6,7 +6,7 @@ updated: 2022-10-14
 
 ## Objective
 
-When you no longer need your [Public Cloud](https://www.ovhcloud.com/en-gb/public-cloud/) project, you can delete it directly from the [OVHcloud Control Panel](/links/manager).
+When you no longer need your [Public Cloud](/links/public-cloud/public-cloud) project, you can delete it directly from the [OVHcloud Control Panel](/links/manager).
 
 When you delete your Public Cloud project, a final invoice is issued for the outstanding amount.
 
@@ -19,7 +19,7 @@ Please note that deleting a project is not the same as deactivating your Public 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-ie.md
@@ -6,7 +6,7 @@ updated: 2022-10-14
 
 ## Objective
 
-When you no longer need your [Public Cloud](https://www.ovhcloud.com/en-ie/public-cloud/) project, you can delete it directly from the [OVHcloud Control Panel](/links/manager).
+When you no longer need your [Public Cloud](/links/public-cloud/public-cloud) project, you can delete it directly from the [OVHcloud Control Panel](/links/manager).
 
 When you delete your Public Cloud project, a final invoice is issued for the outstanding amount.
 
@@ -19,7 +19,7 @@ Please note that deleting a project is not the same as deactivating your Public 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-sg.md
@@ -6,7 +6,7 @@ updated: 2022-10-14
 
 ## Objective
 
-When you no longer need your [Public Cloud](https://www.ovhcloud.com/en-sg/public-cloud/) project, you can delete it directly from the [OVHcloud Control Panel](/links/manager).
+When you no longer need your [Public Cloud](/links/public-cloud/public-cloud) project, you can delete it directly from the [OVHcloud Control Panel](/links/manager).
 
 When you delete your Public Cloud project, a final invoice is issued for the outstanding amount.
 
@@ -19,7 +19,7 @@ Please note that deleting a project is not the same as deactivating your Public 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.en-us.md
@@ -6,7 +6,7 @@ updated: 2022-10-14
 
 ## Objective
 
-When you no longer need your [Public Cloud](https://www.ovhcloud.com/en/public-cloud/) project, you can delete it directly from the [OVHcloud Control Panel](/links/manager).
+When you no longer need your [Public Cloud](/links/public-cloud/public-cloud) project, you can delete it directly from the [OVHcloud Control Panel](/links/manager).
 
 When you delete your Public Cloud project, a final invoice is issued for the outstanding amount.
 
@@ -19,7 +19,7 @@ Please note that deleting a project is not the same as deactivating your Public 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.es-es.md
@@ -10,7 +10,7 @@ updated: 2022-10-14
 
 ## Objetivo
 
-Si ya no necesita un [proyecto de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/), puede eliminarlo directamente desde el área de cliente de [OVHcloud](/links/manager).
+Si ya no necesita un [proyecto de Public Cloud](/links/public-cloud/public-cloud), puede eliminarlo directamente desde el área de cliente de [OVHcloud](/links/manager).
 
 Al eliminar un proyecto de Public Cloud, se emitirá una factura final en la que se indicará el importe pendiente de pago.
 
@@ -24,7 +24,7 @@ Al eliminar un proyecto, los recursos que contiene se pierden definitivamente. E
 
 ## Requisitos
 
-- Un [proyecto de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud
+- Un [proyecto de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager)
 
 ## Procedimiento

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.es-us.md
@@ -10,7 +10,7 @@ updated: 2022-10-14
 
 ## Objetivo
 
-Si ya no necesita un [proyecto de Public Cloud](https://www.ovhcloud.com/es/public-cloud/), puede eliminarlo directamente desde el área de cliente de [OVHcloud](/links/manager).
+Si ya no necesita un [proyecto de Public Cloud](/links/public-cloud/public-cloud), puede eliminarlo directamente desde el área de cliente de [OVHcloud](/links/manager).
 
 Al eliminar un proyecto de Public Cloud, se emitirá una factura final en la que se indicará el importe pendiente de pago.
 
@@ -24,7 +24,7 @@ Al eliminar un proyecto, los recursos que contiene se pierden definitivamente. E
 
 ## Requisitos
 
-- Un [proyecto de Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud
+- Un [proyecto de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager)
 
 ## Procedimiento

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.fr-ca.md
@@ -6,7 +6,7 @@ updated: 2022-10-14
 
 ## Objectif
 
-Lorsque vous n’avez plus besoin d'un [projet Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/), vous pouvez le supprimer directement depuis votre espace client [OVHcloud](/links/manager).
+Lorsque vous n’avez plus besoin d'un [projet Public Cloud](/links/public-cloud/public-cloud), vous pouvez le supprimer directement depuis votre espace client [OVHcloud](/links/manager).
 
 Lorsque vous supprimez un projet Public Cloud, une facture finale est émise qui contient le montant restant à payer.
 
@@ -20,7 +20,7 @@ Lorsque vous supprimez un projet, les ressources qu'il contient sont définitive
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.fr-fr.md
@@ -6,7 +6,7 @@ updated: 2022-10-14
 
 ## Objectif
 
-Lorsque vous n’avez plus besoin d'un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/), vous pouvez le supprimer directement depuis votre espace client [OVHcloud](/links/manager).
+Lorsque vous n’avez plus besoin d'un [projet Public Cloud](/links/public-cloud/public-cloud), vous pouvez le supprimer directement depuis votre espace client [OVHcloud](/links/manager).
 
 Lorsque vous supprimez un projet Public Cloud, une facture finale est émise qui contient le montant restant à payer.
 
@@ -20,7 +20,7 @@ Lorsque vous supprimez un projet, les ressources qu'il contient sont définitive
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.it-it.md
@@ -10,7 +10,7 @@ updated: 2022-10-14
 
 ## Obiettivo
 
-Se non hai più bisogno di un [progetto Public Cloud](https://www.ovhcloud.com/it/public-cloud/), è possibile eliminarlo direttamente dallo Spazio Cliente [OVHcloud](/links/manager).
+Se non hai più bisogno di un [progetto Public Cloud](/links/public-cloud/public-cloud), è possibile eliminarlo direttamente dallo Spazio Cliente [OVHcloud](/links/manager).
 
 Una volta eliminato un progetto Public Cloud, viene emessa una fattura finale contenente l'importo da saldare.
 
@@ -24,7 +24,7 @@ Una volta eliminato un progetto, le risorse in esso contenute vengono definitiva
 
 ## Prerequisiti
 
-- Un [progetto Public Cloud](https://www.ovhcloud.com/it/public-cloud/) nel tuo account OVHcloud
+- Un [progetto Public Cloud](/links/public-cloud/public-cloud) nel tuo account OVHcloud
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 ## Procedura

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.pl-pl.md
@@ -10,7 +10,7 @@ updated: 2022-10-14
 
 ## Wprowadzenie
 
-Jeśli nie potrzebujesz już [projektu Public Cloud](https://www.ovhcloud.com/pl/public-cloud/), możesz go usunąć bezpośrednio z [Panelu klienta OVHcloud](/links/manager).
+Jeśli nie potrzebujesz już [projektu Public Cloud](/links/public-cloud/public-cloud), możesz go usunąć bezpośrednio z [Panelu klienta OVHcloud](/links/manager).
 
 Po usunięciu projektu Public Cloud wystawiana jest faktura zawierająca kwotę pozostającą do zapłaty.
 
@@ -24,7 +24,7 @@ Po usunięciu projektu, zasoby, które on zawiera są nieodwracalnie utracone. O
 
 ## Wymagania początkowe
 
-- Projekt [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na Twoim koncie OVHcloud
+- Projekt [Public Cloud](/links/public-cloud/public-cloud) na Twoim koncie OVHcloud
 - Dostęp do [Panelu klienta OVHcloud](/links/manager)
 
 ## W praktyce

--- a/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_cross_functional/delete_a_project/guide.pt-pt.md
@@ -10,7 +10,7 @@ updated: 2022-10-14
 
 ## Objetivo
 
-Quando já não precisa de um [projeto Public Cloud](https://www.ovhcloud.com/pt/public-cloud/), pode eliminá-lo diretamente na [Área de Cliente OVHcloud](/links/manager).
+Quando já não precisa de um [projeto Public Cloud](/links/public-cloud/public-cloud), pode eliminá-lo diretamente na [Área de Cliente OVHcloud](/links/manager).
 
 Ao eliminar um projeto Public Cloud, será emitida uma fatura final que conterá o montante por pagar.
 
@@ -24,7 +24,7 @@ Quando um projeto é eliminado, os recursos que contém são definitivamente per
 
 ## Requisitos
 
-- Um [projeto Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud.
+- Um [projeto Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud.
 - Estar ligado à [Área de Cliente OVHcloud](/links/manager).
 
 ## Instruções

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_manage_savings_plan/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_manage_savings_plan/guide.fr-ca.md
@@ -36,7 +36,7 @@ Ce guide a pour objectif de fournir une méthode claire et détaillée pour la c
 
 ## Prérequis
 
-- Un [projet Public Cloud OVHcloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud.
+- Un [projet Public Cloud OVHcloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - Être connecté à l'[espace client OVHcloud](/links/manager) ou à l'[API OVHcloud](/links/api) (créez vos identifiants en consultant [ce guide](/pages/manage_and_operate/api/first-steps)).
 - Être familier de l'utilisation de [Terraform](/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform) si vous souhaitez l'utiliser.
 - Connaitre les principes d'un [Savings Plan](/links/public-cloud/savings-plan)

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_manage_savings_plan/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_manage_savings_plan/guide.fr-fr.md
@@ -36,7 +36,7 @@ Ce guide a pour objectif de fournir une méthode claire et détaillée pour la c
 
 ## Prérequis
 
-- Un [projet Public Cloud OVHcloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud.
+- Un [projet Public Cloud OVHcloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - Être connecté à l'[espace client OVHcloud](/links/manager) ou à l'[API OVHcloud](/links/api) (créez vos identifiants en consultant [ce guide](/pages/manage_and_operate/api/first-steps)).
 - Être familier de l'utilisation de [Terraform](/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform) si vous souhaitez l'utiliser.
 - Connaitre les principes d'un [Savings Plan](/links/public-cloud/savings-plan)


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their /links values.

Example: replace all https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB links with /links/manager.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.