### PR TITLE
SMS guides - disabling DE & PT languages

### DIFF
--- a/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/meta.yaml
+++ b/pages/web_cloud/messaging/sms/activer_la_recharge_automatique_du_credit_sms/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: 2afb6264-5aed-43bb-86f7-01735c0ebd7b
 full_slug: sms-credit-management

--- a/pages/web_cloud/messaging/sms/api_sms_cookbook/meta.yaml
+++ b/pages/web_cloud/messaging/sms/api_sms_cookbook/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: f308db6b-f0d4-4996-a89b-cbdb9f5e459a
 full_slug: sms-api-cookbook

--- a/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/meta.yaml
+++ b/pages/web_cloud/messaging/sms/envoi_de_sms_aux_etats-unis/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: d2956f39-79ff-4273-a00f-1e8c4043dee9
 full_slug: sms-sending-sms-to-usa

--- a/pages/web_cloud/messaging/sms/envoyer_des_sms_avec_lapi_ovh_en_c/meta.yaml
+++ b/pages/web_cloud/messaging/sms/envoyer_des_sms_avec_lapi_ovh_en_c/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: 68a51d3f-84ac-4f2b-a4fc-5e451b5733d6
 full_slug: sms-sending-via-api-c

--- a/pages/web_cloud/messaging/sms/envoyer_des_sms_avec_lapi_ovh_en_java/meta.yaml
+++ b/pages/web_cloud/messaging/sms/envoyer_des_sms_avec_lapi_ovh_en_java/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: 1b042b44-a2a4-4baf-bd13-b774c387892b
 full_slug: sms-sending-via-api-java

--- a/pages/web_cloud/messaging/sms/envoyer_des_sms_avec_lapi_ovh_en_nodejs/meta.yaml
+++ b/pages/web_cloud/messaging/sms/envoyer_des_sms_avec_lapi_ovh_en_nodejs/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: 55349f96-666b-4c9b-a9da-48f21a71ea23
 full_slug: sms-sending-via-api-nodejs

--- a/pages/web_cloud/messaging/sms/envoyer_des_sms_avec_lapi_ovh_en_php/meta.yaml
+++ b/pages/web_cloud/messaging/sms/envoyer_des_sms_avec_lapi_ovh_en_php/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: 1a8f6500-5c3a-4317-b4bd-f83255f97d41
 full_slug: sms-sending-via-api-php

--- a/pages/web_cloud/messaging/sms/envoyer_des_sms_depuis_mon_espace_client/meta.yaml
+++ b/pages/web_cloud/messaging/sms/envoyer_des_sms_depuis_mon_espace_client/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: fc50ffbb-002c-412c-a8b8-ccb392fe8836
 full_slug: sms-sending-from-control-panel

--- a/pages/web_cloud/messaging/sms/envoyer_des_sms_depuis_une_adresse_email/meta.yaml
+++ b/pages/web_cloud/messaging/sms/envoyer_des_sms_depuis_une_adresse_email/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: 9e3022f0-c887-46c6-bcd5-8a21c74ba5a0
 full_slug: sms-sending-from-email-address

--- a/pages/web_cloud/messaging/sms/envoyer_des_sms_depuis_une_url_-_http2sms/meta.yaml
+++ b/pages/web_cloud/messaging/sms/envoyer_des_sms_depuis_une_url_-_http2sms/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: 5f573ee0-c8ed-40fb-9c9b-af2655fa6197
 full_slug: sms-sending-via-url-http2sms

--- a/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/meta.yaml
+++ b/pages/web_cloud/messaging/sms/gerer_l_historique_des_sms/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: 95873c79-3dfc-4b60-b232-acf4679b3346
 full_slug: sms-manage-history

--- a/pages/web_cloud/messaging/sms/gerer_les_sms_avec_reponse/meta.yaml
+++ b/pages/web_cloud/messaging/sms/gerer_les_sms_avec_reponse/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: 9a061a3d-f8a4-4f2e-ad9a-060b5a2ab795
 full_slug: sms-managing-answers

--- a/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/meta.yaml
+++ b/pages/web_cloud/messaging/sms/gerer_mes_carnets_dadresses_sms/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: 3ed893bf-e0ff-43c2-8139-e5022bad0090
 full_slug: sms-managing-address-books

--- a/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/meta.yaml
+++ b/pages/web_cloud/messaging/sms/liste_de_destinataire_sms/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: b265bc43-1cfb-491f-8388-879e50822a2c
 full_slug: sms-managing-recipients-lists

--- a/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/meta.yaml
+++ b/pages/web_cloud/messaging/sms/ma_premiere_campagne_sms/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: fdfff1a1-dd1e-44f7-a350-d041c2dea877
 full_slug: sms-first-sms-campaign

--- a/pages/web_cloud/messaging/sms/smpp-control-panel/meta.yaml
+++ b/pages/web_cloud/messaging/sms/smpp-control-panel/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: f727cd0c-11d6-43d7-9269-5add2b58a2df
 full_slug: sms-smpp-control-panel

--- a/pages/web_cloud/messaging/sms/smpp-specification/meta.yaml
+++ b/pages/web_cloud/messaging/sms/smpp-specification/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: 9cf90830-310e-4e81-936f-8effd188dd56
 full_slug: sms-smpp-specifications

--- a/pages/web_cloud/messaging/sms/tout_ce_quil_faut_savoir_sur_le_hlr_-_sms/meta.yaml
+++ b/pages/web_cloud/messaging/sms/tout_ce_quil_faut_savoir_sur_le_hlr_-_sms/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: abefb0bf-6507-4090-8493-add4ffaba9e5
 full_slug: sms-hlr

--- a/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/meta.yaml
+++ b/pages/web_cloud/messaging/sms/tout_savoir_sur_les_utilisateurs_sms/meta.yaml
@@ -1,4 +1,5 @@
 disable_languages:
+- de-de
 - fr-ca
 - en-ca
 - en-asia
@@ -6,5 +7,6 @@ disable_languages:
 - en-sg
 - en-us
 - es-us
+- pt-pt
 id: 6a591dad-2a0e-41a2-b817-5db045123170
 full_slug: sms-users


### PR DESCRIPTION
## What type of Pull Request is this?

- Fix

## Description

Disabling DE & PT languages for SMS guides.

## Mandatory information

The translations in this Pull Request have been done using:
- [ ] OVHcloud integrated translation LLM <!-- If you're interested in this new option, contact the Guides team -->
- [ ] Systran
- [ ] Other tool (specify which tool was used)
- [x] This Pull Request didn't require any translation.

- This Pull Request can be merged as soon as possible.

- This Pull Request content should be replicated for the US OVHcloud documentation : NO 