### PR TITLE
Fix keys syntax in various meta.yaml

### DIFF
--- a/pages/account_and_service_management/account_information/faq-account-management/meta.yaml
+++ b/pages/account_and_service_management/account_information/faq-account-management/meta.yaml
@@ -1,4 +1,4 @@
-id : 0fa1489b-422b-4e3f-8582-fb63d664cb1a
+id: 0fa1489b-422b-4e3f-8582-fb63d664cb1a
 full_slug: faq-account-management
 reference_category: account-and-service-management-account-information-faq
 translation_banner: true

--- a/pages/account_and_service_management/account_information/faq-support/meta.yaml
+++ b/pages/account_and_service_management/account_information/faq-support/meta.yaml
@@ -1,4 +1,4 @@
-id : 464bc7b1-3c2a-428a-9d67-5e4e38b91203
+id: 464bc7b1-3c2a-428a-9d67-5e4e38b91203
 full_slug: faq-support
 reference_category: account-and-service-management-account-information-faq
 translation_banner: true

--- a/pages/account_and_service_management/managing_billing_payments_and_services/faq-billing/meta.yaml
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/faq-billing/meta.yaml
@@ -1,3 +1,3 @@
-id : fd50aa9b-e0fb-4388-ac6c-c77910496e9c
+id: fd50aa9b-e0fb-4388-ac6c-c77910496e9c
 full_slug: faq-billing
 translation_banner: true

--- a/pages/account_and_service_management/managing_billing_payments_and_services/faq-order-tracking/meta.yaml
+++ b/pages/account_and_service_management/managing_billing_payments_and_services/faq-order-tracking/meta.yaml
@@ -1,3 +1,3 @@
-id : 83402f98-60cf-11ed-9b6a-0242ac120002
+id: 83402f98-60cf-11ed-9b6a-0242ac120002
 full_slug: faq-order-tracking
 translation_banner: true

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/concept_vmware_for_sap/meta.yaml
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/concept_vmware_for_sap/meta.yaml
@@ -1,2 +1,2 @@
-id : 2b9667fd-eea6-462a-819d-d244336ff2bb
-full_slug : sap-vmware-concept
+id: 2b9667fd-eea6-462a-819d-d244336ff2bb
+full_slug: sap-vmware-concept

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_ovhcloud_backint_agent_several_buckets/meta.yaml
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_ovhcloud_backint_agent_several_buckets/meta.yaml
@@ -1,2 +1,2 @@
-id : 0fe84db0-58c6-42c3-a235-c365999692b1
-full_slug : sap-hana-use-ovhcloud-backint-agent-several-buckets
+id: 0fe84db0-58c6-42c3-a235-c365999692b1
+full_slug: sap-hana-use-ovhcloud-backint-agent-several-buckets

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/meta.yaml
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_configure_sap_hana_cluster/meta.yaml
@@ -1,2 +1,2 @@
-id : 4ea9ed9f-41d1-4611-af8a-9f08e611d3e5
-full_slug : sap-hana-configure-suse-cluster
+id: 4ea9ed9f-41d1-4611-af8a-9f08e611d3e5
+full_slug: sap-hana-configure-suse-cluster

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_ovhcloud_backint_agent/meta.yaml
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_install_ovhcloud_backint_agent/meta.yaml
@@ -1,2 +1,2 @@
-id : dbfd844e-9003-4f73-92fb-847386686f73
-full_slug : sap-hana-install-ovhcloud-backint-agent
+id: dbfd844e-9003-4f73-92fb-847386686f73
+full_slug: sap-hana-install-ovhcloud-backint-agent

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/meta.yaml
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_application_server/meta.yaml
@@ -1,2 +1,2 @@
-id : c5ba42db-1817-42ff-844d-46148b8069cc
-full_slug : terraform-sap-application-server
+id: c5ba42db-1817-42ff-844d-46148b8069cc
+full_slug: terraform-sap-application-server

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_hana_database/meta.yaml
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_hana_database/meta.yaml
@@ -1,2 +1,2 @@
-id : aa59a5da-28bc-4253-9abb-a94911be9639
-full_slug : terraform-sap-hana-database
+id: aa59a5da-28bc-4253-9abb-a94911be9639
+full_slug: terraform-sap-hana-database

--- a/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_system/meta.yaml
+++ b/pages/hosted_private_cloud/sap_on_ovhcloud/cookbook_terraform_sap_system/meta.yaml
@@ -1,2 +1,2 @@
-id : be2f11c8-880a-47c9-895f-963c04824dd6
-full_slug : terraform-sap-system
+id: be2f11c8-880a-47c9-895f-963c04824dd6
+full_slug: terraform-sap-system


### PR DESCRIPTION
## What type of Pull Request is this?

Update `meta.yaml`

## Description

Fix keys syntax in various `meta.yaml`

> [!NOTE]
> In [pages/account_and_service_management/managing_billing_payments_and_services/faq-order-tracking/meta.yaml](https://github.com/ovh/docs/blob/develop/pages/account_and_service_management/managing_billing_payments_and_services/faq-order-tracking/meta.yaml), the `id` is not an uuid v4.
>
> Also concerned:
>
> - [pages/public_cloud/public_cloud_databases/postgresql_11_terminate_queries/meta.yaml](https://github.com/ovh/docs/blob/develop/pages/public_cloud/public_cloud_databases/postgresql_11_terminate_queries/meta.yaml)
> - [pages/public_cloud/ai_machine_learning/gi_06_dashboard_getting_started/meta.yaml](https://github.com/ovh/docs/blob/develop/pages/public_cloud/ai_machine_learning/gi_06_dashboard_getting_started/meta.yaml)
> - [pages/public_cloud/ai_machine_learning/training_tuto_08_train_marine_mammal_sound/meta.yaml](https://github.com/ovh/docs/blob/develop/pages/public_cloud/ai_machine_learning/training_tuto_08_train_marine_mammal_sound/meta.yaml)
> - [pages/web_cloud/domains/dns_zone_dmarc/meta.yaml](https://github.com/ovh/docs/blob/develop/pages/web_cloud/domains/dns_zone_dmarc/meta.yaml)
> - [pages/web_cloud/internet/internet_access/comment_activer_envoi_mail/meta.yaml](https://github.com/ovh/docs/blob/develop/pages/web_cloud/internet/internet_access/comment_activer_envoi_mail/meta.yaml)
>
> All the ones I mentioned are UUID v1.

## Mandatory information

- This Pull Request didn't require any translation.
- This Pull Request can be merged as soon as possible.

