### PR TITLE
feat(mks): remove eol version 1.29 and update ram allocation on workers

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-02-26
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.27`
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
+* `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.27`: 1.7.18
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,24 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
+* `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.32`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-
+* `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
+* `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -73,25 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -122,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -131,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Kubernetes Plugins (CNI, CRI, CSI...) & softwares versions and reserved resources
 excerpt: ''
-updated: 2025-07-03
+updated: 2025-11-25
 ---
 
 We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) & software versions we use and the resources we reserve on each Node.
@@ -10,12 +10,11 @@ We list here some details on the Control Panel, the plugins (CNI, CRI, CSI...) &
 
 Currently, we support the following Kubernetes releases:
 
-* `1.28`
-* `1.29`
 * `1.30`
 * `1.31`
 * `1.32`
 * `1.33`
+* `1.34`
 
 If you run a Managed Kubernetes Service using an older version we strongly encourage you to use the [version upgrade feature](/pages/public_cloud/containers_orchestration/managed_kubernetes/upgrading-kubernetes-version) to receive official support for your cluster.
 
@@ -35,12 +34,11 @@ The OS, kernel and Docker demon version on your nodes will be regularly updated.
 
 We use `containerd` as the default CRI
 
-* `1.28`: 1.7.18
-* `1.29`: 1.7.18
 * `1.30`: 1.7.18
-* `1.31`: 1.7.18
-* `1.32`: 1.7.25
-* `1.33`: 2.1.3
+* `1.31`: 2.1.4
+* `1.32`: 2.1.4
+* `1.33`: 2.1.4
+* `1.34`: 2.1.4
 
 ## CNI (Cluster Network Interface)
 
@@ -48,25 +46,21 @@ The CNI plugin installed is [canal](https://github.com/projectcalico/canal) whic
 
 The versions installed depends on the Kubernetes version:
 
-* `1.27`: calico v3.28.0, flannel v0.24.3
-* `1.28`: calico v3.28.0, flannel v0.24.3
-* `1.29`: calico v3.28.0, flannel v0.24.3
-* `1.30`: calico v3.28.0, flannel v0.24.3
-* `1.31`: calico v3.28.1, flannel v0.24.4
+* `1.30`: calico v3.29.1, flannel v0.24.4
+* `1.31`: calico v3.29.1, flannel v0.24.4
 * `1.32`: calico v3.29.1, flannel v0.24.4
 * `1.33`: calico v3.30.1, flannel v0.24.4
+* `1.34`: calico v3.30.1, flannel v0.24.4
 
 ## CCM (Cloud-controller-manager)
 
 Our cloud-controller-manager (CCM) is based on the OpenStack cloud-controller-manager (OpenstackCCM) available in the [Cloud provider openstack](https://github.com/kubernetes/cloud-provider-openstack) repository.
 
-* `1.27`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.28`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
-* `1.29`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.30`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.31`: OVH IOLB CCM based on OpenstackCCM 1.18, OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.32`: OVH Octavia CCM based on OpenstackCCM 1.29
 * `1.33`: OVH Octavia CCM based on OpenstackCCM 1.33
+* `1.34`: OVH Octavia CCM based on OpenstackCCM 1.33
 
 ## CSI (Container Storage Interface)
 
@@ -74,26 +68,22 @@ The CSI plugin installed is [cinder](https://github.com/kubernetes/cloud-provide
 
 The versions depend on the Kubernetes cluster version:
 
-* `1.27`: csi-plugin v1.29.0, csi-attacher v4.3.0, csi-provisioner v3.5.0, csi-snapshotter v6.2.2, snapshot-controller: v6.2.2, csi-resizer v1.8.0
-* `1.28`: csi-plugin v1.29.0, csi-attacher v4.4.2, csi-provisioner v3.6.2, csi-snapshotter v6.3.2, snapshot-controller: v6.3.2, csi-resizer v1.9.2
-* `1.29`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
 * `1.30`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.31`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
-* `1.32`: csi-plugin v1.29.0, csi-attacher v4.5.0, csi-provisioner v3.6.3, csi-snapshotter v6.3.3 snapshot-controller: v6.3.3, csi-resizer v1.10.0
+* `1.31`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.32`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.33`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
+* `1.34`: csi-plugin v1.29.0, csi-attacher v4.10.0, csi-provisioner v5.3.0, csi-snapshotter v6.3.3 snapshot-controller: v8.3.0, csi-resizer v1.14.0
 
 
 ## Other components
 
 The versions are:
 
-* `1.26`: coredns v1.11.1, metrics-server v0.6.4
-* `1.27`: coredns v1.11.3, metrics-server v0.7.2
-* `1.28`: coredns v1.11.3, metrics-server v0.7.2
-* `1.29`: coredns v1.11.3, metrics-server v0.7.2
-* `1.30`: coredns v1.11.3, metrics-server v0.7.2
-* `1.31`: coredns v1.11.3, metrics-server v0.7.2
-* `1.32`: coredns v1.12.0, metrics-server v0.7.2
-* `1.33`: coredns v1.12.1, metrics-server v0.7.2
+* `1.30`: coredns v1.12.1, metrics-server v0.7.2
+* `1.31`: coredns v1.12.4, metrics-server v0.8.0
+* `1.32`: coredns v1.12.4, metrics-server v0.8.0
+* `1.33`: coredns v1.12.4, metrics-server v0.8.0
+* `1.34`: coredns v1.12.4, metrics-server v0.8.0
 
 ## Enabled policies
 
@@ -124,8 +114,8 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 * **CPU** reservation is defined through this formula:  
     > 15 % of 1 CPU + 0,5% of all CPU cores
 
-* **RAM** reservation is defined through this formula:  
-    > 1024 MB + 5% of total memory
+* **RAM** reservation is a constant:
+    > 1590 MB
 
 * **Storage** reservation is defined through this formula:  
     > log10(total storage in GB) * 10 + 10% of total storage
@@ -133,18 +123,18 @@ To guarantee the availability of a customer's node, the amount of reserved resou
 This table sums up the reserved resources on b2 and b3 flavors:
 
 | Flavor | vCore | Reserved CPU (ms) | Total RAM | Reserved RAM (GB) | Total storage (GB) | Reserved storage (GB) |
-|-|-|-|-|-|-|-|
-| b2-7 | 2 | 160 | 7 | 1,98 | 50 | 22 |
-| b2-15 | 4 | 170 | 15 | 2,4 | 100 | 30 |
-| b2-30 | 8 | 190 | 30 | 3,16 | 200 | 43 |
-| b2-60 | 16 | 230 | 60 | 4,7 | 400 | 66 |
-| b2-120 | 32 | 310 | 120 | 7,77 | 400 | 66 |
-| b3-8 | 2 | 160 | 8 | 2 | 50 | 22 |
-| b3-16 | 4 | 170 | 16 | 2,44 | 100 | 30 |
-| b3-32 | 8 | 190 | 32 | 3,26 | 200 | 43 |
-| b3-64 | 16 | 230 | 64 | 4,9 | 400 | 66 |
-| b3-128 | 32 | 310 | 128 | 8,18 | 400 | 66 |
-| b3-256 | 64 | 470 | 256 | 14,73 | 400 | 66 |
+| ------ | ----- | ----------------- | --------- | ----------------- | ------------------ | --------------------- |
+| b2-7   | 2     | 160               | 7         | 1,59              | 50                 | 22                    |
+| b2-15  | 4     | 170               | 15        | 1,59              | 100                | 30                    |
+| b2-30  | 8     | 190               | 30        | 1,59              | 200                | 43                    |
+| b2-60  | 16    | 230               | 60        | 1,59              | 400                | 66                    |
+| b2-120 | 32    | 310               | 120       | 1,59              | 400                | 66                    |
+| b3-8   | 2     | 160               | 8         | 1,59              | 50                 | 22                    |
+| b3-16  | 4     | 170               | 16        | 1,59              | 100                | 30                    |
+| b3-32  | 8     | 190               | 32        | 1,59              | 200                | 43                    |
+| b3-64  | 16    | 230               | 64        | 1,59              | 400                | 66                    |
+| b3-128 | 32    | 310               | 128       | 1,59              | 400                | 66                    |
+| b3-256 | 64    | 470               | 256       | 1,59              | 400                | 66                    |
 
 ## Go further
 


### PR DESCRIPTION
## What type of Pull Request is this?

- Update of existing guide(s)

## Description
* Update versions after recent upgrades and 1.29 EOL
* Update RAM allocation value from a dynamic to a fixed value

## Mandatory information

The translations in this Pull Request have been done using:
- [X] This Pull Request didn't require any translation.

- This Pull Request can be merged as soon as possible.

- This Pull Request content should be replicated for the US OVHcloud documentation : YES
