### PR TITLE
Fix global links in Public cloud integrations

### DIFF
--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.de-de.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.de-de.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.de/&ovhSubsidiary=de)
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-asia.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-asia.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/asia/&ovhSubsidiary=asia)
-- A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-au.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-au.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com.au/&ovhSubsidiary=au)
-- A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-ca.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-ca.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/en/&ovhSubsidiary=ca)
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-gb.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-gb.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB)
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-ie.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-ie.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.ie/&ovhSubsidiary=ie)
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-sg.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-sg.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/sg/&ovhSubsidiary=sg)
-- A [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-us.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.en-us.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=we)
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.es-es.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.es-es.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.es/&ovhSubsidiary=es)
-- A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.es-us.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.es-us.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/world/&ovhSubsidiary=ws)
-- A [Public Cloud project](https://www.ovhcloud.com/es/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.fr-ca.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.fr-ca.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://ca.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/ca/fr/&ovhSubsidiary=qc)
-- A [Public Cloud project](https://www.ovhcloud.com/fr-ca/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.fr-fr.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.fr-fr.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.com/fr/&ovhSubsidiary=fr)
-- A [Public Cloud project](https://www.ovhcloud.com/fr/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.it-it.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.it-it.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.it/&ovhSubsidiary=it)
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.pl-pl.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.pl-pl.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pl/&ovhSubsidiary=pl)
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.pt-pt.md
+++ b/pages/public_cloud/integrations/prefect_guide_01_getting_started/guide.pt-pt.md
@@ -13,8 +13,8 @@ Prefect provides a flexible Python framework to easily combine tasks into workfl
 ## Requirements
 
 - An active OVHcloud account and its credentials
-- Access to the [OVHcloud Control Panel](https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.pt/&ovhSubsidiary=pt)
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/)
+- Access to the [OVHcloud Control Panel](/links/manager)
+- A [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their /links values.

Example: replace all https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB links with /links/manager.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.