### PR TITLE
fix: mongoDB behaviour when the disk is full

### DIFF
--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - How to handle 'Disk Full' situations"
 excerpt: Find out how to avoid, analyse and fix a Public Cloud Databases service reaching its full disk capacity
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.de-de.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - How to handle 'Disk Full' situations"
 excerpt: Find out how to avoid, analyse and fix a Public Cloud Databases service reaching its full disk capacity
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-asia.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - How to handle 'Disk Full' situations"
 excerpt: Find out how to avoid, analyse and fix a Public Cloud Databases service reaching its full disk capacity
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-au.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - How to handle 'Disk Full' situations"
 excerpt: Find out how to avoid, analyse and fix a Public Cloud Databases service reaching its full disk capacity
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-ca.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - How to handle 'Disk Full' situations"
 excerpt: Find out how to avoid, analyse and fix a Public Cloud Databases service reaching its full disk capacity
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-gb.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-ie.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes only for the Admin. users
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - How to handle 'Disk Full' situations"
 excerpt: Find out how to avoid, analyse and fix a Public Cloud Databases service reaching its full disk capacity
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-ie.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin. users
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - How to handle 'Disk Full' situations"
 excerpt: Find out how to avoid, analyse and fix a Public Cloud Databases service reaching its full disk capacity
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-sg.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - How to handle 'Disk Full' situations"
 excerpt: Find out how to avoid, analyse and fix a Public Cloud Databases service reaching its full disk capacity
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.en-us.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - How to handle 'Disk Full' situations"
 excerpt: Find out how to avoid, analyse and fix a Public Cloud Databases service reaching its full disk capacity
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.es-es.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - How to handle 'Disk Full' situations"
 excerpt: Find out how to avoid, analyse and fix a Public Cloud Databases service reaching its full disk capacity
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.es-us.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - Comment gérer des situations de 'Full Disk' (EN)"
 excerpt: Découvrez comment éviter, analyser et réparer un service Public Cloud Databases atteignant sa pleine capacité de disque
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.fr-ca.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - Comment gérer des situations de 'Full Disk' (EN)"
 excerpt: Découvrez comment éviter, analyser et réparer un service Public Cloud Databases atteignant sa pleine capacité de disque
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.fr-fr.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB blocks` all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.it-it.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+``MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - How to handle 'Disk Full' situations"
 excerpt: Find out how to avoid, analyse and fix a Public Cloud Databases service reaching its full disk capacity
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - How to handle 'Disk Full' situations"
 excerpt: Find out how to avoid, analyse and fix a Public Cloud Databases service reaching its full disk capacity
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.pl-pl.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Public Cloud Databases - How to handle 'Disk Full' situations"
 excerpt: Find out how to avoid, analyse and fix a Public Cloud Databases service reaching its full disk capacity
-updated: 2023-07-24
+updated: 2025-08-18
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_databases/databases_10_full_disk_handling/guide.pt-pt.md
@@ -36,7 +36,7 @@ Different engines react in different ways, thus Public Cloud Databases services 
 - `Valkey` does not store any user data on disk. Thus, it will not fill up the underlying disk storage.
 - `Cassandra` turns to read-only.
 - `MySQL` and `PostgreSQL` turn to read-only with a way to temporarily revert to read-write.
-- `MongoDB` forbids writes but allows deletes.
+- `MongoDB` forbids writes but allows deletes only for the Admin users.
 
 #### Upgrading your service
 
@@ -48,7 +48,7 @@ It may be that you have reached the full disk situation because of a runaway app
 
 ##### **MongoDB**
 
-`MongoDB` refuses any query that inserts data, but allows queries deleting data. You can thus execute any `MongoDB` command that allows to reclaim disk space.
+`MongoDB` blocks all write operations when the disk is full, except for the Admin users who can execute any `MongoDB` command to reclaim disk space.
 
 ##### **PostgreSQL**, **MySQL**
 


### PR DESCRIPTION
<!--
Hello 👋
Thank you for submitting a Pull Request.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details. As long as your Pull Request is a draft, the OVHcloud Guides Team will not start proofreading it.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

DO NOT USE a fork if you are an OVHcloud employee. Instead, please contact the OVHcloud Guides Team so to be granted /write access to this repository.

Feel free to apply labels on your Pull Request, selecting them from the list to your right.

Before submitting a Pull Request, please ensure you have:

- 📖 Read the OVHcloud Documentation readme: https://github.com/ovh/docs/blob/develop/readme.md
- 🇬🇧 Edited (at least) the en-gb version of a guide.
- 🇫🇷 Edited also the fr-fr version if you are a French speaker.
- 🌐 Edited all the files if you're doing a fix or a minor update (this is not mandatory but recommended).
- 👷‍♀️ Created a small PR, if applicable.
- ✅ Tested every step you're documenting.
- 📝 Used descriptive commit messages.
- 📐 Resized images which width exceeds 1400px.
- 📝 Edited or blurred any sensitive/private information from your text and images (IPs, user IDs, private URLs, etc.).
-->

## What type of Pull Request is this?

<!-- Delete the lines which don't apply: -->
- Fix
- Optimization

## Description

When the mongoDB  disk is full, all writes operations are blocked for all users except for the Admin.

## Mandatory information

<!-- Delete the line which doesn't apply: -->
- This Pull Request can be merged as soon as possible.

<!-- If you know about the following, please mention it. If you don't know, delete the line.-->
- This Pull Request content should be replicated for the US OVHcloud documentation : YES <!-- https://support.us.ovhcloud.com/hc/en-us -->