### PR TITLE
fix: ovhcloud-cli: brew installation method missing a parameter

### DIFF
--- a/pages/manage_and_operate/cli/cli-getting-started/guide.en-gb.md
+++ b/pages/manage_and_operate/cli/cli-getting-started/guide.en-gb.md
@@ -19,7 +19,7 @@ curl -fsSL https://raw.githubusercontent.com/ovh/ovhcloud-cli/main/install.sh | 
 It is also possible to install OVHcloud CLI using Homebrew:
 
 ```sh
-brew install ovh/tap/ovhcloud-cli
+brew install --cask ovh/tap/ovhcloud-cli
 ```
 
 Alternatively, you can download the latest release from the [GitHub repository](https://github.com/ovh/ovhcloud-cli):

--- a/pages/manage_and_operate/cli/cli-getting-started/guide.en-gb.md
+++ b/pages/manage_and_operate/cli/cli-getting-started/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with OVHcloud CLI
 excerpt: Find out about useful resources in order to use the official OVHcloud Command Line Interface (CLI)
-updated: 2025-09-29
+updated: 2025-10-13
 ---
 
 ## Objective

--- a/pages/manage_and_operate/cli/cli-getting-started/guide.fr-fr.md
+++ b/pages/manage_and_operate/cli/cli-getting-started/guide.fr-fr.md
@@ -19,7 +19,7 @@ curl -fsSL https://raw.githubusercontent.com/ovh/ovhcloud-cli/main/install.sh | 
 La CLI OVHcloud est également disponible via Homebrew :
 
 ```sh
-brew install ovh/tap/ovhcloud-cli
+brew install --cask ovh/tap/ovhcloud-cli
 ```
 
 Vous pouvez également télécharger la dernière version depuis le [dépôt GitHub](https://github.com/ovh/ovhcloud-cli) :

--- a/pages/manage_and_operate/cli/cli-getting-started/guide.fr-fr.md
+++ b/pages/manage_and_operate/cli/cli-getting-started/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Premiers pas avec la CLI OVHcloud
 excerpt: "Découvrez les ressources utiles pour utiliser l’interface en ligne de commande officielle OVHcloud"
-updated: 2025-09-29
+updated: 2025-10-13
 ---
 
 ## Objectif


### PR DESCRIPTION
## What type of Pull Request is this?
- Fix
## Description

Fixes the installation method of the ovhcloud-cli using homebrew
Fixes ovh/ovhcloud-cli#58

## Mandatory information

- This Pull Request can be merged as soon as possible.