### PR TITLE
docs(k8s): add LUKS/OMK encrypted volumes support and normalize date. 

### DIFF
--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.de-de.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.de-de.md
@@ -5,16 +5,15 @@ slug: available-upcoming-features
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/available-upcoming-features/'
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-asia.md
@@ -3,16 +3,15 @@ title: Available and planned features
 excerpt: ''
 slug: available-upcoming-features
 section: Technical resources
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-au.md
@@ -3,16 +3,15 @@ title: Available and planned features
 excerpt: ''
 slug: available-upcoming-features
 section: Technical resources
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-ca.md
@@ -3,16 +3,15 @@ title: Available and planned features
 excerpt: ''
 slug: available-upcoming-features
 section: Technical resources
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-gb.md
@@ -3,16 +3,15 @@ title: Available and planned features
 excerpt: ''
 slug: available-upcoming-features
 section: Technical resources
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-ie.md
@@ -3,16 +3,15 @@ title: Available and planned features
 excerpt: ''
 slug: available-upcoming-features
 section: Technical resources
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-sg.md
@@ -3,16 +3,15 @@ title: Available and planned features
 excerpt: ''
 slug: available-upcoming-features
 section: Technical resources
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.en-us.md
@@ -3,16 +3,15 @@ title: Available and planned features
 excerpt: ''
 slug: available-upcoming-features
 section: Technical resources
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.es-es.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.es-es.md
@@ -5,16 +5,15 @@ slug: available-upcoming-features
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/available-upcoming-features/'
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.es-us.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.es-us.md
@@ -5,16 +5,15 @@ slug: available-upcoming-features
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/available-upcoming-features/'
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.fr-ca.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.fr-ca.md
@@ -5,16 +5,15 @@ slug: available-upcoming-features
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/available-upcoming-features/'
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.fr-fr.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.fr-fr.md
@@ -5,16 +5,15 @@ slug: available-upcoming-features
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/available-upcoming-features/'
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.it-it.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.it-it.md
@@ -5,16 +5,15 @@ slug: available-upcoming-features
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/available-upcoming-features/'
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.pl-pl.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.pl-pl.md
@@ -5,16 +5,15 @@ slug: available-upcoming-features
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/available-upcoming-features/'
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/available-upcoming-features/guide.pt-pt.md
+++ b/pages/platform/kubernetes-k8s/available-upcoming-features/guide.pt-pt.md
@@ -5,16 +5,15 @@ slug: available-upcoming-features
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/available-upcoming-features/'
-updated: 2022-08-11
+updated: 2026-01-30
 ---
 
-**Last updated August 11th, 2022.**
 
 We list here the most frequently requested OVHcloud Managed Kubernetes features that are currently available or planned in the upcoming year.
 
 ### Available features
 
-- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide.
+- **Persistent Volumes**: Use the integrated Cinder Volumes to host the persistent data of your stateful containerized workloads. LUKS encrypted volumes using OVHcloud Managed Keys (OMK) are supported for enhanced data security at rest. Details in the [working with persistent volumes](../ovh-kubernetes-persistent-volumes/) guide. For a complete tutorial on encrypted volumes, see [Create encrypted Persistent Volumes with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/). For storage class availability: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
 - **Load Balancer**: Use the integrated External Load Balancers to expose your services on any port of a dedicated public IPv4. Details available in the [exposing your services](../using-lb/) guide.
 - **Private Network**: Deploy your Kubernetes in an OVHcloud Public Cloud private network to consume and expose applications on our multiregion and multiproduct private network (vRack). Note : You can still leverage integrated External Load Balancers to expose some services on a public Internet IPv4.
 - **New versions**: We support the last 3 stable K8s versions and offer the latest one during the quarter following its official release. We also propose managed version upgrades.

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.de-de.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.de-de.md
@@ -6,7 +6,7 @@ section: 'Backup and Restore'
 order: 03
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/backup-restore-pv-volume-snapshot/'
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -44,6 +43,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/de/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-asia.md
@@ -4,7 +4,7 @@ excerpt: Find out how to back up and restore your Persistent Volume with Volume 
 slug: backup-restore-pv-volume-snapshot
 section: 'Backup and Restore'
 order: 03
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -42,6 +41,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/asia/en/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-au.md
@@ -4,7 +4,7 @@ excerpt: Find out how to back up and restore your Persistent Volume with Volume 
 slug: backup-restore-pv-volume-snapshot
 section: 'Backup and Restore'
 order: 03
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -42,6 +41,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/au/en/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-ca.md
@@ -4,7 +4,7 @@ excerpt: Find out how to back up and restore your Persistent Volume with Volume 
 slug: backup-restore-pv-volume-snapshot
 section: 'Backup and Restore'
 order: 03
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -42,6 +41,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/ca/en/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-gb.md
@@ -4,7 +4,7 @@ excerpt: Find out how to back up and restore your Persistent Volume with Volume 
 slug: backup-restore-pv-volume-snapshot
 section: 'Backup and Restore'
 order: 03
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -42,6 +41,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/gb/en/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-ie.md
@@ -4,7 +4,7 @@ excerpt: Find out how to back up and restore your Persistent Volume with Volume 
 slug: backup-restore-pv-volume-snapshot
 section: 'Backup and Restore'
 order: 03
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -42,6 +41,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/ie/en/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-sg.md
@@ -4,7 +4,7 @@ excerpt: Find out how to back up and restore your Persistent Volume with Volume 
 slug: backup-restore-pv-volume-snapshot
 section: 'Backup and Restore'
 order: 03
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -42,6 +41,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/sg/en/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.en-us.md
@@ -4,7 +4,7 @@ excerpt: Find out how to back up and restore your Persistent Volume with Volume 
 slug: backup-restore-pv-volume-snapshot
 section: 'Backup and Restore'
 order: 03
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -42,6 +41,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/us/en/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.es-es.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.es-es.md
@@ -6,7 +6,7 @@ section: 'Backup and Restore'
 order: 03
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/backup-restore-pv-volume-snapshot/'
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -44,6 +43,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/es/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.es-us.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.es-us.md
@@ -6,7 +6,7 @@ section: 'Backup and Restore'
 order: 03
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/backup-restore-pv-volume-snapshot/'
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -44,6 +43,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/us/es/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.fr-ca.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.fr-ca.md
@@ -6,7 +6,7 @@ section: 'Backup and Restore'
 order: 03
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/backup-restore-pv-volume-snapshot/'
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -44,6 +43,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/ca/fr/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.fr-fr.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.fr-fr.md
@@ -6,7 +6,7 @@ section: 'Backup and Restore'
 order: 03
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/backup-restore-pv-volume-snapshot/'
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -44,6 +43,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/fr/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.it-it.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.it-it.md
@@ -6,7 +6,7 @@ section: 'Backup and Restore'
 order: 03
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/backup-restore-pv-volume-snapshot/'
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -44,6 +43,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/it/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.pl-pl.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.pl-pl.md
@@ -6,7 +6,7 @@ section: 'Backup and Restore'
 order: 03
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/backup-restore-pv-volume-snapshot/'
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -44,6 +43,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/pl/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.pt-pt.md
+++ b/pages/platform/kubernetes-k8s/backup-restore-pv-volume-snapshot/guide.pt-pt.md
@@ -6,7 +6,7 @@ section: 'Backup and Restore'
 order: 03
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/backup-restore-pv-volume-snapshot/'
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2023-01-11
  }
 </style>
 
-**Last updated 11th January 2023**
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
 
@@ -44,6 +43,11 @@ They provide the ability to create a “snapshot” of a persistent volume. A sn
 This tutorial presupposes that you already have a working OVHcloud Managed Kubernetes cluster, and some basic knowledge of how to operate it. If you want to know more on those topics, please look at the [OVHcloud Managed Kubernetes Service Quickstart](../deploying-hello-world/).
 
 The tutorial also supposes that you're familiar with [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). You also need to know how PVs are handled on the OVHcloud Managed Kubernetes service. Please refer to the [Persistent Volumes on OVHcloud Managed Kubernetes](https://docs.ovh.com/pt/kubernetes/ovh-kubernetes-persistent-volumes/) guide.
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume Snapshots work with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The backup and restore process is identical for encrypted and non-encrypted volumes.
 
 ## Instructions
 

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.de-de.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.de-de.md
@@ -5,10 +5,9 @@ slug: datacenters-nodes-storage-flavors
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/datacenters-nodes-storage-flavors/'
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -48,11 +47,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-asia.md
@@ -3,10 +3,9 @@ title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
 slug: datacenters-nodes-storage-flavors
 section: Technical resources
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -46,11 +45,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-au.md
@@ -3,10 +3,9 @@ title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
 slug: datacenters-nodes-storage-flavors
 section: Technical resources
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -46,11 +45,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-ca.md
@@ -3,10 +3,9 @@ title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
 slug: datacenters-nodes-storage-flavors
 section: Technical resources
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -46,11 +45,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-gb.md
@@ -3,10 +3,9 @@ title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
 slug: datacenters-nodes-storage-flavors
 section: Technical resources
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -46,11 +45,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-ie.md
@@ -3,10 +3,9 @@ title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
 slug: datacenters-nodes-storage-flavors
 section: Technical resources
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -46,11 +45,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-sg.md
@@ -3,10 +3,9 @@ title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
 slug: datacenters-nodes-storage-flavors
 section: Technical resources
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -46,11 +45,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.en-us.md
@@ -3,10 +3,9 @@ title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
 slug: datacenters-nodes-storage-flavors
 section: Technical resources
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -46,11 +45,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.es-es.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.es-es.md
@@ -5,10 +5,9 @@ slug: datacenters-nodes-storage-flavors
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/datacenters-nodes-storage-flavors/'
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -48,11 +47,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.es-us.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.es-us.md
@@ -5,10 +5,9 @@ slug: datacenters-nodes-storage-flavors
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/datacenters-nodes-storage-flavors/'
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -48,11 +47,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.fr-ca.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.fr-ca.md
@@ -5,10 +5,9 @@ slug: datacenters-nodes-storage-flavors
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/datacenters-nodes-storage-flavors/'
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -48,11 +47,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.fr-fr.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.fr-fr.md
@@ -5,10 +5,9 @@ slug: datacenters-nodes-storage-flavors
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/datacenters-nodes-storage-flavors/'
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -48,11 +47,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.it-it.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.it-it.md
@@ -5,10 +5,9 @@ slug: datacenters-nodes-storage-flavors
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/datacenters-nodes-storage-flavors/'
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -48,11 +47,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.pl-pl.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.pl-pl.md
@@ -5,10 +5,9 @@ slug: datacenters-nodes-storage-flavors
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/datacenters-nodes-storage-flavors/'
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -48,11 +47,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.pt-pt.md
+++ b/pages/platform/kubernetes-k8s/datacenters-nodes-storage-flavors/guide.pt-pt.md
@@ -5,10 +5,9 @@ slug: datacenters-nodes-storage-flavors
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/datacenters-nodes-storage-flavors/'
-updated: 2022-02-16
+updated: 2026-01-30
 ---
 
-**Last updated February 16th, 2022.**
 
 ## Available datacenters, worker nodes and persistent storage flavors
 
@@ -48,11 +47,39 @@ GPU (`T1-*`) instances are now supported! If you want to know [how to deploy GPU
 
 ### Available persistent Storage Classes
 
-When adding a persistent volume though Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
+When adding a persistent volume through Kubernetes API (or `kubectl`), it will actually be deployed using Public Cloud additional disks (Cinder Volumes). We support the following Storage Classes:
 
+**Standard Storage Classes:**
 * `csi-cinder-high-speed` compliant with Managed Kubernetes Service after `1.18.*` release
 * `csi-cinder-classic` compliant with Managed Kubernetes Service after `1.18.*` release
 
-All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device, and the fact that `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. This is detailed in the [Persistent Volumes ](../ovh-kubernetes-persistent-volumes/) guide.
+**Encrypted Storage Classes (LUKS):**
+* `csi-cinder-high-speed-luks`
+* `csi-cinder-classic-luks`
+* `csi-cinder-high-speed-gen2-luks`
+
+All these Storage Classes are based on Cinder, the OpenStack block storage service. The difference between standard classes is the associated physical storage device: `csi-cinder-high-speed` uses SSD, while `csi-cinder-classic` uses traditional spinning disks. Both are distributed transparently across three physical local replicas.
+
+The encrypted storage classes (`*-luks`) provide the same performance characteristics as their non-encrypted counterparts but with additional LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest.
+
+> [!primary]
+> **LUKS encrypted storage classes availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+> 
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet available, they will be automatically deployed when you update your cluster.
+
+For a complete guide on using encrypted Persistent Volumes, visit: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+For more information about storage classes and their regional availability, please refer to: [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+This is detailed in the [Persistent Volumes](../ovh-kubernetes-persistent-volumes/) guide.
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/platform/kubernetes-k8s/known-limits/guide.de-de.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.de-de.md
@@ -5,11 +5,10 @@ slug: known-limits
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/known-limits/'
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -175,3 +174,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-asia.md
@@ -3,11 +3,10 @@ title: Known limits
 excerpt: 'Requirements and limits to respect'
 slug: known-limits
 section: Technical resources
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -173,3 +172,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-au.md
@@ -3,11 +3,10 @@ title: Known limits
 excerpt: 'Requirements and limits to respect'
 slug: known-limits
 section: Technical resources
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -173,3 +172,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ca.md
@@ -3,11 +3,10 @@ title: Known limits
 excerpt: 'Requirements and limits to respect'
 slug: known-limits
 section: Technical resources
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -173,3 +172,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-gb.md
@@ -3,11 +3,10 @@ title: Known limits
 excerpt: 'Requirements and limits to respect'
 slug: known-limits
 section: Technical resources
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -173,3 +172,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-ie.md
@@ -3,11 +3,10 @@ title: Known limits
 excerpt: 'Requirements and limits to respect'
 slug: known-limits
 section: Technical resources
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -173,3 +172,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-sg.md
@@ -3,11 +3,10 @@ title: Known limits
 excerpt: 'Requirements and limits to respect'
 slug: known-limits
 section: Technical resources
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -173,3 +172,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.en-us.md
@@ -3,11 +3,10 @@ title: Known limits
 excerpt: 'Requirements and limits to respect'
 slug: known-limits
 section: Technical resources
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -173,3 +172,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.es-es.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.es-es.md
@@ -5,11 +5,10 @@ slug: known-limits
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/known-limits/'
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -175,3 +174,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.es-us.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.es-us.md
@@ -5,11 +5,10 @@ slug: known-limits
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/known-limits/'
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -175,3 +174,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.fr-ca.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.fr-ca.md
@@ -5,11 +5,10 @@ slug: known-limits
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/known-limits/'
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -175,3 +174,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.fr-fr.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.fr-fr.md
@@ -5,11 +5,10 @@ slug: known-limits
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/known-limits/'
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -175,3 +174,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.it-it.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.it-it.md
@@ -5,11 +5,10 @@ slug: known-limits
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/known-limits/'
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -175,3 +174,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.pl-pl.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.pl-pl.md
@@ -5,11 +5,10 @@ slug: known-limits
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/known-limits/'
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -175,3 +174,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/known-limits/guide.pt-pt.md
+++ b/pages/platform/kubernetes-k8s/known-limits/guide.pt-pt.md
@@ -5,11 +5,10 @@ slug: known-limits
 section: Technical resources
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/known-limits/'
-updated: 2023-03-03
+updated: 2026-01-30
 ---
 
 
-**Last updated 3rd March 2023.**
 
 <style>
  pre {
@@ -175,3 +174,30 @@ For more details, please refer to the [Resizing Persistent Volumes documentation
 The Persistent Volumes are using our Cinder-based block-storage solution through Cinder CSI.  
 A worker node can have a maximum of 254 persistent volumes attached to it, and a persistent volume can only be attached to a single worker node.  
 You can manually [configure multi-attach persistent volumes with NAS-HA](../configuring-multi-attach-persistent-volumes-with-ovhcloud-nas-ha/).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+The following encrypted storage classes are available in supported regions:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.de-de.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.de-de.md
@@ -5,7 +5,7 @@ excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Manage
 section: Getting started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/ovh-kubernetes-persistent-volumes/'
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -30,7 +30,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -91,6 +90,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/de/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-asia.md
@@ -3,7 +3,7 @@ title: Persistent Volumes on OVHcloud Managed Kubernetes
 slug: ovh-kubernetes-persistent-volumes
 excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Getting started
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -28,7 +28,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -89,6 +88,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/asia/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-au.md
@@ -3,7 +3,7 @@ title: Persistent Volumes on OVHcloud Managed Kubernetes
 slug: ovh-kubernetes-persistent-volumes
 excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Getting started
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -28,7 +28,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -89,6 +88,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/en-au/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-ca.md
@@ -3,7 +3,7 @@ title: Persistent Volumes on OVHcloud Managed Kubernetes
 slug: ovh-kubernetes-persistent-volumes
 excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Getting started
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -28,7 +28,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -89,6 +88,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/en-ca/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-gb.md
@@ -3,7 +3,7 @@ title: Persistent Volumes on OVHcloud Managed Kubernetes
 slug: ovh-kubernetes-persistent-volumes
 excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Getting started
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -28,7 +28,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -89,6 +88,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/en-gb/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-ie.md
@@ -3,7 +3,7 @@ title: Persistent Volumes on OVHcloud Managed Kubernetes
 slug: ovh-kubernetes-persistent-volumes
 excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Getting started
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -28,7 +28,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -89,6 +88,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/en-ie/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-sg.md
@@ -3,7 +3,7 @@ title: Persistent Volumes on OVHcloud Managed Kubernetes
 slug: ovh-kubernetes-persistent-volumes
 excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Getting started
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -28,7 +28,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -89,6 +88,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/en-sg/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.en-us.md
@@ -3,7 +3,7 @@ title: Persistent Volumes on OVHcloud Managed Kubernetes
 slug: ovh-kubernetes-persistent-volumes
 excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Getting started
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -28,7 +28,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -89,6 +88,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/en/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.es-es.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.es-es.md
@@ -5,7 +5,7 @@ excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Manage
 section: Getting started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/ovh-kubernetes-persistent-volumes/'
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -30,7 +30,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -91,6 +90,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/es-es/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.es-us.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.es-us.md
@@ -5,7 +5,7 @@ excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Manage
 section: Getting started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/ovh-kubernetes-persistent-volumes/'
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -30,7 +30,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -91,6 +90,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/es/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.fr-ca.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.fr-ca.md
@@ -5,7 +5,7 @@ excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Manage
 section: Getting started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/ovh-kubernetes-persistent-volumes/'
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -30,7 +30,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -91,6 +90,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/fr-ca/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.fr-fr.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.fr-fr.md
@@ -5,7 +5,7 @@ excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Manage
 section: Getting started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/ovh-kubernetes-persistent-volumes/'
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -30,7 +30,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -91,6 +90,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/fr/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.it-it.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.it-it.md
@@ -5,7 +5,7 @@ excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Manage
 section: Getting started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/ovh-kubernetes-persistent-volumes/'
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -30,7 +30,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -91,6 +90,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/it/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.pl-pl.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.pl-pl.md
@@ -5,7 +5,7 @@ excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Manage
 section: Getting started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/ovh-kubernetes-persistent-volumes/'
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -30,7 +30,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -91,6 +90,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/pl/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.pt-pt.md
+++ b/pages/platform/kubernetes-k8s/persistent-volumes-on-ovh-managed-kubernetes/guide.pt-pt.md
@@ -5,7 +5,7 @@ excerpt: 'Find out how to setup and manage Persistent Volumes on OVHcloud Manage
 section: Getting started
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/ovh-kubernetes-persistent-volumes/'
-updated: 2022-10-17
+updated: 2026-01-30
 ---
 
 <style>
@@ -30,7 +30,6 @@ updated: 2022-10-17
  }
 </style>
 
-**Last updated 17th October 2022**
 
 ## Before you begin
 
@@ -91,6 +90,60 @@ The difference between them is the associated physical storage device. The `csi-
 When you create a PersistentVolume Claim on your Kubernetes cluster, we provision the Cinder storage into your account. This storage is charged according to the OVH [Flexible Cloud Block Storage Policy](https://www.ovhcloud.com/pt/public-cloud/block-storage/){.external}.
 
 Since Kubernetes 1.11, support for expanding `PersistentVolumeClaims` (PVCs) is enabled by default, and it works on Cinder volumes. In order to learn how to resize them, please refer to the [Resizing PersistentVolumes](../resizing-persistent-volumes/) tutorial. Kubernetes PVCs resizing only allows to expand volumes, nor to decrease them.
+
+### LUKS Encrypted Storage Classes
+
+In addition to the standard storage classes, OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This provides encryption at rest for your persistent data with keys managed by OVHcloud.
+
+The following encrypted storage classes are available in supported regions:
+
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+These encrypted storage classes work similarly to their non-encrypted counterparts but provide an additional layer of security through LUKS encryption.
+
+> [!primary]
+> **Automatic deployment on cluster updates**
+>
+> If LUKS encrypted volumes are available in your region but the LUKS storage classes are not yet visible in your cluster, updating your cluster will automatically deploy the encrypted storage classes transparently.
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+
+For detailed information about available storage classes and regional availability, please refer to:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+#### Creating encrypted Persistent Volumes
+
+To use LUKS encrypted volumes, specify the encrypted storage class in your PersistentVolumeClaim:
+
+```yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: encrypted-pvc
+  namespace: my-app
+spec:
+  storageClassName: csi-cinder-high-speed-gen2-luks
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+```
+
+> [!primary]
+> **Want to learn more?**
+>
+> For a complete step-by-step tutorial on creating and using encrypted Persistent Volumes with LUKS on OVHcloud Managed Kubernetes, including manual Storage Class creation and practical examples, please visit our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 ## Setting up a PersistentVolume
 

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.de-de.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.de-de.md
@@ -6,7 +6,7 @@ section: Storage
 order: 1
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/resizing-persistent-volumes/'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -51,7 +50,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/de/public-cloud/prices/#storage)
-> 
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-asia.md
@@ -4,7 +4,7 @@ slug: resizing-persistent-volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Storage
 order: 1
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -49,8 +48,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/asia/public-cloud/prices/#storage)
->
 
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-au.md
@@ -4,7 +4,7 @@ slug: resizing-persistent-volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Storage
 order: 1
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -49,8 +48,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/en-au/public-cloud/prices/#storage)
->
 
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-ca.md
@@ -4,7 +4,7 @@ slug: resizing-persistent-volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Storage
 order: 1
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -49,8 +48,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/en-ca/public-cloud/prices/#storage)
->
 
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-gb.md
@@ -4,7 +4,7 @@ slug: resizing-persistent-volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Storage
 order: 1
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -49,7 +48,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/en-gb/public-cloud/prices/#storage)
-> 
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-ie.md
@@ -4,7 +4,7 @@ slug: resizing-persistent-volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Storage
 order: 1
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -49,7 +48,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/en-ie/public-cloud/prices/#storage)
-> 
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-sg.md
@@ -4,7 +4,7 @@ slug: resizing-persistent-volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Storage
 order: 1
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -49,8 +48,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/en-sg/public-cloud/prices/#storage)
->
 
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.en-us.md
@@ -4,7 +4,7 @@ slug: resizing-persistent-volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
 section: Storage
 order: 1
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -29,7 +29,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -49,8 +48,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/en/public-cloud/prices/#storage)
->
 
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.es-es.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.es-es.md
@@ -6,7 +6,7 @@ section: Storage
 order: 1
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/resizing-persistent-volumes/'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -51,7 +50,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/es-es/public-cloud/prices/#storage)
-> 
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.es-us.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.es-us.md
@@ -6,7 +6,7 @@ section: Storage
 order: 1
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/resizing-persistent-volumes/'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -51,7 +50,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/es/public-cloud/prices/#storage)
-> 
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.fr-ca.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.fr-ca.md
@@ -6,7 +6,7 @@ section: Storage
 order: 1
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/resizing-persistent-volumes/'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -51,7 +50,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/fr-ca/public-cloud/prices/#storage)
-> 
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.fr-fr.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.fr-fr.md
@@ -6,7 +6,7 @@ section: Storage
 order: 1
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/resizing-persistent-volumes/'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -51,7 +50,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/fr/public-cloud/prices/#storage)
-> 
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.it-it.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.it-it.md
@@ -6,7 +6,7 @@ section: Storage
 order: 1
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/resizing-persistent-volumes/'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -51,7 +50,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/it/public-cloud/prices/#storage)
-> 
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.pl-pl.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.pl-pl.md
@@ -6,7 +6,7 @@ section: Storage
 order: 1
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/resizing-persistent-volumes/'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -51,7 +50,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/pl/public-cloud/prices/#storage)
-> 
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.pt-pt.md
+++ b/pages/platform/kubernetes-k8s/resizing-persistent-volumes/guide.pt-pt.md
@@ -6,7 +6,7 @@ section: Storage
 order: 1
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/resizing-persistent-volumes/'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 <style>
@@ -31,7 +31,6 @@ updated: 2021-10-19
  }
 </style>
 
-**Last updated 19<sup>th</sup> October 2021.**
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
 
@@ -51,7 +50,12 @@ You also need to know how PVs are handled on OVHcloud Managed Kubernetes service
 > [!warning]
 > When a __Persistent Volumes__ resource is created inside a Managed Kubernetes cluster, an associated Public Cloud __Block Storage__ volume is automatically created with it.
 > This volume is hourly charged and will appear in your Public Cloud project. For more information, please refer to the following documentation: [Volume Block Storage price](https://www.ovhcloud.com/pt/public-cloud/prices/#storage)
-> 
+
+> [!primary]
+> **LUKS encrypted volumes support**
+>
+> Volume resizing works with both standard and LUKS encrypted storage classes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The resizing process is identical for encrypted and non-encrypted volumes.
+ 
 ## Let's make a Persistent Volume Claim
 
 To test the PVs resizing, we will need a PV associated to the cluster, i.e. we need to deploy a service making a PVC. To keep thing simple, we choose to deploy a single instance of [MySQL](https://www.mysql.com/).

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.de-de.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.de-de.md
@@ -6,10 +6,9 @@ section: Storage
 order: 0
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/setting-up-a-persistent-volume/'
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -322,6 +321,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-asia.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-asia.md
@@ -4,10 +4,9 @@ slug: setting-up-a-persistent-volume
 excerpt: 'Find out how to create Persistent Volume Claim (PVC) and Persistent Volumes (PV), attach a Pod to a PVC, change PV reclaim policy and delete created objects'
 section: Storage
 order: 0
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -320,6 +319,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-au.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-au.md
@@ -4,10 +4,9 @@ slug: setting-up-a-persistent-volume
 excerpt: 'Find out how to create Persistent Volume Claim (PVC) and Persistent Volumes (PV), attach a Pod to a PVC, change PV reclaim policy and delete created objects'
 section: Storage
 order: 0
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -320,6 +319,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-ca.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-ca.md
@@ -4,10 +4,9 @@ slug: setting-up-a-persistent-volume
 excerpt: 'Find out how to create Persistent Volume Claim (PVC) and Persistent Volumes (PV), attach a Pod to a PVC, change PV reclaim policy and delete created objects'
 section: Storage
 order: 0
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -320,6 +319,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-gb.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-gb.md
@@ -4,10 +4,9 @@ slug: setting-up-a-persistent-volume
 excerpt: 'Find out how to create Persistent Volume Claim (PVC) and Persistent Volumes (PV), attach a Pod to a PVC, change PV reclaim policy and delete created objects'
 section: Storage
 order: 0
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -320,6 +319,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-ie.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-ie.md
@@ -4,10 +4,9 @@ slug: setting-up-a-persistent-volume
 excerpt: 'Find out how to create Persistent Volume Claim (PVC) and Persistent Volumes (PV), attach a Pod to a PVC, change PV reclaim policy and delete created objects'
 section: Storage
 order: 0
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -320,6 +319,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-sg.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-sg.md
@@ -4,10 +4,9 @@ slug: setting-up-a-persistent-volume
 excerpt: 'Find out how to create Persistent Volume Claim (PVC) and Persistent Volumes (PV), attach a Pod to a PVC, change PV reclaim policy and delete created objects'
 section: Storage
 order: 0
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -320,6 +319,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-us.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.en-us.md
@@ -4,10 +4,9 @@ slug: setting-up-a-persistent-volume
 excerpt: 'Find out how to create Persistent Volume Claim (PVC) and Persistent Volumes (PV), attach a Pod to a PVC, change PV reclaim policy and delete created objects'
 section: Storage
 order: 0
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -320,6 +319,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.es-es.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.es-es.md
@@ -6,10 +6,9 @@ section: Storage
 order: 0
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/setting-up-a-persistent-volume/'
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -322,6 +321,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.es-us.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.es-us.md
@@ -6,10 +6,9 @@ section: Storage
 order: 0
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/setting-up-a-persistent-volume/'
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -322,6 +321,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.fr-ca.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.fr-ca.md
@@ -6,10 +6,9 @@ section: Storage
 order: 0
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/setting-up-a-persistent-volume/'
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -322,6 +321,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.fr-fr.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.fr-fr.md
@@ -6,10 +6,9 @@ section: Storage
 order: 0
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/setting-up-a-persistent-volume/'
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -322,6 +321,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.it-it.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.it-it.md
@@ -6,10 +6,9 @@ section: Storage
 order: 0
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/setting-up-a-persistent-volume/'
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -322,6 +321,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.pl-pl.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.pl-pl.md
@@ -6,10 +6,9 @@ section: Storage
 order: 0
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/setting-up-a-persistent-volume/'
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -322,6 +321,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 

--- a/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.pt-pt.md
+++ b/pages/platform/kubernetes-k8s/setting-up-a-persistent-volume/guide.pt-pt.md
@@ -6,10 +6,9 @@ section: Storage
 order: 0
 routes:
     canonical: 'https://docs.ovh.com/gb/en/kubernetes/setting-up-a-persistent-volume/'
-updated: 2022-11-28
+updated: 2026-01-30
 ---
 
-**Last updated 28th November 2022.**
 
 <style>
  pre {
@@ -322,6 +321,39 @@ ovh-managed-kubernetes-btw8lc-pvc-LONG-ID  10Gi      RWO           Retain       
 
 In the preceding output, you can see that the volume bound to PVC `default/test-pvc` has reclaim policy `Retain`.  
 It will not be automatically deleted when a user deletes PVC `default/test-pvc`
+
+## Using encrypted Persistent Volumes
+
+For enhanced security, you can use LUKS-encrypted Persistent Volumes. Simply replace the `storageClassName` in your PVC with an encrypted storage class:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-encrypted
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: csi-cinder-high-speed-gen2-luks
+```
+
+The encrypted storage classes provide LUKS encryption using OVHcloud Managed Keys (OMK), protecting your data at rest without requiring any changes to your application code.
+
+> [!primary]
+> For a comprehensive guide on using encrypted volumes, including manual Storage Class creation and complete examples, see our blog post: [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
+
+> [!warning]
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), Paris
+> - **Germany**: DE1
+> - **Italy**: Milan
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months. Check the [Block Storage class guide](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119) for the latest regional availability.
 
 ## Go further
 


### PR DESCRIPTION
Hello the Team, 

This PR enhances the documentation covering encrypted block volumes with OMK (LUKS) on OVHcloud Managed Kubernetes.

## What type of Pull Request is this?
- Update of existing guide(s)

## Description

<!-- Please provide a short description for your Pull Request, including (if applicable) a ticket reference (no internal URL!) or GitHub issue -->

## Mandatory information

The translations in this Pull Request have been done using:
- [ ] OVHcloud integrated translation LLM <!-- If you're interested in this new option, contact the Guides team -->
- [ ] Systran
- [ ] Other tool (specify which tool was used)
- [x] This Pull Request didn't require any translation.

<!-- Delete the line which doesn't apply: -->
- This Pull Request can be merged as soon as possible.

<!-- If you know about the following, please mention it. If you don't know, delete the line.-->
- This Pull Request content should be replicated for the US OVHcloud documentation : YES
