### PR TITLE
Fix global links in Public cloud compute

### DIFF
--- a/pages/public_cloud/compute/activate-windows-license-private-mode/guide.de-de.md
+++ b/pages/public_cloud/compute/activate-windows-license-private-mode/guide.de-de.md
@@ -17,7 +17,7 @@ In diesem Fall müssen Sie die Lizenz manuell aktivieren, um Zugriff auf alle Wi
 
 ## Voraussetzungen
 
-- Sie haben ein [Public Cloud Projekt](/links/public-cloud/public-cloud){.external} in Ihrem Kunden-Account.
+- Sie haben ein [Public Cloud Projekt](/links/public-cloud/public-cloud) in Ihrem Kunden-Account.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 - Sie haben einen [OpenStack User erstellt](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user).
 

--- a/pages/public_cloud/compute/activate-windows-license-private-mode/guide.de-de.md
+++ b/pages/public_cloud/compute/activate-windows-license-private-mode/guide.de-de.md
@@ -17,7 +17,7 @@ In diesem Fall müssen Sie die Lizenz manuell aktivieren, um Zugriff auf alle Wi
 
 ## Voraussetzungen
 
-- Sie haben ein [Public Cloud Projekt](https://www.ovhcloud.com/de/public-cloud/){.external} in Ihrem Kunden-Account.
+- Sie haben ein [Public Cloud Projekt](/links/public-cloud/public-cloud){.external} in Ihrem Kunden-Account.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 - Sie haben einen [OpenStack User erstellt](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user).
 

--- a/pages/public_cloud/compute/activate-windows-license-private-mode/guide.es-es.md
+++ b/pages/public_cloud/compute/activate-windows-license-private-mode/guide.es-es.md
@@ -17,7 +17,7 @@ En ese caso, deberá activar la licencia manualmente para poder acceder a todos 
 
 ## Requisitos
 
-- Un [proyecto de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud
+- Un [proyecto de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
 - Estar conectado al [área de cliente de OVHcloud](/links/manager)
 - [Haber creado un usuario de OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 

--- a/pages/public_cloud/compute/activate-windows-license-private-mode/guide.es-us.md
+++ b/pages/public_cloud/compute/activate-windows-license-private-mode/guide.es-us.md
@@ -17,7 +17,7 @@ En ese caso, deberá activar la licencia manualmente para poder acceder a todos 
 
 ## Requisitos
 
-- Un [proyecto de Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud
+- Un [proyecto de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
 - Estar conectado al [área de cliente de OVHcloud](/links/manager)
 - [Haber creado un usuario de OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 

--- a/pages/public_cloud/compute/apps_first_steps/guide.en-asia.md
+++ b/pages/public_cloud/compute/apps_first_steps/guide.en-asia.md
@@ -26,7 +26,7 @@ Using the [OVHcloud Control Panel](/links/manager) / API or the OpenStack Horizo
 
 Once the instance has been installed with your chosen pre-installed application, you can retrieve your login details via the OVHcloud API only.
 
-1. Log in to the [API console here](https://ca.api.ovh.com/).
+1. Log in to the [API console here](/links/api).
 2. Then go to [here](https://ca.api.ovh.com/console/#/cloud/project/%7BserviceName%7D/instance/%7BinstanceId%7D/applicationAccess#POST).
 
 > API call

--- a/pages/public_cloud/compute/apps_first_steps/guide.en-au.md
+++ b/pages/public_cloud/compute/apps_first_steps/guide.en-au.md
@@ -26,7 +26,7 @@ Using the [OVHcloud Control Panel](/links/manager) / API or the OpenStack Horizo
 
 Once the instance has been installed with your chosen pre-installed application, you can retrieve your login details via the OVHcloud API only.
 
-1. Log in to the [API console here](https://ca.api.ovh.com/).
+1. Log in to the [API console here](/links/api).
 2. Then go to [here](https://ca.api.ovh.com/console/#/cloud/project/%7BserviceName%7D/instance/%7BinstanceId%7D/applicationAccess#POST).
 
 > API call

--- a/pages/public_cloud/compute/apps_first_steps/guide.en-ca.md
+++ b/pages/public_cloud/compute/apps_first_steps/guide.en-ca.md
@@ -26,7 +26,7 @@ Using the [OVHcloud Control Panel](/links/manager) / API or the OpenStack Horizo
 
 Once the instance has been installed with your chosen pre-installed application, you can retrieve your login details via the OVHcloud API only.
 
-1. Log in to the [API console here](https://ca.api.ovh.com/).
+1. Log in to the [API console here](/links/api).
 2. Then go to [here](https://ca.api.ovh.com/console/#/cloud/project/%7BserviceName%7D/instance/%7BinstanceId%7D/applicationAccess#POST).
 
 > API call

--- a/pages/public_cloud/compute/apps_first_steps/guide.en-sg.md
+++ b/pages/public_cloud/compute/apps_first_steps/guide.en-sg.md
@@ -26,7 +26,7 @@ Using the [OVHcloud Control Panel](/links/manager) / API or the OpenStack Horizo
 
 Once the instance has been installed with your chosen pre-installed application, you can retrieve your login details via the OVHcloud API only.
 
-1. Log in to the [API console here](https://ca.api.ovh.com/).
+1. Log in to the [API console here](/links/api).
 2. Then go to [here](https://ca.api.ovh.com/console/#/cloud/project/%7BserviceName%7D/instance/%7BinstanceId%7D/applicationAccess#POST).
 
 > API call

--- a/pages/public_cloud/compute/apps_first_steps/guide.en-us.md
+++ b/pages/public_cloud/compute/apps_first_steps/guide.en-us.md
@@ -26,7 +26,7 @@ Using the [OVHcloud Control Panel](/links/manager) / API or the OpenStack Horizo
 
 Once the instance has been installed with your chosen pre-installed application, you can retrieve your login details via the OVHcloud API only.
 
-1. Log in to the [API console here](https://ca.api.ovh.com/).
+1. Log in to the [API console here](/links/api).
 2. Then go to [here](https://ca.api.ovh.com/console/#/cloud/project/%7BserviceName%7D/instance/%7BinstanceId%7D/applicationAccess#POST).
 
 > API call

--- a/pages/public_cloud/compute/apps_first_steps/guide.fr-ca.md
+++ b/pages/public_cloud/compute/apps_first_steps/guide.fr-ca.md
@@ -26,7 +26,7 @@ Depuis [l'espace client OVHcloud](/links/manager), les API OVHcloud ou de l'API 
 
 Une fois l'instance créée et une application préinstallée choisie, vous pouvez récupérer vos informations de connexion uniquement via l'API OVHcloud.
 
-1. Connectez-vous à la [console API](https://ca.api.ovh.com/)
+1. Connectez-vous à la [console API](/links/api)
 2. Utilisez ensuite [cet appel API](https://ca.api.ovh.com/console/#/cloud/project/%7BserviceName%7D/instance/%7BinstanceId%7D/applicationAccess#POST)
 
 > Appel API

--- a/pages/public_cloud/compute/change_project_contacts/guide.en-asia.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.en-asia.md
@@ -13,7 +13,7 @@ Modifying these contacts enables you to separate the technical management of ser
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Admin and billing contacts in the same OVHcloud subsidiary
 

--- a/pages/public_cloud/compute/change_project_contacts/guide.en-au.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.en-au.md
@@ -13,7 +13,7 @@ Modifying these contacts enables you to separate the technical management of ser
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Admin and billing contacts in the same OVHcloud subsidiary
 

--- a/pages/public_cloud/compute/change_project_contacts/guide.en-ca.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.en-ca.md
@@ -13,7 +13,7 @@ Modifying these contacts enables you to separate the technical management of ser
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Admin and billing contacts in the same OVHcloud subsidiary
 

--- a/pages/public_cloud/compute/change_project_contacts/guide.en-gb.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.en-gb.md
@@ -13,7 +13,7 @@ Modifying these contacts enables you to separate the technical management of ser
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Admin and billing contacts in the same OVHcloud subsidiary
 

--- a/pages/public_cloud/compute/change_project_contacts/guide.en-ie.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.en-ie.md
@@ -13,7 +13,7 @@ Modifying these contacts enables you to separate the technical management of ser
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Admin and billing contacts in the same OVHcloud subsidiary
 

--- a/pages/public_cloud/compute/change_project_contacts/guide.en-sg.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.en-sg.md
@@ -13,7 +13,7 @@ Modifying these contacts enables you to separate the technical management of ser
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Admin and billing contacts in the same OVHcloud subsidiary
 

--- a/pages/public_cloud/compute/change_project_contacts/guide.en-us.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.en-us.md
@@ -13,7 +13,7 @@ Modifying these contacts enables you to separate the technical management of ser
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Admin and billing contacts in the same OVHcloud subsidiary
 

--- a/pages/public_cloud/compute/change_project_contacts/guide.es-es.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.es-es.md
@@ -17,7 +17,7 @@ La modificación de estos contactos permite disociar la gestión técnica de la 
 
 ## Requisitos
 
-- Tener un proyecto de [Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud.
+- Tener un proyecto de [Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud.
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager).
 - Contactos de administrador y facturación en la misma filial de OVHcloud.
 

--- a/pages/public_cloud/compute/change_project_contacts/guide.es-us.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.es-us.md
@@ -17,7 +17,7 @@ La modificación de estos contactos permite disociar la gestión técnica de la 
 
 ## Requisitos
 
-- Tener un proyecto de [Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud.
+- Tener un proyecto de [Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud.
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager).
 - Contactos de administrador y facturación en la misma filial de OVHcloud.
 

--- a/pages/public_cloud/compute/change_project_contacts/guide.fr-ca.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.fr-ca.md
@@ -13,7 +13,7 @@ La modification de ces contacts permet de dissocier la gestion technique de la g
 
 ## Prérequis
 
-- Avoir un projet [Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud
+- Avoir un projet [Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 - Contacts administrateur et facturation dans la même filiale OVHcloud
 

--- a/pages/public_cloud/compute/change_project_contacts/guide.fr-fr.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.fr-fr.md
@@ -13,7 +13,7 @@ La modification de ces contacts permet de dissocier la gestion technique de la g
 
 ## Prérequis
 
-- Avoir un projet [Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
+- Avoir un projet [Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 - Contacts administrateur et facturation dans la même filiale OVHcloud
 

--- a/pages/public_cloud/compute/change_project_contacts/guide.it-it.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.it-it.md
@@ -17,7 +17,7 @@ La modifica di questi contatti permette di dissociare la gestione tecnica dalla 
 
 ## Prerequisiti
 
-- Disporre di un progetto [Public Cloud](https://www.ovhcloud.com/it/public-cloud/) nel proprio account OVHcloud
+- Disporre di un progetto [Public Cloud](/links/public-cloud/public-cloud) nel proprio account OVHcloud
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 - Contatti amministratore e fatturazione nella stessa filiale OVHcloud
 

--- a/pages/public_cloud/compute/change_project_contacts/guide.pl-pl.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.pl-pl.md
@@ -17,7 +17,7 @@ Zmiana tych kontaktów pozwala na oddzielenie zarządzania technicznego i księg
 
 ## Wymagania początkowe
 
-- Posiadanie projektu [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na koncie OVHcloud
+- Posiadanie projektu [Public Cloud](/links/public-cloud/public-cloud) na koncie OVHcloud
 - Dostęp do [Panelu klienta OVHcloud](/links/manager)
 - Kontakt administracyjny i księgowy w tym samym oddziale OVHcloud
 

--- a/pages/public_cloud/compute/change_project_contacts/guide.pt-pt.md
+++ b/pages/public_cloud/compute/change_project_contacts/guide.pt-pt.md
@@ -17,7 +17,7 @@ A modificação destes contactos permite dissociar a gestão técnica da gestão
 
 ## Requisitos
 
-- Ter um projeto [Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud
+- Ter um projeto [Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager)
 - Contactos de administrador e faturação na mesma filial OVHcloud
 

--- a/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.en-asia.md
+++ b/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.en-asia.md
@@ -6,7 +6,7 @@ updated: 2025-03-20
 
 ## Objective
 
-With the cloud-init module, you can configure your [Public Cloud instance](https://www.ovhcloud.com/asia/public-cloud/){.external} when you create it, and each time you reboot it. Consequently, if you wish to reconfigure your hostname, because of an error when creating your instance or to reconfigure your email server, you will need to disable the Cloud-init module. This will configure the hostname so that it is not re-established.
+With the cloud-init module, you can configure your [Public Cloud instance](/links/public-cloud/public-cloud){.external} when you create it, and each time you reboot it. Consequently, if you wish to reconfigure your hostname, because of an error when creating your instance or to reconfigure your email server, you will need to disable the Cloud-init module. This will configure the hostname so that it is not re-established.
 
 **This guide will show you how to reconfigure cloud-init so that you can modify your instance’s hostname.**
 

--- a/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.en-au.md
+++ b/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.en-au.md
@@ -6,7 +6,7 @@ updated: 2025-03-20
 
 ## Objective
 
-With the cloud-init module, you can configure your [Public Cloud instance](https://www.ovhcloud.com/en-au/public-cloud/){.external} when you create it, and each time you reboot it. Consequently, if you wish to reconfigure your hostname, because of an error when creating your instance or to reconfigure your email server, you will need to disable the Cloud-init module. This will configure the hostname so that it is not re-established.
+With the cloud-init module, you can configure your [Public Cloud instance](/links/public-cloud/public-cloud){.external} when you create it, and each time you reboot it. Consequently, if you wish to reconfigure your hostname, because of an error when creating your instance or to reconfigure your email server, you will need to disable the Cloud-init module. This will configure the hostname so that it is not re-established.
 
 **This guide will show you how to reconfigure cloud-init so that you can modify your instance’s hostname.**
 

--- a/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.en-ca.md
+++ b/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.en-ca.md
@@ -6,7 +6,7 @@ updated: 2025-03-20
 
 ## Objective
 
-With the cloud-init module, you can configure your [Public Cloud instance](https://www.ovhcloud.com/en-ca/public-cloud/){.external} when you create it, and each time you reboot it. Consequently, if you wish to reconfigure your hostname, because of an error when creating your instance or to reconfigure your email server, you will need to disable the Cloud-init module. This will configure the hostname so that it is not re-established.
+With the cloud-init module, you can configure your [Public Cloud instance](/links/public-cloud/public-cloud){.external} when you create it, and each time you reboot it. Consequently, if you wish to reconfigure your hostname, because of an error when creating your instance or to reconfigure your email server, you will need to disable the Cloud-init module. This will configure the hostname so that it is not re-established.
 
 **This guide will show you how to reconfigure cloud-init so that you can modify your instance’s hostname.**
 

--- a/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.en-ie.md
+++ b/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.en-ie.md
@@ -6,7 +6,7 @@ updated: 2025-03-20
 
 ## Objective
 
-With the cloud-init module, you can configure your [Public Cloud instance](https://www.ovhcloud.com/en-ie/public-cloud/){.external} when you create it, and each time you reboot it. Consequently, if you wish to reconfigure your hostname, because of an error when creating your instance or to reconfigure your email server, you will need to disable the Cloud-init module. This will configure the hostname so that it is not re-established.
+With the cloud-init module, you can configure your [Public Cloud instance](/links/public-cloud/public-cloud){.external} when you create it, and each time you reboot it. Consequently, if you wish to reconfigure your hostname, because of an error when creating your instance or to reconfigure your email server, you will need to disable the Cloud-init module. This will configure the hostname so that it is not re-established.
 
 **This guide will show you how to reconfigure cloud-init so that you can modify your instance’s hostname.**
 

--- a/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.en-sg.md
+++ b/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.en-sg.md
@@ -6,7 +6,7 @@ updated: 2025-03-20
 
 ## Objective
 
-With the cloud-init module, you can configure your [Public Cloud instance](https://www.ovhcloud.com/en-sg/public-cloud/){.external} when you create it, and each time you reboot it. Consequently, if you wish to reconfigure your hostname, because of an error when creating your instance or to reconfigure your email server, you will need to disable the Cloud-init module. This will configure the hostname so that it is not re-established.
+With the cloud-init module, you can configure your [Public Cloud instance](/links/public-cloud/public-cloud){.external} when you create it, and each time you reboot it. Consequently, if you wish to reconfigure your hostname, because of an error when creating your instance or to reconfigure your email server, you will need to disable the Cloud-init module. This will configure the hostname so that it is not re-established.
 
 **This guide will show you how to reconfigure cloud-init so that you can modify your instance’s hostname.**
 

--- a/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.en-us.md
+++ b/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.en-us.md
@@ -6,7 +6,7 @@ updated: 2025-03-20
 
 ## Objective
 
-With the cloud-init module, you can configure your [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/){.external} when you create it, and each time you reboot it. Consequently, if you wish to reconfigure your hostname, because of an error when creating your instance or to reconfigure your email server, you will need to disable the Cloud-init module. This will configure the hostname so that it is not re-established.
+With the cloud-init module, you can configure your [Public Cloud instance](/links/public-cloud/public-cloud){.external} when you create it, and each time you reboot it. Consequently, if you wish to reconfigure your hostname, because of an error when creating your instance or to reconfigure your email server, you will need to disable the Cloud-init module. This will configure the hostname so that it is not re-established.
 
 **This guide will show you how to reconfigure cloud-init so that you can modify your instance’s hostname.**
 

--- a/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.es-es.md
+++ b/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.es-es.md
@@ -6,7 +6,7 @@ updated: 2025-03-20
 
 ## Objetivo
 
-El módulo **cloud-init** permite configurar una [instancia de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/){.external} al crearla, pero también cada vez que se reinicie. Por eso, si quiere volver a configurar el hostname, bien porque se produjo un error al crear la instancia, o bien para reconfigurar el servidor de correo, deberá desactivar primero el módulo cloud-init, que es el encargado de configurar el hostname para que no se restablezca.
+El módulo **cloud-init** permite configurar una [instancia de Public Cloud](/links/public-cloud/public-cloud){.external} al crearla, pero también cada vez que se reinicie. Por eso, si quiere volver a configurar el hostname, bien porque se produjo un error al crear la instancia, o bien para reconfigurar el servidor de correo, deberá desactivar primero el módulo cloud-init, que es el encargado de configurar el hostname para que no se restablezca.
 
 **Esta guía explica cómo reconfigurar cloud-init para poder cambiar el hostname de una instancia.**
 

--- a/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.es-us.md
+++ b/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.es-us.md
@@ -6,7 +6,7 @@ updated: 2025-03-20
 
 ## Objetivo
 
-El módulo **cloud-init** permite configurar una [instancia de Public Cloud](https://www.ovhcloud.com/es/public-cloud/){.external} al crearla, pero también cada vez que se reinicie. Por eso, si quiere volver a configurar el hostname, bien porque se produjo un error al crear la instancia, o bien para reconfigurar el servidor de correo, deberá desactivar primero el módulo cloud-init, que es el encargado de configurar el hostname para que no se restablezca.
+El módulo **cloud-init** permite configurar una [instancia de Public Cloud](/links/public-cloud/public-cloud){.external} al crearla, pero también cada vez que se reinicie. Por eso, si quiere volver a configurar el hostname, bien porque se produjo un error al crear la instancia, o bien para reconfigurar el servidor de correo, deberá desactivar primero el módulo cloud-init, que es el encargado de configurar el hostname para que no se restablezca.
 
 **Esta guía explica cómo reconfigurar cloud-init para poder cambiar el hostname de una instancia.**
 

--- a/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.fr-ca.md
+++ b/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.fr-ca.md
@@ -6,7 +6,7 @@ updated: 2025-03-20
 
 ## Objectif
 
-Le module Cloud-init permet de configurer votre [instance Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/){.external} lors de sa création, mais aussi à chaque redémarrage. Par conséquent, si vous souhaitez reconfigurer votre hostname, à cause d'une erreur lors de la création de votre instance ou pour reconfigurer votre serveur e-mail, il vous sera nécessaire de désactiver le module Cloud-init. Celui-ci se charge de configurer le hostname afin que celui ci ne soit pas rétabli.
+Le module Cloud-init permet de configurer votre [instance Public Cloud](/links/public-cloud/public-cloud){.external} lors de sa création, mais aussi à chaque redémarrage. Par conséquent, si vous souhaitez reconfigurer votre hostname, à cause d'une erreur lors de la création de votre instance ou pour reconfigurer votre serveur e-mail, il vous sera nécessaire de désactiver le module Cloud-init. Celui-ci se charge de configurer le hostname afin que celui ci ne soit pas rétabli.
 
 **Ce guide vous explique comment reconfigurer cloud-init afin d'être en mesure de modifier le hostname de votre instance.**
 

--- a/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.fr-fr.md
+++ b/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.fr-fr.md
@@ -6,7 +6,7 @@ updated: 2025-03-20
 
 ## Objectif
 
-Le module Cloud-init permet de configurer votre [instance Public Cloud](https://www.ovhcloud.com/fr/public-cloud/){.external} lors de sa création, mais aussi à chaque redémarrage. Par conséquent, si vous souhaitez reconfigurer votre hostname, à cause d'une erreur lors de la création de votre instance ou pour reconfigurer votre serveur e-mail, il vous sera nécessaire de désactiver le module Cloud-init. Celui-ci se charge de configurer le hostname afin que celui ci ne soit pas rétabli.
+Le module Cloud-init permet de configurer votre [instance Public Cloud](/links/public-cloud/public-cloud){.external} lors de sa création, mais aussi à chaque redémarrage. Par conséquent, si vous souhaitez reconfigurer votre hostname, à cause d'une erreur lors de la création de votre instance ou pour reconfigurer votre serveur e-mail, il vous sera nécessaire de désactiver le module Cloud-init. Celui-ci se charge de configurer le hostname afin que celui ci ne soit pas rétabli.
 
 **Ce guide vous explique comment reconfigurer cloud-init afin d'être en mesure de modifier le hostname de votre instance.**
 

--- a/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.it-it.md
+++ b/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.it-it.md
@@ -10,7 +10,7 @@ updated: 2025-03-20
 
 ## Obiettivo
 
-Nel momento in cui crei un’[istanza Public Cloud](https://www.ovhcloud.com/it/public-cloud/){.external}, così come ad ogni riavvio, puoi configurarla grazie al modulo Cloud-init. Di conseguenza, se si desidera riconfigurare l'hostname, a causa di un errore durante la creazione dell'istanza o per riconfigurare il server di posta elettronica, è necessario disabilitare il modulo Cloud-init. Questo è responsabile della configurazione dell'hostname in modo che non venga ripristinato.
+Nel momento in cui crei un’[istanza Public Cloud](/links/public-cloud/public-cloud){.external}, così come ad ogni riavvio, puoi configurarla grazie al modulo Cloud-init. Di conseguenza, se si desidera riconfigurare l'hostname, a causa di un errore durante la creazione dell'istanza o per riconfigurare il server di posta elettronica, è necessario disabilitare il modulo Cloud-init. Questo è responsabile della configurazione dell'hostname in modo che non venga ripristinato.
 
 **Questa guida spiega come riconfigurare cloud-init in modo da poter cambiare l'hostname dell'istanza.**
 

--- a/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.pl-pl.md
+++ b/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.pl-pl.md
@@ -10,7 +10,7 @@ updated: 2025-03-20
 
 ## Wprowadzenie
 
-Moduł Cloud-init pozwala na skonfigurowanie [instancji Public Cloud](https://www.ovhcloud.com/pl/public-cloud/){.external} podczas jej tworzenia oraz podczas każdego restartu. Jeśli chcesz ponownie skonfigurować hostname, na przykład na skutek błędu podczas tworzenia instancji lub aby zmienić konfigurację serwera mailowego, musisz wyłączyć moduł Cloud-init, który zajmuje się konfiguracją hostname, aby nie został on przywrócony. 
+Moduł Cloud-init pozwala na skonfigurowanie [instancji Public Cloud](/links/public-cloud/public-cloud){.external} podczas jej tworzenia oraz podczas każdego restartu. Jeśli chcesz ponownie skonfigurować hostname, na przykład na skutek błędu podczas tworzenia instancji lub aby zmienić konfigurację serwera mailowego, musisz wyłączyć moduł Cloud-init, który zajmuje się konfiguracją hostname, aby nie został on przywrócony. 
 
 **Przewodnik ten wyjaśnia, jak skonfigurować Cloud-init, aby móc zmienić hostname instancji.**
 

--- a/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.pt-pt.md
+++ b/pages/public_cloud/compute/changing_the_hostname_of_an_instance/guide.pt-pt.md
@@ -10,7 +10,7 @@ updated: 2025-03-20
 
 ## Sumário
 
-O módulo Cloud-init permite configurar a [instância Public Cloud](https://www.ovhcloud.com/pt/public-cloud/){.external} quando é criada, mas também em cada reinicialização. Por isso, se pretender reconfigurar o hostname devido a um erro durante a criação da instância ou para reconfigurar o seu servidor de e-mail, terá de desativar o módulo Cloud-init. Este último encarrega-se de configurar o hostname de modo que não seja restabelecido.
+O módulo Cloud-init permite configurar a [instância Public Cloud](/links/public-cloud/public-cloud){.external} quando é criada, mas também em cada reinicialização. Por isso, se pretender reconfigurar o hostname devido a um erro durante a criação da instância ou para reconfigurar o seu servidor de e-mail, terá de desativar o módulo Cloud-init. Este último encarrega-se de configurar o hostname de modo que não seja restabelecido.
 
 **Este manual explica como reconfigurar o Cloud-init, de forma a poder modificar o hostname da instância.**
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-asia.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-asia.md
@@ -19,7 +19,7 @@ This may be useful in the following cases:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud instance](https://www.ovhcloud.com/asia/public-cloud/){.external} in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud){.external} in your OVHcloud account
 - A volume snapshot in the same OpenStack region
 - Administrative access (sudo) to your instance via SSH or RDP
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-au.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-au.md
@@ -19,7 +19,7 @@ This may be useful in the following cases:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud instance](https://www.ovhcloud.com/en-au/public-cloud/){.external} in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud){.external} in your OVHcloud account
 - A volume snapshot in the same OpenStack region
 - Administrative access (sudo) to your instance via SSH or RDP
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-ca.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-ca.md
@@ -19,7 +19,7 @@ This may be useful in the following cases:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ca/public-cloud/){.external} in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud){.external} in your OVHcloud account
 - A volume snapshot in the same OpenStack region
 - Administrative access (sudo) to your instance via SSH or RDP
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-gb.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-gb.md
@@ -19,7 +19,7 @@ This may be useful in the following cases:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud instance](https://www.ovhcloud.com/en-gb/public-cloud/){.external} in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud){.external} in your OVHcloud account
 - A volume snapshot in the same OpenStack region
 - Administrative access (sudo) to your instance via SSH or RDP
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-ie.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-ie.md
@@ -19,7 +19,7 @@ This may be useful in the following cases:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ie/public-cloud/){.external} in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud){.external} in your OVHcloud account
 - A volume snapshot in the same OpenStack region
 - Administrative access (sudo) to your instance via SSH or RDP
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-sg.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-sg.md
@@ -19,7 +19,7 @@ This may be useful in the following cases:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud instance](https://www.ovhcloud.com/en-sg/public-cloud/){.external} in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud){.external} in your OVHcloud account
 - A volume snapshot in the same OpenStack region
 - Administrative access (sudo) to your instance via SSH or RDP
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-us.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.en-us.md
@@ -19,7 +19,7 @@ This may be useful in the following cases:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/){.external} in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud){.external} in your OVHcloud account
 - A volume snapshot in the same OpenStack region
 - Administrative access (sudo) to your instance via SSH or RDP
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.es-es.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.es-es.md
@@ -23,7 +23,7 @@ Esto puede ser útil en los siguientes casos:
 ## Requisitos
 
 - Estar conectado al [área de cliente de OVHcloud](/links/manager){.external}.
-- Tener una [instancia de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/){.external} en su cuenta de OVHcloud.
+- Tener una [instancia de Public Cloud](/links/public-cloud/public-cloud){.external} en su cuenta de OVHcloud.
 - Tener una copia de seguridad del disco en la misma región de OpenStack.
 - Tener acceso a su instancia por SSH como administrador (sudo).
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.es-us.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.es-us.md
@@ -23,7 +23,7 @@ Esto puede ser útil en los siguientes casos:
 ## Requisitos
 
 - Estar conectado al [área de cliente de OVHcloud](/links/manager){.external}.
-- Tener una [instancia de Public Cloud](https://www.ovhcloud.com/es/public-cloud/){.external} en su cuenta de OVHcloud.
+- Tener una [instancia de Public Cloud](/links/public-cloud/public-cloud){.external} en su cuenta de OVHcloud.
 - Tener una copia de seguridad del disco en la misma región de OpenStack.
 - Tener acceso a su instancia por SSH como administrador (sudo).
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.fr-ca.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.fr-ca.md
@@ -19,7 +19,7 @@ Cela peut être utile dans les cas suivants :
 ## Prérequis
 
 - Être connecté votre [espace client OVHcloud](/links/manager).
-- Avoir une [instance Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/){.external} dans votre compte OVHcloud.
+- Avoir une [instance Public Cloud](/links/public-cloud/public-cloud){.external} dans votre compte OVHcloud.
 - Avoir une sauvegarde disque dans la même région OpenStack.
 - Avoir accès à votre instance via SSH en tant qu'administrateur (sudo).
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.fr-fr.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.fr-fr.md
@@ -19,7 +19,7 @@ Cela peut être utile dans les cas suivants :
 ## Prérequis
 
 - Être connecté votre [espace client OVHcloud](/links/manager).
-- Avoir une [instance Public Cloud](https://www.ovhcloud.com/fr/public-cloud/){.external} dans votre compte OVHcloud.
+- Avoir une [instance Public Cloud](/links/public-cloud/public-cloud){.external} dans votre compte OVHcloud.
 - Avoir une sauvegarde disque dans la même région OpenStack.
 - Avoir accès à votre instance via SSH en tant qu'administrateur (sudo).
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.it-it.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.it-it.md
@@ -23,7 +23,7 @@ Ciò può essere utile nei seguenti casi:
 ## Prerequisiti
 
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager){.external}
-- Disporre di un'[istanza Public Cloud](https://www.ovhcloud.com/it/public-cloud/){.external} sul proprio account OVHcloud
+- Disporre di un'[istanza Public Cloud](/links/public-cloud/public-cloud){.external} sul proprio account OVHcloud
 - Disco nella stessa Region OpenStack
 - Avere accesso alla tua istanza via SSH come amministratore (sudo)
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.pl-pl.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.pl-pl.md
@@ -23,7 +23,7 @@ Może to być przydatne w następujących przypadkach:
 ## Wymagania początkowe
 
 - Dostęp do [Panelu klienta OVHcloud](/links/manager){.external}
-- Posiadanie [instancji Public Cloud](https://www.ovhcloud.com/pl/public-cloud/){.external} na koncie OVHcloud
+- Posiadanie [instancji Public Cloud](/links/public-cloud/public-cloud){.external} na koncie OVHcloud
 - Posiadanie kopii zapasowej dysku w tym samym regionie OpenStack
 - Dostęp do instancji przez SSH jako administrator (sudo)
 

--- a/pages/public_cloud/compute/create-volume-from-snapshot/guide.pt-pt.md
+++ b/pages/public_cloud/compute/create-volume-from-snapshot/guide.pt-pt.md
@@ -23,7 +23,7 @@ Tal pode ser útil nos seguintes casos:
 ## Requisitos
 
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager){.external}.
-- Ter uma [instância Public Cloud](https://www.ovhcloud.com/pt/public-cloud/){.external} na sua conta OVHcloud.
+- Ter uma [instância Public Cloud](/links/public-cloud/public-cloud){.external} na sua conta OVHcloud.
 - Ter um backup de disco na mesma região OpenStack.
 - Ter acesso à instância via SSH enquanto administrador (sudo).
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.de-de.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.de-de.md
@@ -16,7 +16,7 @@ Sie können Ihre Public Cloud Instanzen in Ihrem [Kundencenter](/links/manager) 
 
 ## Voraussetzungen
 
-- Sie haben ein [Public Cloud Projekt](https://www.ovhcloud.com/de/public-cloud/) in Ihrem OVHcloud Kunden-Account.
+- Sie haben ein [Public Cloud Projekt](/links/public-cloud/public-cloud) in Ihrem OVHcloud Kunden-Account.
 - Sie haben eine [Public Cloud Instanz](/pages/public_cloud/compute/public-cloud-first-steps) in Ihrem Projekt erstellt.
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-asia.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-asia.md
@@ -12,7 +12,7 @@ You can manage your Public Cloud instances in the [OVHcloud Control Panel](/link
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-au.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-au.md
@@ -12,7 +12,7 @@ You can manage your Public Cloud instances in the [OVHcloud Control Panel](/link
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-ca.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-ca.md
@@ -12,7 +12,7 @@ You can manage your Public Cloud instances in the [OVHcloud Control Panel](/link
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-gb.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-gb.md
@@ -12,7 +12,7 @@ You can manage your Public Cloud instances in the [OVHcloud Control Panel](/link
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-ie.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-ie.md
@@ -12,7 +12,7 @@ You can manage your Public Cloud instances in the [OVHcloud Control Panel](/link
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-sg.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-sg.md
@@ -12,7 +12,7 @@ You can manage your Public Cloud instances in the [OVHcloud Control Panel](/link
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-us.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.en-us.md
@@ -12,7 +12,7 @@ You can manage your Public Cloud instances in the [OVHcloud Control Panel](/link
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.es-es.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.es-es.md
@@ -16,7 +16,7 @@ Puede gestionar sus instancias de Public Cloud desde el [área de cliente de OVH
 
 ## Requisitos
 
-- Un [proyecto de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud
+- Un [proyecto de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
 - Una [instancia de Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) en su proyecto
 - Tienes acceso a tu [área de cliente de OVHcloud](/links/manager)
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.es-us.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.es-us.md
@@ -16,7 +16,7 @@ Puede gestionar sus instancias de Public Cloud desde el [área de cliente de OVH
 
 ## Requisitos
 
-- Un [proyecto de Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud
+- Un [proyecto de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
 - Una [instancia de Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) en su proyecto
 - Tienes acceso a tu [área de cliente de OVHcloud](/links/manager)
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.fr-ca.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.fr-ca.md
@@ -12,7 +12,7 @@ Vous pouvez gérer vos instances Public Cloud dans votre [espace client OVHcloud
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Une [instance Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) dans votre projet
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.fr-fr.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.fr-fr.md
@@ -12,7 +12,7 @@ Vous pouvez gérer vos instances Public Cloud dans votre [espace client OVHcloud
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Une [instance Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) dans votre projet
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.it-it.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.it-it.md
@@ -16,7 +16,7 @@ Le istanze Public Cloud possono essere gestite direttamente dallo [Spazio Client
 
 ## Prerequisiti
 
-- Un [progetto Public Cloud](https://www.ovhcloud.com/it/public-cloud/) nel tuo account OVHcloud
+- Un [progetto Public Cloud](/links/public-cloud/public-cloud) nel tuo account OVHcloud
 - Un'[istanza Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) nel tuo progetto
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.pl-pl.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.pl-pl.md
@@ -16,7 +16,7 @@ Możesz zarządzać instancjami Public Cloud w [Panelu klienta OVHcloud](/links/
 
 ## Wymagania początkowe
 
-- Projekt [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na Twoim koncie OVHcloud
+- Projekt [Public Cloud](/links/public-cloud/public-cloud) na Twoim koncie OVHcloud
 - Instancja [Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) w Twoim projekcie
 - Dostęp do [Panelu klienta OVHcloud](/links/manager)
 

--- a/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.pt-pt.md
+++ b/pages/public_cloud/compute/first_steps_with_public_cloud_instance/guide.pt-pt.md
@@ -16,7 +16,7 @@ Pode gerir as suas instâncias Public Cloud na sua [Área de Cliente OVHcloud](/
 
 ## Requisitos
 
-- Um [projeto Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud
+- Um [projeto Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud
 - Uma [instância Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) no seu projeto
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager)
 

--- a/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-asia.md
+++ b/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-asia.md
@@ -26,7 +26,7 @@ If you have reached the maximum capacity on your additional disk, you can add mo
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/asia/public-cloud/) in your Public Cloud project
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your Public Cloud project
 - An [additional disk](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your instance via SSH (Linux) or RDP (Windows)

--- a/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-au.md
+++ b/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-au.md
@@ -26,7 +26,7 @@ If you have reached the maximum capacity on your additional disk, you can add mo
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-au/public-cloud/) in your Public Cloud project
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your Public Cloud project
 - An [additional disk](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your instance via SSH (Linux) or RDP (Windows)

--- a/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-ca.md
+++ b/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-ca.md
@@ -26,7 +26,7 @@ If you have reached the maximum capacity on your additional disk, you can add mo
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ca/public-cloud/) in your Public Cloud project
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your Public Cloud project
 - An [additional disk](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your instance via SSH (Linux) or RDP (Windows)

--- a/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-gb.md
+++ b/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-gb.md
@@ -26,7 +26,7 @@ If you have reached the maximum capacity on your additional disk, you can add mo
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-gb/public-cloud/) in your Public Cloud project
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your Public Cloud project
 - An [additional disk](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your instance via SSH (Linux) or RDP (Windows)

--- a/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-ie.md
+++ b/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-ie.md
@@ -26,7 +26,7 @@ If you have reached the maximum capacity on your additional disk, you can add mo
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ie/public-cloud/) in your Public Cloud project
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your Public Cloud project
 - An [additional disk](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your instance via SSH (Linux) or RDP (Windows)

--- a/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-sg.md
+++ b/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-sg.md
@@ -26,7 +26,7 @@ If you have reached the maximum capacity on your additional disk, you can add mo
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-sg/public-cloud/) in your Public Cloud project
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your Public Cloud project
 - An [additional disk](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your instance via SSH (Linux) or RDP (Windows)

--- a/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-us.md
+++ b/pages/public_cloud/compute/increase_the_size_of_an_additional_disk/guide.en-us.md
@@ -26,7 +26,7 @@ If you have reached the maximum capacity on your additional disk, you can add mo
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/) in your Public Cloud project
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your Public Cloud project
 - An [additional disk](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your project
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative (sudo) access to your instance via SSH (Linux) or RDP (Windows)

--- a/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-asia.md
+++ b/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-asia.md
@@ -6,14 +6,14 @@ updated: 2019-04-10
 
 - Level: Intermediate
 - OS used: Ubuntu 18.04
-- Infrastructure used: B2-15 [Public Cloud Instance](https://www.ovhcloud.com/asia/public-cloud/){.external}
+- Infrastructure used: B2-15 [Public Cloud Instance](/links/public-cloud/public-cloud){.external}
 - Additional information: If you have intensive storage requirements, it is recommended to use a high-performance additional disk or object storage
 
 > [!warning]
 >
 > While OVHcloud provides you with the devices, the responsibility for their security rests solely in your hands. Since we have no access to these machines, we are not their administrators. It is your responsibility to manage the software, and apply proper security measures on an ongoing basis.
 >   
-> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/asia/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
+> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
 >
 
 ## Objective
@@ -32,10 +32,10 @@ Before following this tutorial, please refer to these guides:
 
 ## Requirements
 
-- A [Public Cloud Instance](https://www.ovhcloud.com/asia/public-cloud/prices/){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
+- A [Public Cloud Instance](/links/public-cloud/prices){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
 - Root SSH access on the Instance
-- [Object Storage](https://www.ovhcloud.com/asia/public-cloud/object-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
-- [High-performance additional disk](https://www.ovhcloud.com/asia/public-cloud/block-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [Object Storage](/links/public-cloud/object-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [High-performance additional disk](/links/public-cloud/block-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
 
 ## Instructions
 
@@ -224,14 +224,14 @@ There are advantages and disadvantages to using local disk storage to store your
 
 Using OpenStack Object Storage by OVHcloud, you can store your files externally, with no limit on the total volume of data or how long you store it for. Furthermore, OVHcloud guarantees 100% data durability, and replicates your data in three different locations, delivering exceptional value for money.
 
-Find out more about [OVHcloud Object Storage](https://www.ovhcloud.com/asia/public-cloud/object-storage/){.external}.
+Find out more about [OVHcloud Object Storage](/links/public-cloud/object-storage){.external}.
 Read out guide to using Object Storage for ownCloud: [Object Storage for ownCloud](/pages/storage_and_backup/object_storage/pcs_configure_owncloud_with_object_storage){.external}.
 
 ### Using an additional disk as storage (optional)
 
 As with Object Storage, the advantage of using an additional disk is that you are less restricted by storage problems. You can also increase the size of an additional disk after its creation, up to 10TB.
 
-Find out more about [Public Cloud additional disks](https://www.ovhcloud.com/asia/public-cloud/block-storage/){.external}.
+Find out more about [Public Cloud additional disks](/links/public-cloud/block-storage){.external}.
 
 > [!warning]
 >

--- a/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-au.md
+++ b/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-au.md
@@ -6,14 +6,14 @@ updated: 2019-04-10
 
 - Level: Intermediate
 - OS used: Ubuntu 18.04
-- Infrastructure used: B2-15 [Public Cloud Instance](https://www.ovhcloud.com/en-au/public-cloud/){.external}
+- Infrastructure used: B2-15 [Public Cloud Instance](/links/public-cloud/public-cloud){.external}
 - Additional information: If you have intensive storage requirements, it is recommended to use a high-performance additional disk or object storage
 
 > [!warning]
 >
 > While OVHcloud provides you with the devices, the responsibility for their security rests solely in your hands. Since we have no access to these machines, we are not their administrators. It is your responsibility to manage the software, and apply proper security measures on an ongoing basis.
 >   
-> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-au/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
+> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
 >
 
 ## Objective
@@ -32,10 +32,10 @@ Before following this tutorial, please refer to these guides:
 
 ## Requirements
 
-- A [Public Cloud Instance](https://www.ovhcloud.com/en-au/public-cloud/prices/){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
+- A [Public Cloud Instance](/links/public-cloud/prices){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
 - Root SSH access on the Instance
-- [Object Storage](https://www.ovhcloud.com/en-au/public-cloud/object-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
-- [High-performance additional disk](https://www.ovhcloud.com/en-au/public-cloud/block-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [Object Storage](/links/public-cloud/object-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [High-performance additional disk](/links/public-cloud/block-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
 
 ## Instructions
 
@@ -224,14 +224,14 @@ There are advantages and disadvantages to using local disk storage to store your
 
 Using OpenStack Object Storage by OVHcloud, you can store your files externally, with no limit on the total volume of data or how long you store it for. Furthermore, OVHcloud guarantees 100% data durability, and replicates your data in three different locations, delivering exceptional value for money.
 
-Find out more about [OVHcloud Object Storage](https://www.ovhcloud.com/en-au/public-cloud/object-storage/){.external}.
+Find out more about [OVHcloud Object Storage](/links/public-cloud/object-storage){.external}.
 Read out guide to using Object Storage for ownCloud: [Object Storage for ownCloud](/pages/storage_and_backup/object_storage/pcs_configure_owncloud_with_object_storage){.external}.
 
 ### Using an additional disk as storage (optional)
 
 As with Object Storage, the advantage of using an additional disk is that you are less restricted by storage problems. You can also increase the size of an additional disk after its creation, up to 10TB.
 
-Find out more about [Public Cloud additional disks](https://www.ovhcloud.com/en-au/public-cloud/block-storage/){.external}.
+Find out more about [Public Cloud additional disks](/links/public-cloud/block-storage){.external}.
 
 > [!warning]
 >

--- a/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-ca.md
+++ b/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-ca.md
@@ -6,14 +6,14 @@ updated: 2019-04-10
 
 - Level: Intermediate
 - OS used: Ubuntu 18.04
-- Infrastructure used: B2-15 [Public Cloud Instance](https://www.ovhcloud.com/en-ca/public-cloud/){.external}
+- Infrastructure used: B2-15 [Public Cloud Instance](/links/public-cloud/public-cloud){.external}
 - Additional information: If you have intensive storage requirements, it is recommended to use a high-performance additional disk or object storage
 
 > [!warning]
 >
 > While OVHcloud provides you with the devices, the responsibility for their security rests solely in your hands. Since we have no access to these machines, we are not their administrators. It is your responsibility to manage the software, and apply proper security measures on an ongoing basis.
 >   
-> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
+> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
 >
 
 ## Objective
@@ -32,10 +32,10 @@ Before following this tutorial, please refer to these guides:
 
 ## Requirements
 
-- A [Public Cloud Instance](https://www.ovhcloud.com/en-ca/public-cloud/prices/){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
+- A [Public Cloud Instance](/links/public-cloud/prices){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
 - Root SSH access on the Instance
-- [Object Storage](https://www.ovhcloud.com/en-ca/public-cloud/object-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
-- [High-performance additional disk](https://www.ovhcloud.com/en-ca/public-cloud/block-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [Object Storage](/links/public-cloud/object-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [High-performance additional disk](/links/public-cloud/block-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
 
 ## Instructions
 
@@ -224,14 +224,14 @@ There are advantages and disadvantages to using local disk storage to store your
 
 Using OpenStack Object Storage by OVHcloud, you can store your files externally, with no limit on the total volume of data or how long you store it for. Furthermore, OVHcloud guarantees 100% data durability, and replicates your data in three different locations, delivering exceptional value for money.
 
-Find out more about [OVHcloud Object Storage](https://www.ovhcloud.com/en-ca/public-cloud/object-storage/){.external}.
+Find out more about [OVHcloud Object Storage](/links/public-cloud/object-storage){.external}.
 Read out guide to using Object Storage for ownCloud: [Object Storage for ownCloud](/pages/storage_and_backup/object_storage/pcs_configure_owncloud_with_object_storage){.external}.
 
 ### Using an additional disk as storage (optional)
 
 As with Object Storage, the advantage of using an additional disk is that you are less restricted by storage problems. You can also increase the size of an additional disk after its creation, up to 10TB.
 
-Find out more about [Public Cloud additional disks](https://www.ovhcloud.com/en-ca/public-cloud/block-storage/){.external}.
+Find out more about [Public Cloud additional disks](/links/public-cloud/block-storage){.external}.
 
 > [!warning]
 >

--- a/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-gb.md
+++ b/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-gb.md
@@ -6,14 +6,14 @@ updated: 2019-04-10
 
 - Level: Intermediate
 - OS used: Ubuntu 18.04
-- Infrastructure used: B2-15 [Public Cloud Instance](https://www.ovhcloud.com/en-gb/public-cloud/){.external}
+- Infrastructure used: B2-15 [Public Cloud Instance](/links/public-cloud/public-cloud){.external}
 - Additional information: If you have intensive storage requirements, it is recommended to use a high-performance additional disk or object storage
 
 > [!warning]
 >
 > While OVHcloud provides you with the devices, the responsibility for their security rests solely in your hands. Since we have no access to these machines, we are not their administrators. It is your responsibility to manage the software, and apply proper security measures on an ongoing basis.
 >   
-> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
+> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
 >
 
 ## Objective
@@ -32,10 +32,10 @@ Before following this tutorial, please refer to these guides:
 
 ## Requirements
 
-- A [Public Cloud Instance](https://www.ovhcloud.com/en-gb/public-cloud/prices/){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
+- A [Public Cloud Instance](/links/public-cloud/prices){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
 - Root SSH access on the Instance
-- [Object Storage](https://www.ovhcloud.com/en-gb/public-cloud/object-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
-- [High-performance additional disk](https://www.ovhcloud.com/en-gb/public-cloud/block-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [Object Storage](/links/public-cloud/object-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [High-performance additional disk](/links/public-cloud/block-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
 
 ## Instructions
 
@@ -224,14 +224,14 @@ There are advantages and disadvantages to using local disk storage to store your
 
 Using OpenStack Object Storage by OVHcloud, you can store your files externally, with no limit on the total volume of data or how long you store it for. Furthermore, OVHcloud guarantees 100% data durability, and replicates your data in three different locations, delivering exceptional value for money.
 
-Find out more about [OVHcloud Object Storage](https://www.ovhcloud.com/en-gb/public-cloud/object-storage/){.external}.
+Find out more about [OVHcloud Object Storage](/links/public-cloud/object-storage){.external}.
 Read out guide to using Object Storage for ownCloud: [Object Storage for ownCloud](/pages/storage_and_backup/object_storage/pcs_configure_owncloud_with_object_storage){.external}.
 
 ### Using an additional disk as storage (optional)
 
 As with Object Storage, the advantage of using an additional disk is that you are less restricted by storage problems. You can also increase the size of an additional disk after its creation, up to 10TB.
 
-Find out more about [Public Cloud additional disks](https://www.ovhcloud.com/en-gb/public-cloud/block-storage/){.external}.
+Find out more about [Public Cloud additional disks](/links/public-cloud/block-storage){.external}.
 
 > [!warning]
 >

--- a/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-ie.md
+++ b/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-ie.md
@@ -6,14 +6,14 @@ updated: 2019-04-10
 
 - Level: Intermediate
 - OS used: Ubuntu 18.04
-- Infrastructure used: B2-15 [Public Cloud Instance](https://www.ovhcloud.com/en-ie/public-cloud/){.external}
+- Infrastructure used: B2-15 [Public Cloud Instance](/links/public-cloud/public-cloud){.external}
 - Additional information: If you have intensive storage requirements, it is recommended to use a high-performance additional disk or object storage
 
 > [!warning]
 >
 > While OVHcloud provides you with the devices, the responsibility for their security rests solely in your hands. Since we have no access to these machines, we are not their administrators. It is your responsibility to manage the software, and apply proper security measures on an ongoing basis.
 >   
-> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
+> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
 >
 
 ## Objective
@@ -32,10 +32,10 @@ Before following this tutorial, please refer to these guides:
 
 ## Requirements
 
-- A [Public Cloud Instance](https://www.ovhcloud.com/en-ie/public-cloud/prices/){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
+- A [Public Cloud Instance](/links/public-cloud/prices){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
 - Root SSH access on the Instance
-- [Object Storage](https://www.ovhcloud.com/en-ie/public-cloud/object-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
-- [High-performance additional disk](https://www.ovhcloud.com/en-ie/public-cloud/block-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [Object Storage](/links/public-cloud/object-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [High-performance additional disk](/links/public-cloud/block-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
 
 ## Instructions
 
@@ -224,14 +224,14 @@ There are advantages and disadvantages to using local disk storage to store your
 
 Using OpenStack Object Storage by OVHcloud, you can store your files externally, with no limit on the total volume of data or how long you store it for. Furthermore, OVHcloud guarantees 100% data durability, and replicates your data in three different locations, delivering exceptional value for money.
 
-Find out more about [OVHcloud Object Storage](https://www.ovhcloud.com/en-ie/public-cloud/object-storage/){.external}.
+Find out more about [OVHcloud Object Storage](/links/public-cloud/object-storage){.external}.
 Read out guide to using Object Storage for ownCloud: [Object Storage for ownCloud](/pages/storage_and_backup/object_storage/pcs_configure_owncloud_with_object_storage){.external}.
 
 ### Using an additional disk as storage (optional)
 
 As with Object Storage, the advantage of using an additional disk is that you are less restricted by storage problems. You can also increase the size of an additional disk after its creation, up to 10TB.
 
-Find out more about [Public Cloud additional disks](https://www.ovhcloud.com/en-ie/public-cloud/block-storage/){.external}.
+Find out more about [Public Cloud additional disks](/links/public-cloud/block-storage){.external}.
 
 > [!warning]
 >

--- a/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-sg.md
+++ b/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-sg.md
@@ -6,14 +6,14 @@ updated: 2019-04-10
 
 - Level: Intermediate
 - OS used: Ubuntu 18.04
-- Infrastructure used: B2-15 [Public Cloud Instance](https://www.ovhcloud.com/en-sg/public-cloud/){.external}
+- Infrastructure used: B2-15 [Public Cloud Instance](/links/public-cloud/public-cloud){.external}
 - Additional information: If you have intensive storage requirements, it is recommended to use a high-performance additional disk or object storage
 
 > [!warning]
 >
 > While OVHcloud provides you with the devices, the responsibility for their security rests solely in your hands. Since we have no access to these machines, we are not their administrators. It is your responsibility to manage the software, and apply proper security measures on an ongoing basis.
 >   
-> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
+> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
 >
 
 ## Objective
@@ -32,10 +32,10 @@ Before following this tutorial, please refer to these guides:
 
 ## Requirements
 
-- A [Public Cloud Instance](https://www.ovhcloud.com/en-sg/public-cloud/prices/){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
+- A [Public Cloud Instance](/links/public-cloud/prices){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
 - Root SSH access on the Instance
-- [Object Storage](https://www.ovhcloud.com/en-sg/public-cloud/object-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
-- [High-performance additional disk](https://www.ovhcloud.com/en-sg/public-cloud/block-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [Object Storage](/links/public-cloud/object-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [High-performance additional disk](/links/public-cloud/block-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
 
 ## Instructions
 
@@ -224,14 +224,14 @@ There are advantages and disadvantages to using local disk storage to store your
 
 Using OpenStack Object Storage by OVHcloud, you can store your files externally, with no limit on the total volume of data or how long you store it for. Furthermore, OVHcloud guarantees 100% data durability, and replicates your data in three different locations, delivering exceptional value for money.
 
-Find out more about [OVHcloud Object Storage](https://www.ovhcloud.com/en-sg/public-cloud/object-storage/){.external}.
+Find out more about [OVHcloud Object Storage](/links/public-cloud/object-storage){.external}.
 Read out guide to using Object Storage for ownCloud: [Object Storage for ownCloud](/pages/storage_and_backup/object_storage/pcs_configure_owncloud_with_object_storage){.external}.
 
 ### Using an additional disk as storage (optional)
 
 As with Object Storage, the advantage of using an additional disk is that you are less restricted by storage problems. You can also increase the size of an additional disk after its creation, up to 10TB.
 
-Find out more about [Public Cloud additional disks](https://www.ovhcloud.com/en-sg/public-cloud/block-storage/){.external}.
+Find out more about [Public Cloud additional disks](/links/public-cloud/block-storage){.external}.
 
 > [!warning]
 >

--- a/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-us.md
+++ b/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.en-us.md
@@ -6,14 +6,14 @@ updated: 2019-04-10
 
 - Level: Intermediate
 - OS used: Ubuntu 18.04
-- Infrastructure used: B2-15 [Public Cloud Instance](https://www.ovhcloud.com/en/public-cloud/){.external}
+- Infrastructure used: B2-15 [Public Cloud Instance](/links/public-cloud/public-cloud){.external}
 - Additional information: If you have intensive storage requirements, it is recommended to use a high-performance additional disk or object storage
 
 > [!warning]
 >
 > While OVHcloud provides you with the devices, the responsibility for their security rests solely in your hands. Since we have no access to these machines, we are not their administrators. It is your responsibility to manage the software, and apply proper security measures on an ongoing basis.
 >   
-> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
+> This tutorial is designed to help you with the most common tasks. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) if you have difficulties or doubts concerning the administration, usage or implementation of security measures on a server.
 >
 
 ## Objective
@@ -32,10 +32,10 @@ Before following this tutorial, please refer to these guides:
 
 ## Requirements
 
-- A [Public Cloud Instance](https://www.ovhcloud.com/en/public-cloud/prices/){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
+- A [Public Cloud Instance](/links/public-cloud/prices){.external} in the [OVHcloud Control Panel](/links/manager){.external} with Ubuntu 18.04 installed
 - Root SSH access on the Instance
-- [Object Storage](https://www.ovhcloud.com/en/public-cloud/object-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
-- [High-performance additional disk](https://www.ovhcloud.com/en/public-cloud/block-storage/){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [Object Storage](/links/public-cloud/object-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
+- [High-performance additional disk](/links/public-cloud/block-storage){.external} in the same datacentre as your Public Cloud Instance (optional)
 
 ## Instructions
 
@@ -224,14 +224,14 @@ There are advantages and disadvantages to using local disk storage to store your
 
 Using OpenStack Object Storage by OVHcloud, you can store your files externally, with no limit on the total volume of data or how long you store it for. Furthermore, OVHcloud guarantees 100% data durability, and replicates your data in three different locations, delivering exceptional value for money.
 
-Find out more about [OVHcloud Object Storage](https://www.ovhcloud.com/en/public-cloud/object-storage/){.external}.
+Find out more about [OVHcloud Object Storage](/links/public-cloud/object-storage){.external}.
 Read out guide to using Object Storage for ownCloud: [Object Storage for ownCloud](/pages/storage_and_backup/object_storage/pcs_configure_owncloud_with_object_storage){.external}.
 
 ### Using an additional disk as storage (optional)
 
 As with Object Storage, the advantage of using an additional disk is that you are less restricted by storage problems. You can also increase the size of an additional disk after its creation, up to 10TB.
 
-Find out more about [Public Cloud additional disks](https://www.ovhcloud.com/en/public-cloud/block-storage/){.external}.
+Find out more about [Public Cloud additional disks](/links/public-cloud/block-storage){.external}.
 
 > [!warning]
 >

--- a/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.fr-ca.md
+++ b/pages/public_cloud/compute/install-owncloud-on-a-public-cloud-instance/guide.fr-ca.md
@@ -6,7 +6,7 @@ updated: 2019-04-10
 
 - Niveau : Intermédiaire
 - Système d’exploitation utilisé : Ubuntu 18.04
-- Infrastructure utilisée : B2-15 [Instance Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/){.external}
+- Infrastructure utilisée : B2-15 [Instance Public Cloud](/links/public-cloud/public-cloud){.external}
 - Information supplémentaire : Si vous avez des besoins de stockage intensifs, il est recommandé d'utiliser un disque ou un objet de stockage supplémentaire de haute performance.
 
 > [!warning]
@@ -32,10 +32,10 @@ Avant de suivre ce tutoriel, veuillez vous référer à ces guides :
 
 ## Prérequis
 
-- Avoir une [instance de Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/){.external} dans [l’espace client d’OVH](/links/manager){.external} avec Ubuntu 18.04 installé
+- Avoir une [instance de Public Cloud](/links/public-cloud/public-cloud){.external} dans [l’espace client d’OVH](/links/manager){.external} avec Ubuntu 18.04 installé
 - Accès root SSH sur l'Instance
-- [ Stockage d'objets](https://www.ovhcloud.com/fr-ca/public-cloud/object-storage/){.external} dans le même datacenter que votre Public Cloud Instance (facultatif)
-- [Disque supplémentaire de haute performance](https://www.ovhcloud.com/fr-ca/public-cloud/block-storage/){.external} dans le même datacenter que votre instance de Public Cloud (en option)
+- [ Stockage d'objets](/links/public-cloud/object-storage){.external} dans le même datacenter que votre Public Cloud Instance (facultatif)
+- [Disque supplémentaire de haute performance](/links/public-cloud/block-storage){.external} dans le même datacenter que votre instance de Public Cloud (en option)
 
 ## Instructions
 Dans cette section, vous trouverez des instructions étape par étape pour installer ownCloud sur votre Instance de Public Cloud d’OVH.
@@ -199,13 +199,13 @@ Il y a des avantages et des inconvénients à utiliser le stockage sur disque lo
 
 En utilisant l’Object Storage OpenStack d’OVH, vous pouvez stocker vos fichiers en externe, sans limite sur le volume total des données ou la durée de stockage. De plus, OVH garantit une durabilité des données à 100 % et réplique vos données sur trois sites différents, pour un rapport qualité/prix exceptionnel.
 
-En savoir plus sur [l’Object Storage d’OVH](https://www.ovhcloud.com/fr-ca/public-cloud/object-storage/){.external}.
+En savoir plus sur [l’Object Storage d’OVH](/links/public-cloud/object-storage){.external}.
 Lire le guide d'utilisation de l’Object Storage pour ownCloud : [Object Storage pour ownCloud](/pages/storage_and_backup/object_storage/pcs_configure_owncloud_with_object_storage){.external}.
 
 ### Utilisation d'un disque supplémentaire comme stockage (facultatif)
 Comme pour l'Object storage, l'avantage d'utiliser un disque supplémentaire est que vous êtes moins limité par les problèmes de stockage. Vous pouvez également augmenter la taille d'un disque supplémentaire après sa création, jusqu'à 10 To.
 
-En savoir plus sur [les disques supplémentaires du Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/object-storage/){.external}.
+En savoir plus sur [les disques supplémentaires du Public Cloud](/links/public-cloud/object-storage){.external}.
 
 > [!warning]
 >

--- a/pages/public_cloud/compute/install_plesk_on_an_instance/guide.pl-pl.md
+++ b/pages/public_cloud/compute/install_plesk_on_an_instance/guide.pl-pl.md
@@ -6,7 +6,7 @@ updated: 2025-04-08
 
 ## Wprowadzenie
 
-Plesk to prosty w użytkowaniu interfejs administracyjny dla serwerów dedykowanych.  Można go zainstalować i z niego korzystać na jednej z instancji [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/){.external}.
+Plesk to prosty w użytkowaniu interfejs administracyjny dla serwerów dedykowanych.  Można go zainstalować i z niego korzystać na jednej z instancji [Public Cloud](/links/public-cloud/public-cloud){.external}.
 
 **Dowiedz się, jak wdrożyć Plesk na instancji Public Cloud.** 
 

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-asia.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-asia.md
@@ -15,12 +15,12 @@ This tutorial provides the basic steps for a manual installation of WordPress on
 > [!warning]
 >This guide will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/asia/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) with Debian or Ubuntu installed
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access (sudo) to your instance via SSH

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-au.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-au.md
@@ -15,12 +15,12 @@ This tutorial provides the basic steps for a manual installation of WordPress on
 > [!warning]
 >This guide will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-au/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) with Debian or Ubuntu installed
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access (sudo) to your instance via SSH

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-ca.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-ca.md
@@ -15,12 +15,12 @@ This tutorial provides the basic steps for a manual installation of WordPress on
 > [!warning]
 >This guide will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ca/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) with Debian or Ubuntu installed
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access (sudo) to your instance via SSH

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-gb.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-gb.md
@@ -15,12 +15,12 @@ This tutorial provides the basic steps for a manual installation of WordPress on
 > [!warning]
 >This guide will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-gb/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) with Debian or Ubuntu installed
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access (sudo) to your instance via SSH

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-ie.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-ie.md
@@ -15,12 +15,12 @@ This tutorial provides the basic steps for a manual installation of WordPress on
 > [!warning]
 >This guide will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-ie/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) with Debian or Ubuntu installed
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access (sudo) to your instance via SSH

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-sg.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-sg.md
@@ -15,12 +15,12 @@ This tutorial provides the basic steps for a manual installation of WordPress on
 > [!warning]
 >This guide will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en-sg/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) with Debian or Ubuntu installed
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access (sudo) to your instance via SSH

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-us.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.en-us.md
@@ -15,12 +15,12 @@ This tutorial provides the basic steps for a manual installation of WordPress on
 > [!warning]
 >This guide will show you how to use one or more OVHcloud solutions with external tools, and will describe the actions to be carried out in a specific context. Please remember to adapt these actions to fit your situation.
 >
->If you encounter any difficulties performing these actions, please contact a [specialist service provider](https://partner.ovhcloud.com/en/directory/) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
+>If you encounter any difficulties performing these actions, please contact a [specialist service provider](/links/partner) and/or discuss the issue with [our community](https://community.ovh.com/en/). OVHcloud cannot provide you with technical support in this regard.
 >
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud instance](/pages/public_cloud/compute/public-cloud-first-steps) with Debian or Ubuntu installed
 - Access to the [OVHcloud Control Panel](/links/manager)
 - Administrative access (sudo) to your instance via SSH

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.es-es.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.es-es.md
@@ -25,7 +25,7 @@ Este tutorial explica cómo instalar WordPress manualmente en una instancia de P
 
 ## Requisitos
 
-- Un [proyecto de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud.
+- Un [proyecto de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud.
 - Tener una [instancia de Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) con Debian o Ubuntu instalado.
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager).
 - Acceso de administrador (sudo) a su instancia a través de SSH.

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.es-us.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.es-us.md
@@ -25,7 +25,7 @@ Este tutorial explica cómo instalar WordPress manualmente en una instancia de P
 
 ## Requisitos
 
-- Un [proyecto de Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud.
+- Un [proyecto de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud.
 - Tener una [instancia de Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) con Debian o Ubuntu instalado.
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager).
 - Acceso de administrador (sudo) a su instancia a través de SSH.

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.fr-ca.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.fr-ca.md
@@ -14,7 +14,7 @@ Ce tutoriel fournit les étapes de base pour une installation manuelle de WordPr
 
 ## Prérequis
 
-- Un projet [Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud
+- Un projet [Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Avoir une [instance Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) avec Debian ou Ubuntu installé
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 - Disposer d’un accès administratif (sudo) à votre instance via SSH

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.fr-fr.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.fr-fr.md
@@ -14,7 +14,7 @@ Ce tutoriel fournit les étapes de base pour une installation manuelle de WordPr
 
 ## Prérequis
 
-- Un projet [Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
+- Un projet [Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Avoir une [instance Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) avec Debian ou Ubuntu installé
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 - Disposer d’un accès administratif (sudo) à votre instance via SSH

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.it-it.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.it-it.md
@@ -25,7 +25,7 @@ Questa guida ti mostra gli step fondamentali per l'installazione manuale di Word
 
 ## Prerequisiti
 
-- Un [progetto Public Cloud](https://www.ovhcloud.com/it/public-cloud/) nel tuo account OVHcloud.
+- Un [progetto Public Cloud](/links/public-cloud/public-cloud) nel tuo account OVHcloud.
 - Disporre di un'[istanza Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) con Debian o Ubuntu installato.
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager).
 - Un accesso amministratore (sudo) alla tua istanza via SSH.

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.pl-pl.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.pl-pl.md
@@ -25,7 +25,7 @@ Tutorial ten przedstawia podstawowe etapy ręcznej instalacji WordPressa na inst
 
 ## Wymagania początkowe
 
-- Projekt [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na Twoim koncie OVHcloud
+- Projekt [Public Cloud](/links/public-cloud/public-cloud) na Twoim koncie OVHcloud
 - Posiadanie zainstalowanej [instancji Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) z systemem Debian lub Ubuntu
 - Dostęp do [Panelu client OVHcloud](/links/manager)
 - Dostęp administratora (sudo) do Twojej instancji przez SSH

--- a/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.pt-pt.md
+++ b/pages/public_cloud/compute/install_wordpress_on_an_instance/guide.pt-pt.md
@@ -25,7 +25,7 @@ Este tutorial fornece as etapas de base para uma instalação manual do WordPres
 
 ## Requisitos
 
-- Um [projeto Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud.
+- Um [projeto Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud.
 - Ter uma [instância Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) com Debian ou Ubuntu instalado.
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager).
 - Um acesso administrador (sudo) à sua instância através de SSH.

--- a/pages/public_cloud/compute/rescue_mode_metal_instance/guide.de-de.md
+++ b/pages/public_cloud/compute/rescue_mode_metal_instance/guide.de-de.md
@@ -17,7 +17,7 @@ Unlike other Public Cloud Instances where the rescue mode can be activated from 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud Metal instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 
 ## Instructions

--- a/pages/public_cloud/compute/rescue_mode_metal_instance/guide.en-ca.md
+++ b/pages/public_cloud/compute/rescue_mode_metal_instance/guide.en-ca.md
@@ -17,7 +17,7 @@ Unlike other Public Cloud Instances where the rescue mode can be activated from 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud Metal instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 
 ## Instructions

--- a/pages/public_cloud/compute/rescue_mode_metal_instance/guide.en-gb.md
+++ b/pages/public_cloud/compute/rescue_mode_metal_instance/guide.en-gb.md
@@ -17,7 +17,7 @@ Unlike other Public Cloud Instances where the rescue mode can be activated from 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud Metal instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 
 ## Instructions

--- a/pages/public_cloud/compute/rescue_mode_metal_instance/guide.en-ie.md
+++ b/pages/public_cloud/compute/rescue_mode_metal_instance/guide.en-ie.md
@@ -17,7 +17,7 @@ Unlike other Public Cloud Instances where the rescue mode can be activated from 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud Metal instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 
 ## Instructions

--- a/pages/public_cloud/compute/rescue_mode_metal_instance/guide.en-us.md
+++ b/pages/public_cloud/compute/rescue_mode_metal_instance/guide.en-us.md
@@ -17,7 +17,7 @@ Unlike other Public Cloud Instances where the rescue mode can be activated from 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud Metal instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 
 ## Instructions

--- a/pages/public_cloud/compute/rescue_mode_metal_instance/guide.es-es.md
+++ b/pages/public_cloud/compute/rescue_mode_metal_instance/guide.es-es.md
@@ -17,7 +17,7 @@ Unlike other Public Cloud Instances where the rescue mode can be activated from 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud Metal instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 
 ## Instructions

--- a/pages/public_cloud/compute/rescue_mode_metal_instance/guide.es-us.md
+++ b/pages/public_cloud/compute/rescue_mode_metal_instance/guide.es-us.md
@@ -17,7 +17,7 @@ Unlike other Public Cloud Instances where the rescue mode can be activated from 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/es/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud Metal instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 
 ## Instructions

--- a/pages/public_cloud/compute/rescue_mode_metal_instance/guide.fr-ca.md
+++ b/pages/public_cloud/compute/rescue_mode_metal_instance/guide.fr-ca.md
@@ -17,7 +17,7 @@ Contrairement aux autres instances Public Cloud pour lesquelles le mode rescue p
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud.
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - Une [instance Metal Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) dans votre projet.
 
 ## En pratique

--- a/pages/public_cloud/compute/rescue_mode_metal_instance/guide.fr-fr.md
+++ b/pages/public_cloud/compute/rescue_mode_metal_instance/guide.fr-fr.md
@@ -17,7 +17,7 @@ Contrairement aux autres instances Public Cloud pour lesquelles le mode rescue p
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud.
+- Un [projet Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - Une [instance Metal Public Cloud](/pages/public_cloud/compute/public-cloud-first-steps) dans votre projet.
 
 ## En pratique

--- a/pages/public_cloud/compute/rescue_mode_metal_instance/guide.it-it.md
+++ b/pages/public_cloud/compute/rescue_mode_metal_instance/guide.it-it.md
@@ -17,7 +17,7 @@ Unlike other Public Cloud Instances where the rescue mode can be activated from 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud Metal instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 
 ## Instructions

--- a/pages/public_cloud/compute/rescue_mode_metal_instance/guide.pl-pl.md
+++ b/pages/public_cloud/compute/rescue_mode_metal_instance/guide.pl-pl.md
@@ -17,7 +17,7 @@ Unlike other Public Cloud Instances where the rescue mode can be activated from 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud Metal instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 
 ## Instructions

--- a/pages/public_cloud/compute/rescue_mode_metal_instance/guide.pt-pt.md
+++ b/pages/public_cloud/compute/rescue_mode_metal_instance/guide.pt-pt.md
@@ -17,7 +17,7 @@ Unlike other Public Cloud Instances where the rescue mode can be activated from 
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
+- A [Public Cloud project](/links/public-cloud/public-cloud) in your OVHcloud account
 - A [Public Cloud Metal instance](/pages/public_cloud/compute/public-cloud-first-steps) in your project
 
 ## Instructions

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.de-de.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.de-de.md
@@ -14,7 +14,7 @@ In dieser Anleitung erfahren Sie, wie Sie Ihr Dateisystem nach der Installation 
 
 ## Voraussetzungen
 
-- Sie haben eine Instanz mit FreeBSD 12 in Ihrem [Public Cloud Projekt](https://www.ovhcloud.com/de/public-cloud/) oder einen [VPS](https://www.ovhcloud.com/de/vps/) mit FreeBSD 12
+- Sie haben eine Instanz mit FreeBSD 12 in Ihrem [Public Cloud Projekt](/links/public-cloud/public-cloud) oder einen [VPS](/links/bare-metal/vps) mit FreeBSD 12
 - Sie haben die Instanz / den VPS kürzlich installiert oder [angepasst](/pages/public_cloud/compute/resize_of_an_instance)
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-asia.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-asia.md
@@ -10,7 +10,7 @@ The purpose of this guide is to explain how to resize your file system after ins
 
 ## Requirements
 
-- Having an instance with FreeBSD 12 in your [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/) or a [Virtual Private Server](https://www.ovhcloud.com/asia/vps/) with FreeBSD 12
+- Having an instance with FreeBSD 12 in your [Public Cloud project](/links/public-cloud/public-cloud) or a [Virtual Private Server](/links/bare-metal/vps) with FreeBSD 12
 - Having freshly installed the instance/VPS or having resized it
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-au.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-au.md
@@ -10,7 +10,7 @@ The purpose of this guide is to explain how to resize your file system after ins
 
 ## Requirements
 
-- Having an instance with FreeBSD 12 in your [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/) or a [Virtual Private Server](https://www.ovhcloud.com/en-au/vps/) with FreeBSD 12
+- Having an instance with FreeBSD 12 in your [Public Cloud project](/links/public-cloud/public-cloud) or a [Virtual Private Server](/links/bare-metal/vps) with FreeBSD 12
 - Having freshly installed the instance/VPS or having resized it
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-ca.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-ca.md
@@ -10,7 +10,7 @@ The purpose of this guide is to explain how to resize your file system after ins
 
 ## Requirements
 
-- Having an instance with FreeBSD 12 in your [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/) or a [Virtual Private Server](https://www.ovhcloud.com/en-ca/vps/) with FreeBSD 12
+- Having an instance with FreeBSD 12 in your [Public Cloud project](/links/public-cloud/public-cloud) or a [Virtual Private Server](/links/bare-metal/vps) with FreeBSD 12
 - Having freshly installed the instance/VPS or having resized it
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-gb.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-gb.md
@@ -10,7 +10,7 @@ The purpose of this guide is to explain how to resize your file system after ins
 
 ## Requirements
 
-- Having an instance with FreeBSD 12 in your [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/) or a [Virtual Private Server](https://www.ovhcloud.com/en-gb/vps) with FreeBSD 12
+- Having an instance with FreeBSD 12 in your [Public Cloud project](/links/public-cloud/public-cloud) or a [Virtual Private Server](https://www.ovhcloud.com/en-gb/vps) with FreeBSD 12
 - Having freshly installed the instance/VPS or having resized it
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-ie.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-ie.md
@@ -10,7 +10,7 @@ The purpose of this guide is to explain how to resize your file system after ins
 
 ## Requirements
 
-- Having an instance with FreeBSD 12 in your [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/) or a [Virtual Private Server](https://www.ovhcloud.com/en-ie/vps/) with FreeBSD 12
+- Having an instance with FreeBSD 12 in your [Public Cloud project](/links/public-cloud/public-cloud) or a [Virtual Private Server](/links/bare-metal/vps) with FreeBSD 12
 - Having freshly installed the instance/VPS or having resized it
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-sg.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-sg.md
@@ -10,7 +10,7 @@ The purpose of this guide is to explain how to resize your file system after ins
 
 ## Requirements
 
-- Having an instance with FreeBSD 12 in your [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/) or a [Virtual Private Server](https://www.ovhcloud.com/en-sg/vps/) with FreeBSD 12
+- Having an instance with FreeBSD 12 in your [Public Cloud project](/links/public-cloud/public-cloud) or a [Virtual Private Server](/links/bare-metal/vps) with FreeBSD 12
 - Having freshly installed the instance/VPS or having resized it
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-us.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.en-us.md
@@ -10,7 +10,7 @@ The purpose of this guide is to explain how to resize your file system after ins
 
 ## Requirements
 
-- Having an instance with FreeBSD 12 in your [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/) or a [Virtual Private Server](https://www.ovhcloud.com/en/vps/) with FreeBSD 12
+- Having an instance with FreeBSD 12 in your [Public Cloud project](/links/public-cloud/public-cloud) or a [Virtual Private Server](/links/bare-metal/vps) with FreeBSD 12
 - Having freshly installed the instance/VPS or having resized it
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.es-es.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.es-es.md
@@ -14,7 +14,7 @@ Esta guía explica cómo redimensionar el sistema de archivos después de la ins
 
 ## Requisitos
 
- * Tener una instancia con FreeBSD 12 en su proyecto de [Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) o un [VPS](https://www.ovhcloud.com/es-es/vps/) con FreeBSD 12.
+ * Tener una instancia con FreeBSD 12 en su proyecto de [Public Cloud](/links/public-cloud/public-cloud) o un [VPS](/links/bare-metal/vps) con FreeBSD 12.
  * Haber instalado recientemente la instancia/VPS o [haberla redimensionado.](/pages/public_cloud/compute/resize_of_an_instance)
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.es-us.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.es-us.md
@@ -14,7 +14,7 @@ Esta guía explica cómo redimensionar el sistema de archivos después de la ins
 
 ## Requisitos
 
- * Tener una instancia con FreeBSD 12 en su proyecto de [Public Cloud](https://www.ovhcloud.com/es/public-cloud/) o un [VPS](https://www.ovhcloud.com/es/vps/) con FreeBSD 12.
+ * Tener una instancia con FreeBSD 12 en su proyecto de [Public Cloud](/links/public-cloud/public-cloud) o un [VPS](/links/bare-metal/vps) con FreeBSD 12.
  * Haber instalado recientemente la instancia/VPS o [haberla redimensionado.](/pages/public_cloud/compute/resize_of_an_instance)
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.fr-ca.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.fr-ca.md
@@ -10,7 +10,7 @@ Ce guide a pour but de vous expliquer comment redimensionner votre système de f
 
 ## Prérequis
 
- * Avoir une instance avec FreeBSD 12 dans votre projet [Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) ou un [VPS](https://www.ovhcloud.com/fr-ca/vps/) sous FreeBSD 12
+ * Avoir une instance avec FreeBSD 12 dans votre projet [Public Cloud](/links/public-cloud/public-cloud) ou un [VPS](/links/bare-metal/vps) sous FreeBSD 12
  * Avoir récemment installé l'instance/le VPS ou [l'avoir redimensionnée](/pages/public_cloud/compute/resize_of_an_instance)
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.fr-fr.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.fr-fr.md
@@ -10,7 +10,7 @@ Ce guide a pour but de vous expliquer comment redimensionner votre système de f
 
 ## Prérequis
 
- * Avoir une instance avec FreeBSD 12 dans votre projet [Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) ou un [VPS](https://www.ovhcloud.com/fr/vps/) sous FreeBSD 12
+ * Avoir une instance avec FreeBSD 12 dans votre projet [Public Cloud](/links/public-cloud/public-cloud) ou un [VPS](/links/bare-metal/vps) sous FreeBSD 12
  * Avoir récemment installé l'instance/le VPS ou [l'avoir redimensionnée](/pages/public_cloud/compute/resize_of_an_instance)
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.it-it.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.it-it.md
@@ -14,7 +14,7 @@ Questa guida ti mostra come ridimensionare il tuo file system dopo l'installazio
 
 ## Prerequisiti
 
- * Disporre di un'istanza con FreeBSD 12 nel tuo progetto [Public Cloud](https://www.ovhcloud.com/it/public-cloud/) o di un [VPS](https://www.ovhcloud.com/it/vps/) con FreeBSD 12
+ * Disporre di un'istanza con FreeBSD 12 nel tuo progetto [Public Cloud](/links/public-cloud/public-cloud) o di un [VPS](/links/bare-metal/vps) con FreeBSD 12
  * Aver installato di recente l'istanza/il VPS o [averne ridimensionato il volume](/pages/public_cloud/compute/resize_of_an_instance)
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.pt-pt.md
+++ b/pages/public_cloud/compute/resize_freebsd_file_system_after_install/guide.pt-pt.md
@@ -14,7 +14,7 @@ Este manual explica como redimensionar o sistema de ficheiros após a instalaç�
 
 ## Requisitos
 
- * Ter uma instância com FreeBSD 12 no seu projeto [Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) ou um [VPS](https://www.ovhcloud.com/pt/vps/) com FreeBSD 12
+ * Ter uma instância com FreeBSD 12 no seu projeto [Public Cloud](/links/public-cloud/public-cloud) ou um [VPS](/links/bare-metal/vps) com FreeBSD 12
  * * Ter instalado recentemente a instância/o VPS ou [ter redimensionado](/pages/public_cloud/compute/resize_of_an_instance)
 
 > [!primary]

--- a/pages/public_cloud/compute/resize_instance_manager/guide.en-asia.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.en-asia.md
@@ -23,7 +23,7 @@ As a result of increased activity, or simply new needs, your instance may not be
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Access to the OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/resize_instance_manager/guide.en-au.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.en-au.md
@@ -23,7 +23,7 @@ As a result of increased activity, or simply new needs, your instance may not be
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Access to the OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/resize_instance_manager/guide.en-ca.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.en-ca.md
@@ -23,7 +23,7 @@ As a result of increased activity, or simply new needs, your instance may not be
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Access to the OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/resize_instance_manager/guide.en-gb.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.en-gb.md
@@ -23,7 +23,7 @@ As a result of increased activity, or simply new needs, your instance may not be
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Access to the OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/resize_instance_manager/guide.en-ie.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.en-ie.md
@@ -23,7 +23,7 @@ As a result of increased activity, or simply new needs, your instance may not be
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Access to the OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/resize_instance_manager/guide.en-sg.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.en-sg.md
@@ -23,7 +23,7 @@ As a result of increased activity, or simply new needs, your instance may not be
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Access to the OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/resize_instance_manager/guide.en-us.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.en-us.md
@@ -23,7 +23,7 @@ As a result of increased activity, or simply new needs, your instance may not be
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Access to the OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/resize_instance_manager/guide.es-es.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.es-es.md
@@ -27,7 +27,7 @@ En algunos casos, bien debido a un aumento de la actividad o a sus nuevas necesi
 
 ## Requisitos
 
-- Tener una [instancia de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud.
+- Tener una [instancia de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud.
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager).
 
 ## Procedimiento

--- a/pages/public_cloud/compute/resize_instance_manager/guide.es-us.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.es-us.md
@@ -27,7 +27,7 @@ En algunos casos, bien debido a un aumento de la actividad o a sus nuevas necesi
 
 ## Requisitos
 
-- Tener una [instancia de Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud.
+- Tener una [instancia de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud.
 - Tienes acceso a tu [Panel de configuración de OVHcloud](/links/manager).
 
 ## Procedimiento

--- a/pages/public_cloud/compute/resize_instance_manager/guide.fr-ca.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.fr-ca.md
@@ -23,7 +23,7 @@ En raison d'une activité accrue, ou simplement de nouveaux besoins, votre insta
 
 ## Prérequis
 
-- Avoir [créé une instance Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud
+- Avoir [créé une instance Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/public_cloud/compute/resize_instance_manager/guide.fr-fr.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.fr-fr.md
@@ -23,7 +23,7 @@ En raison d'une activité accrue, ou simplement de nouveaux besoins, votre insta
 
 ## Prérequis
 
-- Avoir [créé une instance Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
+- Avoir [créé une instance Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Être connecté à votre [espace client OVHcloud](/links/manager)
 
 ## En pratique

--- a/pages/public_cloud/compute/resize_instance_manager/guide.it-it.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.it-it.md
@@ -27,7 +27,7 @@ In seguito allo sviluppo della tua attività o semplicemente all’evoluzione de
 
 ## Prerequisiti
 
-- Disporre di un'istanza [Public Cloud](https://www.ovhcloud.com/it/public-cloud/) sul proprio account OVHcloud
+- Disporre di un'istanza [Public Cloud](/links/public-cloud/public-cloud) sul proprio account OVHcloud
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 ## Procedura

--- a/pages/public_cloud/compute/resize_instance_manager/guide.pl-pl.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.pl-pl.md
@@ -27,7 +27,7 @@ Jeśli Twoja działalność się rozwija i zapotrzebowanie na zasoby wzrasta, mo
 
 ## Wymagania początkowe
 
-- Posiadanie [instancji Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na Twoim koncie OVHcloud
+- Posiadanie [instancji Public Cloud](/links/public-cloud/public-cloud) na Twoim koncie OVHcloud
 - Dostęp do [Panelu client OVHcloud](/links/manager)
 
 ## W praktyce

--- a/pages/public_cloud/compute/resize_instance_manager/guide.pt-pt.md
+++ b/pages/public_cloud/compute/resize_instance_manager/guide.pt-pt.md
@@ -28,7 +28,7 @@ No seguimento de um crescimento da sua atividade, ou simplesmente porque tem nov
 
 ## Requisitos
 
-- Ter uma [instância Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud.
+- Ter uma [instância Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud.
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager).
 
 ## Instruções

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.de-de.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.de-de.md
@@ -24,7 +24,7 @@ Ihre Instanz kann aufgrund erhöhter Aktivität oder einfach aufgrund neuer Anfo
 
 ## Voraussetzungen
 
-- Sie verfügen über eine [Public Cloud Instanz](https://www.ovhcloud.com/de/public-cloud/).
+- Sie verfügen über eine [Public Cloud Instanz](/links/public-cloud/public-cloud).
 - Sie haben einen [OpenStack User erstellt](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user).
 - Sie haben [OpenStack CLI auf Ihrem System installiert](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api).
 - Sie haben die [OpenStack Umgebungsvariablen konfiguriert](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables).

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.en-asia.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.en-asia.md
@@ -20,7 +20,7 @@ As a result of increased activity, or simply to address new needs, your instance
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - An [OpenStack CLI ready environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.en-au.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.en-au.md
@@ -20,7 +20,7 @@ As a result of increased activity, or simply to address new needs, your instance
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - An [OpenStack CLI ready environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.en-ca.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.en-ca.md
@@ -20,7 +20,7 @@ As a result of increased activity, or simply to address new needs, your instance
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - An [OpenStack CLI ready environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.en-gb.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.en-gb.md
@@ -20,7 +20,7 @@ As a result of increased activity, or simply to address new needs, your instance
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - An [OpenStack CLI ready environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.en-ie.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.en-ie.md
@@ -20,7 +20,7 @@ As a result of increased activity, or simply to address new needs, your instance
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - An [OpenStack CLI ready environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.en-sg.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.en-sg.md
@@ -20,7 +20,7 @@ As a result of increased activity, or simply to address new needs, your instance
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - An [OpenStack CLI ready environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.en-us.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.en-us.md
@@ -20,7 +20,7 @@ As a result of increased activity, or simply to address new needs, your instance
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - An [OpenStack user account](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - An [OpenStack CLI ready environment](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - [Set OpenStack environment variables](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.es-es.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.es-es.md
@@ -24,7 +24,7 @@ Debido al aumento de la actividad, o simplemente para responder a nuevas necesid
 
 ## Requisitos
 
-- Una [instancia de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud
+- Una [instancia de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
 - Un [usuario de OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Disponga de un [entorno OpenStack preparado para CLI](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - Haber definido las [variables de entorno OpenStack](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.es-us.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.es-us.md
@@ -24,7 +24,7 @@ Debido al aumento de la actividad, o simplemente para responder a nuevas necesid
 
 ## Requisitos
 
-- Una [instancia de Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud
+- Una [instancia de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud
 - Un [usuario de OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Disponga de un [entorno OpenStack preparado para CLI](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - Haber definido las [variables de entorno OpenStack](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.fr-ca.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.fr-ca.md
@@ -20,7 +20,7 @@ En raison d'une activité accrue, ou simplement pour répondre à de nouveaux be
 
 ## Prérequis
 
-- Une [instance Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud
+- Une [instance Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Un [utilisateur OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Avoir un [environnement OpenStack préparé pour le CLI](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - Avoir défini les [variables d'environnement OpenStack](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.fr-fr.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.fr-fr.md
@@ -20,7 +20,7 @@ En raison d'une activité accrue, ou simplement pour répondre à de nouveaux be
 
 ## Prérequis
 
-- Une [instance Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud
+- Une [instance Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud
 - Un [utilisateur OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Avoir un [environnement OpenStack préparé pour le CLI](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - Avoir défini les [variables d'environnement OpenStack](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.it-it.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.it-it.md
@@ -24,7 +24,7 @@ A causa di un aumento dell'attività o semplicemente per rispondere a nuove esig
 
 ## Prerequisiti
 
-- Disporre di un'istanza [Public Cloud](https://www.ovhcloud.com/it/public-cloud/) sul proprio account OVHcloud
+- Disporre di un'istanza [Public Cloud](/links/public-cloud/public-cloud) sul proprio account OVHcloud
 - Un [utente OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Disporre di un [ambiente OpenStack predisposto per la CLI](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - Aver definito le [variabili d’ambiente OpenStack](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)

--- a/pages/public_cloud/compute/resize_instance_openstack/guide.pt-pt.md
+++ b/pages/public_cloud/compute/resize_instance_openstack/guide.pt-pt.md
@@ -24,7 +24,7 @@ Devido a uma atividade acrescida, ou simplesmente para responder a novas necessi
 
 ## Requisitos
 
-- Uma [instância Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud
+- Uma [instância Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud
 - Um [utilizador OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 - Ter um [ambiente OpenStack preparado para CLI](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api)
 - Ter definido as [variáveis de ambiente do OpenStack](/pages/public_cloud/public_cloud_cross_functional/loading_openstack_environment_variables)

--- a/pages/public_cloud/compute/save_an_instance/guide.en-asia.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-asia.md
@@ -12,7 +12,7 @@ You can create a single backup of an instance or configure a schedule in order t
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/save_an_instance/guide.en-au.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-au.md
@@ -12,7 +12,7 @@ You can create a single backup of an instance or configure a schedule in order t
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/save_an_instance/guide.en-ca.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-ca.md
@@ -12,7 +12,7 @@ You can create a single backup of an instance or configure a schedule in order t
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/save_an_instance/guide.en-gb.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-gb.md
@@ -12,7 +12,7 @@ You can create a single backup of an instance or configure a schedule in order t
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/save_an_instance/guide.en-ie.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-ie.md
@@ -12,7 +12,7 @@ You can create a single backup of an instance or configure a schedule in order t
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/save_an_instance/guide.en-sg.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-sg.md
@@ -12,7 +12,7 @@ You can create a single backup of an instance or configure a schedule in order t
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/save_an_instance/guide.en-us.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.en-us.md
@@ -12,7 +12,7 @@ You can create a single backup of an instance or configure a schedule in order t
 
 ## Requirements
 
-- A [Public Cloud instance](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - Access to the [OVHcloud Control Panel](/links/manager)
 
 ## Instructions

--- a/pages/public_cloud/compute/save_an_instance/guide.es-es.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.es-es.md
@@ -16,7 +16,7 @@ Puede crear una copia de seguridad única de una instancia o configurar una plan
 
 ## Requisitos
 
-- Tener una instancia de [Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud.
+- Tener una instancia de [Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud.
 - Tienes acceso a tu [área de cliente de OVHcloud](/links/manager).
 
 ## Procedimiento

--- a/pages/public_cloud/compute/save_an_instance/guide.es-us.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.es-us.md
@@ -16,7 +16,7 @@ Puede crear una copia de seguridad única de una instancia o configurar una plan
 
 ## Requisitos
 
-- Tener una instancia de [Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud.
+- Tener una instancia de [Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud.
 - Tienes acceso a tu [área de cliente de OVHcloud](/links/manager).
 
 ## Procedimiento

--- a/pages/public_cloud/compute/save_an_instance/guide.fr-ca.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.fr-ca.md
@@ -12,7 +12,7 @@ Vous pouvez créer une sauvegarde unique d'une instance ou configurer un plannin
 
 ## Prérequis
 
-- Avoir une instance [Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud.
+- Avoir une instance [Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - Être connecté à votre [espace client OVHcloud](/links/manager).
 
 ## En pratique

--- a/pages/public_cloud/compute/save_an_instance/guide.fr-fr.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.fr-fr.md
@@ -12,7 +12,7 @@ Vous pouvez créer une sauvegarde unique d'une instance ou configurer un plannin
 
 ## Prérequis
 
-- Avoir une instance [Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud.
+- Avoir une instance [Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud.
 - Être connecté à votre [espace client OVHcloud](/links/manager).
 
 ## En pratique

--- a/pages/public_cloud/compute/save_an_instance/guide.it-it.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.it-it.md
@@ -16,7 +16,7 @@ Crea un backup unico di un'istanza o configura una pianificazione per automatizz
 
 ## Prerequisiti
 
-- Disporre di un'istanza [Public Cloud](https://www.ovhcloud.com/it/public-cloud/) sul proprio account OVHcloud
+- Disporre di un'istanza [Public Cloud](/links/public-cloud/public-cloud) sul proprio account OVHcloud
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
 
 ## Procedura

--- a/pages/public_cloud/compute/save_an_instance/guide.pl-pl.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.pl-pl.md
@@ -16,7 +16,7 @@ Możesz utworzyć kopię zapasową instancji lub skonfigurować harmonogram, aby
 
 ## Wymagania początkowe
 
-- Posiadanie instancji [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na Twoim koncie OVHcloud
+- Posiadanie instancji [Public Cloud](/links/public-cloud/public-cloud) na Twoim koncie OVHcloud
 - Dostęp do [Panelu client OVHcloud](/links/manager)
 
 ## W praktyce

--- a/pages/public_cloud/compute/save_an_instance/guide.pt-pt.md
+++ b/pages/public_cloud/compute/save_an_instance/guide.pt-pt.md
@@ -16,7 +16,7 @@ Pode criar um backup único de uma instância ou configurar um planeamento para 
 
 ## Requisitos
 
-- Ter uma instância [Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud.
+- Ter uma instância [Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud.
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager).
 
 ## Instruções

--- a/pages/public_cloud/compute/setup_security_group/guide.en-asia.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.en-asia.md
@@ -12,7 +12,7 @@ For security reasons, you can configure and use filtering rules that will define
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/).
+- A [Public Cloud project](/links/public-cloud/public-cloud).
 - Access to the [Horizon interface](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 ## Instructions

--- a/pages/public_cloud/compute/setup_security_group/guide.en-au.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.en-au.md
@@ -12,7 +12,7 @@ For security reasons, you can configure and use filtering rules that will define
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/).
+- A [Public Cloud project](/links/public-cloud/public-cloud).
 - Access to the [Horizon interface](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 ## Instructions

--- a/pages/public_cloud/compute/setup_security_group/guide.en-ca.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.en-ca.md
@@ -12,7 +12,7 @@ For security reasons, you can configure and use filtering rules that will define
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/).
+- A [Public Cloud project](/links/public-cloud/public-cloud).
 - Access to the [Horizon interface](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 ## Instructions

--- a/pages/public_cloud/compute/setup_security_group/guide.en-gb.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.en-gb.md
@@ -12,7 +12,7 @@ For security reasons, you can configure and use filtering rules that will define
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/).
+- A [Public Cloud project](/links/public-cloud/public-cloud).
 - Access to the [Horizon interface](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 ## Instructions

--- a/pages/public_cloud/compute/setup_security_group/guide.en-ie.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.en-ie.md
@@ -12,7 +12,7 @@ For security reasons, you can configure and use filtering rules that will define
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/).
+- A [Public Cloud project](/links/public-cloud/public-cloud).
 - Access to the [Horizon interface](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 ## Instructions

--- a/pages/public_cloud/compute/setup_security_group/guide.en-sg.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.en-sg.md
@@ -12,7 +12,7 @@ For security reasons, you can configure and use filtering rules that will define
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/).
+- A [Public Cloud project](/links/public-cloud/public-cloud).
 - Access to the [Horizon interface](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 ## Instructions

--- a/pages/public_cloud/compute/setup_security_group/guide.en-us.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.en-us.md
@@ -12,7 +12,7 @@ For security reasons, you can configure and use filtering rules that will define
 
 ## Requirements
 
-- A [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/).
+- A [Public Cloud project](/links/public-cloud/public-cloud).
 - Access to the [Horizon interface](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 ## Instructions

--- a/pages/public_cloud/compute/setup_security_group/guide.es-es.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.es-es.md
@@ -16,7 +16,7 @@ Por motivos de seguridad, es posible configurar y utilizar reglas de filtrado qu
 
 ## Requisitos
 
-- Un [proyecto de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/)
+- Un [proyecto de Public Cloud](/links/public-cloud/public-cloud)
 - [Estar conectado a Horizon](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 ## Procedimiento

--- a/pages/public_cloud/compute/setup_security_group/guide.es-us.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.es-us.md
@@ -16,7 +16,7 @@ Por motivos de seguridad, es posible configurar y utilizar reglas de filtrado qu
 
 ## Requisitos
 
-- Un [proyecto de Public Cloud](https://www.ovhcloud.com/es/public-cloud/)
+- Un [proyecto de Public Cloud](/links/public-cloud/public-cloud)
 - [Estar conectado a Horizon](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 ## Procedimiento

--- a/pages/public_cloud/compute/setup_security_group/guide.fr-ca.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.fr-ca.md
@@ -12,7 +12,7 @@ Pour des raisons de sécurité, il est possible de configurer et d'utiliser des 
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/).
+- Un [projet Public Cloud](/links/public-cloud/public-cloud).
 - [Être connecté à l'interface Horizon](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user).
 
 ## En pratique

--- a/pages/public_cloud/compute/setup_security_group/guide.fr-fr.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.fr-fr.md
@@ -12,7 +12,7 @@ Pour des raisons de sécurité, il est possible de configurer et d'utiliser des 
 
 ## Prérequis
 
-- Un [projet Public Cloud](https://www.ovhcloud.com/fr/public-cloud/).
+- Un [projet Public Cloud](/links/public-cloud/public-cloud).
 - [Être connecté à l'interface Horizon](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user).
 
 ## En pratique

--- a/pages/public_cloud/compute/setup_security_group/guide.it-it.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.it-it.md
@@ -16,7 +16,7 @@ Per motivi di sicurezza, è possibile configurare e utilizzare regole di filtrag
 
 ## Prerequisiti
 
-- Un [progetto Public Cloud](https://www.ovhcloud.com/it/public-cloud/)
+- Un [progetto Public Cloud](/links/public-cloud/public-cloud)
 - [Essere connesso all'interfaccia Horizon](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 ## Procedura

--- a/pages/public_cloud/compute/setup_security_group/guide.pl-pl.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.pl-pl.md
@@ -16,7 +16,7 @@ Ze względów bezpieczeństwa możesz konfigurować i używać reguł filtrowani
 
 ## Wymagania początkowe
 
-- Projekt [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/)
+- Projekt [Public Cloud](/links/public-cloud/public-cloud)
 - [Dostęp do interfejsu Horizon](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 ## W praktyce

--- a/pages/public_cloud/compute/setup_security_group/guide.pt-pt.md
+++ b/pages/public_cloud/compute/setup_security_group/guide.pt-pt.md
@@ -16,7 +16,7 @@ Por razões de segurança, é possível configurar e utilizar regras de filtrage
 
 ## Requisitos
 
-- Um [projeto Public Cloud](https://www.ovhcloud.com/pt/public-cloud/)
+- Um [projeto Public Cloud](/links/public-cloud/public-cloud)
 - [Ter acesso à interface Horizon](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 ## Instruções

--- a/pages/public_cloud/compute/share_images_between_projects/guide.de-de.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.de-de.md
@@ -27,7 +27,7 @@ Weitere Informationen finden Sie in der offiziellen [OpenStack Dokumentation](ht
 ## Voraussetzungen
 
 - Sie haben [Ihre Umgebung für die Verwendung der OpenStack API vorbereitet](/pages/public_cloud/public_cloud_cross_functional/prepare_the_environment_for_using_the_openstack_api).
-- Sie haben eine [Public Cloud Instanz](https://www.ovhcloud.com/de/public-cloud/) in Ihrem Account erstellt.
+- Sie haben eine [Public Cloud Instanz](/links/public-cloud/public-cloud) in Ihrem Account erstellt.
 - Sie haben einen [OpenStack User erstellt](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user).
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.en-asia.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.en-asia.md
@@ -32,7 +32,7 @@ Before following these steps, it is recommended that you first read this guide:
 
 You will also need the following:
 
-- a [Public Cloud Instance](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- a [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - an [OpenStack user](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.en-au.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.en-au.md
@@ -32,7 +32,7 @@ Before following these steps, it is recommended that you first read this guide:
 
 You will also need the following:
 
-- a [Public Cloud Instance](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- a [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - an [OpenStack user](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.en-ca.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.en-ca.md
@@ -32,7 +32,7 @@ Before following these steps, it is recommended that you first read this guide:
 
 You will also need the following:
 
-- a [Public Cloud Instance](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- a [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - an [OpenStack user](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.en-gb.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.en-gb.md
@@ -32,7 +32,7 @@ Before following these steps, it is recommended that you first read this guide:
 
 You will also need the following:
 
-- a [Public Cloud Instance](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- a [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - an [OpenStack user](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.en-ie.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.en-ie.md
@@ -32,7 +32,7 @@ Before following these steps, it is recommended that you first read this guide:
 
 You will also need the following:
 
-- a [Public Cloud Instance](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- a [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - an [OpenStack user](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.en-sg.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.en-sg.md
@@ -32,7 +32,7 @@ Before following these steps, it is recommended that you first read this guide:
 
 You will also need the following:
 
-- a [Public Cloud Instance](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- a [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - an [OpenStack user](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.en-us.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.en-us.md
@@ -32,7 +32,7 @@ Before following these steps, it is recommended that you first read this guide:
 
 You will also need the following:
 
-- a [Public Cloud Instance](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- a [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - an [OpenStack user](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.es-es.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.es-es.md
@@ -32,7 +32,7 @@ Antes de seguir estos pasos, le recomendamos que consulte esta guía:
 
 También necesitará:
 
-- Tener una [instancia de Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/) en su cuenta de OVHcloud;
+- Tener una [instancia de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud;
 - [Haber creado un usuario de OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.es-us.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.es-us.md
@@ -32,7 +32,7 @@ Antes de seguir estos pasos, le recomendamos que consulte esta guía:
 
 También necesitará:
 
-- Tener una [instancia de Public Cloud](https://www.ovhcloud.com/es/public-cloud/) en su cuenta de OVHcloud;
+- Tener una [instancia de Public Cloud](/links/public-cloud/public-cloud) en su cuenta de OVHcloud;
 - [Haber creado un usuario de OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.fr-ca.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.fr-ca.md
@@ -32,7 +32,7 @@ Avant de suivre ces étapes, il est recommandé de consulter d'abord ce guide :
 
 Vous aurez également besoin de :
 
-- posséder une [Instance Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/) dans votre compte OVHcloud ;
+- posséder une [Instance Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud ;
 - Un utilisateur [OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user) créé dans votre projet ;
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.fr-fr.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.fr-fr.md
@@ -32,7 +32,7 @@ Avant de suivre ces étapes, il est recommandé de consulter d'abord ce guide :
 
 Vous aurez également besoin de :
 
-- posséder une [Instance Public Cloud](https://www.ovhcloud.com/fr/public-cloud/) dans votre compte OVHcloud ;
+- posséder une [Instance Public Cloud](/links/public-cloud/public-cloud) dans votre compte OVHcloud ;
 - Un utilisateur [OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user) créé dans votre projet ;
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.it-it.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.it-it.md
@@ -32,7 +32,7 @@ Prima di seguire questi passaggi, ti consigliamo di consultare questa guida:
 
 Avrai anche bisogno di:
 
-- Disporre di un’[Istanza Public Cloud](https://www.ovhcloud.com/it/public-cloud/) iscritta nel proprio account OVHcloud
+- Disporre di un’[Istanza Public Cloud](/links/public-cloud/public-cloud) iscritta nel proprio account OVHcloud
 - [Aver creato un utente OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.pl-pl.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.pl-pl.md
@@ -32,7 +32,7 @@ Przed wykonaniem tych kroków, należy najpierw zapoznać się z treścią przew
 
 Będziesz również potrzebował:
 
-- Posiadanie [instancji Public Cloud](https://www.ovhcloud.com/pl/public-cloud/) na koncie OVHcloud;
+- Posiadanie [instancji Public Cloud](/links/public-cloud/public-cloud) na koncie OVHcloud;
 - [Utworzenie użytkownika OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 > [!primary]

--- a/pages/public_cloud/compute/share_images_between_projects/guide.pt-pt.md
+++ b/pages/public_cloud/compute/share_images_between_projects/guide.pt-pt.md
@@ -32,7 +32,7 @@ Antes de seguir estes passos, recomendamos que consulte primeiro este guia:
 
 Necessitará igualmente de:
 
-- Dispor de uma [Instância Public Cloud](https://www.ovhcloud.com/pt/public-cloud/) na sua conta OVHcloud
+- Dispor de uma [Instância Public Cloud](/links/public-cloud/public-cloud) na sua conta OVHcloud
 - [Ter criado um utilizador OpenStack](/pages/public_cloud/public_cloud_cross_functional/create_and_delete_a_user)
 
 > [!primary]

--- a/pages/public_cloud/compute/switch_volume_type/guide.de-de.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.de-de.md
@@ -15,7 +15,7 @@ In dieser Anleitung wird erläutert, wie Sie einen Block Storage Volume vom Typ 
 ## Voraussetzungen
 
 - Sie haben Zugriff auf das [Horizon Interface](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon).
-- Sie haben ein [Block Storage Volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) in Ihrem [Public Cloud Projekt](https://www.ovhcloud.com/de/public-cloud/) erstellt.
+- Sie haben ein [Block Storage Volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) in Ihrem [Public Cloud Projekt](/links/public-cloud/public-cloud) erstellt.
 
 ## In der praktischen Anwendung
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.en-asia.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.en-asia.md
@@ -11,7 +11,7 @@ The purpose of this guide is to show you how to change a block storage volume ty
 ## Requirements
 
 - [Access to the Horizon interface](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.en-au.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.en-au.md
@@ -11,7 +11,7 @@ The purpose of this guide is to show you how to change a block storage volume ty
 ## Requirements
 
 - [Access to the Horizon interface](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.en-ca.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.en-ca.md
@@ -11,7 +11,7 @@ The purpose of this guide is to show you how to change a block storage volume ty
 ## Requirements
 
 - [Access to the Horizon interface](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.en-gb.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.en-gb.md
@@ -11,7 +11,7 @@ The purpose of this guide is to show you how to change a block storage volume ty
 ## Requirements
 
 - [Access to the Horizon interface](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.en-ie.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.en-ie.md
@@ -11,7 +11,7 @@ The purpose of this guide is to show you how to change a block storage volume ty
 ## Requirements
 
 - [Access to the Horizon interface](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.en-sg.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.en-sg.md
@@ -11,7 +11,7 @@ The purpose of this guide is to show you how to change a block storage volume ty
 ## Requirements
 
 - [Access to the Horizon interface](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.en-us.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.en-us.md
@@ -11,7 +11,7 @@ The purpose of this guide is to show you how to change a block storage volume ty
 ## Requirements
 
 - [Access to the Horizon interface](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.es-es.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.es-es.md
@@ -15,7 +15,7 @@ El objetivo de esta guía es mostrarle cómo cambiar un tipo de volumen Block St
 ## Requisitos
 
 - [Conectarse a Horizon](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- Un volumen [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) creado en su proyecto [Public Cloud](https://www.ovhcloud.com/es-es/public-cloud/)
+- Un volumen [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) creado en su proyecto [Public Cloud](/links/public-cloud/public-cloud)
 
 ## Procedimiento
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.es-us.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.es-us.md
@@ -15,7 +15,7 @@ El objetivo de esta guía es mostrarle cómo cambiar un tipo de volumen Block St
 ## Requisitos
 
 - [Conectarse a Horizon](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- Un volumen [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) creado en su proyecto [Public Cloud](https://www.ovhcloud.com/es/public-cloud/)
+- Un volumen [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) creado en su proyecto [Public Cloud](/links/public-cloud/public-cloud)
 
 ## Procedimiento
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.fr-ca.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.fr-ca.md
@@ -11,7 +11,7 @@ L'objectif de ce guide est de vous montrer comment changer un type de volume Blo
 ## Prérequis
 
 - [Accéder à l'interface Horizon](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- Un volume [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) créé dans votre projet [Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/)
+- Un volume [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) créé dans votre projet [Public Cloud](/links/public-cloud/public-cloud)
 
 ## En pratique
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.fr-fr.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.fr-fr.md
@@ -11,7 +11,7 @@ L'objectif de ce guide est de vous montrer comment changer un type de volume Blo
 ## Prérequis
 
 - [Accéder à l'interface Horizon](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- Un volume [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) créé dans votre projet [Public Cloud](https://www.ovhcloud.com/fr/public-cloud/)
+- Un volume [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) créé dans votre projet [Public Cloud](/links/public-cloud/public-cloud)
 
 ## En pratique
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.it-it.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.it-it.md
@@ -15,7 +15,7 @@ L’obiettivo di questa guida è mostrarti come modificare un tipo di volume Blo
 ## Prerequisiti
 
 - [Accedere all'interfaccia Horizon](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- Un volume [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) creato nel tuo progetto [Public Cloud](https://www.ovhcloud.com/it/public-cloud/)
+- Un volume [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) creato nel tuo progetto [Public Cloud](/links/public-cloud/public-cloud)
 
 ## Procedura
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.pl-pl.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.pl-pl.md
@@ -15,7 +15,7 @@ Celem niniejszego przewodnika jest pokazanie, jak zmienić rodzaj wolumenu Block
 ## Wymagania początkowe
 
 - [Dostęp do interfejsu Horizon](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- Wolumen [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) utworzony w Twoim projekcie [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/)
+- Wolumen [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) utworzony w Twoim projekcie [Public Cloud](/links/public-cloud/public-cloud)
 
 ## W praktyce
 

--- a/pages/public_cloud/compute/switch_volume_type/guide.pt-pt.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.pt-pt.md
@@ -15,7 +15,7 @@ O objetivo deste guia é mostrar-lhe como alterar um tipo de volume Block Storag
 ## Requisitos
 
 - [Aceder à interface Horizon](/pages/public_cloud/public_cloud_cross_functional/introducing_horizon)
-- Um volume [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) criado no seu projeto [Public Cloud](https://www.ovhcloud.com/pt/public-cloud/)
+- Um volume [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) criado no seu projeto [Public Cloud](/links/public-cloud/public-cloud)
 
 ## Instruções
 

--- a/pages/public_cloud/compute/transfer_volume_backup_from_one_datacentre_to_another/guide.it-it.md
+++ b/pages/public_cloud/compute/transfer_volume_backup_from_one_datacentre_to_another/guide.it-it.md
@@ -6,7 +6,7 @@ updated: 2024-01-11
 
 ## Obiettivo
 
-In alcuni casi potrebbe essere necessario spostare volumi aggiuntivi da una Region OpenStack a un'altra, perché è disponibile una nuova Region o perché si desidera migrare da [OVHcloud Labs](https://labs.ovh.com/) al [Public Cloud](https://www.ovhcloud.com/it/public-cloud/).
+In alcuni casi potrebbe essere necessario spostare volumi aggiuntivi da una Region OpenStack a un'altra, perché è disponibile una nuova Region o perché si desidera migrare da [OVHcloud Labs](https://labs.ovh.com/) al [Public Cloud](/links/public-cloud/public-cloud).
 
 **Questa guida ti mostra come migrare un backup di un volume da una Region OpenStack ad un'altra.**
 

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.de-de.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.de-de.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/de/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-asia.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-asia.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/asia/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-au.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-au.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/en-au/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-ca.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-ca.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/en-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-gb.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-gb.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/en-gb/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-ie.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-ie.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/en-ie/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-sg.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-sg.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/en-sg/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-us.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.en-us.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/en/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.es-es.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.es-es.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/es-es/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.es-us.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.es-us.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/es/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.fr-ca.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.fr-ca.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/fr-ca/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.fr-fr.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.fr-fr.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/fr/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.it-it.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.it-it.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/it/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.pl-pl.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.pl-pl.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/pl/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.pt-pt.md
+++ b/pages/public_cloud/compute/use_object_storage_pulumi_backend_state/guide.pt-pt.md
@@ -16,7 +16,7 @@ In this tutorial you will:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Public Cloud Instance](https://www.ovhcloud.com/pt/public-cloud/) in your OVHcloud account
+- A [Public Cloud Instance](/links/public-cloud/public-cloud) in your OVHcloud account
 - [Pulumi CLI](https://www.pulumi.com/docs/install/){.external} installed
 
 **Before you begin**

--- a/pages/public_cloud/compute/volume-backup/guide.de-de.md
+++ b/pages/public_cloud/compute/volume-backup/guide.de-de.md
@@ -30,7 +30,7 @@ Volume Snapshot und Volume Backup ermöglichen:
 ## Voraussetzungen
 
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager).
-- Sie haben ein [Block Storage Volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) in Ihrem [Public Cloud Projekt](https://www.ovhcloud.com/de/public-cloud/) erstellt.
+- Sie haben ein [Block Storage Volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) in Ihrem [Public Cloud Projekt](/links/public-cloud/public-cloud) erstellt.
 
 ## In der praktischen Anwendung
 

--- a/pages/public_cloud/compute/volume-backup/guide.en-asia.md
+++ b/pages/public_cloud/compute/volume-backup/guide.en-asia.md
@@ -24,7 +24,7 @@ Both volume snapshot and volume backup allow you to:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/asia/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/volume-backup/guide.en-au.md
+++ b/pages/public_cloud/compute/volume-backup/guide.en-au.md
@@ -24,7 +24,7 @@ Both volume snapshot and volume backup allow you to:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/en-au/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/volume-backup/guide.en-ca.md
+++ b/pages/public_cloud/compute/volume-backup/guide.en-ca.md
@@ -24,7 +24,7 @@ Both volume snapshot and volume backup allow you to:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/en-ca/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/volume-backup/guide.en-gb.md
+++ b/pages/public_cloud/compute/volume-backup/guide.en-gb.md
@@ -24,7 +24,7 @@ Both volume snapshot and volume backup allow you to:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/en-gb/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/volume-backup/guide.en-ie.md
+++ b/pages/public_cloud/compute/volume-backup/guide.en-ie.md
@@ -24,7 +24,7 @@ Both volume snapshot and volume backup allow you to:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/en-ie/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/volume-backup/guide.en-sg.md
+++ b/pages/public_cloud/compute/volume-backup/guide.en-sg.md
@@ -24,7 +24,7 @@ Both volume snapshot and volume backup allow you to:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/en-sg/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/volume-backup/guide.en-us.md
+++ b/pages/public_cloud/compute/volume-backup/guide.en-us.md
@@ -24,7 +24,7 @@ Both volume snapshot and volume backup allow you to:
 ## Requirements
 
 - Access to the [OVHcloud Control Panel](/links/manager)
-- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](https://www.ovhcloud.com/en/public-cloud/)
+- A [Block Storage volume](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) created in your [Public Cloud project](/links/public-cloud/public-cloud)
 
 ## Instructions
 

--- a/pages/public_cloud/compute/volume-backup/guide.es-es.md
+++ b/pages/public_cloud/compute/volume-backup/guide.es-es.md
@@ -30,7 +30,7 @@ El volumen de snapshot y el volumen de backup le permiten:
 ## Requisitos
 
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
-- Un volumen de [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) creado en su proyecto de [Public Cloud.](https://www.ovhcloud.com/es-es/public-cloud/)
+- Un volumen de [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) creado en su proyecto de [Public Cloud.](/links/public-cloud/public-cloud)
 
 ## Procedimiento
 

--- a/pages/public_cloud/compute/volume-backup/guide.es-us.md
+++ b/pages/public_cloud/compute/volume-backup/guide.es-us.md
@@ -30,7 +30,7 @@ El volumen de snapshot y el volumen de backup le permiten:
 ## Requisitos
 
 - Haber iniciado sesión en el [área de cliente de OVHcloud](/links/manager).
-- Un volumen de [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) creado en su proyecto de [Public Cloud](https://www.ovhcloud.com/es/public-cloud/).
+- Un volumen de [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) creado en su proyecto de [Public Cloud](/links/public-cloud/public-cloud).
 
 ## Procedimiento
 

--- a/pages/public_cloud/compute/volume-backup/guide.fr-ca.md
+++ b/pages/public_cloud/compute/volume-backup/guide.fr-ca.md
@@ -26,7 +26,7 @@ Le Volume Snapshot et le Volume Backup vous permettent de :
 ## Prérequis
 
 - Être connecté à votre [espace client OVHcloud](/links/manager)
-- Un volume [Block storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) créé dans votre projet [Public Cloud](https://www.ovhcloud.com/fr-ca/public-cloud/)
+- Un volume [Block storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) créé dans votre projet [Public Cloud](/links/public-cloud/public-cloud)
 
 ## En pratique
 

--- a/pages/public_cloud/compute/volume-backup/guide.fr-fr.md
+++ b/pages/public_cloud/compute/volume-backup/guide.fr-fr.md
@@ -26,7 +26,7 @@ Le Volume Snapshot et le Volume Backup vous permettent de :
 ## Prérequis
 
 - Être connecté à votre [espace client OVHcloud](/links/manager)
-- Un volume [Block storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) créé dans votre projet [Public Cloud](https://www.ovhcloud.com/fr/public-cloud/)
+- Un volume [Block storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) créé dans votre projet [Public Cloud](/links/public-cloud/public-cloud)
 
 ## En pratique
 

--- a/pages/public_cloud/compute/volume-backup/guide.it-it.md
+++ b/pages/public_cloud/compute/volume-backup/guide.it-it.md
@@ -30,7 +30,7 @@ Il Volume Snapshot e il Volume Backup ti permettono di:
 ## Prerequisiti
 
 - Avere accesso allo [Spazio Cliente OVHcloud](/links/manager)
-- Un volume [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) creato nel tuo progetto [Public Cloud](https://www.ovhcloud.com/it/public-cloud/)
+- Un volume [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) creato nel tuo progetto [Public Cloud](/links/public-cloud/public-cloud)
 
 ## Procedura
 

--- a/pages/public_cloud/compute/volume-backup/guide.pl-pl.md
+++ b/pages/public_cloud/compute/volume-backup/guide.pl-pl.md
@@ -30,7 +30,7 @@ Wolumen Snapshot oraz Backup Wolumenu pozwalają na:
 ## Wymagania początkowe
 
 - Zalogowanie do [Panelu klienta OVHcloud](/links/manager)
-- Wolumen [Block storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) utworzony w Twoim projekcie [Public Cloud](https://www.ovhcloud.com/pl/public-cloud/)
+- Wolumen [Block storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) utworzony w Twoim projekcie [Public Cloud](/links/public-cloud/public-cloud)
 
 ## W praktyce
 

--- a/pages/public_cloud/compute/volume-backup/guide.pt-pt.md
+++ b/pages/public_cloud/compute/volume-backup/guide.pt-pt.md
@@ -30,7 +30,7 @@ O Volume Snapshot e o Volume Backup permitem-lhe:
 ## Requisitos
 
 - Estar ligado à [Área de Cliente OVHcloud](/links/manager).
-- Um volume [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) criado no seu projeto [Public Cloud](https://www.ovhcloud.com/pt/public-cloud/).
+- Um volume [Block Storage](/pages/public_cloud/compute/create_and_configure_an_additional_disk_on_an_instance) criado no seu projeto [Public Cloud](/links/public-cloud/public-cloud).
 
 ## Instruções
 


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their /links values.

Example: replace all https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB links with /links/manager.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.