### PR TITLE
fix(KB0062873): fix default value for loadbalancer annotations

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-22
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-10-22
+updated: 2025-10-23
 ---
 
 > [!warning]

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Expose your applications using OVHcloud Public Cloud Load Balancer
 excerpt: "How to expose your applications hosted on Managed Kubernetes Service using the OVHcloud Public Cloud Load Balancer"
-updated: 2025-02-17
+updated: 2025-10-23
 ---
 
 > [!warning]
@@ -284,15 +284,15 @@ Authorized values: 'octavia' = Public Cloud Load Balancer, 'iolb' = Loadbalancer
 
 - `loadbalancer.openstack.org/timeout-client-data`
 
-  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Frontend client inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-member-connect`
 
-  Backend member connection timeout in milliseconds for the load balancer. Default value (ms) = 5000.
+  Backend member connection timeout in milliseconds for the load balancer. Default value (s) = 5.
 
 - `loadbalancer.openstack.org/timeout-member-data`
 
-  Backend member inactivity timeout in milliseconds for the load balancer. Default value (ms) = 50000.
+  Backend member inactivity timeout in milliseconds for the load balancer. Default value (s) = 50.
 
 - `loadbalancer.openstack.org/timeout-tcp-inspect`
 


### PR DESCRIPTION
## What type of Pull Request is this?
- Update of existing guide(s)

## Description
Fix default value for annotations in KB0062873 Expose your applications using OVHcloud Public Cloud Load Balancer for the following ones :
- loadbalancer.openstack.org/timeout-client-data
- loadbalancer.openstack.org/timeout-member-connect
- loadbalancer.openstack.org/timeout-member-data

## Mandatory information
- This Pull Request can be merged as soon as possible.
- This Pull Request content should be replicated for the US OVHcloud documentation : YES