### PR TITLE
[Public Cloud DB] Add warning that TimescaleDB extension is not yet available on PG18

### DIFF
--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 

--- a/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_databases/postgresql_02_extensions/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL - Available extensions
 excerpt: List of available PostgreSQL extensions
-updated: 2025-05-05
+updated: 2026-01-08
 ---
 
 ## List of available extensions
@@ -38,7 +38,7 @@ Also some extensions may require disconnecting the client and reconnecting befor
 | `isn` | <https://www.postgresql.org/docs/current/isn.html> | Data types for international product numbering standards. |
 | `ltree` | <https://www.postgresql.org/docs/current/ltree.html> | Data type for hierarchical tree-like structures. |
 | `seg` | <https://www.postgresql.org/docs/current/seg.html> | Data type for representing line segments or floating-point intervals. |
-| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. |
+| `timescaledb` | <https://github.com/timescale/timescaledb> | Enables scalable inserts and complex queries for time-series data. `Not yet available on PG18` |
 | `unit` | <https://github.com/df7cb/postgresql-unit> | SI units extension. |
 | `uuid-ossp` | <https://www.postgresql.org/docs/current/uuid-ossp.html> | Generate universally unique identifiers (UUIDs). |
 


### PR DESCRIPTION
Aiven have not yet made available the TimescaleDB extension for PG version 18.