### PR TITLE
Update max number of nodes limit in a nutanix cluster

### DIFF
--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.de-de.md
@@ -22,7 +22,7 @@ Nutanix clusters on OVHcloud are scalable. You can now **add (scale out)** or **
 
 ## Technical Information
 
-- Your cluster must have between **3 and 15 nodes**
+- Your cluster must have between **3 and 32 nodes**
 - All new nodes must run the **same AOS version** as the existing cluster
 
 ## Instructions

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.de-de.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Hinzufügen oder Entfernen eines Nodes in einem Nutanix-Cluster (Scale In/Out) (EN)"
 excerpt: 'Scale your Nutanix on OVHcloud cluster by adding or removing nodes via the Control Panel or the API'
-updated: 2025-05-23
+updated: 2025-08-05
 ---
 
 ## Objective

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-ca.md
@@ -22,7 +22,7 @@ Nutanix clusters on OVHcloud are scalable. You can now **add (scale out)** or **
 
 ## Technical Information
 
-- Your cluster must have between **3 and 15 nodes**
+- Your cluster must have between **3 and 32 nodes**
 - All new nodes must run the **same AOS version** as the existing cluster
 
 ## Instructions

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Add or Remove Nodes in a Nutanix Cluster (Scale In/Out)"
 excerpt: 'Scale your Nutanix on OVHcloud cluster by adding or removing nodes via the Control Panel or the API'
-updated: 2025-05-23
+updated: 2025-08-05
 ---
 
 ## Objective

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-gb.md
@@ -22,7 +22,7 @@ Nutanix clusters on OVHcloud are scalable. You can now **add (scale out)** or **
 
 ## Technical Information
 
-- Your cluster must have between **3 and 15 nodes**
+- Your cluster must have between **3 and 32 nodes**
 - All new nodes must run the **same AOS version** as the existing cluster
 
 ## Instructions

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-gb.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Add or Remove Nodes in a Nutanix Cluster (Scale In/Out)"
 excerpt: 'Scale your Nutanix on OVHcloud cluster by adding or removing nodes via the Control Panel or the API'
-updated: 2025-05-23
+updated: 2025-08-05
 ---
 
 ## Objective

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-ie.md
@@ -22,7 +22,7 @@ Nutanix clusters on OVHcloud are scalable. You can now **add (scale out)** or **
 
 ## Technical Information
 
-- Your cluster must have between **3 and 15 nodes**
+- Your cluster must have between **3 and 32 nodes**
 - All new nodes must run the **same AOS version** as the existing cluster
 
 ## Instructions

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-ie.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Add or Remove Nodes in a Nutanix Cluster (Scale In/Out)"
 excerpt: 'Scale your Nutanix on OVHcloud cluster by adding or removing nodes via the Control Panel or the API'
-updated: 2025-05-23
+updated: 2025-08-05
 ---
 
 ## Objective

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-us.md
@@ -22,7 +22,7 @@ Nutanix clusters on OVHcloud are scalable. You can now **add (scale out)** or **
 
 ## Technical Information
 
-- Your cluster must have between **3 and 15 nodes**
+- Your cluster must have between **3 and 32 nodes**
 - All new nodes must run the **same AOS version** as the existing cluster
 
 ## Instructions

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Add or Remove Nodes in a Nutanix Cluster (Scale In/Out)"
 excerpt: 'Scale your Nutanix on OVHcloud cluster by adding or removing nodes via the Control Panel or the API'
-updated: 2025-05-23
+updated: 2025-08-05
 ---
 
 ## Objective

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.es-es.md
@@ -22,7 +22,7 @@ Nutanix clusters on OVHcloud are scalable. You can now **add (scale out)** or **
 
 ## Technical Information
 
-- Your cluster must have between **3 and 15 nodes**
+- Your cluster must have between **3 and 32 nodes**
 - All new nodes must run the **same AOS version** as the existing cluster
 
 ## Instructions

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.es-es.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Añadir o retirar un nodo en un cluster Nutanix (Scale In/Out) (EN)"
 excerpt: 'Scale your Nutanix on OVHcloud cluster by adding or removing nodes via the Control Panel or the API'
-updated: 2025-05-23
+updated: 2025-08-05
 ---
 
 ## Objective

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.es-us.md
@@ -22,7 +22,7 @@ Nutanix clusters on OVHcloud are scalable. You can now **add (scale out)** or **
 
 ## Technical Information
 
-- Your cluster must have between **3 and 15 nodes**
+- Your cluster must have between **3 and 32 nodes**
 - All new nodes must run the **same AOS version** as the existing cluster
 
 ## Instructions

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.es-us.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Añadir o retirar un nodo en un cluster Nutanix (Scale In/Out) (EN)"
 excerpt: 'Scale your Nutanix on OVHcloud cluster by adding or removing nodes via the Control Panel or the API'
-updated: 2025-05-23
+updated: 2025-08-05
 ---
 
 ## Objective

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Ajouter ou retirer un nœud dans un cluster Nutanix (Scale In/Out)"
 excerpt: "Ajustez dynamiquement votre cluster Nutanix on OVHcloud en ajoutant ou retirant des nœuds via l'espace client ou l'API OVHcloud"
-updated: 2025-05-23
+updated: 2025-08-05
 ---
 
 ## Objectif

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.fr-ca.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.fr-ca.md
@@ -21,7 +21,7 @@ Les clusters Nutanix sur OVHcloud sont évolutifs. Vous pouvez désormais **ajou
 
 ## Informations techniques
 
-- Votre cluster doit comporter entre **3 et 15 nœuds**
+- Votre cluster doit comporter entre **3 et 32 nœuds**
 - Tous les nouveaux nœuds doivent utiliser la **même version d’AOS** que le cluster existant
 
 ## En pratique

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Ajouter ou retirer un nœud dans un cluster Nutanix (Scale In/Out)"
 excerpt: "Ajustez dynamiquement votre cluster Nutanix on OVHcloud en ajoutant ou retirant des nœuds via l'espace client ou l'API OVHcloud"
-updated: 2025-05-23
+updated: 2025-08-05
 ---
 
 ## Objectif

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.fr-fr.md
@@ -21,7 +21,7 @@ Les clusters Nutanix sur OVHcloud sont évolutifs. Vous pouvez désormais **ajou
 
 ## Informations techniques
 
-- Votre cluster doit comporter entre **3 et 15 nœuds**
+- Votre cluster doit comporter entre **3 et 32 nœuds**
 - Tous les nouveaux nœuds doivent utiliser la **même version d’AOS** que le cluster existant
 
 ## En pratique

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.it-it.md
@@ -22,7 +22,7 @@ Nutanix clusters on OVHcloud are scalable. You can now **add (scale out)** or **
 
 ## Technical Information
 
-- Your cluster must have between **3 and 15 nodes**
+- Your cluster must have between **3 and 32 nodes**
 - All new nodes must run the **same AOS version** as the existing cluster
 
 ## Instructions

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.it-it.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Aggiungere o rimuovere un nodo in un cluster Nutanix (Scale In/Out) (EN)"
 excerpt: 'Scale your Nutanix on OVHcloud cluster by adding or removing nodes via the Control Panel or the API'
-updated: 2025-05-23
+updated: 2025-08-05
 ---
 
 ## Objective

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.pl-pl.md
@@ -22,7 +22,7 @@ Nutanix clusters on OVHcloud are scalable. You can now **add (scale out)** or **
 
 ## Technical Information
 
-- Your cluster must have between **3 and 15 nodes**
+- Your cluster must have between **3 and 32 nodes**
 - All new nodes must run the **same AOS version** as the existing cluster
 
 ## Instructions

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.pl-pl.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Dodaj lub usuń węzeł w klastrze Nutanix (Scale In/Out) (EN)"
 excerpt: 'Scale your Nutanix on OVHcloud cluster by adding or removing nodes via the Control Panel or the API'
-updated: 2025-05-23
+updated: 2025-08-05
 ---
 
 ## Objective

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.pt-pt.md
@@ -22,7 +22,7 @@ Nutanix clusters on OVHcloud are scalable. You can now **add (scale out)** or **
 
 ## Technical Information
 
-- Your cluster must have between **3 and 15 nodes**
+- Your cluster must have between **3 and 32 nodes**
 - All new nodes must run the **same AOS version** as the existing cluster
 
 ## Instructions

--- a/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.pt-pt.md
+++ b/pages/hosted_private_cloud/nutanix_on_ovhcloud/33-add-node/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Adicionar ou retirar um nó num cluster Nutanix (Scale In/Out) (EN)"
 excerpt: 'Scale your Nutanix on OVHcloud cluster by adding or removing nodes via the Control Panel or the API'
-updated: 2025-05-23
+updated: 2025-08-05
 ---
 
 ## Objective


### PR DESCRIPTION
## What type of Pull Request is this?

- Update of existing guide(s)

## Description

It is now possible to run Nutanix on OVHcloud cluster up-to 32 nodes

## Mandatory information


- This Pull Request can be merged as soon as possible.
- This Pull Request content should be replicated for the US OVHcloud documentation : YES