### PR TITLE
[Public Cloud DB] Update Valkey available versions and max connections formulaé

### DIFF
--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capacités et limites (EN)
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capacités et limites (EN)
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 

--- a/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_databases/redis_01_capabilities/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Valkey - Capabilities and Limitations
 excerpt: Discover the capabilities and limitations of Public Cloud Databases for Valkey
-updated: 2025-07-31
+updated: 2026-01-26
 ---
 
 ## Objective
@@ -34,6 +34,7 @@ The Public Cloud Databases offer uses the following Redis® open source and Valk
 
 - Valkey 7.2
 - Valkey 8.0
+- Valkey 8.1
 
 Please refer to the [DBMS lifecycle policy guide](/pages/public_cloud/public_cloud_databases/information_02_lifecycle_policy) for recommendations on version upgrades and end of life announcements of major versions. Additionally, you can follow Redis® release cycle on their official page: <https://redis.io/topics/releases>
 
@@ -103,7 +104,7 @@ Once your service is up and running, you will be able to specify IP addresses (o
 
 The number of simultaneous connections in Public Cloud Databases for Valkey depends on the available total memory on the server. We allow 4 \* megabytes_of_bytes_memory connections per RAM GB, but at least 10000 connections, even on the smallest servers.
 
-So for example on a server with 7GB memory, you will get up to 7 \* 4096 = 28672 simultaneous connections.
+So for example on a server with 8GB memory, you will get up to 8 \* 4096 = 32768 simultaneous connections.
 
 #### Advanced parameters
 


### PR DESCRIPTION
Add version 8.1 as available.
Update the formula to showcase an example using the B3-8 instead of the DB1-7.