### PR TITLE
fix: public-cloud-terraform: remove provider/alias informations from examples

### DIFF
--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.de-de.md
@@ -78,7 +78,7 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
@@ -90,11 +90,9 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/" # Authentication URL
   domain_name = "default" # Domain name - Always at 'default' for OVHcloud
-  alias       = "ovh" # An alias
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<your_access_key>"
   application_secret = "<your_application_secret>"
@@ -145,15 +143,13 @@ For example purposes, we will create a simple instance on **Debian 10** with the
 ```python
 # Creating an SSH key pair resource
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh # Provider name declared in provider.tf
   name       = "test_keypair" # Name of the SSH key to use for creation
   public_key = file("~/.ssh/id_rsa.pub") # Path to your previously generated SSH key
 }
- 
+
 # Creating the instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance" # Instance name
-  provider    = openstack.ovh  # Provider name
   image_name  = "Debian 10" # Image name
   flavor_name = "d2-2" # Instance type name
   # Name of openstack_compute_keypair_v2 resource named keypair_test
@@ -162,7 +158,7 @@ resource "openstack_compute_instance_v2" "test_terraform_instance" {
     name      = "Ext-Net" # Adds the network component to reach your instance
   }
   lifecycle {
-    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance 
+    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance
     # To avoid terraform to have some issue with that, the following ignore_changes is required.
     ignore_changes = [
       image_name
@@ -281,22 +277,20 @@ To do this, we will create a file named `multiple_instance.tf`. In it, we first 
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Creating an SSH key pair
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh # Specify provider name
    name = "test_keypair_all" # Name of the SSH key
    public_key = file("~/.ssh/id_rsa.pub") # Your SSH key path
    region = element(var.region, count.index)
  }
-  
+
  # Create a resource that is an OpenStack instance in each region
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Number of times the resource will be created
    # defined by the length of the list named region
    count = length(var.region)
-   provider = openstack.ovh # Provider name
    name = "terraform_instances" # Instance name
    flavor_name = "d2-2" # Instance flavor
    image_name = "Debian 10" # Image name
@@ -334,9 +328,8 @@ In this example we will attach a new storage volume to our first instance. Open 
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume" # Volume name
   size = 10 # Volume size in GB
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Attach the volume created previously to the instance
 resource "openstack_compute_volume_attach_v2" "attached" {
   # ID of openstack_compute_instance_v2 resource named test_terraform_instance
@@ -381,18 +374,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Creating a private network
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network" # Network name
     regions      = [var.region]
-    provider     = ovh.ovh # Provider name
     vlan_id      = 168 # VLAN ID for vRack
     depends_on   = [ovh_vrack_cloudproject.vcp] # Depends on the vRack's association with the cloud project
  }
-  
+
  # Creating a subnet using the previously created private network
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +395,11 @@ variable "region" {
     network      = "192.168.168.0/24" # Subnet IP address location
     dhcp         = true # Enables DHCP
     region       = var.region
-    provider     = ovh.ovh # Provider name
     no_gateway   = true # No default gateway
  }
-  
+
  # Creating an instance with 2 network interfaces
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh # Provider name
    name         = "proxy_instance" # Instance name
    image_name   = "Debian 10" # Image name
    flavor_name  = "d2-2" # Flavor name
@@ -465,12 +455,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend" # Network name
-  regions       = [var.myregion] 
-  provider      = ovh.ovh # Provider name
+  regions       = [var.myregion]
   vlan_id       = 42 # vRack vlan ID
   depends_on    = [ovh_vrack_cloudproject.vcp] # Depends on vRack being associated with the cloud project
 }
- 
+
 # Creating a private subnet
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # ID for the ovh_cloud_network_private resource named private_network
@@ -481,27 +470,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2" # First IP of the subnet
   end           = "192.168.42.200" # Last IP of the subnet
   dhcp          = false # Disabling DHCP
-  provider      = ovh.ovh # Provider name
   no_gateway    = true # No default gateway
 }
- 
+
 # Search for the latest Archlinux image
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux" # Image name
   most_recent   = true # Limits search to the most recent
-  provider      = openstack.ovh # Provider name
 }
- 
+
 # List of possible private IP addresses for front-ends
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Create 2 instances with 2 network interfaces
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip) # Number of instances to create
-  provider        = openstack.ovh # Provider name
   name            = "front" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name
@@ -518,17 +504,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Depends on private network
 }
- 
+
 # Create an attachable storage device for the backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Name of storage device
   size     = 10 # Size
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Create an instance with a network interface and storage device
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh # Provider name
   name            = "back" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-asia.md
@@ -78,7 +78,7 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
@@ -90,11 +90,9 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/" # Authentication URL
   domain_name = "default" # Domain name - Always at 'default' for OVHcloud
-  alias       = "ovh" # An alias
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<your_access_key>"
   application_secret = "<your_application_secret>"
@@ -145,15 +143,13 @@ For example purposes, we will create a simple instance on **Debian 10** with the
 ```python
 # Creating an SSH key pair resource
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh # Provider name declared in provider.tf
   name       = "test_keypair" # Name of the SSH key to use for creation
   public_key = file("~/.ssh/id_rsa.pub") # Path to your previously generated SSH key
 }
- 
+
 # Creating the instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance" # Instance name
-  provider    = openstack.ovh  # Provider name
   image_name  = "Debian 10" # Image name
   flavor_name = "d2-2" # Instance type name
   # Name of openstack_compute_keypair_v2 resource named keypair_test
@@ -162,7 +158,7 @@ resource "openstack_compute_instance_v2" "test_terraform_instance" {
     name      = "Ext-Net" # Adds the network component to reach your instance
   }
   lifecycle {
-    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance 
+    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance
     # To avoid terraform to have some issue with that, the following ignore_changes is required.
     ignore_changes = [
       image_name
@@ -281,22 +277,20 @@ To do this, we will create a file named `multiple_instance.tf`. In it, we first 
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Creating an SSH key pair
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh # Specify provider name
    name = "test_keypair_all" # Name of the SSH key
    public_key = file("~/.ssh/id_rsa.pub") # Your SSH key path
    region = element(var.region, count.index)
  }
-  
+
  # Create a resource that is an OpenStack instance in each region
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Number of times the resource will be created
    # defined by the length of the list named region
    count = length(var.region)
-   provider = openstack.ovh # Provider name
    name = "terraform_instances" # Instance name
    flavor_name = "d2-2" # Instance flavor
    image_name = "Debian 10" # Image name
@@ -334,9 +328,8 @@ In this example we will attach a new storage volume to our first instance. Open 
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume" # Volume name
   size = 10 # Volume size in GB
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Attach the volume created previously to the instance
 resource "openstack_compute_volume_attach_v2" "attached" {
   # ID of openstack_compute_instance_v2 resource named test_terraform_instance
@@ -381,18 +374,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Creating a private network
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network" # Network name
     regions      = [var.region]
-    provider     = ovh.ovh # Provider name
     vlan_id      = 168 # VLAN ID for vRack
     depends_on   = [ovh_vrack_cloudproject.vcp] # Depends on the vRack's association with the cloud project
  }
-  
+
  # Creating a subnet using the previously created private network
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +395,11 @@ variable "region" {
     network      = "192.168.168.0/24" # Subnet IP address location
     dhcp         = true # Enables DHCP
     region       = var.region
-    provider     = ovh.ovh # Provider name
     no_gateway   = true # No default gateway
  }
-  
+
  # Creating an instance with 2 network interfaces
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh # Provider name
    name         = "proxy_instance" # Instance name
    image_name   = "Debian 10" # Image name
    flavor_name  = "d2-2" # Flavor name
@@ -465,12 +455,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend" # Network name
-  regions       = [var.myregion] 
-  provider      = ovh.ovh # Provider name
+  regions       = [var.myregion]
   vlan_id       = 42 # vRack vlan ID
   depends_on    = [ovh_vrack_cloudproject.vcp] # Depends on vRack being associated with the cloud project
 }
- 
+
 # Creating a private subnet
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # ID for the ovh_cloud_network_private resource named private_network
@@ -481,27 +470,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2" # First IP of the subnet
   end           = "192.168.42.200" # Last IP of the subnet
   dhcp          = false # Disabling DHCP
-  provider      = ovh.ovh # Provider name
   no_gateway    = true # No default gateway
 }
- 
+
 # Search for the latest Archlinux image
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux" # Image name
   most_recent   = true # Limits search to the most recent
-  provider      = openstack.ovh # Provider name
 }
- 
+
 # List of possible private IP addresses for front-ends
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Create 2 instances with 2 network interfaces
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip) # Number of instances to create
-  provider        = openstack.ovh # Provider name
   name            = "front" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name
@@ -518,17 +504,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Depends on private network
 }
- 
+
 # Create an attachable storage device for the backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Name of storage device
   size     = 10 # Size
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Create an instance with a network interface and storage device
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh # Provider name
   name            = "back" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-au.md
@@ -78,7 +78,7 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
@@ -90,11 +90,9 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/" # Authentication URL
   domain_name = "default" # Domain name - Always at 'default' for OVHcloud
-  alias       = "ovh" # An alias
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<your_access_key>"
   application_secret = "<your_application_secret>"
@@ -145,15 +143,13 @@ For example purposes, we will create a simple instance on **Debian 10** with the
 ```python
 # Creating an SSH key pair resource
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh # Provider name declared in provider.tf
   name       = "test_keypair" # Name of the SSH key to use for creation
   public_key = file("~/.ssh/id_rsa.pub") # Path to your previously generated SSH key
 }
- 
+
 # Creating the instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance" # Instance name
-  provider    = openstack.ovh  # Provider name
   image_name  = "Debian 10" # Image name
   flavor_name = "d2-2" # Instance type name
   # Name of openstack_compute_keypair_v2 resource named keypair_test
@@ -162,7 +158,7 @@ resource "openstack_compute_instance_v2" "test_terraform_instance" {
     name      = "Ext-Net" # Adds the network component to reach your instance
   }
   lifecycle {
-    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance 
+    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance
     # To avoid terraform to have some issue with that, the following ignore_changes is required.
     ignore_changes = [
       image_name
@@ -281,22 +277,20 @@ To do this, we will create a file named `multiple_instance.tf`. In it, we first 
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Creating an SSH key pair
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh # Specify provider name
    name = "test_keypair_all" # Name of the SSH key
    public_key = file("~/.ssh/id_rsa.pub") # Your SSH key path
    region = element(var.region, count.index)
  }
-  
+
  # Create a resource that is an OpenStack instance in each region
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Number of times the resource will be created
    # defined by the length of the list named region
    count = length(var.region)
-   provider = openstack.ovh # Provider name
    name = "terraform_instances" # Instance name
    flavor_name = "d2-2" # Instance flavor
    image_name = "Debian 10" # Image name
@@ -334,9 +328,8 @@ In this example we will attach a new storage volume to our first instance. Open 
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume" # Volume name
   size = 10 # Volume size in GB
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Attach the volume created previously to the instance
 resource "openstack_compute_volume_attach_v2" "attached" {
   # ID of openstack_compute_instance_v2 resource named test_terraform_instance
@@ -381,18 +374,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Creating a private network
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network" # Network name
     regions      = [var.region]
-    provider     = ovh.ovh # Provider name
     vlan_id      = 168 # VLAN ID for vRack
     depends_on   = [ovh_vrack_cloudproject.vcp] # Depends on the vRack's association with the cloud project
  }
-  
+
  # Creating a subnet using the previously created private network
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +395,11 @@ variable "region" {
     network      = "192.168.168.0/24" # Subnet IP address location
     dhcp         = true # Enables DHCP
     region       = var.region
-    provider     = ovh.ovh # Provider name
     no_gateway   = true # No default gateway
  }
-  
+
  # Creating an instance with 2 network interfaces
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh # Provider name
    name         = "proxy_instance" # Instance name
    image_name   = "Debian 10" # Image name
    flavor_name  = "d2-2" # Flavor name
@@ -465,12 +455,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend" # Network name
-  regions       = [var.myregion] 
-  provider      = ovh.ovh # Provider name
+  regions       = [var.myregion]
   vlan_id       = 42 # vRack vlan ID
   depends_on    = [ovh_vrack_cloudproject.vcp] # Depends on vRack being associated with the cloud project
 }
- 
+
 # Creating a private subnet
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # ID for the ovh_cloud_network_private resource named private_network
@@ -481,27 +470,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2" # First IP of the subnet
   end           = "192.168.42.200" # Last IP of the subnet
   dhcp          = false # Disabling DHCP
-  provider      = ovh.ovh # Provider name
   no_gateway    = true # No default gateway
 }
- 
+
 # Search for the latest Archlinux image
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux" # Image name
   most_recent   = true # Limits search to the most recent
-  provider      = openstack.ovh # Provider name
 }
- 
+
 # List of possible private IP addresses for front-ends
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Create 2 instances with 2 network interfaces
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip) # Number of instances to create
-  provider        = openstack.ovh # Provider name
   name            = "front" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name
@@ -518,17 +504,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Depends on private network
 }
- 
+
 # Create an attachable storage device for the backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Name of storage device
   size     = 10 # Size
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Create an instance with a network interface and storage device
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh # Provider name
   name            = "back" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-ca.md
@@ -78,7 +78,7 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
@@ -90,11 +90,9 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/" # Authentication URL
   domain_name = "default" # Domain name - Always at 'default' for OVHcloud
-  alias       = "ovh" # An alias
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<your_access_key>"
   application_secret = "<your_application_secret>"
@@ -145,15 +143,13 @@ For example purposes, we will create a simple instance on **Debian 10** with the
 ```python
 # Creating an SSH key pair resource
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh # Provider name declared in provider.tf
   name       = "test_keypair" # Name of the SSH key to use for creation
   public_key = file("~/.ssh/id_rsa.pub") # Path to your previously generated SSH key
 }
- 
+
 # Creating the instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance" # Instance name
-  provider    = openstack.ovh  # Provider name
   image_name  = "Debian 10" # Image name
   flavor_name = "d2-2" # Instance type name
   # Name of openstack_compute_keypair_v2 resource named keypair_test
@@ -162,7 +158,7 @@ resource "openstack_compute_instance_v2" "test_terraform_instance" {
     name      = "Ext-Net" # Adds the network component to reach your instance
   }
   lifecycle {
-    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance 
+    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance
     # To avoid terraform to have some issue with that, the following ignore_changes is required.
     ignore_changes = [
       image_name
@@ -281,22 +277,20 @@ To do this, we will create a file named `multiple_instance.tf`. In it, we first 
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Creating an SSH key pair
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh # Specify provider name
    name = "test_keypair_all" # Name of the SSH key
    public_key = file("~/.ssh/id_rsa.pub") # Your SSH key path
    region = element(var.region, count.index)
  }
-  
+
  # Create a resource that is an OpenStack instance in each region
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Number of times the resource will be created
    # defined by the length of the list named region
    count = length(var.region)
-   provider = openstack.ovh # Provider name
    name = "terraform_instances" # Instance name
    flavor_name = "d2-2" # Instance flavor
    image_name = "Debian 10" # Image name
@@ -334,9 +328,8 @@ In this example we will attach a new storage volume to our first instance. Open 
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume" # Volume name
   size = 10 # Volume size in GB
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Attach the volume created previously to the instance
 resource "openstack_compute_volume_attach_v2" "attached" {
   # ID of openstack_compute_instance_v2 resource named test_terraform_instance
@@ -381,18 +374,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Creating a private network
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network" # Network name
     regions      = [var.region]
-    provider     = ovh.ovh # Provider name
     vlan_id      = 168 # VLAN ID for vRack
     depends_on   = [ovh_vrack_cloudproject.vcp] # Depends on the vRack's association with the cloud project
  }
-  
+
  # Creating a subnet using the previously created private network
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +395,11 @@ variable "region" {
     network      = "192.168.168.0/24" # Subnet IP address location
     dhcp         = true # Enables DHCP
     region       = var.region
-    provider     = ovh.ovh # Provider name
     no_gateway   = true # No default gateway
  }
-  
+
  # Creating an instance with 2 network interfaces
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh # Provider name
    name         = "proxy_instance" # Instance name
    image_name   = "Debian 10" # Image name
    flavor_name  = "d2-2" # Flavor name
@@ -465,12 +455,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend" # Network name
-  regions       = [var.myregion] 
-  provider      = ovh.ovh # Provider name
+  regions       = [var.myregion]
   vlan_id       = 42 # vRack vlan ID
   depends_on    = [ovh_vrack_cloudproject.vcp] # Depends on vRack being associated with the cloud project
 }
- 
+
 # Creating a private subnet
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # ID for the ovh_cloud_network_private resource named private_network
@@ -481,27 +470,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2" # First IP of the subnet
   end           = "192.168.42.200" # Last IP of the subnet
   dhcp          = false # Disabling DHCP
-  provider      = ovh.ovh # Provider name
   no_gateway    = true # No default gateway
 }
- 
+
 # Search for the latest Archlinux image
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux" # Image name
   most_recent   = true # Limits search to the most recent
-  provider      = openstack.ovh # Provider name
 }
- 
+
 # List of possible private IP addresses for front-ends
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Create 2 instances with 2 network interfaces
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip) # Number of instances to create
-  provider        = openstack.ovh # Provider name
   name            = "front" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name
@@ -518,17 +504,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Depends on private network
 }
- 
+
 # Create an attachable storage device for the backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Name of storage device
   size     = 10 # Size
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Create an instance with a network interface and storage device
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh # Provider name
   name            = "back" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-gb.md
@@ -78,7 +78,7 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
@@ -90,11 +90,9 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/" # Authentication URL
   domain_name = "default" # Domain name - Always at 'default' for OVHcloud
-  alias       = "ovh" # An alias
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<your_access_key>"
   application_secret = "<your_application_secret>"
@@ -145,15 +143,13 @@ For example purposes, we will create a simple instance on **Debian 10** with the
 ```python
 # Creating an SSH key pair resource
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh # Provider name declared in provider.tf
   name       = "test_keypair" # Name of the SSH key to use for creation
   public_key = file("~/.ssh/id_rsa.pub") # Path to your previously generated SSH key
 }
- 
+
 # Creating the instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance" # Instance name
-  provider    = openstack.ovh  # Provider name
   image_name  = "Debian 10" # Image name
   flavor_name = "d2-2" # Instance type name
   # Name of openstack_compute_keypair_v2 resource named keypair_test
@@ -162,7 +158,7 @@ resource "openstack_compute_instance_v2" "test_terraform_instance" {
     name      = "Ext-Net" # Adds the network component to reach your instance
   }
   lifecycle {
-    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance 
+    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance
     # To avoid terraform to have some issue with that, the following ignore_changes is required.
     ignore_changes = [
       image_name
@@ -281,22 +277,20 @@ To do this, we will create a file named `multiple_instance.tf`. In it, we first 
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Creating an SSH key pair
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh # Specify provider name
    name = "test_keypair_all" # Name of the SSH key
    public_key = file("~/.ssh/id_rsa.pub") # Your SSH key path
    region = element(var.region, count.index)
  }
-  
+
  # Create a resource that is an OpenStack instance in each region
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Number of times the resource will be created
    # defined by the length of the list named region
    count = length(var.region)
-   provider = openstack.ovh # Provider name
    name = "terraform_instances" # Instance name
    flavor_name = "d2-2" # Instance flavor
    image_name = "Debian 10" # Image name
@@ -334,9 +328,8 @@ In this example we will attach a new storage volume to our first instance. Open 
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume" # Volume name
   size = 10 # Volume size in GB
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Attach the volume created previously to the instance
 resource "openstack_compute_volume_attach_v2" "attached" {
   # ID of openstack_compute_instance_v2 resource named test_terraform_instance
@@ -381,18 +374,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Creating a private network
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network" # Network name
     regions      = [var.region]
-    provider     = ovh.ovh # Provider name
     vlan_id      = 168 # VLAN ID for vRack
     depends_on   = [ovh_vrack_cloudproject.vcp] # Depends on the vRack's association with the cloud project
  }
-  
+
  # Creating a subnet using the previously created private network
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +395,11 @@ variable "region" {
     network      = "192.168.168.0/24" # Subnet IP address location
     dhcp         = true # Enables DHCP
     region       = var.region
-    provider     = ovh.ovh # Provider name
     no_gateway   = true # No default gateway
  }
-  
+
  # Creating an instance with 2 network interfaces
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh # Provider name
    name         = "proxy_instance" # Instance name
    image_name   = "Debian 10" # Image name
    flavor_name  = "d2-2" # Flavor name
@@ -465,12 +455,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend" # Network name
-  regions       = [var.myregion] 
-  provider      = ovh.ovh # Provider name
+  regions       = [var.myregion]
   vlan_id       = 42 # vRack vlan ID
   depends_on    = [ovh_vrack_cloudproject.vcp] # Depends on vRack being associated with the cloud project
 }
- 
+
 # Creating a private subnet
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # ID for the ovh_cloud_network_private resource named private_network
@@ -481,27 +470,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2" # First IP of the subnet
   end           = "192.168.42.200" # Last IP of the subnet
   dhcp          = false # Disabling DHCP
-  provider      = ovh.ovh # Provider name
   no_gateway    = true # No default gateway
 }
- 
+
 # Search for the latest Archlinux image
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux" # Image name
   most_recent   = true # Limits search to the most recent
-  provider      = openstack.ovh # Provider name
 }
- 
+
 # List of possible private IP addresses for front-ends
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Create 2 instances with 2 network interfaces
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip) # Number of instances to create
-  provider        = openstack.ovh # Provider name
   name            = "front" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name
@@ -518,17 +504,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Depends on private network
 }
- 
+
 # Create an attachable storage device for the backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Name of storage device
   size     = 10 # Size
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Create an instance with a network interface and storage device
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh # Provider name
   name            = "back" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-ie.md
@@ -78,7 +78,7 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
@@ -90,11 +90,9 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/" # Authentication URL
   domain_name = "default" # Domain name - Always at 'default' for OVHcloud
-  alias       = "ovh" # An alias
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<your_access_key>"
   application_secret = "<your_application_secret>"
@@ -145,15 +143,13 @@ For example purposes, we will create a simple instance on **Debian 10** with the
 ```python
 # Creating an SSH key pair resource
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh # Provider name declared in provider.tf
   name       = "test_keypair" # Name of the SSH key to use for creation
   public_key = file("~/.ssh/id_rsa.pub") # Path to your previously generated SSH key
 }
- 
+
 # Creating the instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance" # Instance name
-  provider    = openstack.ovh  # Provider name
   image_name  = "Debian 10" # Image name
   flavor_name = "d2-2" # Instance type name
   # Name of openstack_compute_keypair_v2 resource named keypair_test
@@ -162,7 +158,7 @@ resource "openstack_compute_instance_v2" "test_terraform_instance" {
     name      = "Ext-Net" # Adds the network component to reach your instance
   }
   lifecycle {
-    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance 
+    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance
     # To avoid terraform to have some issue with that, the following ignore_changes is required.
     ignore_changes = [
       image_name
@@ -281,22 +277,20 @@ To do this, we will create a file named `multiple_instance.tf`. In it, we first 
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Creating an SSH key pair
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh # Specify provider name
    name = "test_keypair_all" # Name of the SSH key
    public_key = file("~/.ssh/id_rsa.pub") # Your SSH key path
    region = element(var.region, count.index)
  }
-  
+
  # Create a resource that is an OpenStack instance in each region
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Number of times the resource will be created
    # defined by the length of the list named region
    count = length(var.region)
-   provider = openstack.ovh # Provider name
    name = "terraform_instances" # Instance name
    flavor_name = "d2-2" # Instance flavor
    image_name = "Debian 10" # Image name
@@ -334,9 +328,8 @@ In this example we will attach a new storage volume to our first instance. Open 
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume" # Volume name
   size = 10 # Volume size in GB
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Attach the volume created previously to the instance
 resource "openstack_compute_volume_attach_v2" "attached" {
   # ID of openstack_compute_instance_v2 resource named test_terraform_instance
@@ -381,18 +374,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Creating a private network
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network" # Network name
     regions      = [var.region]
-    provider     = ovh.ovh # Provider name
     vlan_id      = 168 # VLAN ID for vRack
     depends_on   = [ovh_vrack_cloudproject.vcp] # Depends on the vRack's association with the cloud project
  }
-  
+
  # Creating a subnet using the previously created private network
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +395,11 @@ variable "region" {
     network      = "192.168.168.0/24" # Subnet IP address location
     dhcp         = true # Enables DHCP
     region       = var.region
-    provider     = ovh.ovh # Provider name
     no_gateway   = true # No default gateway
  }
-  
+
  # Creating an instance with 2 network interfaces
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh # Provider name
    name         = "proxy_instance" # Instance name
    image_name   = "Debian 10" # Image name
    flavor_name  = "d2-2" # Flavor name
@@ -465,12 +455,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend" # Network name
-  regions       = [var.myregion] 
-  provider      = ovh.ovh # Provider name
+  regions       = [var.myregion]
   vlan_id       = 42 # vRack vlan ID
   depends_on    = [ovh_vrack_cloudproject.vcp] # Depends on vRack being associated with the cloud project
 }
- 
+
 # Creating a private subnet
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # ID for the ovh_cloud_network_private resource named private_network
@@ -481,27 +470,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2" # First IP of the subnet
   end           = "192.168.42.200" # Last IP of the subnet
   dhcp          = false # Disabling DHCP
-  provider      = ovh.ovh # Provider name
   no_gateway    = true # No default gateway
 }
- 
+
 # Search for the latest Archlinux image
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux" # Image name
   most_recent   = true # Limits search to the most recent
-  provider      = openstack.ovh # Provider name
 }
- 
+
 # List of possible private IP addresses for front-ends
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Create 2 instances with 2 network interfaces
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip) # Number of instances to create
-  provider        = openstack.ovh # Provider name
   name            = "front" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name
@@ -518,17 +504,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Depends on private network
 }
- 
+
 # Create an attachable storage device for the backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Name of storage device
   size     = 10 # Size
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Create an instance with a network interface and storage device
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh # Provider name
   name            = "back" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-sg.md
@@ -78,7 +78,7 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
@@ -90,11 +90,9 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/" # Authentication URL
   domain_name = "default" # Domain name - Always at 'default' for OVHcloud
-  alias       = "ovh" # An alias
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<your_access_key>"
   application_secret = "<your_application_secret>"
@@ -145,15 +143,13 @@ For example purposes, we will create a simple instance on **Debian 10** with the
 ```python
 # Creating an SSH key pair resource
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh # Provider name declared in provider.tf
   name       = "test_keypair" # Name of the SSH key to use for creation
   public_key = file("~/.ssh/id_rsa.pub") # Path to your previously generated SSH key
 }
- 
+
 # Creating the instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance" # Instance name
-  provider    = openstack.ovh  # Provider name
   image_name  = "Debian 10" # Image name
   flavor_name = "d2-2" # Instance type name
   # Name of openstack_compute_keypair_v2 resource named keypair_test
@@ -162,7 +158,7 @@ resource "openstack_compute_instance_v2" "test_terraform_instance" {
     name      = "Ext-Net" # Adds the network component to reach your instance
   }
   lifecycle {
-    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance 
+    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance
     # To avoid terraform to have some issue with that, the following ignore_changes is required.
     ignore_changes = [
       image_name
@@ -281,22 +277,20 @@ To do this, we will create a file named `multiple_instance.tf`. In it, we first 
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Creating an SSH key pair
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh # Specify provider name
    name = "test_keypair_all" # Name of the SSH key
    public_key = file("~/.ssh/id_rsa.pub") # Your SSH key path
    region = element(var.region, count.index)
  }
-  
+
  # Create a resource that is an OpenStack instance in each region
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Number of times the resource will be created
    # defined by the length of the list named region
    count = length(var.region)
-   provider = openstack.ovh # Provider name
    name = "terraform_instances" # Instance name
    flavor_name = "d2-2" # Instance flavor
    image_name = "Debian 10" # Image name
@@ -334,9 +328,8 @@ In this example we will attach a new storage volume to our first instance. Open 
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume" # Volume name
   size = 10 # Volume size in GB
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Attach the volume created previously to the instance
 resource "openstack_compute_volume_attach_v2" "attached" {
   # ID of openstack_compute_instance_v2 resource named test_terraform_instance
@@ -381,18 +374,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Creating a private network
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network" # Network name
     regions      = [var.region]
-    provider     = ovh.ovh # Provider name
     vlan_id      = 168 # VLAN ID for vRack
     depends_on   = [ovh_vrack_cloudproject.vcp] # Depends on the vRack's association with the cloud project
  }
-  
+
  # Creating a subnet using the previously created private network
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +395,11 @@ variable "region" {
     network      = "192.168.168.0/24" # Subnet IP address location
     dhcp         = true # Enables DHCP
     region       = var.region
-    provider     = ovh.ovh # Provider name
     no_gateway   = true # No default gateway
  }
-  
+
  # Creating an instance with 2 network interfaces
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh # Provider name
    name         = "proxy_instance" # Instance name
    image_name   = "Debian 10" # Image name
    flavor_name  = "d2-2" # Flavor name
@@ -465,12 +455,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend" # Network name
-  regions       = [var.myregion] 
-  provider      = ovh.ovh # Provider name
+  regions       = [var.myregion]
   vlan_id       = 42 # vRack vlan ID
   depends_on    = [ovh_vrack_cloudproject.vcp] # Depends on vRack being associated with the cloud project
 }
- 
+
 # Creating a private subnet
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # ID for the ovh_cloud_network_private resource named private_network
@@ -481,27 +470,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2" # First IP of the subnet
   end           = "192.168.42.200" # Last IP of the subnet
   dhcp          = false # Disabling DHCP
-  provider      = ovh.ovh # Provider name
   no_gateway    = true # No default gateway
 }
- 
+
 # Search for the latest Archlinux image
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux" # Image name
   most_recent   = true # Limits search to the most recent
-  provider      = openstack.ovh # Provider name
 }
- 
+
 # List of possible private IP addresses for front-ends
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Create 2 instances with 2 network interfaces
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip) # Number of instances to create
-  provider        = openstack.ovh # Provider name
   name            = "front" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name
@@ -518,17 +504,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Depends on private network
 }
- 
+
 # Create an attachable storage device for the backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Name of storage device
   size     = 10 # Size
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Create an instance with a network interface and storage device
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh # Provider name
   name            = "back" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.en-us.md
@@ -78,7 +78,7 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
@@ -90,11 +90,9 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/" # Authentication URL
   domain_name = "default" # Domain name - Always at 'default' for OVHcloud
-  alias       = "ovh" # An alias
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<your_access_key>"
   application_secret = "<your_application_secret>"
@@ -145,15 +143,13 @@ For example purposes, we will create a simple instance on **Debian 10** with the
 ```python
 # Creating an SSH key pair resource
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh # Provider name declared in provider.tf
   name       = "test_keypair" # Name of the SSH key to use for creation
   public_key = file("~/.ssh/id_rsa.pub") # Path to your previously generated SSH key
 }
- 
+
 # Creating the instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance" # Instance name
-  provider    = openstack.ovh  # Provider name
   image_name  = "Debian 10" # Image name
   flavor_name = "d2-2" # Instance type name
   # Name of openstack_compute_keypair_v2 resource named keypair_test
@@ -162,7 +158,7 @@ resource "openstack_compute_instance_v2" "test_terraform_instance" {
     name      = "Ext-Net" # Adds the network component to reach your instance
   }
   lifecycle {
-    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance 
+    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance
     # To avoid terraform to have some issue with that, the following ignore_changes is required.
     ignore_changes = [
       image_name
@@ -281,22 +277,20 @@ To do this, we will create a file named `multiple_instance.tf`. In it, we first 
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Creating an SSH key pair
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh # Specify provider name
    name = "test_keypair_all" # Name of the SSH key
    public_key = file("~/.ssh/id_rsa.pub") # Your SSH key path
    region = element(var.region, count.index)
  }
-  
+
  # Create a resource that is an OpenStack instance in each region
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Number of times the resource will be created
    # defined by the length of the list named region
    count = length(var.region)
-   provider = openstack.ovh # Provider name
    name = "terraform_instances" # Instance name
    flavor_name = "d2-2" # Instance flavor
    image_name = "Debian 10" # Image name
@@ -334,9 +328,8 @@ In this example we will attach a new storage volume to our first instance. Open 
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume" # Volume name
   size = 10 # Volume size in GB
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Attach the volume created previously to the instance
 resource "openstack_compute_volume_attach_v2" "attached" {
   # ID of openstack_compute_instance_v2 resource named test_terraform_instance
@@ -381,18 +374,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Creating a private network
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network" # Network name
     regions      = [var.region]
-    provider     = ovh.ovh # Provider name
     vlan_id      = 168 # VLAN ID for vRack
     depends_on   = [ovh_vrack_cloudproject.vcp] # Depends on the vRack's association with the cloud project
  }
-  
+
  # Creating a subnet using the previously created private network
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +395,11 @@ variable "region" {
     network      = "192.168.168.0/24" # Subnet IP address location
     dhcp         = true # Enables DHCP
     region       = var.region
-    provider     = ovh.ovh # Provider name
     no_gateway   = true # No default gateway
  }
-  
+
  # Creating an instance with 2 network interfaces
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh # Provider name
    name         = "proxy_instance" # Instance name
    image_name   = "Debian 10" # Image name
    flavor_name  = "d2-2" # Flavor name
@@ -465,12 +455,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend" # Network name
-  regions       = [var.myregion] 
-  provider      = ovh.ovh # Provider name
+  regions       = [var.myregion]
   vlan_id       = 42 # vRack vlan ID
   depends_on    = [ovh_vrack_cloudproject.vcp] # Depends on vRack being associated with the cloud project
 }
- 
+
 # Creating a private subnet
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # ID for the ovh_cloud_network_private resource named private_network
@@ -481,27 +470,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2" # First IP of the subnet
   end           = "192.168.42.200" # Last IP of the subnet
   dhcp          = false # Disabling DHCP
-  provider      = ovh.ovh # Provider name
   no_gateway    = true # No default gateway
 }
- 
+
 # Search for the latest Archlinux image
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux" # Image name
   most_recent   = true # Limits search to the most recent
-  provider      = openstack.ovh # Provider name
 }
- 
+
 # List of possible private IP addresses for front-ends
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Create 2 instances with 2 network interfaces
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip) # Number of instances to create
-  provider        = openstack.ovh # Provider name
   name            = "front" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name
@@ -518,17 +504,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Depends on private network
 }
- 
+
 # Create an attachable storage device for the backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Name of storage device
   size     = 10 # Size
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Create an instance with a network interface and storage device
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh # Provider name
   name            = "back" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.es-es.md
@@ -78,7 +78,7 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
@@ -90,11 +90,9 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/" # Authentication URL
   domain_name = "default" # Domain name - Always at 'default' for OVHcloud
-  alias       = "ovh" # An alias
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<your_access_key>"
   application_secret = "<your_application_secret>"
@@ -145,15 +143,13 @@ For example purposes, we will create a simple instance on **Debian 10** with the
 ```python
 # Creating an SSH key pair resource
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh # Provider name declared in provider.tf
   name       = "test_keypair" # Name of the SSH key to use for creation
   public_key = file("~/.ssh/id_rsa.pub") # Path to your previously generated SSH key
 }
- 
+
 # Creating the instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance" # Instance name
-  provider    = openstack.ovh  # Provider name
   image_name  = "Debian 10" # Image name
   flavor_name = "d2-2" # Instance type name
   # Name of openstack_compute_keypair_v2 resource named keypair_test
@@ -162,7 +158,7 @@ resource "openstack_compute_instance_v2" "test_terraform_instance" {
     name      = "Ext-Net" # Adds the network component to reach your instance
   }
   lifecycle {
-    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance 
+    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance
     # To avoid terraform to have some issue with that, the following ignore_changes is required.
     ignore_changes = [
       image_name
@@ -281,22 +277,20 @@ To do this, we will create a file named `multiple_instance.tf`. In it, we first 
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Creating an SSH key pair
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh # Specify provider name
    name = "test_keypair_all" # Name of the SSH key
    public_key = file("~/.ssh/id_rsa.pub") # Your SSH key path
    region = element(var.region, count.index)
  }
-  
+
  # Create a resource that is an OpenStack instance in each region
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Number of times the resource will be created
    # defined by the length of the list named region
    count = length(var.region)
-   provider = openstack.ovh # Provider name
    name = "terraform_instances" # Instance name
    flavor_name = "d2-2" # Instance flavor
    image_name = "Debian 10" # Image name
@@ -334,9 +328,8 @@ In this example we will attach a new storage volume to our first instance. Open 
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume" # Volume name
   size = 10 # Volume size in GB
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Attach the volume created previously to the instance
 resource "openstack_compute_volume_attach_v2" "attached" {
   # ID of openstack_compute_instance_v2 resource named test_terraform_instance
@@ -381,18 +374,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Creating a private network
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network" # Network name
     regions      = [var.region]
-    provider     = ovh.ovh # Provider name
     vlan_id      = 168 # VLAN ID for vRack
     depends_on   = [ovh_vrack_cloudproject.vcp] # Depends on the vRack's association with the cloud project
  }
-  
+
  # Creating a subnet using the previously created private network
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +395,11 @@ variable "region" {
     network      = "192.168.168.0/24" # Subnet IP address location
     dhcp         = true # Enables DHCP
     region       = var.region
-    provider     = ovh.ovh # Provider name
     no_gateway   = true # No default gateway
  }
-  
+
  # Creating an instance with 2 network interfaces
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh # Provider name
    name         = "proxy_instance" # Instance name
    image_name   = "Debian 10" # Image name
    flavor_name  = "d2-2" # Flavor name
@@ -465,12 +455,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend" # Network name
-  regions       = [var.myregion] 
-  provider      = ovh.ovh # Provider name
+  regions       = [var.myregion]
   vlan_id       = 42 # vRack vlan ID
   depends_on    = [ovh_vrack_cloudproject.vcp] # Depends on vRack being associated with the cloud project
 }
- 
+
 # Creating a private subnet
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # ID for the ovh_cloud_network_private resource named private_network
@@ -481,27 +470,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2" # First IP of the subnet
   end           = "192.168.42.200" # Last IP of the subnet
   dhcp          = false # Disabling DHCP
-  provider      = ovh.ovh # Provider name
   no_gateway    = true # No default gateway
 }
- 
+
 # Search for the latest Archlinux image
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux" # Image name
   most_recent   = true # Limits search to the most recent
-  provider      = openstack.ovh # Provider name
 }
- 
+
 # List of possible private IP addresses for front-ends
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Create 2 instances with 2 network interfaces
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip) # Number of instances to create
-  provider        = openstack.ovh # Provider name
   name            = "front" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name
@@ -518,17 +504,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Depends on private network
 }
- 
+
 # Create an attachable storage device for the backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Name of storage device
   size     = 10 # Size
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Create an instance with a network interface and storage device
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh # Provider name
   name            = "back" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.es-us.md
@@ -78,7 +78,7 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
@@ -90,11 +90,9 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/" # Authentication URL
   domain_name = "default" # Domain name - Always at 'default' for OVHcloud
-  alias       = "ovh" # An alias
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<your_access_key>"
   application_secret = "<your_application_secret>"
@@ -145,15 +143,13 @@ For example purposes, we will create a simple instance on **Debian 10** with the
 ```python
 # Creating an SSH key pair resource
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh # Provider name declared in provider.tf
   name       = "test_keypair" # Name of the SSH key to use for creation
   public_key = file("~/.ssh/id_rsa.pub") # Path to your previously generated SSH key
 }
- 
+
 # Creating the instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance" # Instance name
-  provider    = openstack.ovh  # Provider name
   image_name  = "Debian 10" # Image name
   flavor_name = "d2-2" # Instance type name
   # Name of openstack_compute_keypair_v2 resource named keypair_test
@@ -162,7 +158,7 @@ resource "openstack_compute_instance_v2" "test_terraform_instance" {
     name      = "Ext-Net" # Adds the network component to reach your instance
   }
   lifecycle {
-    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance 
+    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance
     # To avoid terraform to have some issue with that, the following ignore_changes is required.
     ignore_changes = [
       image_name
@@ -281,22 +277,20 @@ To do this, we will create a file named `multiple_instance.tf`. In it, we first 
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Creating an SSH key pair
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh # Specify provider name
    name = "test_keypair_all" # Name of the SSH key
    public_key = file("~/.ssh/id_rsa.pub") # Your SSH key path
    region = element(var.region, count.index)
  }
-  
+
  # Create a resource that is an OpenStack instance in each region
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Number of times the resource will be created
    # defined by the length of the list named region
    count = length(var.region)
-   provider = openstack.ovh # Provider name
    name = "terraform_instances" # Instance name
    flavor_name = "d2-2" # Instance flavor
    image_name = "Debian 10" # Image name
@@ -334,9 +328,8 @@ In this example we will attach a new storage volume to our first instance. Open 
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume" # Volume name
   size = 10 # Volume size in GB
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Attach the volume created previously to the instance
 resource "openstack_compute_volume_attach_v2" "attached" {
   # ID of openstack_compute_instance_v2 resource named test_terraform_instance
@@ -381,18 +374,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Creating a private network
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network" # Network name
     regions      = [var.region]
-    provider     = ovh.ovh # Provider name
     vlan_id      = 168 # VLAN ID for vRack
     depends_on   = [ovh_vrack_cloudproject.vcp] # Depends on the vRack's association with the cloud project
  }
-  
+
  # Creating a subnet using the previously created private network
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +395,11 @@ variable "region" {
     network      = "192.168.168.0/24" # Subnet IP address location
     dhcp         = true # Enables DHCP
     region       = var.region
-    provider     = ovh.ovh # Provider name
     no_gateway   = true # No default gateway
  }
-  
+
  # Creating an instance with 2 network interfaces
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh # Provider name
    name         = "proxy_instance" # Instance name
    image_name   = "Debian 10" # Image name
    flavor_name  = "d2-2" # Flavor name
@@ -465,12 +455,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend" # Network name
-  regions       = [var.myregion] 
-  provider      = ovh.ovh # Provider name
+  regions       = [var.myregion]
   vlan_id       = 42 # vRack vlan ID
   depends_on    = [ovh_vrack_cloudproject.vcp] # Depends on vRack being associated with the cloud project
 }
- 
+
 # Creating a private subnet
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # ID for the ovh_cloud_network_private resource named private_network
@@ -481,27 +470,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2" # First IP of the subnet
   end           = "192.168.42.200" # Last IP of the subnet
   dhcp          = false # Disabling DHCP
-  provider      = ovh.ovh # Provider name
   no_gateway    = true # No default gateway
 }
- 
+
 # Search for the latest Archlinux image
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux" # Image name
   most_recent   = true # Limits search to the most recent
-  provider      = openstack.ovh # Provider name
 }
- 
+
 # List of possible private IP addresses for front-ends
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Create 2 instances with 2 network interfaces
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip) # Number of instances to create
-  provider        = openstack.ovh # Provider name
   name            = "front" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name
@@ -518,17 +504,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Depends on private network
 }
- 
+
 # Create an attachable storage device for the backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Name of storage device
   size     = 10 # Size
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Create an instance with a network interface and storage device
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh # Provider name
   name            = "back" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.fr-ca.md
@@ -78,14 +78,14 @@ required_version    = ">= 0.14.0"                    # Prend en compte les versi
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
     }
   }
 }
- 
+
 # Configure le fournisseur OpenStack hébergé par OVHcloud
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/"    # URL d'authentification
@@ -94,7 +94,6 @@ provider "openstack" {
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<votre_access_key>"
   application_secret = "<votre_application_secret>"
@@ -104,7 +103,7 @@ provider "ovh" {
 
 > [!primary]
 > Si vous ne souhaitez pas définir vos secrets dans le fichier de configuration Terraform, vous pouvez également les définir dans des variables d'environnement :
-> 
+>
 > ```console
 > $ export OVH_ENDPOINT=ovh-eu
 > $ export OVH_APPLICATION_KEY=Your_key_application_OVH(or_AK)
@@ -145,15 +144,13 @@ A des fins d'exemple, nous allons créer une instance simple sur **Debian 10** a
 ```python
 # Création d'une ressource de paire de clés SSH
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh             # Nom du fournisseur déclaré dans provider.tf
   name       = "test_keypair"            # Nom de la clé SSH à utiliser pour la création
   public_key = file("~/.ssh/id_rsa.pub") # Chemin vers votre clé SSH précédemment générée
 }
- 
+
 # Création d'une instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance"    # Nom de l'instance
-  provider    = openstack.ovh           # Nom du fournisseur
   image_name  = "Debian 10"             # Nom de l'image
   flavor_name = "d2-2"                  # Nom du type d'instance
   # Nom de la ressource openstack_compute_keypair_v2 nommée test_keypair
@@ -274,22 +271,20 @@ Pour ce faire, vous pouvez créer un fichier nommé `multiple_instance.tf`. Vous
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Création d'une paire de clé SSH
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh                         # Préciser le nom du fournisseur
    name = "test_keypair_all"                        # Nom de la clé SSH
    public_key = file("~/.ssh/id_rsa.pub")           # Chemin de votre clé SSH
    region = element(var.region, count.index)
  }
-  
+
  # Créer une ressource qui est une instance OpenStack dans chaque région
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Nombre de fois où la ressource sera créée
    # défini par la longueur de la liste nommée région
    count = length(var.region)
-   provider = openstack.ovh                         # Nom du fournisseur
    name = "terraform_instances"                     # Nom de l'instance
    flavor_name = "d2-2"                             # Nom du type d'instance
    image_name = "Debian 10"                         # Nom de l'image
@@ -327,9 +322,8 @@ Dans cet exemple, nous allons attacher un nouveau volume de stockage à notre pr
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume"                           # Nom du volume
   size = 10                                        # Taille du volume en GB
-  provider = openstack.ovh                         # Nom du fournisseur
 }
- 
+
 # Ajouter à l'instance le volume créé précédemment
 resource "openstack_compute_volume_attach_v2" "attached" {
   # Identifiant de la ressource openstack_compute_instance_v2 nommée test_terraform_instance
@@ -374,18 +368,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Création d'un réseau privé
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network"                        # Nom du réseau
     regions      = [var.region]
-    provider     = ovh.ovh                                  # Nom du fournisseur
     vlan_id      = 168                                      # Identifiant du vlan pour le vRrack
     depends_on   = [ovh_vrack_cloudproject.vcp]             # Dépend de l'association du vrack au projet cloud
  }
-  
+
  # Création d'un sous-réseau grâce au réseau privé créé précédemment
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -396,13 +389,11 @@ variable "region" {
     network      = "192.168.168.0/24"                           # Place d'adressage IP du sous réseau
     dhcp         = true                                         # Activation du DHCP
     region       = var.region
-    provider     = ovh.ovh                                      # Nom du fournisseur
     no_gateway   = true                                         # Pas de gateway par defaut
  }
-  
+
  # Création d'une instance avec 2 interfaces réseau
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh                             # Nom du fournisseur
    name         = "proxy_instance"                              # Nom de l'instance
    image_name   = "Debian 10"                           # Nom de l'image
    flavor_name  = "d2-2"                                # Nom du type d'instance
@@ -458,12 +449,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend"                          # Nom du réseau
-  regions       = [var.myregion] 
-  provider      = ovh.ovh                            # Nom du fournisseur
+  regions       = [var.myregion]
   vlan_id       = 42                                 # Identifiant du vlan pour le vRrack
   depends_on    = [ovh_vrack_cloudproject.vcp]       # Depend de l'association du vRack au projet cloud
 }
- 
+
 # Création d'un sous réseau privé
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # Identifiant de la ressource ovh_cloud_network_private nommée private_network
@@ -474,27 +464,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2"                     # Première IP du sous réseau
   end           = "192.168.42.200"                   # Dernière IP du sous réseau
   dhcp          = false                              # Désactivation du DHCP
-  provider      = ovh.ovh                            # Nom du fournisseur
   no_gateway    = true                               # Pas de gateway par defaut
 }
- 
+
 # Chercher l'image Archlinux la plus récente
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux"   # Nom de l'image
   most_recent   = true          # Limite la recherche à la plus récente
-  provider      = openstack.ovh # Nom du fournisseur
 }
- 
+
 # Liste d'adresses IP privées possibles pour les frontaux
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Création de 2 instances avec 2 interfaces réseau
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip)                # Nombre d'instances à créer
-  provider        = openstack.ovh                               # Nom du fournisseur
   name            = "front"                                     # Nom de l'instance
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2"                                      # Nom du type d'instance
@@ -511,17 +498,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Dépend du réseau privé
 }
- 
+
 # Création d'un périphérique de stockage attachable pour le backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Nom du périphérique de stockage
   size     = 10            # Taille
-  provider = openstack.ovh # Nom du fournisseur
 }
- 
+
 # Création d'une instance avec une interface réseau et d'un phériphérique de stockage
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh                                        # Nom du fournisseur
   name            = "back"                                               # Nom de l'instance
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2"                                               # Nom du type d'instance

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.fr-fr.md
@@ -78,14 +78,14 @@ required_version    = ">= 0.14.0"                    # Prend en compte les versi
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
     }
   }
 }
- 
+
 # Configure le fournisseur OpenStack hébergé par OVHcloud
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/"    # URL d'authentification
@@ -94,7 +94,6 @@ provider "openstack" {
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<votre_access_key>"
   application_secret = "<votre_application_secret>"
@@ -104,7 +103,7 @@ provider "ovh" {
 
 > [!primary]
 > Si vous ne souhaitez pas définir vos secrets dans le fichier de configuration Terraform, vous pouvez également les définir dans des variables d'environnement :
-> 
+>
 > ```console
 > $ export OVH_ENDPOINT=ovh-eu
 > $ export OVH_APPLICATION_KEY=Your_key_application_OVH(or_AK)
@@ -145,15 +144,13 @@ A des fins d'exemple, nous allons créer une instance simple sur **Debian 10** a
 ```python
 # Création d'une ressource de paire de clés SSH
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh             # Nom du fournisseur déclaré dans provider.tf
   name       = "test_keypair"            # Nom de la clé SSH à utiliser pour la création
   public_key = file("~/.ssh/id_rsa.pub") # Chemin vers votre clé SSH précédemment générée
 }
- 
+
 # Création d'une instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance"    # Nom de l'instance
-  provider    = openstack.ovh           # Nom du fournisseur
   image_name  = "Debian 10"             # Nom de l'image
   flavor_name = "d2-2"                  # Nom du type d'instance
   # Nom de la ressource openstack_compute_keypair_v2 nommée test_keypair
@@ -281,22 +278,20 @@ Pour ce faire, vous pouvez créer un fichier nommé `multiple_instance.tf`. Vous
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Création d'une paire de clé SSH
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh                         # Préciser le nom du fournisseur
    name = "test_keypair_all"                        # Nom de la clé SSH
    public_key = file("~/.ssh/id_rsa.pub")           # Chemin de votre clé SSH
    region = element(var.region, count.index)
  }
-  
+
  # Créer une ressource qui est une instance OpenStack dans chaque région
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Nombre de fois où la ressource sera créée
    # défini par la longueur de la liste nommée région
    count = length(var.region)
-   provider = openstack.ovh                         # Nom du fournisseur
    name = "terraform_instances"                     # Nom de l'instance
    flavor_name = "d2-2"                             # Nom du type d'instance
    image_name = "Debian 10"                         # Nom de l'image
@@ -334,9 +329,8 @@ Dans cet exemple, nous allons attacher un nouveau volume de stockage à notre pr
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume"                           # Nom du volume
   size = 10                                        # Taille du volume en GB
-  provider = openstack.ovh                         # Nom du fournisseur
 }
- 
+
 # Ajouter à l'instance le volume créé précédemment
 resource "openstack_compute_volume_attach_v2" "attached" {
   # Identifiant de la ressource openstack_compute_instance_v2 nommée test_terraform_instance
@@ -381,18 +375,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Création d'un réseau privé
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network"                        # Nom du réseau
     regions      = [var.region]
-    provider     = ovh.ovh                                  # Nom du fournisseur
     vlan_id      = 168                                      # Identifiant du vlan pour le vRrack
     depends_on   = [ovh_vrack_cloudproject.vcp]             # Dépend de l'association du vrack au projet cloud
  }
-  
+
  # Création d'un sous-réseau grâce au réseau privé créé précédemment
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +396,11 @@ variable "region" {
     network      = "192.168.168.0/24"                           # Place d'adressage IP du sous réseau
     dhcp         = true                                         # Activation du DHCP
     region       = var.region
-    provider     = ovh.ovh                                      # Nom du fournisseur
     no_gateway   = true                                         # Pas de gateway par defaut
  }
-  
+
  # Création d'une instance avec 2 interfaces réseau
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh                             # Nom du fournisseur
    name         = "proxy_instance"                              # Nom de l'instance
    image_name   = "Debian 10"                           # Nom de l'image
    flavor_name  = "d2-2"                                # Nom du type d'instance
@@ -465,12 +456,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend"                          # Nom du réseau
-  regions       = [var.myregion] 
-  provider      = ovh.ovh                            # Nom du fournisseur
+  regions       = [var.myregion]
   vlan_id       = 42                                 # Identifiant du vlan pour le vRrack
   depends_on    = [ovh_vrack_cloudproject.vcp]       # Depend de l'association du vRack au projet cloud
 }
- 
+
 # Création d'un sous réseau privé
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # Identifiant de la ressource ovh_cloud_network_private nommée private_network
@@ -481,27 +471,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2"                     # Première IP du sous réseau
   end           = "192.168.42.200"                   # Dernière IP du sous réseau
   dhcp          = false                              # Désactivation du DHCP
-  provider      = ovh.ovh                            # Nom du fournisseur
   no_gateway    = true                               # Pas de gateway par defaut
 }
- 
+
 # Chercher l'image Archlinux la plus récente
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux"   # Nom de l'image
   most_recent   = true          # Limite la recherche à la plus récente
-  provider      = openstack.ovh # Nom du fournisseur
 }
- 
+
 # Liste d'adresses IP privées possibles pour les frontaux
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Création de 2 instances avec 2 interfaces réseau
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip)                # Nombre d'instances à créer
-  provider        = openstack.ovh                               # Nom du fournisseur
   name            = "front"                                     # Nom de l'instance
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2"                                      # Nom du type d'instance
@@ -518,17 +505,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Dépend du réseau privé
 }
- 
+
 # Création d'un périphérique de stockage attachable pour le backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Nom du périphérique de stockage
   size     = 10            # Taille
-  provider = openstack.ovh # Nom du fournisseur
 }
- 
+
 # Création d'une instance avec une interface réseau et d'un phériphérique de stockage
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh                                        # Nom du fournisseur
   name            = "back"                                               # Nom de l'instance
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2"                                               # Nom du type d'instance

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.it-it.md
@@ -78,7 +78,7 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
@@ -90,11 +90,9 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/" # Authentication URL
   domain_name = "default" # Domain name - Always at 'default' for OVHcloud
-  alias       = "ovh" # An alias
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<your_access_key>"
   application_secret = "<your_application_secret>"
@@ -145,15 +143,13 @@ For example purposes, we will create a simple instance on **Debian 10** with the
 ```python
 # Creating an SSH key pair resource
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh # Provider name declared in provider.tf
   name       = "test_keypair" # Name of the SSH key to use for creation
   public_key = file("~/.ssh/id_rsa.pub") # Path to your previously generated SSH key
 }
- 
+
 # Creating the instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance" # Instance name
-  provider    = openstack.ovh  # Provider name
   image_name  = "Debian 10" # Image name
   flavor_name = "d2-2" # Instance type name
   # Name of openstack_compute_keypair_v2 resource named keypair_test
@@ -162,7 +158,7 @@ resource "openstack_compute_instance_v2" "test_terraform_instance" {
     name      = "Ext-Net" # Adds the network component to reach your instance
   }
   lifecycle {
-    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance 
+    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance
     # To avoid terraform to have some issue with that, the following ignore_changes is required.
     ignore_changes = [
       image_name
@@ -281,22 +277,20 @@ To do this, we will create a file named `multiple_instance.tf`. In it, we first 
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Creating an SSH key pair
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh # Specify provider name
    name = "test_keypair_all" # Name of the SSH key
    public_key = file("~/.ssh/id_rsa.pub") # Your SSH key path
    region = element(var.region, count.index)
  }
-  
+
  # Create a resource that is an OpenStack instance in each region
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Number of times the resource will be created
    # defined by the length of the list named region
    count = length(var.region)
-   provider = openstack.ovh # Provider name
    name = "terraform_instances" # Instance name
    flavor_name = "d2-2" # Instance flavor
    image_name = "Debian 10" # Image name
@@ -334,9 +328,8 @@ In this example we will attach a new storage volume to our first instance. Open 
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume" # Volume name
   size = 10 # Volume size in GB
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Attach the volume created previously to the instance
 resource "openstack_compute_volume_attach_v2" "attached" {
   # ID of openstack_compute_instance_v2 resource named test_terraform_instance
@@ -381,18 +374,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Creating a private network
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network" # Network name
     regions      = [var.region]
-    provider     = ovh.ovh # Provider name
     vlan_id      = 168 # VLAN ID for vRack
     depends_on   = [ovh_vrack_cloudproject.vcp] # Depends on the vRack's association with the cloud project
  }
-  
+
  # Creating a subnet using the previously created private network
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +395,11 @@ variable "region" {
     network      = "192.168.168.0/24" # Subnet IP address location
     dhcp         = true # Enables DHCP
     region       = var.region
-    provider     = ovh.ovh # Provider name
     no_gateway   = true # No default gateway
  }
-  
+
  # Creating an instance with 2 network interfaces
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh # Provider name
    name         = "proxy_instance" # Instance name
    image_name   = "Debian 10" # Image name
    flavor_name  = "d2-2" # Flavor name
@@ -465,12 +455,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend" # Network name
-  regions       = [var.myregion] 
-  provider      = ovh.ovh # Provider name
+  regions       = [var.myregion]
   vlan_id       = 42 # vRack vlan ID
   depends_on    = [ovh_vrack_cloudproject.vcp] # Depends on vRack being associated with the cloud project
 }
- 
+
 # Creating a private subnet
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # ID for the ovh_cloud_network_private resource named private_network
@@ -481,27 +470,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2" # First IP of the subnet
   end           = "192.168.42.200" # Last IP of the subnet
   dhcp          = false # Disabling DHCP
-  provider      = ovh.ovh # Provider name
   no_gateway    = true # No default gateway
 }
- 
+
 # Search for the latest Archlinux image
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux" # Image name
   most_recent   = true # Limits search to the most recent
-  provider      = openstack.ovh # Provider name
 }
- 
+
 # List of possible private IP addresses for front-ends
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Create 2 instances with 2 network interfaces
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip) # Number of instances to create
-  provider        = openstack.ovh # Provider name
   name            = "front" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name
@@ -518,17 +504,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Depends on private network
 }
- 
+
 # Create an attachable storage device for the backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Name of storage device
   size     = 10 # Size
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Create an instance with a network interface and storage device
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh # Provider name
   name            = "back" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.pl-pl.md
@@ -78,7 +78,7 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
@@ -90,11 +90,9 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/" # Authentication URL
   domain_name = "default" # Domain name - Always at 'default' for OVHcloud
-  alias       = "ovh" # An alias
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<your_access_key>"
   application_secret = "<your_application_secret>"
@@ -145,15 +143,13 @@ For example purposes, we will create a simple instance on **Debian 10** with the
 ```python
 # Creating an SSH key pair resource
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh # Provider name declared in provider.tf
   name       = "test_keypair" # Name of the SSH key to use for creation
   public_key = file("~/.ssh/id_rsa.pub") # Path to your previously generated SSH key
 }
- 
+
 # Creating the instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance" # Instance name
-  provider    = openstack.ovh  # Provider name
   image_name  = "Debian 10" # Image name
   flavor_name = "d2-2" # Instance type name
   # Name of openstack_compute_keypair_v2 resource named keypair_test
@@ -162,7 +158,7 @@ resource "openstack_compute_instance_v2" "test_terraform_instance" {
     name      = "Ext-Net" # Adds the network component to reach your instance
   }
   lifecycle {
-    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance 
+    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance
     # To avoid terraform to have some issue with that, the following ignore_changes is required.
     ignore_changes = [
       image_name
@@ -281,22 +277,20 @@ To do this, we will create a file named `multiple_instance.tf`. In it, we first 
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Creating an SSH key pair
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh # Specify provider name
    name = "test_keypair_all" # Name of the SSH key
    public_key = file("~/.ssh/id_rsa.pub") # Your SSH key path
    region = element(var.region, count.index)
  }
-  
+
  # Create a resource that is an OpenStack instance in each region
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Number of times the resource will be created
    # defined by the length of the list named region
    count = length(var.region)
-   provider = openstack.ovh # Provider name
    name = "terraform_instances" # Instance name
    flavor_name = "d2-2" # Instance flavor
    image_name = "Debian 10" # Image name
@@ -334,9 +328,8 @@ In this example we will attach a new storage volume to our first instance. Open 
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume" # Volume name
   size = 10 # Volume size in GB
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Attach the volume created previously to the instance
 resource "openstack_compute_volume_attach_v2" "attached" {
   # ID of openstack_compute_instance_v2 resource named test_terraform_instance
@@ -381,18 +374,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Creating a private network
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network" # Network name
     regions      = [var.region]
-    provider     = ovh.ovh # Provider name
     vlan_id      = 168 # VLAN ID for vRack
     depends_on   = [ovh_vrack_cloudproject.vcp] # Depends on the vRack's association with the cloud project
  }
-  
+
  # Creating a subnet using the previously created private network
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +395,11 @@ variable "region" {
     network      = "192.168.168.0/24" # Subnet IP address location
     dhcp         = true # Enables DHCP
     region       = var.region
-    provider     = ovh.ovh # Provider name
     no_gateway   = true # No default gateway
  }
-  
+
  # Creating an instance with 2 network interfaces
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh # Provider name
    name         = "proxy_instance" # Instance name
    image_name   = "Debian 10" # Image name
    flavor_name  = "d2-2" # Flavor name
@@ -465,12 +455,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend" # Network name
-  regions       = [var.myregion] 
-  provider      = ovh.ovh # Provider name
+  regions       = [var.myregion]
   vlan_id       = 42 # vRack vlan ID
   depends_on    = [ovh_vrack_cloudproject.vcp] # Depends on vRack being associated with the cloud project
 }
- 
+
 # Creating a private subnet
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # ID for the ovh_cloud_network_private resource named private_network
@@ -481,27 +470,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2" # First IP of the subnet
   end           = "192.168.42.200" # Last IP of the subnet
   dhcp          = false # Disabling DHCP
-  provider      = ovh.ovh # Provider name
   no_gateway    = true # No default gateway
 }
- 
+
 # Search for the latest Archlinux image
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux" # Image name
   most_recent   = true # Limits search to the most recent
-  provider      = openstack.ovh # Provider name
 }
- 
+
 # List of possible private IP addresses for front-ends
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Create 2 instances with 2 network interfaces
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip) # Number of instances to create
-  provider        = openstack.ovh # Provider name
   name            = "front" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name
@@ -518,17 +504,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Depends on private network
 }
- 
+
 # Create an attachable storage device for the backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Name of storage device
   size     = 10 # Size
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Create an instance with a network interface and storage device
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh # Provider name
   name            = "back" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/guide.pt-pt.md
@@ -78,7 +78,7 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
       source  = "terraform-provider-openstack/openstack"
       version = ">= 3.0.0"
     }
- 
+
     ovh = {
       source  = "ovh/ovh"
       version = ">= 2.1.0"
@@ -90,11 +90,9 @@ required_version    = ">= 0.14.0" # Takes into account Terraform versions from 0
 provider "openstack" {
   auth_url    = "https://auth.cloud.ovh.net/v3/" # Authentication URL
   domain_name = "default" # Domain name - Always at 'default' for OVHcloud
-  alias       = "ovh" # An alias
 }
 
 provider "ovh" {
-  alias              = "ovh"
   endpoint           = "ovh-eu"
   application_key    = "<your_access_key>"
   application_secret = "<your_application_secret>"
@@ -145,15 +143,13 @@ For example purposes, we will create a simple instance on **Debian 10** with the
 ```python
 # Creating an SSH key pair resource
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh # Provider name declared in provider.tf
   name       = "test_keypair" # Name of the SSH key to use for creation
   public_key = file("~/.ssh/id_rsa.pub") # Path to your previously generated SSH key
 }
- 
+
 # Creating the instance
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance" # Instance name
-  provider    = openstack.ovh  # Provider name
   image_name  = "Debian 10" # Image name
   flavor_name = "d2-2" # Instance type name
   # Name of openstack_compute_keypair_v2 resource named keypair_test
@@ -162,7 +158,7 @@ resource "openstack_compute_instance_v2" "test_terraform_instance" {
     name      = "Ext-Net" # Adds the network component to reach your instance
   }
   lifecycle {
-    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance 
+    # OVHcloud regularly updates the base image of a given OS so that customer has less packages to update after spawning a new instance
     # To avoid terraform to have some issue with that, the following ignore_changes is required.
     ignore_changes = [
       image_name
@@ -281,22 +277,20 @@ To do this, we will create a file named `multiple_instance.tf`. In it, we first 
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
 # Creating an SSH key pair
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh # Specify provider name
    name = "test_keypair_all" # Name of the SSH key
    public_key = file("~/.ssh/id_rsa.pub") # Your SSH key path
    region = element(var.region, count.index)
  }
-  
+
  # Create a resource that is an OpenStack instance in each region
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    # Number of times the resource will be created
    # defined by the length of the list named region
    count = length(var.region)
-   provider = openstack.ovh # Provider name
    name = "terraform_instances" # Instance name
    flavor_name = "d2-2" # Instance flavor
    image_name = "Debian 10" # Image name
@@ -334,9 +328,8 @@ In this example we will attach a new storage volume to our first instance. Open 
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume" # Volume name
   size = 10 # Volume size in GB
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Attach the volume created previously to the instance
 resource "openstack_compute_volume_attach_v2" "attached" {
   # ID of openstack_compute_instance_v2 resource named test_terraform_instance
@@ -381,18 +374,17 @@ variable "region" {
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = var.service_name
   project_id   = var.project_id
-} 
+}
 
  # Creating a private network
  resource "ovh_cloud_project_network_private" "network" {
     service_name = var.service_name
     name         = "private_network" # Network name
     regions      = [var.region]
-    provider     = ovh.ovh # Provider name
     vlan_id      = 168 # VLAN ID for vRack
     depends_on   = [ovh_vrack_cloudproject.vcp] # Depends on the vRack's association with the cloud project
  }
-  
+
  # Creating a subnet using the previously created private network
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = var.service_name
@@ -403,13 +395,11 @@ variable "region" {
     network      = "192.168.168.0/24" # Subnet IP address location
     dhcp         = true # Enables DHCP
     region       = var.region
-    provider     = ovh.ovh # Provider name
     no_gateway   = true # No default gateway
  }
-  
+
  # Creating an instance with 2 network interfaces
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh # Provider name
    name         = "proxy_instance" # Instance name
    image_name   = "Debian 10" # Image name
    flavor_name  = "d2-2" # Flavor name
@@ -465,12 +455,11 @@ variable myregion {
 resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = var.service_name
   name          = "backend" # Network name
-  regions       = [var.myregion] 
-  provider      = ovh.ovh # Provider name
+  regions       = [var.myregion]
   vlan_id       = 42 # vRack vlan ID
   depends_on    = [ovh_vrack_cloudproject.vcp] # Depends on vRack being associated with the cloud project
 }
- 
+
 # Creating a private subnet
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   # ID for the ovh_cloud_network_private resource named private_network
@@ -481,27 +470,24 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2" # First IP of the subnet
   end           = "192.168.42.200" # Last IP of the subnet
   dhcp          = false # Disabling DHCP
-  provider      = ovh.ovh # Provider name
   no_gateway    = true # No default gateway
 }
- 
+
 # Search for the latest Archlinux image
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux" # Image name
   most_recent   = true # Limits search to the most recent
-  provider      = openstack.ovh # Provider name
 }
- 
+
 # List of possible private IP addresses for front-ends
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 # Create 2 instances with 2 network interfaces
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip) # Number of instances to create
-  provider        = openstack.ovh # Provider name
   name            = "front" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name
@@ -518,17 +504,15 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet] # Depends on private network
 }
- 
+
 # Create an attachable storage device for the backup (volume)
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk" # Name of storage device
   size     = 10 # Size
-  provider = openstack.ovh # Provider name
 }
- 
+
 # Create an instance with a network interface and storage device
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh # Provider name
   name            = "back" # Instance name
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2" # Instance type name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/images/TF2.txt
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/images/TF2.txt
@@ -1,12 +1,10 @@
 resource "openstack_compute_keypair_v2" "test_keypair" {
-  provider   = openstack.ovh
   name       = "test_keypair"
   public_key = file("~/.ssh/id_rsa.pub")
 }
- 
+
 resource "openstack_compute_instance_v2" "test_terraform_instance" {
   name        = "terraform_instance"
-  provider    = openstack.ovh
   image_name  = "Debian 10"
   flavor_name = "d2-2"
   key_pair    = openstack_compute_keypair_v2.test_keypair.name

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/images/TF3.txt
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/images/TF3.txt
@@ -2,18 +2,16 @@ variable "region" {
    type = list
    default = ["GRA11", "SBG5", "BHS5"]
  }
-  
+
  resource "openstack_compute_keypair_v2" "test_keypair_all" {
    count = length(var.region)
-   provider = openstack.ovh
    name = "test_keypair_all"
    public_key = file("~/.ssh/id_rsa.pub")
    region = element(var.region, count.index)
  }
-  
+
  resource "openstack_compute_instance_v2" "instances_on_all_regions" {
    count = length(var.region)
-   provider = openstack.ovh
    name = "terraform_instances"
    flavor_name = "d2-2"
    image_name = "Debian 10"

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/images/TF4.txt
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/images/TF4.txt
@@ -1,9 +1,8 @@
 resource "openstack_blockstorage_volume_v2" "volume_to_add" {
   name = "simple_volume"
   size = 10
-  provider = openstack.ovh
 }
- 
+
 resource "openstack_compute_volume_attach_v2" "attached" {
   instance_id = openstack_compute_instance_v2.test_terraform_instance.id
   volume_id = openstack_blockstorage_volume_v2.volume_to_add.id

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/images/TF6.txt
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/images/TF6.txt
@@ -1,16 +1,15 @@
  resource "ovh_vrack_cloudproject" "vcp" {
   service_name = "VRACK_NAME"
   project_id   = "OS_TENANT_ID"
-} 
+}
  resource "ovh_cloud_project_network_private" "network" {
     service_name = "OS_TENANT_ID"
     name         = "private_network"
     regions      = ["OS_REGION_NAME"]
-    provider     = ovh.ovh
     vlan_id      = 168
     depends_on   = [ovh_vrack_cloudproject.vcp]
  }
-  
+
  resource "ovh_cloud_project_network_private_subnet" "subnet" {
     service_name = "OS_TENANT_ID"
     network_id   = ovh_cloud_project_network_private.network.id
@@ -19,12 +18,10 @@
     network      = "192.168.168.0/24"
     dhcp         = true
     region       = "OS_REGION_NAME"
-    provider     = ovh.ovh
     no_gateway   = true
  }
-  
+
  resource "openstack_compute_instance_v2" "proxy_instance" {
-   provider     = openstack.ovh
    name         = "proxy_instance"
    image_name   = "Debian 10"
    flavor_name  = "d2-2"

--- a/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/images/TF7.txt
+++ b/pages/public_cloud/public_cloud_cross_functional/how_to_use_terraform/images/TF7.txt
@@ -2,11 +2,10 @@ resource "ovh_cloud_project_network_private" "private_network" {
   service_name  = "c076ca2979904ef6bf93faff181dab18"
   name          = "backend"
   regions       = ["SBG5"]
-  provider      = ovh.ovh
   vlan_id       = 42
   depends_on    = [ovh_vrack_cloudproject.vcp]
 }
- 
+
 resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   network_id    = ovh_cloud_project_network_private.private_network.id
   service_name  = "c076ca2979904ef6bf93faff181dab18"
@@ -15,24 +14,21 @@ resource "ovh_cloud_project_network_private_subnet" "private_subnet" {
   start         = "192.168.42.2"
   end           = "192.168.42.200"
   dhcp          = false
-  provider      = ovh.ovh
   no_gateway    = true
 }
- 
+
 data "openstack_images_image_v2" "archlinux" {
   name          = "Archlinux"
   most_recent   = true
-  provider      = openstack.ovh
 }
- 
+
 variable "front_private_ip" {
   type          = list(any)
   default       = ["192.168.42.2", "192.168.42.3"]
 }
- 
+
 resource "openstack_compute_instance_v2" "front" {
   count           = length(var.front_private_ip)
-  provider        = openstack.ovh
   name            = "front"
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2"
@@ -47,15 +43,13 @@ resource "openstack_compute_instance_v2" "front" {
   }
   depends_on = [ovh_cloud_project_network_private_subnet.private_subnet]
 }
- 
+
 resource "openstack_blockstorage_volume_v2" "backup" {
   name     = "backup_disk"
   size     = 10
-  provider = openstack.ovh
 }
- 
+
 resource "openstack_compute_instance_v2" "back" {
-  provider        = openstack.ovh
   name            = "back"
   key_pair        = openstack_compute_keypair_v2.test_keypair.name
   flavor_name     = "d2-2"


### PR DESCRIPTION


## What type of Pull Request is this?

- Update of existing guide(s)

## Description

alias and provider keyword are an expert way of doing Terraform, and is complexifying the quick start example for no added value.

Customers that add resource must take this complexity into account and can lead to complicated errors.
Removing the complexity is better, as advanced users that want to deal with multiple configuration of the same provider know how to do that.

## Mandatory information

- This Pull Request can be merged as soon as possible.