### PR TITLE
[Update] Removing beta mention from Secret Manager guide

### DIFF
--- a/pages/manage_and_operate/secret_manager/external-secret-operator/guide.en-gb.md
+++ b/pages/manage_and_operate/secret_manager/external-secret-operator/guide.en-gb.md
@@ -4,9 +4,6 @@ excerpt: "Configure External Secret Operator to store Kubernetes secrets on the 
 updated: 2026-01-07
 ---
 
-> [!primary]
-> Secret Manager is currently in Beta phase. This guide can be updated in the future with the advancements made by our teams in charge of this product.
-
 ## Objective
 
 This guide explains how to set up the Kubernetes External Secret Operator to use the OVHcloud Secret Manager as a provider.

--- a/pages/manage_and_operate/secret_manager/external-secret-operator/guide.en-gb.md
+++ b/pages/manage_and_operate/secret_manager/external-secret-operator/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "How to use Kubernetes External Secret Operator with Secret Manager"
 excerpt: "Configure External Secret Operator to store Kubernetes secrets on the OVHcloud Secret Manager"
-updated: 2026-01-07
+updated: 2026-01-15
 ---
 
 ## Objective

--- a/pages/manage_and_operate/secret_manager/external-secret-operator/guide.fr-fr.md
+++ b/pages/manage_and_operate/secret_manager/external-secret-operator/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Comment utiliser Kubernetes External Secret Operator avec Secret Manager"
 excerpt: "Découvrez comment configurer External Secret Operator pour stocker les secrets Kubernetes sur le Secret Manager d'OVHcloud"
-updated: 2026-01-07
+updated: 2026-01-15
 ---
 
 ## Objectif

--- a/pages/manage_and_operate/secret_manager/external-secret-operator/guide.fr-fr.md
+++ b/pages/manage_and_operate/secret_manager/external-secret-operator/guide.fr-fr.md
@@ -4,9 +4,6 @@ excerpt: "Découvrez comment configurer External Secret Operator pour stocker le
 updated: 2026-01-07
 ---
 
-> [!primary]
-> Secret Manager est actuellement en phase bêta. Ce guide peut être mis à jour à l'avenir avec les avancées apportées par nos équipes en charge de ce produit.
-
 ## Objectif
 
 Ce guide explique comment configurer l'External Secret Operator Kubernetes pour utiliser le Secret Manager d'OVHcloud en tant que fournisseur.

--- a/pages/manage_and_operate/secret_manager/secret-manager-ui/guide.en-gb.md
+++ b/pages/manage_and_operate/secret_manager/secret-manager-ui/guide.en-gb.md
@@ -4,9 +4,6 @@ excerpt: "Discover how to use the Secret Manager with the graphical interface"
 updated: 2025-10-15
 ---
 
-> [!primary]
-> Secret Manager is currently in beta phase. This guide can be updated in the future with the advances of our teams in charge of this product.
-
 ## Objective
 
 The objective of this guide is to present the use of the Secret Manager through the OVHcloud Control Panel.

--- a/pages/manage_and_operate/secret_manager/secret-manager-ui/guide.en-gb.md
+++ b/pages/manage_and_operate/secret_manager/secret-manager-ui/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Using the Secret Manager in the OVHcloud Control Panel"
 excerpt: "Discover how to use the Secret Manager with the graphical interface"
-updated: 2025-10-15
+updated: 2025-01-15
 ---
 
 ## Objective

--- a/pages/manage_and_operate/secret_manager/secret-manager-ui/guide.fr-fr.md
+++ b/pages/manage_and_operate/secret_manager/secret-manager-ui/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Utiliser le Secret Manager dans l'espace client OVHcloud"
 excerpt: "Découvrez comment utiliser le Secret Manager avec l'interface graphique"
-updated: 2025-10-15
+updated: 2025-01-15
 ---
 
 ## Objectif

--- a/pages/manage_and_operate/secret_manager/secret-manager-ui/guide.fr-fr.md
+++ b/pages/manage_and_operate/secret_manager/secret-manager-ui/guide.fr-fr.md
@@ -4,10 +4,6 @@ excerpt: "Découvrez comment utiliser le Secret Manager avec l'interface graphiq
 updated: 2025-10-15
 ---
 
-> [!primary]
-> Le Secret Manager est actuellement en phase bêta. Ce guide est susceptible d’être mis à jour ultérieurement avec les avancées de nos équipes en charge de ce produit.
->
-
 ## Objectif
 
 L'objectif de ce guide est de présenter l'utilisation du Secret Manager à travers l'espace client OVHcloud.


### PR DESCRIPTION
## What type of Pull Request is this?

- Update of existing guide(s)

## Description

Following GA of Secret Manager this 15/01, removing all beta warning from guides

## Mandatory information

The translations in this Pull Request have been done using:
- [ ] OVHcloud integrated translation LLM <!-- If you're interested in this new option, contact the Guides team -->
- [ ] Systran
- [ ] Other tool (specify which tool was used)
- [ x] This Pull Request didn't require any translation.

- This Pull Request can be merged as soon as possible.
- This Pull Request content should be replicated for the US OVHcloud documentation : YES
