### PR TITLE
feat(l2c): Logs-to-Customer endpoints are not longer in Beta

### DIFF
--- a/pages/manage_and_operate/observability/logs_data_platform/introduction_to_services_logs/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/introduction_to_services_logs/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction to OVHcloud Service Logs with Logs Data Platform
 excerpt: Discover how to retrieve your OVHcloud managed products logs in Logs Data Platform
-updated: 2025-12-02
+updated: 2025-12-11
 ---
 
 ## Objective
@@ -48,23 +48,23 @@ Get the most out of the Graylog UI and OpenSearch Dashboards by building easy-to
 Here is the list of compatible products with OVHcloud Service Logs so far.
 Our ambition is to make all OVHcloud products compatible with OVHcloud Service Logs. We will endeavor to update this table as new availability evolves.
 
-| Product name | Availability | Status | Guide link |
-| :----------- | :----------- | :----: | :--------- |
-| Security & Identity - OVHcloud Account - Activity | OVHcloud Control Panel & API | Beta | [Generating OVHcloud account logs with Logs Data Platform](/pages/manage_and_operate/iam/iam-logs-forwarding) |
-| Security & Identity - OVHcloud Account - Audit | OVHcloud Control Panel & API | Beta | [Generating OVHcloud account logs with Logs Data Platform](/pages/manage_and_operate/iam/iam-logs-forwarding) |
-| Security & Identity - OVHcloud Account - IAM | OVHcloud Control Panel & API | Beta | [Generating OVHcloud account logs with Logs Data Platform](/pages/manage_and_operate/iam/iam-logs-forwarding) |
-| Security & Identity - Key Management Service | OVHcloud Control Panel & API | Beta | [Pushing logs from OVHcloud KMS to Logs Data Platform](/pages/manage_and_operate/kms/kms-troubleshooting) |
-| Public Cloud - Managed Kubernetes Service | OVHcloud Control Panel & API | Beta | [Managed Kubernetes Service Audit Logs Forwarding](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) |
-| Public Cloud - Load Balancer | OVHcloud Control Panel & API | Beta | [Public Cloud Load Balancer TCP / HTTP / HTTPS Logs Forwarding](/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers) |
-| Public Cloud - Managed Databases | OVHcloud Control Panel & API | Beta | [Public Cloud Databases - How to setup logs forwarding](/pages/public_cloud/public_cloud_databases/databases_16_logs_to_customer) |
-| Hosted Private Cloud - Managed VMware vSphere | OVHcloud Control Panel & API | Beta | - |
-| Hosting & Collaboration - Web Cloud Databases | OVHcloud Control Panel & API | Beta | [Web Cloud Databases - How to manage logs](/pages/web_cloud/web_cloud_databases/retrieve-logs) |
-| Hosting & Collaboration - Microsoft Private Exchange | OVHcloud Control Panel & API | Beta | [Exchange - How to manage logs](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_manage_logs) |
-| Hosting & Collaboration - Microsoft Trusted Exchange | OVHcloud Control Panel & API | Beta | [Exchange - How to manage logs](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_manage_logs) |
-| Infrastructure solutions - OVHcloud Connect | OVHcloud Control Panel & API | Beta | [OVHcloud Connect Logs Forwarding](/pages/network/ovhcloud_connect/occ-logs-2-customers) |
-| Infrastructure solutions - OVHcloud Load Balancer | OVHcloud Control Panel & API | Beta | [OVHcloud Load Balancer TCP / HTTP / HTTPS Logs Forwarding](/pages/network/load_balancer/use_api_logs_2_customers) |
-| Telecom - Internet Access | API only | Beta | - |
-| Telecom - OverTheBox | API only | Beta | - |
+| Product name | Availability | Guide link |
+| :----------- | :----------- | :--------- |
+| Security & Identity - OVHcloud Account - Activity | OVHcloud Control Panel & API | [Generating OVHcloud account logs with Logs Data Platform](/pages/manage_and_operate/iam/iam-logs-forwarding) |
+| Security & Identity - OVHcloud Account - Audit | OVHcloud Control Panel & API | [Generating OVHcloud account logs with Logs Data Platform](/pages/manage_and_operate/iam/iam-logs-forwarding) |
+| Security & Identity - OVHcloud Account - IAM | OVHcloud Control Panel & API | [Generating OVHcloud account logs with Logs Data Platform](/pages/manage_and_operate/iam/iam-logs-forwarding) |
+| Security & Identity - Key Management Service | OVHcloud Control Panel & API | [Pushing logs from OVHcloud KMS to Logs Data Platform](/pages/manage_and_operate/kms/kms-troubleshooting) |
+| Public Cloud - Managed Kubernetes Service | OVHcloud Control Panel & API | [Managed Kubernetes Service Audit Logs Forwarding](/pages/public_cloud/containers_orchestration/managed_kubernetes/forwarding-audit-logs-to-logs-data-platform) |
+| Public Cloud - Load Balancer | OVHcloud Control Panel & API | [Public Cloud Load Balancer TCP / HTTP / HTTPS Logs Forwarding](/pages/public_cloud/public_cloud_network_services/technical-resources-05-lb_logs_2_customers) |
+| Public Cloud - Managed Databases | OVHcloud Control Panel & API | [Public Cloud Databases - How to setup logs forwarding](/pages/public_cloud/public_cloud_databases/databases_16_logs_to_customer) |
+| Hosted Private Cloud - Managed VMware vSphere | OVHcloud Control Panel & API | - |
+| Hosting & Collaboration - Web Cloud Databases | OVHcloud Control Panel & API | [Web Cloud Databases - How to manage logs](/pages/web_cloud/web_cloud_databases/retrieve-logs) |
+| Hosting & Collaboration - Microsoft Private Exchange | OVHcloud Control Panel & API | [Exchange - How to manage logs](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_manage_logs) |
+| Hosting & Collaboration - Microsoft Trusted Exchange | OVHcloud Control Panel & API | [Exchange - How to manage logs](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_manage_logs) |
+| Infrastructure solutions - OVHcloud Connect | OVHcloud Control Panel & API | [OVHcloud Connect Logs Forwarding](/pages/network/ovhcloud_connect/occ-logs-2-customers) |
+| Infrastructure solutions - OVHcloud Load Balancer | OVHcloud Control Panel & API | [OVHcloud Load Balancer TCP / HTTP / HTTPS Logs Forwarding](/pages/network/load_balancer/use_api_logs_2_customers) |
+| Telecom - Internet Access | API only | - |
+| Telecom - OverTheBox | API only | - |
 
 ## Instructions
 


### PR DESCRIPTION
## What type of Pull Request is this?

- Update of existing guide(s)

## Description
The "Logs-to-Customers" / "Service Logs" is no longer in Beta but in General Availability
https://www.ovhcloud.com/en/identity-security-operations/service-logs/

Thus we should remove this "Beta" state from out documentation

## Mandatory information

The translations in this Pull Request have been done using:
- [x] This Pull Request didn't require any translation.
- This Pull Request can be merged as soon as possible.
- This Pull Request content should be replicated for the US OVHcloud documentation : YES
