### PR TITLE
BYOI and multiple disks: unused disks may prevent boot

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-asia.md
@@ -40,9 +40,17 @@ There are some technical limitations linked to the use of physical products such
 > [!warning]
 > **About RAID:**
 >
+> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+>
 > - Bring Your Own Image (BYOI) does not support software RAID configuration at install-time, but you can use the service [Bring Your Own Linux (BYOLinux)](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux) for that. Choose the custom image method that fits your needs: [Bring Your Own Image (BYOI) / Bring Your Own Linux (BYOLinux), a comparison sheet](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image-versus-bring-your-own-linux).
 >
-> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+> - If you stay with BYOI, the image will only get deployed to the first disk, other disks will be left unmodified.\
+>   However some motherboards will not boot with uninitialized disks: if your server does not respond to pings, please verify that your unused disks are minimally partitioned.\
+>   For example, starting your server in rescue mode:\
+>   `parted --list` should return, on unused disks (`/dev/sdb`, `/dev/sdc`, etc.), at least a GPT table containing one partition (even untyped and empty).\
+>   Otherwise:\
+>   `parted /dev/sdb mkt gpt`\
+>   `parted /dev/sdb mkpart bios_grub 1049k 2097k`
 >
 
 **Deployment methods:**

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-au.md
@@ -40,9 +40,17 @@ There are some technical limitations linked to the use of physical products such
 > [!warning]
 > **About RAID:**
 >
+> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+>
 > - Bring Your Own Image (BYOI) does not support software RAID configuration at install-time, but you can use the service [Bring Your Own Linux (BYOLinux)](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux) for that. Choose the custom image method that fits your needs: [Bring Your Own Image (BYOI) / Bring Your Own Linux (BYOLinux), a comparison sheet](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image-versus-bring-your-own-linux).
 >
-> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+> - If you stay with BYOI, the image will only get deployed to the first disk, other disks will be left unmodified.\
+>   However some motherboards will not boot with uninitialized disks: if your server does not respond to pings, please verify that your unused disks are minimally partitioned.\
+>   For example, starting your server in rescue mode:\
+>   `parted --list` should return, on unused disks (`/dev/sdb`, `/dev/sdc`, etc.), at least a GPT table containing one partition (even untyped and empty).\
+>   Otherwise:\
+>   `parted /dev/sdb mkt gpt`\
+>   `parted /dev/sdb mkpart bios_grub 1049k 2097k`
 >
 
 **Deployment methods:**

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-ca.md
@@ -40,9 +40,17 @@ There are some technical limitations linked to the use of physical products such
 > [!warning]
 > **About RAID:**
 >
+> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+>
 > - Bring Your Own Image (BYOI) does not support software RAID configuration at install-time, but you can use the service [Bring Your Own Linux (BYOLinux)](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux) for that. Choose the custom image method that fits your needs: [Bring Your Own Image (BYOI) / Bring Your Own Linux (BYOLinux), a comparison sheet](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image-versus-bring-your-own-linux).
 >
-> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+> - If you stay with BYOI, the image will only get deployed to the first disk, other disks will be left unmodified.\
+>   However some motherboards will not boot with uninitialized disks: if your server does not respond to pings, please verify that your unused disks are minimally partitioned.\
+>   For example, starting your server in rescue mode:\
+>   `parted --list` should return, on unused disks (`/dev/sdb`, `/dev/sdc`, etc.), at least a GPT table containing one partition (even untyped and empty).\
+>   Otherwise:\
+>   `parted /dev/sdb mkt gpt`\
+>   `parted /dev/sdb mkpart bios_grub 1049k 2097k`
 >
 
 **Deployment methods:**

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-gb.md
@@ -40,9 +40,17 @@ There are some technical limitations linked to the use of physical products such
 > [!warning]
 > **About RAID:**
 >
+> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+>
 > - Bring Your Own Image (BYOI) does not support software RAID configuration at install-time, but you can use the service [Bring Your Own Linux (BYOLinux)](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux) for that. Choose the custom image method that fits your needs: [Bring Your Own Image (BYOI) / Bring Your Own Linux (BYOLinux), a comparison sheet](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image-versus-bring-your-own-linux).
 >
-> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+> - If you stay with BYOI, the image will only get deployed to the first disk, other disks will be left unmodified.\
+>   However some motherboards will not boot with uninitialized disks: if your server does not respond to pings, please verify that your unused disks are minimally partitioned.\
+>   For example, starting your server in rescue mode:\
+>   `parted --list` should return, on unused disks (`/dev/sdb`, `/dev/sdc`, etc.), at least a GPT table containing one partition (even untyped and empty).\
+>   Otherwise:\
+>   `parted /dev/sdb mkt gpt`\
+>   `parted /dev/sdb mkpart bios_grub 1049k 2097k`
 >
 
 **Deployment methods:**

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-ie.md
@@ -40,9 +40,17 @@ There are some technical limitations linked to the use of physical products such
 > [!warning]
 > **About RAID:**
 >
+> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+>
 > - Bring Your Own Image (BYOI) does not support software RAID configuration at install-time, but you can use the service [Bring Your Own Linux (BYOLinux)](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux) for that. Choose the custom image method that fits your needs: [Bring Your Own Image (BYOI) / Bring Your Own Linux (BYOLinux), a comparison sheet](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image-versus-bring-your-own-linux).
 >
-> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+> - If you stay with BYOI, the image will only get deployed to the first disk, other disks will be left unmodified.\
+>   However some motherboards will not boot with uninitialized disks: if your server does not respond to pings, please verify that your unused disks are minimally partitioned.\
+>   For example, starting your server in rescue mode:\
+>   `parted --list` should return, on unused disks (`/dev/sdb`, `/dev/sdc`, etc.), at least a GPT table containing one partition (even untyped and empty).\
+>   Otherwise:\
+>   `parted /dev/sdb mkt gpt`\
+>   `parted /dev/sdb mkpart bios_grub 1049k 2097k`
 >
 
 **Deployment methods:**

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-sg.md
@@ -40,9 +40,17 @@ There are some technical limitations linked to the use of physical products such
 > [!warning]
 > **About RAID:**
 >
+> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+>
 > - Bring Your Own Image (BYOI) does not support software RAID configuration at install-time, but you can use the service [Bring Your Own Linux (BYOLinux)](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux) for that. Choose the custom image method that fits your needs: [Bring Your Own Image (BYOI) / Bring Your Own Linux (BYOLinux), a comparison sheet](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image-versus-bring-your-own-linux).
 >
-> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+> - If you stay with BYOI, the image will only get deployed to the first disk, other disks will be left unmodified.\
+>   However some motherboards will not boot with uninitialized disks: if your server does not respond to pings, please verify that your unused disks are minimally partitioned.\
+>   For example, starting your server in rescue mode:\
+>   `parted --list` should return, on unused disks (`/dev/sdb`, `/dev/sdc`, etc.), at least a GPT table containing one partition (even untyped and empty).\
+>   Otherwise:\
+>   `parted /dev/sdb mkt gpt`\
+>   `parted /dev/sdb mkpart bios_grub 1049k 2097k`
 >
 
 **Deployment methods:**

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-us.md
@@ -40,9 +40,17 @@ There are some technical limitations linked to the use of physical products such
 > [!warning]
 > **About RAID:**
 >
+> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+>
 > - Bring Your Own Image (BYOI) does not support software RAID configuration at install-time, but you can use the service [Bring Your Own Linux (BYOLinux)](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux) for that. Choose the custom image method that fits your needs: [Bring Your Own Image (BYOI) / Bring Your Own Linux (BYOLinux), a comparison sheet](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image-versus-bring-your-own-linux).
 >
-> - Hardware RAID is supported, if your server supports it, because it is configured before the image is deployed on disk.
+> - If you stay with BYOI, the image will only get deployed to the first disk, other disks will be left unmodified.\
+>   However some motherboards will not boot with uninitialized disks: if your server does not respond to pings, please verify that your unused disks are minimally partitioned.\
+>   For example, starting your server in rescue mode:\
+>   `parted --list` should return, on unused disks (`/dev/sdb`, `/dev/sdc`, etc.), at least a GPT table containing one partition (even untyped and empty).\
+>   Otherwise:\
+>   `parted /dev/sdb mkt gpt`\
+>   `parted /dev/sdb mkpart bios_grub 1049k 2097k`
 >
 
 **Deployment methods:**

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-ca.md
@@ -40,9 +40,17 @@ Certaines limites techniques sont liées à l’utilisation de produits physique
 > [!warning]
 > **À propos du RAID :**
 >
+> - Le RAID matériel est pris en charge, si votre serveur le supporte, car il est configuré avant le déploiement de l'image sur le disque.
+>
 > - Bring Your Own Image (BYOI) ne prend pas en charge la configuration RAID logicielle au moment de l'installation, mais vous pouvez utiliser le service [Bring Your Own Linux (BYOLinux)](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux) pour le faire. Choisissez le type d'installation personnalisée le plus adapté : [Comparaison entre Bring Your Own Image (BYOI) et Bring Your Own Linux (BYOLinux)](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image-versus-bring-your-own-linux).
 >
-> - Le RAID matériel est pris en charge, si votre serveur le supporte, car il est configuré avant le déploiement de l'image sur le disque.
+> - Si vous restez sur une BYOI, l'image ne sera déployée que sur le premier disque, les autres disques seront laissés en l'état.\
+>   Cependant certaines cartes mères ne démarrent pas avec des disques non initialisés: si votre serveur ne répond pas au ping après installation, vérifiez le partitionnement des disques inutilisés.\
+>   Par exemple depuis la rescue Debian:\
+>   `parted --list` doit renvoyer pour les disques inutilisés (`/dev/sdb`, `/dev/sdc`, etc.) a minima une table GPT comportant une partition (même non typée, et vide)\
+>   Dans le cas contraire:\
+>   `parted /dev/sdb mkt gpt`\
+>   `parted /dev/sdb mkpart bios_grub 1049k 2097k`
 >
 
 **Méthodes de déploiement :**

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-fr.md
@@ -40,9 +40,17 @@ Certaines limites techniques sont liées à l’utilisation de produits physique
 > [!warning]
 > **À propos du RAID :**
 >
+> - Le RAID matériel est pris en charge, si votre serveur le supporte, car il est configuré avant le déploiement de l'image sur le disque.
+>
 > - Bring Your Own Image (BYOI) ne prend pas en charge la configuration RAID logicielle au moment de l'installation, mais vous pouvez utiliser le service [Bring Your Own Linux (BYOLinux)](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux) pour le faire. Choisissez le type d'installation personnalisée le plus adapté : [Comparaison entre Bring Your Own Image (BYOI) et Bring Your Own Linux (BYOLinux)](/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image-versus-bring-your-own-linux).
 >
-> - Le RAID matériel est pris en charge, si votre serveur le supporte, car il est configuré avant le déploiement de l'image sur le disque.
+> - Si vous restez sur une BYOI, l'image ne sera déployée que sur le premier disque, les autres disques seront laissés en l'état.\
+>   Cependant certaines cartes mères ne démarrent pas avec des disques non initialisés: si votre serveur ne répond pas au ping après installation, vérifiez le partitionnement des disques inutilisés.\
+>   Par exemple depuis la rescue Debian:\
+>   `parted --list` doit renvoyer pour les disques inutilisés (`/dev/sdb`, `/dev/sdc`, etc.) a minima une table GPT comportant une partition (même non typée, et vide)\
+>   Dans le cas contraire:\
+>   `parted /dev/sdb mkt gpt`\
+>   `parted /dev/sdb mkpart bios_grub 1049k 2097k`
 >
 
 **Méthodes de déploiement :**


### PR DESCRIPTION
## What type of Pull Request is this?

- Update of existing guide(s)

## Description

As shown in a [Community discussion](https://community.ovhcloud.com/community/fr/freebsd-en-cloudinit-marchait-en-mars-ne-marche-plus-en-decembre?id=community_question&sys_id=da84c34985353654476bb1da92914b4f) with @sbraz about a BYOI install not working anymore,\
the **RAID-ready secondary disks that are left unmodified in a BYOI installation may prevent booting**, with no hint on what is stuck (on a non-KVM machine).

This PR adds the minimal info to help detect and solve this problem.

## Hesitations

* I voluntarily omitted the conditions that lead to a stuck machine (BYOI, multiple disks, secondary disks unitialized and potentially badly ordered in the BIOS, no KVM to diagnose): too much details would loose readers, and ensuring to have a clean machine to deploy to can be seen as a general best practice, wether those conditions are met or not
* the how-to part (starting with "For example, starting your server in rescue mode:" is of lesser importance, and could be in a smaller text size; however, the [GH-flavored solutions I found](https://stackoverflow.com/questions/66380290/how-to-use-smaller-font-size-in-a-github-table) (wrapping text in `<sup><sub></sub></sup>`) were not as clean as one would hope: do OVH Docs have a way to reduce some paragraph's text size? 

## Mandatory information

The translations in this Pull Request have been done using:
- [ ] OVHcloud integrated translation LLM
- [ ] Systran
- [x] Other tool (my hands and brain)
- [ ] This Pull Request didn't require any translation.

- This Pull Request can be merged as soon as possible.