### PR TITLE
Fix global links in Web cloud internet

### DIFF
--- a/pages/web_cloud/internet/internet_access/comment_resilier_mon_acces_xdsl/guide.fr-fr.md
+++ b/pages/web_cloud/internet/internet_access/comment_resilier_mon_acces_xdsl/guide.fr-fr.md
@@ -20,7 +20,7 @@ La résiliation sera effective à la prochaine facturation de votre accès à In
 ![espace client Telecom Accès Internet](/pages/assets/screens/control_panel/product-selection/telecom/tpl-telecom-01-fr-internet.png){.thumbnail}
 
 > [!primary]
-> La résiliation d'un [pack SIP Trunk](https://www.ovhtelecom.fr/telephonie/sip-trunk/) doit faire l'objet d'une [demande d'assistance](https://help.ovhcloud.com/csm?id=csm_get_help) via le centre d'aide OVHcloud afin que les équipes du support la mettent en place.
+> La résiliation d'un [pack SIP Trunk](/links/telecom/telephonie-sip-trunk) doit faire l'objet d'une [demande d'assistance](https://help.ovhcloud.com/csm?id=csm_get_help) via le centre d'aide OVHcloud afin que les équipes du support la mettent en place.
 >
 
 ## En pratique

--- a/pages/web_cloud/internet/internet_access/connectivity-api/guide.en-gb.md
+++ b/pages/web_cloud/internet/internet_access/connectivity-api/guide.en-gb.md
@@ -20,7 +20,7 @@ This guide is designed to help developers use our APIs to create their own appli
 
 OVHcloud offers various internet access packages that contain at least one internet access but also VoIP lines, emails and domain names.
 
-You can view offers [here](https://www.ovhcloud.com/fr/internet/).
+You can view offers [here](/links/telecom/offre-internet).
 
 Services can be managed using these API endpoints:
 


### PR DESCRIPTION
The purpose of these pull requests (Fix global links in KB ...) is to replace all links referenced in /links with their /links values.

Example: replace all https://www.ovh.com/auth/?action=gotomanager&from=https://www.ovh.co.uk/&ovhSubsidiary=GB links with /links/manager.

I've seen that a lot have been replaced by your work, but I've also found a lot, which is why I'm making pr by kb.

These are not a priority, however, I think they can help you make the documentation source more consistent and can prevent possible errors.

Sorry for closing my last pull requests, but I noticed a first error followed by a second one... so I fixed them and for me it's now OK.

FYI it is also possible to automate it using the methods I mentioned in the issue: https://github.com/ovh/docs/issues/8038

Be free to change the titles or to ask me any question.

Thank you for your reviews.